### PR TITLE
Stabilize Tops save/delete behavior in tests and update STATUS.md

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -20,6 +20,7 @@ Sie ergänzt:
 - `AGENTS.md` und `PLAN.md` sind vorhanden.
 - Codex Cloud ist eingerichtet und kann das Repo lesen.
 - Der erste CSS-Schritt im Modul `Protokoll` wurde umgesetzt.
+- Der Speichern-/Löschen-Vertrag im Tops-Bereich wurde zwischen Verhalten und Tests synchronisiert.
 
 ---
 
@@ -40,18 +41,30 @@ Sie ergänzt:
 - Hinweise:
   - Commit enthält zusätzlich das Entfernen von ChatGPT-Export-Artefakten
 
+#### Paket: Speichern-/Löschen-Vertrag im Tops-Bereich stabilisieren
+- Status: erledigt
+- Beschreibung:
+  - `topsCommands`-Testvertrag an den realen Reload-Ablauf nach `saveDraft` und `deleteSelectedTop` angepasst
+  - Reload nach Speichern/Löschen im Test explizit abgedeckt (inkl. Erhalt/Entfernung der Selektion im Ablauf)
+- Betroffene Dateien:
+  - `scripts/tests/topsCommands.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `50cdbc3`
+- Hinweise:
+  - Keine Änderungen an Router, UI, Restarbeiten oder fachlicher Tops-Logik
+
 ---
 
 ## Offene Meilensteine
 1. Weitere kleine Altpfade im Modul `Protokoll` abbauen
-2. Speichern-/Löschen-Vertrag im Tops-Bereich stabilisieren
-3. Restarbeiten-Modul sauberer an die bestehende Navigation anbinden
+2. Restarbeiten-Modul sauberer an die bestehende Navigation anbinden
 
 ---
 
 ## Zuletzt bearbeitet
 - Letzter sinnvoller bestätigter Stand:
-  - CSS-Altpfad im Modul `Protokoll` bereinigt
+  - Speichern-/Löschen-Vertrag im Tops-Bereich über zugehörigen Testvertrag stabilisiert
 - Letzter Cloud-Kontrolllauf:
   - `AGENTS.md` gefunden
   - `PLAN.md` gefunden
@@ -64,13 +77,13 @@ Sie ergänzt:
 ## Aktuell nächster sinnvoller Schritt
 Der nächste noch nicht erledigte Meilenstein ist:
 
-### Weitere kleine Altpfade im Modul Protokoll abbauen
+### Restarbeiten-Modul sauberer an die bestehende Navigation anbinden
 - Ziel:
-  - einen weiteren kleinen, klar abgegrenzten Altpfad aus der Altstruktur in die Modulstruktur überführen
+  - einen kleinen, klar abgegrenzten Integrationsschritt für `Restarbeiten` in der bestehenden Navigation umsetzen
 - Wichtig:
   - nur ein kleines Paket
   - keine Nebenumbauten
-  - keine neue Fachlogik
+  - keine breiten Router-Umbauten
   - keine Änderungen außerhalb des aktuellen Meilensteins
 
 ---
@@ -78,7 +91,6 @@ Der nächste noch nicht erledigte Meilenstein ist:
 ## Offene Hindernisse / bekannte Probleme
 - Bestehende Tests sind aktuell nicht vollständig grün.
 - Frühere Läufe zeigten bestehende Altprobleme, u. a.:
-  - `topsCommands`-bezogene Testfehler
   - `ERR_INVALID_URL` im Zusammenhang mit ESM/CSS-Importpfaden
 - Diese Probleme gelten nicht automatisch als Teil jedes neuen Mini-Pakets.
 - Wenn ein neuer Meilenstein an diesen Punkten hängen bleibt, stoppen und offen berichten.

--- a/scripts/tests/topsCommands.test.cjs
+++ b/scripts/tests/topsCommands.test.cjs
@@ -55,6 +55,7 @@ async function runTopsCommandsTests(run) {
 
     let savedPayload = null;
     let deletedId = null;
+    const reloadedMeetingIds = [];
 
     const repository = {
       async saveTop(payload) {
@@ -64,6 +65,16 @@ async function runTopsCommandsTests(run) {
       async deleteTop(topId) {
         deletedId = topId && typeof topId === "object" ? topId.topId : topId;
         return { ok: true };
+      },
+      async loadByMeeting(payload) {
+        const id = payload && typeof payload === "object" ? payload.meetingId : payload;
+        reloadedMeetingIds.push(id);
+        const isAfterSaveReload = reloadedMeetingIds.length === 1;
+        return {
+          ok: true,
+          meeting: { id, is_closed: 0 },
+          list: isAfterSaveReload ? [{ id: 33, title: "TOP 33" }] : [],
+        };
       },
     };
 
@@ -81,6 +92,7 @@ async function runTopsCommandsTests(run) {
     });
     assert.equal(deletedId, 33);
     assert.equal(store.getState().selectedTopId, null);
+    assert.deepEqual(reloadedMeetingIds, [9, 9]);
   });
 }
 


### PR DESCRIPTION
### Motivation
- Tests for the `TopsCommands` save/delete flow relied on an implicit reload behavior that caused intermittent failures and needed to explicitly mirror the real reload sequence.
- The project status needed updating to reflect that the save/delete contract in the Tops area has been stabilized and documented.

### Description
- Updated `scripts/tests/topsCommands.test.cjs` to add a `loadByMeeting` stub that records reload calls and returns different lists before/after save to emulate the real reload sequence. 
- Added an assertion in the test to verify that the meeting was reloaded twice (`[9, 9]`) after `saveDraft` and `deleteSelectedTop`, and kept existing repository interaction assertions. 
- Updated `STATUS.md` to mark the "Speichern-/Löschen-Vertrag im Tops-Bereich stabilisieren" package as completed and to adjust the next steps and last-edited notes.

### Testing
- Ran the `runTopsCommandsTests` for the modified `scripts/tests/topsCommands.test.cjs`, and the test completed successfully with the new reload assertions passing. 
- Existing assertions for `saveDraft` and `deleteSelectedTop` interactions with the repository also passed under the updated test harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea86dfa2848322996a08ad411cde5e)