### PR TITLE
docs(plan): Klarstellung Projekt-Arbeitsbereich-Richtung

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -30,6 +30,8 @@ Hinweis:
 - Das Mutter-/Kind-Prinzip ist die verbindliche Leitlinie fuer alle weiteren Modularisierungsschritte.
 - Auswählbare Projektmodule und Maschinenraum-Bereiche sind architektonisch getrennt.
 - Der naechste Planungsschritt ist die fachliche Beschreibung von Projektverwaltung und Projekt-Arbeitsbereich.
+- Die Projektverwaltung setzt den Projektkontext; ein Projektklick startet kuenftig nicht direkt `Protokoll`.
+- Der Projekt-Arbeitsbereich bietet auswählbare Projektmodule: aktuell `Protokoll`, spaeter `Restarbeiten`.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Kleinhaltenes Dokumentations-Update, um die Projekt-Arbeitsbereich-Richtung explizit zu machen (Projektverwaltung setzt Projektkontext; Projektklick startet nicht direkt `Protokoll`; Projekt-Arbeitsbereich bietet auswählbare Projektmodule). 

### Description
- In `PLAN.md` wurden auf Branch `cloud/test-vscode-workflow` genau zwei kurze Bulletpoints ergänzt und sonst keine Dateien, kein Code und keine UI-/Router-Entscheidungen geändert. 

### Testing
- Keine automatisierten Tests für diese reine Dokumentationsänderung ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecbc7cb97c8322b61c6c81f7506699)