### PR TITLE
Stabilisiere ProjectWorkspaceScreen (robuste Anzeige, Projektliste-Button)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -91,7 +91,7 @@ Sie ergänzt:
   - `src/renderer/modules/protokoll/styles.js`
   - `src/renderer/modules/protokoll/styles/tops.css`
 - Commit:
-  - `a0585ef`
+  - `siehe aktuellen Branch-Commit`
 - Hinweise:
   - Commit enthält zusätzlich das Entfernen von ChatGPT-Export-Artefakten
 
@@ -109,6 +109,22 @@ Sie ergänzt:
   - Keine Änderungen an Router, UI oder fachlicher Tops-Logik
 
 ---
+
+#### Paket: ProjectWorkspaceScreen minimal stabilisiert
+- Status: erledigt
+- Beschreibung:
+  - robuste Anzeige fuer Projektnummer und Projektname im Projekt-Arbeitsbereich nachgezogen
+  - Nachladen ohne direkt uebergebenes Projekt bleibt ueber `window.bbmDb.projectsList()` erhalten
+  - klare Meldung fuer nicht gefundenes Projekt und Ruecksprung-Button `Zur Projektliste` ueber `showProjects()` ergaenzt
+  - Projektauswahl bleibt auf `Protokoll` begrenzt; Maschinenraumdienste weiterhin unsichtbar
+  - passende Modul-Tests fuer robuste Anzeige, Ruecksprung und Projektlade-Faelle erweitert
+- Betroffene Dateien:
+  - `src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js`
+  - `scripts/tests/projektverwaltungModule.test.cjs`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine Router-Aenderungen, keine Protokoll-Aenderungen
 
 ## Offene Meilensteine
 1. Weitere kleine Altpfade im Modul `Protokoll` abbauen

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -64,6 +64,9 @@ async function runProjektverwaltungModuleTests(run) {
     assert.equal(typeof ProjectWorkspaceScreen, "function");
     assert.equal(workspaceSource.includes("export default class ProjectWorkspaceScreen"), true);
     assert.equal(workspaceSource.includes("Protokoll öffnen"), true);
+    assert.equal(workspaceSource.includes("Zur Projektliste"), true);
+    assert.equal(workspaceSource.includes("showProjectsList"), true);
+    assert.equal(workspaceSource.includes("Projekt konnte nicht gefunden werden."), true);
     assert.equal(workspaceSource.includes("Ausgabe"), false);
     assert.equal(workspaceSource.includes("Audio"), false);
     assert.equal(workspaceSource.includes("Lizenzierung"), false);
@@ -103,6 +106,88 @@ async function runProjektverwaltungModuleTests(run) {
     const opened = await screen.openProjectModule("protokoll");
     assert.equal(opened, true);
     assert.deepEqual(routerCalls, [{ meetingId: null, projectId: "9" }]);
+  });
+
+  await run("Projektverwaltung: Projektanzeige ist robust und Projektliste-Button nutzt showProjects", async () => {
+    const calls = [];
+    const screen = new ProjectWorkspaceScreen({
+      router: {
+        currentProjectId: "77",
+        async showProjects() {
+          calls.push("showProjects");
+        },
+      },
+      projectId: "77",
+      project: {
+        id: "77",
+        projectNumber: "X-77",
+        project_name: "Umbau Schule",
+      },
+    });
+
+    assert.equal(screen.getProjectDisplayText(), "X-77 - Umbau Schule");
+
+    const opened = await screen.showProjectsList();
+    assert.equal(opened, true);
+    assert.deepEqual(calls, ["showProjects"]);
+  });
+
+  await run("Projektverwaltung: Projektdaten werden bei fehlendem Projekt weiter ueber projectsList geladen", async () => {
+    const previousWindow = global.window;
+    let listCalls = 0;
+    global.window = {
+      bbmDb: {
+        async projectsList() {
+          listCalls += 1;
+          return {
+            ok: true,
+            list: [{ id: "4", project_number: "P-4", short: "Nord" }],
+          };
+        },
+      },
+    };
+
+    try {
+      const screen = new ProjectWorkspaceScreen({
+        router: { currentProjectId: "4" },
+        projectId: "4",
+      });
+
+      const loaded = await screen._loadProject();
+      assert.equal(listCalls, 1);
+      assert.equal(loaded?.id, "4");
+      assert.equal(screen.projectMissing, false);
+    } finally {
+      global.window = previousWindow;
+    }
+  });
+
+  await run("Projektverwaltung: nicht gefundenes Projekt wird klar markiert", async () => {
+    const previousWindow = global.window;
+    global.window = {
+      bbmDb: {
+        async projectsList() {
+          return {
+            ok: true,
+            list: [{ id: "1", project_number: "P-1", short: "Sued" }],
+          };
+        },
+      },
+    };
+
+    try {
+      const screen = new ProjectWorkspaceScreen({
+        router: { currentProjectId: "404" },
+        projectId: "404",
+      });
+
+      const loaded = await screen._loadProject();
+      assert.equal(loaded, null);
+      assert.equal(screen.projectMissing, true);
+      assert.equal(screen.getProjectDisplayText(), "#404");
+    } finally {
+      global.window = previousWindow;
+    }
   });
 
   await run("Projektverwaltung: Projektklick öffnet den Arbeitsbereich statt direkt Tops", async () => {

--- a/src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js
@@ -13,18 +13,27 @@ function normalizeText(value) {
 }
 
 function getProjectNumber(project) {
-  const raw = project?.project_number ?? project?.projectNumber ?? "";
+  const raw =
+    project?.project_number ??
+    project?.projectNumber ??
+    project?.nummer ??
+    project?.number ??
+    "";
   return normalizeText(raw);
+}
+
+function getProjectName(project) {
+  const short = normalizeText(project?.short);
+  const name = normalizeText(project?.name ?? project?.project_name ?? project?.title);
+  return short || name;
 }
 
 function getProjectTitle(project, fallbackProjectId = null) {
   const number = getProjectNumber(project);
-  const short = normalizeText(project?.short);
-  const name = normalizeText(project?.name);
+  const name = getProjectName(project);
 
-  if (number && short) return `${number} - ${short}`;
+  if (number && name) return `${number} - ${name}`;
   if (number) return number;
-  if (short) return short;
   if (name) return name;
   if (fallbackProjectId) return `#${fallbackProjectId}`;
   return "Projekt";
@@ -41,6 +50,7 @@ export default class ProjectWorkspaceScreen {
     this.msgEl = null;
 
     this.loading = false;
+    this.projectMissing = false;
   }
 
   getAvailableProjectModules() {
@@ -71,17 +81,27 @@ export default class ProjectWorkspaceScreen {
     try {
       const res = await api.projectsList();
       if (res?.ok && Array.isArray(res.list)) {
-        this.project =
-          res.list.find((item) => String(item?.id ?? "") === String(effectiveProjectId)) ||
-          { id: effectiveProjectId };
+        const foundProject = res.list.find(
+          (item) => String(item?.id ?? "") === String(effectiveProjectId)
+        );
+        this.project = foundProject || null;
+        this.projectMissing = !foundProject;
       } else {
         this.project = { id: effectiveProjectId };
+        this.projectMissing = false;
       }
     } catch (_err) {
       this.project = { id: effectiveProjectId };
+      this.projectMissing = false;
     }
 
     return this.project;
+  }
+
+  async showProjectsList() {
+    if (typeof this.router?.showProjects !== "function") return false;
+    await this.router.showProjects();
+    return true;
   }
 
   async openProjectModule(moduleId) {
@@ -141,27 +161,17 @@ export default class ProjectWorkspaceScreen {
     title.style.fontSize = "20px";
     title.style.marginBottom = "6px";
 
-    const number = getProjectNumber(project);
-    if (number) {
-      const numberLine = document.createElement("div");
-      numberLine.textContent = `Projektnummer: ${number}`;
-      numberLine.style.fontSize = "12px";
-      numberLine.style.opacity = "0.85";
-      container.appendChild(numberLine);
-    }
+    const numberLine = document.createElement("div");
+    numberLine.textContent = `Projektnummer: ${getProjectNumber(project) || "-"}`;
+    numberLine.style.fontSize = "12px";
+    numberLine.style.opacity = "0.85";
 
-    const name = normalizeText(project?.name);
-    const short = normalizeText(project?.short);
-    const extraLine = document.createElement("div");
-    extraLine.textContent = name && short && name !== short ? name : short || name || "";
-    extraLine.style.fontSize = "12px";
-    extraLine.style.opacity = "0.85";
-    if (extraLine.textContent) {
-      container.appendChild(title);
-      container.appendChild(extraLine);
-    } else {
-      container.appendChild(title);
-    }
+    const nameLine = document.createElement("div");
+    nameLine.textContent = `Projektname: ${getProjectName(project) || "-"}`;
+    nameLine.style.fontSize = "12px";
+    nameLine.style.opacity = "0.85";
+
+    container.append(title, numberLine, nameLine);
   }
 
   _renderContent() {
@@ -184,7 +194,19 @@ export default class ProjectWorkspaceScreen {
 
     this._renderModuleTiles(grid);
 
-    this.hostEl.append(info, sectionTitle, grid);
+    this.hostEl.append(info);
+
+    if (this.projectMissing) {
+      const missing = document.createElement("div");
+      missing.textContent = "Projekt konnte nicht gefunden werden.";
+      missing.style.fontSize = "14px";
+      missing.style.fontWeight = "700";
+      missing.style.color = "var(--danger-text, #a40000)";
+      this.hostEl.appendChild(missing);
+      return;
+    }
+
+    this.hostEl.append(sectionTitle, grid);
   }
 
   render() {
@@ -200,12 +222,20 @@ export default class ProjectWorkspaceScreen {
     h.textContent = "Projekt-Arbeitsbereich";
     h.style.margin = "0";
 
+    const navBtn = document.createElement("button");
+    navBtn.type = "button";
+    navBtn.textContent = "Zur Projektliste";
+    applyPopupButtonStyle(navBtn, { variant: "secondary" });
+    navBtn.onclick = async () => {
+      await this.showProjectsList();
+    };
+
     const msg = document.createElement("div");
     msg.style.marginLeft = "auto";
     msg.style.fontSize = "12px";
     msg.style.opacity = "0.85";
 
-    head.append(h, msg);
+    head.append(h, navBtn, msg);
 
     const host = document.createElement("div");
     root.append(head, host);


### PR DESCRIPTION
### Motivation
- Der Projekt-Arbeitsbereich soll Projektnamen/-nummer robuster anzeigen und fehlende Projekte klar behandeln, ohne bestehende Modul-/Router- oder Protokoll-Logik zu verändern.
- Kleinere UX-Verbesserung: Rücksprung zur Projektliste ermöglichen, dabei bestehende Maschinenraumdienste weiterhin unsichtbar lassen.

### Description
- Ergänzt robuste Feldableitung für Projektnummer und -name (`getProjectNumber`, `getProjectName`, `getProjectTitle`) und verbessert die Anzeige im Workspace. (`src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js`)
- Beibehaltung des Nachladens über `window.bbmDb.projectsList()` wenn kein `project` direkt übergeben wird; Treffer setzt `this.project`, Nicht-Treffer markiert `this.projectMissing` und zeigt die Meldung „Projekt konnte nicht gefunden werden.“ an. (`src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js`)
- Neuer Button `Zur Projektliste` hinzugefügt, implementiert `showProjectsList()` und nutzt den vorhandenen Router-Pfad `showProjects()`; `Protokoll öffnen` bleibt unverändert und verwendet weiterhin `showTops()`. (`src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js`)
- Nur notwendige Tests erweitert, keine Änderungen an Router, Protokoll, Modulkatalog oder anderen Modulen vorgenommen; geänderte Dateien: `src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js`, `scripts/tests/projektverwaltungModule.test.cjs`, `STATUS.md`.
- Base-Branch: `modularisierung/projektverwaltung`; Ergebnis-Branch: `codex/projectworkspace-stabilisieren`.

### Testing
- Automatisierte Tests: `npm test` ausgeführt und alle Tests sind grün (inkl. neuen/erweiterten Tests für robuste Anzeige, `showProjects()`-Aufruf, `projectsList()`-Ladefälle und Nicht-gefunden-Zustand). 
- Testdatei erweitert: `scripts/tests/projektverwaltungModule.test.cjs` (alle Assertions erfolgreich).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecfb34ab9c83228bb88ab18ceeaa8e)