### PR TITLE
docs: Abschluss Meilenstein Projektverwaltung / Projekt-Arbeitsbereich

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,7 +40,7 @@ Nicht jedes Modul ist ein auswählbares Projektmodul:
 - `Audio / Diktat` ist kein auswählbares Projektmodul, sondern ein Maschinenraum-Dienst.
 - `Lizenzierung` ist in der Mutter-App ein Verwaltungs-/Maschinenraum-Bereich, in Kinder-Apps nur Lizenzpruefung und Status.
 - `Settings`, `Updates`, `Backup` und `Diagnose` sind Maschinenraum oder Verwaltung, keine Projektmodule.
-- Die Projektverwaltung setzt den Projektkontext und oeffnet spaeter einen Projekt-Arbeitsbereich.
+- Die Projektverwaltung setzt den Projektkontext und oeffnet den Projekt-Arbeitsbereich.
 - Die Projektverwaltung ist nicht fachlicher Besitzer des `Protokoll`-Moduls.
 - Die Projektverwaltung kann Projekte anlegen, bearbeiten, archivieren, wiederherstellen und auswaehlen.
 - Ein Projektklick startet nicht direkt `Protokoll`; er oeffnet den Projekt-Arbeitsbereich.

--- a/PLAN.md
+++ b/PLAN.md
@@ -29,28 +29,29 @@ Hinweis:
 - `npm test` war gruen.
 - Das Mutter-/Kind-Prinzip ist die verbindliche Leitlinie fuer alle weiteren Modularisierungsschritte.
 - Auswählbare Projektmodule und Maschinenraum-Bereiche sind architektonisch getrennt.
-- Der naechste Planungsschritt ist die fachliche Beschreibung von Projektverwaltung und Projekt-Arbeitsbereich.
+- Der Meilenstein „Projektverwaltung / Projekt-Arbeitsbereich“ ist fachlich und technisch abgeschlossen und dokumentiert.
 
 ---
 
-## Planungsmeilenstein: Projektverwaltung und Projekt-Arbeitsbereich
+## Meilensteinabschluss: Projektverwaltung / Projekt-Arbeitsbereich
 
-### Ziel
-Die fachliche Rolle der Projektverwaltung und des Projekt-Arbeitsbereichs soll klar beschrieben sein, bevor der Projekt-Arbeitsbereich technisch gebaut wird.
+### Ziel (abgeschlossen)
+Der Projekt-Arbeitsbereich ist als eigener Schritt nach der Projektverwaltung fachlich und technisch abgeschlossen und in der Doku konsistent nachgezogen.
 
-### Fachliche Planung
-- Projektverwaltung ist der Einstieg in den Projektkontext.
+### Fachliches Ergebnis
+- Projektverwaltung bleibt Einstieg in den Projektkontext.
 - Projektverwaltung kann Projekte anlegen, bearbeiten, archivieren, wiederherstellen und auswaehlen.
-- Projektverwaltung setzt den aktiven Projektkontext.
-- Die Projektverwaltung ist nicht fachlicher Besitzer des Protokolls.
-- Der Projekt-Arbeitsbereich zeigt das aktive Projekt.
-- Der Projekt-Arbeitsbereich zeigt nur auswaehlbare Projektmodule.
-- Aktuell ist `Protokoll` auswaehlbar.
-- Spaeter kann `Restarbeiten` als weiteres Projektmodul hinzukommen.
-- Maschinenraum-Dienste wie Ausgabe, Audio, Lizenzierung, Settings, Updates, Backup und Diagnose erscheinen nicht als Projektmodule.
-- Ein Projektklick oeffnet kuenftig den Projekt-Arbeitsbereich.
-- `Protokoll` wird erst im Projekt-Arbeitsbereich aktiv geoeffnet.
-- Der bisherige direkte Start ins `Protokoll` bleibt bis dahin Alt-/Uebergangsverhalten.
+- Projektklick fuehrt in den Projekt-Arbeitsbereich (nicht direkt in `Protokoll`).
+- Der Projekt-Arbeitsbereich zeigt das aktive Projekt und nur auswaehlbare Projektmodule.
+- Aktuell ist `Protokoll` der einzige auswaehlbare Projektmodul-Einstieg.
+- `Restarbeiten` bleibt nur als spaetere Option benannt, ohne aktuelle Freischaltung.
+- Maschinenraum-Dienste (`Ausgabe / Drucken / E-Mail`, `Audio / Diktat`, `Lizenzierung`, `Settings`, `Updates`, `Backup`, `Diagnose`) sind keine Projektmodule.
+
+### Nachweise
+- Technischer Stand in der Doku: Projekt-Arbeitsbereich eingebaut und stabilisiert.
+- `npm test` laeuft gruen.
+- GitHub Action `.github/workflows/npm-test.yml` fuehrt `npm test` fuer `main` und `modularisierung/projektverwaltung` bei Push und Pull Request aus.
+- App-Sichtung ist als fachliche Abnahme fuer diesen Meilenstein dokumentiert.
 
 ### Betroffene Dateien
 - `PLAN.md`
@@ -64,17 +65,9 @@ Die fachliche Rolle der Projektverwaltung und des Projekt-Arbeitsbereichs soll k
 - Navigationsverhalten
 - Datenbank
 
-### Fertig wenn
-- die fachliche Abfolge von Projektverwaltung und Projekt-Arbeitsbereich kurz und eindeutig beschrieben ist
-- die Uebergangsregel zum direkten Protokollstart klar benannt ist
-- keine Implementierungsdetails enthalten sind
-
 ### Status
-- nur Dokumentation
+- abgeschlossen (Dokumentations-Meilenstein)
 - kein Code
-- kein Merge
-- kein Push
-- Technischer Stand: Projekt-Arbeitsbereich ist umgesetzt, der Projektklick fuehrt dorthin statt direkt ins Protokoll.
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -28,6 +28,8 @@ Sie ergänzt:
   - Main-/IPC-/Whisper-/Lizenz-/Settings-Logik bleibt unverändert.
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
+- GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.
+- App-Sichtung fuer den Projekt-Arbeitsbereich wurde durchgefuehrt und passt (Projektklick -> Arbeitsbereich, Modulauswahl unveraendert auf `Protokoll`).
 - Repo ist auf GitHub aktualisiert.
 - `AGENTS.md` und `PLAN.md` sind vorhanden.
 - Codex Cloud ist eingerichtet und kann das Repo lesen.
@@ -46,7 +48,7 @@ Sie ergänzt:
 - Aktuell auswählbares Projektmodul ist `Protokoll`; `Restarbeiten` kann spaeter als Projektmodul hinzukommen.
 - `Ausgabe / Drucken / E-Mail` und `Audio / Diktat` sind Maschinenraum-Dienste, keine Projektmodule.
 - `Lizenzierung`, `Settings`, `Updates`, `Backup` und `Diagnose` sind Verwaltung oder Maschinenraum, keine Projektmodule.
-- Die Projektverwaltung setzt den Projektkontext und oeffnet spaeter einen Projekt-Arbeitsbereich.
+- Die Projektverwaltung setzt den Projektkontext und oeffnet den Projekt-Arbeitsbereich.
 - Ein Projektklick startet nicht direkt `Protokoll`.
 - Im Projekt-Arbeitsbereich werden nur auswählbare Projektmodule angeboten.
 - Das Protokoll-Modul ist aktuell eingefroren.
@@ -64,6 +66,8 @@ Sie ergänzt:
 - Die alten View-Dateien bleiben als Compatibility-Re-Exports bestehen.
 - Keine DB-/IPC-Logik wurde verschoben.
 - `npm test` war gruen.
+- GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.
+- App-Sichtung fuer den Projekt-Arbeitsbereich wurde durchgefuehrt und passt (Projektklick -> Arbeitsbereich, Modulauswahl unveraendert auf `Protokoll`).
 
 ## Ausgabe
 - Das Renderer-Modul ist aufgestellt.
@@ -129,6 +133,8 @@ Sie ergänzt:
 ## Offene Meilensteine
 1. Weitere kleine Altpfade im Modul `Protokoll` abbauen
 
+Hinweis: Der Meilenstein „Projektverwaltung / Projekt-Arbeitsbereich“ ist abgeschlossen und dokumentiert.
+
 ---
 
 ## Zuletzt bearbeitet
@@ -138,12 +144,12 @@ Sie ergänzt:
   - `AGENTS.md` gefunden
   - `PLAN.md` gefunden
   - Codex konnte den Repo-Stand lesen
-- Aktueller Branch:
-  - `modularisierung/projektverwaltung`
-  - `HEAD` und `origin/modularisierung/projektverwaltung` sind identisch
-  - der lokale Diff ist leer
+- Cloud-Kontrolllauf (zum damaligen Stand):
+  - Branch: `modularisierung/projektverwaltung`
+  - `HEAD` und `origin/modularisierung/projektverwaltung` waren identisch
+  - der lokale Diff war leer
 - Abgeschlossener Meilenstein:
-  - Projekt-Arbeitsbereich ist technisch umgesetzt
+  - Projekt-Arbeitsbereich ist technisch umgesetzt und stabilisiert
   - Projektklick oeffnet nicht mehr direkt Protokoll
   - Projektklick oeffnet den Projekt-Arbeitsbereich
   - einziges auswaehlbares Projektmodul ist aktuell Protokoll
@@ -170,7 +176,6 @@ Der nächste noch nicht erledigte Meilenstein ist:
 ---
 
 ## Offene Hindernisse / bekannte Probleme
-- Bestehende Tests sind aktuell nicht vollständig grün.
 - Frühere Läufe zeigten bestehende Altprobleme, u. a.:
   - `ERR_INVALID_URL` im Zusammenhang mit ESM/CSS-Importpfaden
 - Diese Probleme gelten nicht automatisch als Teil jedes neuen Mini-Pakets.


### PR DESCRIPTION
### Motivation
- Den abgeschlossenen Meilenstein „Projektverwaltung / Projekt-Arbeitsbereich“ dokumentieren und Plan/Status/Architektur auf den aktuellen technischen Stand bringen.
- Sicherstellen, dass die Doku klar festhält, dass ein Projektklick in den Projekt-Arbeitsbereich führt und `Protokoll` aktuell das einzige auswählbare Projektmodul ist.

### Description
- Aktualisiert `PLAN.md`, um den Planungsmeilenstein in einen abgeschlossenen Meilenstein mit fachlichem Ergebnis und Nachweisen umzuwandeln.
- Korrigiert Formulierung in `ARCHITECTURE.md`, so dass die Projektverwaltung den Projekt-Arbeitsbereich (nicht „später“) öffnet.
- Ergänzt `STATUS.md` um den Meilenstein-Abschluss, den Hinweis auf die eingerichtete GitHub-Action für `npm test` und die durchgeführte App-Sichtung; es wurden keine Code-Dateien verändert.
- Geänderte Dateien: `PLAN.md`, `ARCHITECTURE.md`, `STATUS.md` (keine Änderungen an Code, Tests, Router oder Modulen).

### Testing
- Lokaler Testlauf: `npm test` wurde ausgeführt und alle Tests bestanden (siehe Testlaufausgabe: "Alle Tests bestanden.").
- CI-Workflow: `.github/workflows/npm-test.yml` ist vorhanden und konfiguriert, um `npm test` bei Push/PR für `main` und `modularisierung/projektverwaltung` auszuführen.
- Git-Informationen: Änderung committed auf Branch `work` (Commit `d305315`), Ziel-Base für den PR ist `modularisierung/projektverwaltung`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecfeaf2eb88322b16e0c10b23f881b)