### PR TITLE
Phase 5 Paket 1: Adminbereich und Lizenzverwaltungs-Modul-Skeleton vorbereiten

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -37,6 +37,10 @@ Sie ergänzt:
   - Der interne Key bleibt `audio`.
   - Die sichtbare Feature-Liste zeigt kein `audio` und `Dictate` nebeneinander.
 - Lizenzverwaltung ist als eigenes Zielmodul geplant; die Detailbeschreibung liegt unter `docs/modules/lizenzverwaltung.md`.
+- Lizenzverwaltung Paket 1 ist vorbereitet:
+  - neues Modulverzeichnis `src/renderer/modules/lizenzverwaltung/` mit Skeleton-Screen
+  - Einstieg im Entwicklungsbereich unter `Adminbereich` angebunden
+  - weiterhin kein Modulkatalog-/Projektmodul-Eintrag
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.
@@ -178,6 +182,29 @@ Sie ergänzt:
 - Hinweise:
   - Keine Router-Aenderungen, keine Protokoll-Aenderungen
 
+#### Paket: Lizenzverwaltung Paket 1 (Adminbereich + Modul-Skeleton)
+- Status: erledigt
+- Beschreibung:
+  - neues Admin-Modul `src/renderer/modules/lizenzverwaltung/` mit `index.js`, `README.md`, `screens/index.js` und `screens/LicenseAdminScreen.js` angelegt
+  - Skeleton-Screen mit Platzhaltern `Kunden`, `Lizenzen`, `Produktumfang`, `Historie` ergänzt
+  - Entwicklungsbereich in `SettingsView` minimal um den Einstieg `Adminbereich` erweitert
+  - Modulkatalog und Projektmodule bleiben unverändert (`Protokoll` bleibt einziges Projektmodul)
+  - Testlauf um `lizenzverwaltungModule.test.cjs` ergänzt
+- Betroffene Dateien:
+  - `src/renderer/modules/lizenzverwaltung/index.js`
+  - `src/renderer/modules/lizenzverwaltung/README.md`
+  - `src/renderer/modules/lizenzverwaltung/screens/index.js`
+  - `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`
+  - `src/renderer/views/SettingsView.js`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `scripts/test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Kein Umbau am bestehenden Lizenz-bearbeiten-Popup
+  - Keine Lizenzlogik-, Produktumfangs-, Kunden- oder Historienimplementierung
+
 ## Offene Meilensteine
 1. Weitere kleine Altpfade im Modul `Protokoll` abbauen
 
@@ -212,12 +239,11 @@ Hinweis: Der Meilenstein „Projektverwaltung / Projekt-Arbeitsbereich“ ist ab
 ## Aktuell nächster sinnvoller Schritt
 Der naechste sinnvolle kleine Schritt nach diesem Paket ist:
 
-### Diktieren-Tab fachlich gegen App-Sichtung pruefen
+### Lizenzverwaltung Paket 2 vorbereiten
 - Ziel:
-  - visuell bestaetigen, dass `Diktieren -> Diktierprodukt -> Aktuelle Engine: Whisper -> Whisper-Modelle` wie geplant sichtbar ist
-  - bestaetigen, dass `Woerterbuch` als vorbereitet/noch nicht eingerichtet erscheint
+  - bestehendes Lizenz-bearbeiten-Popup schrittweise in Richtung Produktumfangsgliederung vorbereiten
 - Wichtig:
-  - keine weitere Funktionslogik nachziehen
+  - weiterhin keine Lizenzlogik oder Dateierzeugung umbauen
   - Audio / Diktat bleibt Maschinenraum ohne Projektmodul- oder Sidebar-Eintrag
 
 ---

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -16,6 +16,7 @@ const { runProtokollRouterFallbackTests } = require("./tests/protokollRouterFall
 const { runProjektverwaltungModuleTests } = require("./tests/projektverwaltungModule.test.cjs");
 const { runAusgabeModuleTests } = require("./tests/ausgabeModule.test.cjs");
 const { runAudioModuleTests } = require("./tests/audioModule.test.cjs");
+const { runLizenzverwaltungModuleTests } = require("./tests/lizenzverwaltungModule.test.cjs");
 
 let failed = false;
 
@@ -78,6 +79,7 @@ async function main() {
   await runProjektverwaltungModuleTests(run);
   await runAusgabeModuleTests(run);
   await runAudioModuleTests(run);
+  await runLizenzverwaltungModuleTests(run);
 
   if (failed) {
     process.exitCode = 1;

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -1,0 +1,71 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+function read(relPath) {
+  return fs.readFileSync(path.join(process.cwd(), relPath), "utf8");
+}
+
+async function runLizenzverwaltungModuleTests(run) {
+  const [
+    {
+      getLizenzverwaltungModuleEntry,
+      LIZENZVERWALTUNG_MODULE_ID,
+      LIZENZVERWALTUNG_WORK_SCREEN_ID,
+      LicenseAdminScreen,
+    },
+    {
+      getProjektverwaltungModuleEntry,
+    },
+  ] = await Promise.all([
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/lizenzverwaltung/index.js")),
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/projektverwaltung/index.js")),
+  ]);
+
+  const screenSource = read("src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js");
+  const moduleCatalogSource = read("src/renderer/app/modules/moduleCatalog.js");
+  const projectWorkspaceSource = read("src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js");
+  const settingsViewSource = read("src/renderer/views/SettingsView.js");
+
+  await run("Lizenzverwaltung: Modul exportiert LicenseAdminScreen", () => {
+    const entry = getLizenzverwaltungModuleEntry();
+
+    assert.equal(LIZENZVERWALTUNG_MODULE_ID, "lizenzverwaltung");
+    assert.equal(LIZENZVERWALTUNG_WORK_SCREEN_ID, "licenseAdmin");
+    assert.equal(typeof LicenseAdminScreen, "function");
+    assert.equal(entry.moduleId, "lizenzverwaltung");
+    assert.equal(entry.workScreenId, "licenseAdmin");
+    assert.equal(entry.screens?.licenseAdmin, LicenseAdminScreen);
+  });
+
+  await run("Lizenzverwaltung: Skeleton enthaelt alle Platzhalterbereiche", () => {
+    assert.equal(screenSource.includes("Lizenzverwaltung"), true);
+    assert.equal(screenSource.includes("Admin-/Mutter-App-Modul"), true);
+    assert.equal(screenSource.includes("Umsetzung erfolgt schrittweise"), true);
+    assert.equal(screenSource.includes("Kunden"), true);
+    assert.equal(screenSource.includes("Lizenzen"), true);
+    assert.equal(screenSource.includes("Produktumfang"), true);
+    assert.equal(screenSource.includes("Historie"), true);
+  });
+
+  await run("Lizenzverwaltung: bleibt Adminbereich und erscheint nicht als Projektmodul", () => {
+    const projektEntry = getProjektverwaltungModuleEntry();
+
+    assert.equal(moduleCatalogSource.includes("lizenzverwaltung"), false);
+    assert.equal(moduleCatalogSource.includes("LIZENZVERWALTUNG_MODULE_ID"), false);
+    assert.equal(projectWorkspaceSource.includes("lizenzverwaltung"), false);
+    assert.equal(projectWorkspaceSource.includes("Lizenzverwaltung"), false);
+    assert.equal(projectWorkspaceSource.includes("Protokoll öffnen"), true);
+    assert.equal(projektEntry.moduleId, "projektverwaltung");
+    assert.equal(projektEntry.moduleLabel, "Projektverwaltung");
+  });
+
+  await run("Lizenzverwaltung: Entwicklung enthaelt den Einstieg Adminbereich", () => {
+    assert.equal(settingsViewSource.includes("../modules/lizenzverwaltung/index.js"), true);
+    assert.equal(settingsViewSource.includes("makeDevTabButton(\"Adminbereich\", \"admin\")"), true);
+    assert.equal(settingsViewSource.includes("new LicenseAdminScreen()"), true);
+  });
+}
+
+module.exports = { runLizenzverwaltungModuleTests };

--- a/src/renderer/modules/lizenzverwaltung/README.md
+++ b/src/renderer/modules/lizenzverwaltung/README.md
@@ -1,0 +1,12 @@
+# Modul `Lizenzverwaltung`
+
+Dieses Verzeichnis ist die fachliche Heimat fuer das Admin-/Mutter-App-Modul `Lizenzverwaltung`.
+
+Status:
+- Paket 1 vorbereitet: Skeleton-Screen als Einstieg
+- keine produktive Lizenzlogik verschoben
+- keine Projektmodul-Anbindung
+
+Enthaelt:
+- `screens/LicenseAdminScreen.js` als einfacher Admin-Skeleton-Screen
+- `index.js` als Modul-Einstieg

--- a/src/renderer/modules/lizenzverwaltung/index.js
+++ b/src/renderer/modules/lizenzverwaltung/index.js
@@ -1,0 +1,22 @@
+import { LicenseAdminScreen, LIZENZVERWALTUNG_WORK_SCREEN_ID } from "./screens/index.js";
+
+export const LIZENZVERWALTUNG_MODULE_ID = "lizenzverwaltung";
+export const LIZENZVERWALTUNG_MODULE_LABEL = "Lizenzverwaltung";
+
+function buildLizenzverwaltungScreens() {
+  return Object.freeze({
+    [LIZENZVERWALTUNG_WORK_SCREEN_ID]: LicenseAdminScreen,
+  });
+}
+
+export function getLizenzverwaltungModuleEntry() {
+  return Object.freeze({
+    moduleId: LIZENZVERWALTUNG_MODULE_ID,
+    moduleLabel: LIZENZVERWALTUNG_MODULE_LABEL,
+    workScreenId: LIZENZVERWALTUNG_WORK_SCREEN_ID,
+    screens: buildLizenzverwaltungScreens(),
+  });
+}
+
+export { LicenseAdminScreen, LIZENZVERWALTUNG_WORK_SCREEN_ID };
+export * from "./screens/index.js";

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -1,0 +1,58 @@
+function buildPlaceholderCard(title) {
+  const card = document.createElement("section");
+  card.style.border = "1px solid var(--card-border)";
+  card.style.borderRadius = "10px";
+  card.style.padding = "12px";
+  card.style.background = "var(--card-bg)";
+  card.style.minHeight = "90px";
+
+  const heading = document.createElement("h3");
+  heading.textContent = title;
+  heading.style.margin = "0 0 6px";
+  heading.style.fontSize = "16px";
+
+  const hint = document.createElement("p");
+  hint.textContent = "Platzhalter";
+  hint.style.margin = "0";
+  hint.style.fontSize = "12px";
+  hint.style.opacity = "0.75";
+
+  card.append(heading, hint);
+  return card;
+}
+
+export default class LicenseAdminScreen {
+  render() {
+    const root = document.createElement("div");
+    root.style.display = "grid";
+    root.style.gap = "12px";
+
+    const title = document.createElement("h2");
+    title.textContent = "Lizenzverwaltung";
+    title.style.margin = "0";
+
+    const adminHint = document.createElement("p");
+    adminHint.textContent = "Admin-/Mutter-App-Modul";
+    adminHint.style.margin = "0";
+
+    const rolloutHint = document.createElement("p");
+    rolloutHint.textContent = "Umsetzung erfolgt schrittweise";
+    rolloutHint.style.margin = "0";
+    rolloutHint.style.opacity = "0.85";
+
+    const grid = document.createElement("div");
+    grid.style.display = "grid";
+    grid.style.gridTemplateColumns = "repeat(auto-fit, minmax(180px, 1fr))";
+    grid.style.gap = "10px";
+
+    grid.append(
+      buildPlaceholderCard("Kunden"),
+      buildPlaceholderCard("Lizenzen"),
+      buildPlaceholderCard("Produktumfang"),
+      buildPlaceholderCard("Historie")
+    );
+
+    root.append(title, adminHint, rolloutHint, grid);
+    return root;
+  }
+}

--- a/src/renderer/modules/lizenzverwaltung/screens/index.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/index.js
@@ -1,0 +1,3 @@
+export { default as LicenseAdminScreen } from "./LicenseAdminScreen.js";
+
+export const LIZENZVERWALTUNG_WORK_SCREEN_ID = "licenseAdmin";

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -13,6 +13,7 @@ import {
   parseCssColor,
 } from "../theme/themes.js";
 import { createDictationDevSection } from "../modules/audio/index.js";
+import { LicenseAdminScreen } from "../modules/lizenzverwaltung/index.js";
 
 const DEFAULT_V2_PRE_REMARKS_TEXT =
   "folgende Punkte gelten als fest vereinbart, Diesen Text anpassen unter Einstellungen - Druckeinstellungen - Vorbemergung";
@@ -4638,9 +4639,16 @@ export default class SettingsView {
         tabTools.style.gap = "10px";
         tabTools.append(printBox, topsLimitBox);
 
+        const tabAdmin = document.createElement("div");
+        tabAdmin.style.display = "grid";
+        tabAdmin.style.gap = "10px";
+        const licenseAdminScreen = new LicenseAdminScreen();
+        tabAdmin.append(licenseAdminScreen.render());
+
         const devTabs = [
           { key: "version", label: "Versionierung", el: tabVersion },
           { key: "license", label: "Lizenz / bearbeiten", el: tabLicense },
+          { key: "admin", label: "Adminbereich", el: tabAdmin },
           { key: "db", label: "DB-Diagnose", el: tabDb },
           { key: "dictation", label: "Diktieren", el: tabDictation },
           { key: "tools", label: "Druck / TOP-Liste", el: tabTools },
@@ -4679,12 +4687,13 @@ export default class SettingsView {
         devTabHead.append(
           makeDevTabButton("Versionierung", "version"),
           makeDevTabButton("Lizenz / bearbeiten", "license"),
+          makeDevTabButton("Adminbereich", "admin"),
           makeDevTabButton("DB-Diagnose", "db"),
           makeDevTabButton("Diktieren", "dictation"),
           makeDevTabButton("Druck / TOP-Liste", "tools")
         );
 
-        devTabBody.append(tabVersion, tabLicense, tabDb, tabDictation, tabTools);
+        devTabBody.append(tabVersion, tabLicense, tabAdmin, tabDb, tabDictation, tabTools);
         devTabWrap.append(devTabHead, devTabBody);
         setDevTab("version");
 


### PR DESCRIPTION
### Motivation
- Vorbereitung des Admin-/Mutter-App-Moduls „Lizenzverwaltung“ gemäß `docs/modules/lizenzverwaltung.md` als kleiner, sicherer erster Schritt ohne Änderung der vorhandenen Lizenzlogik oder Projektmodul-Sichtbarkeit.

### Description
- Neues Modul unter `src/renderer/modules/lizenzverwaltung/` angelegt mit `index.js`, `README.md`, `screens/index.js` und `screens/LicenseAdminScreen.js` und sauberem Export von `LicenseAdminScreen` und `LIZENZVERWALTUNG_WORK_SCREEN_ID`.
- `SettingsView` minimal angebunden: im Entwicklungsbereich wurde ein neuer Dev-Tab `Adminbereich` eingefügt, der eine Instanz von `LicenseAdminScreen` rendert, wobei die fachliche Logik im neuen Modul verbleibt.
- Tests und Test-Runner ergänzt: neue Datei `scripts/tests/lizenzverwaltungModule.test.cjs` und Registrierung in `scripts/test.cjs` sowie `STATUS.md` aktualisiert (siehe geänderte Dateien `src/renderer/modules/lizenzverwaltung/index.js`, `src/renderer/modules/lizenzverwaltung/README.md`, `src/renderer/modules/lizenzverwaltung/screens/index.js`, `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`, `src/renderer/views/SettingsView.js`, `scripts/tests/lizenzverwaltungModule.test.cjs`, `scripts/test.cjs`, `STATUS.md`).

### Testing
- Ausgeführt: `npm test`, die komplette Test-Suite lief inklusive der neuen Modultests und endete grün (`Alle Tests bestanden.`).
- Branch-/PR-Status: Base-Branch ist `main`, Ergebnis-Branch ist `work`, ein Pull-Request wurde via PR-Tool ausgelöst but the tool did not return a URL in this environment.
- Git-Status: `git status --short --branch` zeigte die Ergebnis-Branch `work` (Ausgabe: `## work`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed256fa11c83228d64087a89009645)