### PR TITLE
Korrigiere Adminbereich‑Einstieg in Einstellungen → Entwicklung

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -39,7 +39,8 @@ Sie ergänzt:
 - Lizenzverwaltung ist als eigenes Zielmodul geplant; die Detailbeschreibung liegt unter `docs/modules/lizenzverwaltung.md`.
 - Lizenzverwaltung Paket 1 ist vorbereitet:
   - neues Modulverzeichnis `src/renderer/modules/lizenzverwaltung/` mit Skeleton-Screen
-  - Einstieg im Entwicklungsbereich unter `Adminbereich` angebunden
+  - Einstieg im Entwicklungsbereich unter `Adminbereich` als eigene Kachel angebunden
+  - `Adminbereich` oeffnet als eigenes Popup mit Kachel `Lizenzverwaltung`
   - weiterhin kein Modulkatalog-/Projektmodul-Eintrag
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
@@ -205,6 +206,23 @@ Sie ergänzt:
   - Kein Umbau am bestehenden Lizenz-bearbeiten-Popup
   - Keine Lizenzlogik-, Produktumfangs-, Kunden- oder Historienimplementierung
 
+#### Paket: Lizenzverwaltung Paket 2 (Adminbereich als eigenes Popup)
+- Status: erledigt
+- Beschreibung:
+  - `Adminbereich` aus den Entwicklung-Tabs entfernt und als eigener Einstieg/Kachel im Entwicklungs-Popup verankert
+  - neues Adminbereich-Popup mit Kachel `Lizenzverwaltung` ergänzt
+  - Klick auf `Lizenzverwaltung` zeigt weiterhin den bestehenden `LicenseAdminScreen`-Skeleton
+  - bestehende Entwicklung-Tabs (`Versionierung`, `Lizenz / bearbeiten`, `DB-Diagnose`, `Diktieren`, `Druck / TOP-Liste`) bleiben unverändert erhalten
+  - Testvertrag fuer Adminbereich-/Lizenzverwaltung-Einstieg entsprechend erweitert
+- Betroffene Dateien:
+  - `src/renderer/views/SettingsView.js`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine Aenderung an Lizenzlogik, Projektmodulen, Sidebar oder Whisper/Diktier-Backends
+
 ## Offene Meilensteine
 1. Weitere kleine Altpfade im Modul `Protokoll` abbauen
 
@@ -239,9 +257,9 @@ Hinweis: Der Meilenstein „Projektverwaltung / Projekt-Arbeitsbereich“ ist ab
 ## Aktuell nächster sinnvoller Schritt
 Der naechste sinnvolle kleine Schritt nach diesem Paket ist:
 
-### Lizenzverwaltung Paket 2 vorbereiten
+### Lizenzverwaltung Paket 3 vorbereiten
 - Ziel:
-  - bestehendes Lizenz-bearbeiten-Popup schrittweise in Richtung Produktumfangsgliederung vorbereiten
+  - Adminbereich-Popup fachlich weiter strukturieren, ohne neue Logik freizuschalten
 - Wichtig:
   - weiterhin keine Lizenzlogik oder Dateierzeugung umbauen
   - Audio / Diktat bleibt Maschinenraum ohne Projektmodul- oder Sidebar-Eintrag

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -61,9 +61,21 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(projektEntry.moduleLabel, "Projektverwaltung");
   });
 
-  await run("Lizenzverwaltung: Entwicklung enthaelt den Einstieg Adminbereich", () => {
+  await run("Lizenzverwaltung: Entwicklung enthaelt den Einstieg Adminbereich als Kachel, nicht als Tab", () => {
     assert.equal(settingsViewSource.includes("../modules/lizenzverwaltung/index.js"), true);
-    assert.equal(settingsViewSource.includes("makeDevTabButton(\"Adminbereich\", \"admin\")"), true);
+    assert.equal(settingsViewSource.includes("makeDevTabButton(\"Adminbereich\", \"admin\")"), false);
+    assert.equal(settingsViewSource.includes("titleText: \"Adminbereich\""), true);
+    assert.equal(settingsViewSource.includes("openAdminbereichPopup"), true);
+  });
+
+  await run("Lizenzverwaltung: Adminbereich-Popup enthaelt Kachel Lizenzverwaltung", () => {
+    assert.equal(settingsViewSource.includes("title: \"Adminbereich\""), true);
+    assert.equal(settingsViewSource.includes("titleText: \"Lizenzverwaltung\""), true);
+    assert.equal(settingsViewSource.includes("openLicenseAdminPopup"), true);
+  });
+
+  await run("Lizenzverwaltung: Kachel Lizenzverwaltung zeigt weiter den LicenseAdminScreen-Skeleton", () => {
+    assert.equal(settingsViewSource.includes("title: \"Lizenzverwaltung\""), true);
     assert.equal(settingsViewSource.includes("new LicenseAdminScreen()"), true);
   });
 }

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -4639,16 +4639,55 @@ export default class SettingsView {
         tabTools.style.gap = "10px";
         tabTools.append(printBox, topsLimitBox);
 
-        const tabAdmin = document.createElement("div");
-        tabAdmin.style.display = "grid";
-        tabAdmin.style.gap = "10px";
-        const licenseAdminScreen = new LicenseAdminScreen();
-        tabAdmin.append(licenseAdminScreen.render());
+        const openLicenseAdminPopup = () => {
+          const licenseAdminScreen = new LicenseAdminScreen();
+          openSettingsModal({
+            title: "Lizenzverwaltung",
+            content: [licenseAdminScreen.render()],
+            closeOnly: true,
+          });
+        };
+
+        const openAdminbereichPopup = () => {
+          const adminTiles = document.createElement("div");
+          adminTiles.style.display = "grid";
+          adminTiles.style.gridTemplateColumns = "repeat(auto-fill, minmax(220px, 1fr))";
+          adminTiles.style.gap = "10px";
+          adminTiles.style.maxWidth = "720px";
+          adminTiles.append(
+            mkTile({
+              titleText: "Lizenzverwaltung",
+              subText: "Kunden, Lizenzen, Produktumfang, Historie",
+              onClick: async () => {
+                openLicenseAdminPopup();
+              },
+            })
+          );
+          openSettingsModal({
+            title: "Adminbereich",
+            content: [adminTiles],
+            closeOnly: true,
+          });
+        };
+
+        const devEntryTiles = document.createElement("div");
+        devEntryTiles.style.display = "grid";
+        devEntryTiles.style.gridTemplateColumns = "repeat(auto-fill, minmax(220px, 1fr))";
+        devEntryTiles.style.gap = "10px";
+        devEntryTiles.style.maxWidth = "720px";
+        devEntryTiles.append(
+          mkTile({
+            titleText: "Adminbereich",
+            subText: "Adminmodule und Verwaltungswerkzeuge",
+            onClick: async () => {
+              openAdminbereichPopup();
+            },
+          })
+        );
 
         const devTabs = [
           { key: "version", label: "Versionierung", el: tabVersion },
           { key: "license", label: "Lizenz / bearbeiten", el: tabLicense },
-          { key: "admin", label: "Adminbereich", el: tabAdmin },
           { key: "db", label: "DB-Diagnose", el: tabDb },
           { key: "dictation", label: "Diktieren", el: tabDictation },
           { key: "tools", label: "Druck / TOP-Liste", el: tabTools },
@@ -4687,14 +4726,13 @@ export default class SettingsView {
         devTabHead.append(
           makeDevTabButton("Versionierung", "version"),
           makeDevTabButton("Lizenz / bearbeiten", "license"),
-          makeDevTabButton("Adminbereich", "admin"),
           makeDevTabButton("DB-Diagnose", "db"),
           makeDevTabButton("Diktieren", "dictation"),
           makeDevTabButton("Druck / TOP-Liste", "tools")
         );
 
-        devTabBody.append(tabVersion, tabLicense, tabAdmin, tabDb, tabDictation, tabTools);
-        devTabWrap.append(devTabHead, devTabBody);
+        devTabBody.append(tabVersion, tabLicense, tabDb, tabDictation, tabTools);
+        devTabWrap.append(devEntryTiles, devTabHead, devTabBody);
         setDevTab("version");
 
         this._openSettingsModal({


### PR DESCRIPTION
### Motivation
- Der neue Adminbereich wurde fälschlich als eigener Tab im Entwicklungspopup gerendert, fachlich ist aber ein eigener Einstieg/Kachel mit einem separaten Admin‑Popup vorgesehen.
- Ziel war, die Navigation so zu korrigieren, dass Einstellungen → Entwicklung → [Kachel „Adminbereich“] → (öffnet Admin‑Popup) → [Kachel „Lizenzverwaltung“] → (öffnet LicenseAdminScreen) funktioniert, ohne bestehende Tabs oder Lizenzlogik zu verändern.

### Description
- Entferne den `admin`‑Tab aus dem Development‑Tabset und lege stattdessen eine Kachel `Adminbereich` als Einstieg in `Einstellungen → Entwicklung` an, die ein eigenes Admin‑Popup öffnet; Änderungen in `src/renderer/views/SettingsView.js`.
- Implementiere im Admin‑Popup eine Kachel `Lizenzverwaltung`, die beim Klick das bestehende `LicenseAdminScreen`‑Skeleton öffnet (keine Änderung an `LicenseAdminScreen`‑Logik oder Modulort).
- Passe die Dev‑UI‑Struktur so an, dass die bestehenden Entwicklungstabs (`Versionierung`, `Lizenz / bearbeiten`, `DB‑Diagnose`, `Diktieren`, `Druck / TOP‑Liste`) unverändert bleiben; füge das neue Dev‑Einstiegs‑Tile vor den Tabs ein.
- Aktualisiere und erweitere die Test‑Assertionen in `scripts/tests/lizenzverwaltungModule.test.cjs` und pflege `STATUS.md` entsprechend.
- Geänderte Dateien: `src/renderer/views/SettingsView.js`, `scripts/tests/lizenzverwaltungModule.test.cjs`, `STATUS.md`.

### Testing
- Ausgeführt: `npm test` (voller Testlauf orchestriert über `node scripts/test.cjs`).
- Ergebnis: Alle Tests sind grün; die aktualisierten Lizenzverwaltungs‑Tests bestätigen, dass der Adminbereich jetzt als Kachel vorhanden ist, kein `admin`‑Tab mehr erzeugt wird, das Admin‑Popup eine Kachel `Lizenzverwaltung` enthält und der Klickpfad zum `LicenseAdminScreen`‑Skeleton intakt bleibt.
- Keine weiteren automatischen Prüfungen wurden verändert; Build/Lint nicht Teil dieses Mini‑Pakets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2c1da9c08322aed1127da6e50aab)