### PR TITLE
Einstellungen: Adminbereich als eigene Kachel & Lizenzverwaltung in Admin-Popup

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -43,7 +43,7 @@ Sie ergänzt:
 - Lizenzverwaltung ist als eigenes Zielmodul geplant; die Detailbeschreibung liegt unter `docs/modules/lizenzverwaltung.md`.
 - Lizenzverwaltung Paket 1 ist vorbereitet:
   - neues Modulverzeichnis `src/renderer/modules/lizenzverwaltung/` mit Skeleton-Screen
-  - Einstieg im Entwicklungsbereich unter `Adminbereich` als eigene Kachel angebunden
+  - Einstieg `Adminbereich` als eigene Kachel auf oberster Ebene in `Einstellungen` angebunden
   - `Adminbereich` oeffnet als eigenes Popup mit Kachel `Lizenzverwaltung`
   - weiterhin kein Modulkatalog-/Projektmodul-Eintrag
 - Protokoll-Modul ist eingefroren.
@@ -245,6 +245,25 @@ Sie ergänzt:
 - Hinweise:
   - Keine Aenderung an Projektmodul-Katalog, Sidebar, Whisper, Diktierfunktion oder Protokoll-Modul
 
+#### Paket: Lizenzverwaltung Paket 3 (Adminbereich in Einstellungen-Hauptebene verortet)
+- Status: erledigt
+- Beschreibung:
+  - `Adminbereich` als eigene Kachel direkt auf oberster Ebene in `Einstellungen` verankert
+  - `Adminbereich` aus dem Entwicklung-Popup entfernt (kein Kachel- oder Tab-Einstieg mehr dort)
+  - im `Adminbereich` bleibt die Kachel `Lizenzverwaltung` der sichtbare Zielpfad
+  - Klick auf `Lizenzverwaltung` zeigt weiterhin den bestehenden `LicenseAdminScreen`-Skeleton
+  - bestehender Bereich `Lizenz / bearbeiten` bleibt im Code als Altbestand erhalten, aber ohne sichtbaren Entwicklung-Tab-Einstieg
+  - Testvertrag fuer Einstellungen/Entwicklung/Adminbereich entsprechend angepasst und erweitert
+- Betroffene Dateien:
+  - `src/renderer/views/SettingsView.js`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine Lizenzlogik-Aenderung
+  - Keine Projektmodul-, Sidebar-, Diktier- oder Whisper-Aenderung
+
 ## Offene Meilensteine
 1. Weitere kleine Altpfade im Modul `Protokoll` abbauen
 
@@ -279,11 +298,11 @@ Hinweis: Der Meilenstein „Projektverwaltung / Projekt-Arbeitsbereich“ ist ab
 ## Aktuell nächster sinnvoller Schritt
 Der naechste sinnvolle kleine Schritt nach diesem Paket ist:
 
-### Lizenzverwaltung Paket 3 vorbereiten
+### Lizenzverwaltung Paket 4 vorbereiten
 - Ziel:
-  - Produktumfang intern als getrennte Datenstruktur (Standardumfang/Zusatzfunktionen/Module) weiter vorbereiten, ohne neue Lizenzlogik freizuschalten
+  - Adminbereich-Popup in kleinen Schritten um weitere echte Adminbereiche erweiterbar halten, ohne neue Lizenzlogik freizuschalten
 - Wichtig:
-  - weiterhin keine tiefgreifende Umstellung der Lizenzdatei-Erzeugung
+  - weiterhin keine tiefgreifende Umstellung der Lizenzdatei-Erzeugung oder Kundenverwaltung
   - Audio / Diktat bleibt Maschinenraum ohne Projektmodul- oder Sidebar-Eintrag
 
 ---

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -61,11 +61,18 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(projektEntry.moduleLabel, "Projektverwaltung");
   });
 
-  await run("Lizenzverwaltung: Entwicklung enthaelt den Einstieg Adminbereich als Kachel, nicht als Tab", () => {
+  await run("Lizenzverwaltung: Einstellungen enthaelt den Einstieg Adminbereich auf oberster Ebene", () => {
     assert.equal(settingsViewSource.includes("../modules/lizenzverwaltung/index.js"), true);
-    assert.equal(settingsViewSource.includes("makeDevTabButton(\"Adminbereich\", \"admin\")"), false);
+    assert.equal(settingsViewSource.includes("tiles.append(tileUser, tilePrint, tileLicense, tileAdmin);"), true);
     assert.equal(settingsViewSource.includes("titleText: \"Adminbereich\""), true);
-    assert.equal(settingsViewSource.includes("openAdminbereichPopup"), true);
+    assert.equal(settingsViewSource.includes("subText: \"Adminmodule und Verwaltungswerkzeuge\""), true);
+  });
+
+  await run("Lizenzverwaltung: Entwicklung enthaelt keinen Einstieg oder Tab fuer Adminbereich", () => {
+    assert.equal(settingsViewSource.includes("makeDevTabButton(\"Adminbereich\", \"admin\")"), false);
+    assert.equal(settingsViewSource.includes("const devEntryTiles = document.createElement(\"div\")"), false);
+    assert.equal(settingsViewSource.includes("devTabWrap.append(devEntryTiles, devTabHead, devTabBody);"), false);
+    assert.equal(settingsViewSource.includes("title: \"Entwicklung\""), true);
   });
 
   await run("Lizenzverwaltung: Adminbereich-Popup enthaelt Kachel Lizenzverwaltung", () => {
@@ -85,6 +92,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(settingsViewSource.includes("Standardumfang"), true);
     assert.equal(settingsViewSource.includes("Zusatzfunktionen"), true);
     assert.equal(settingsViewSource.includes("Module"), true);
+  });
+
+  await run("Lizenz / bearbeiten: ist nicht mehr als normaler Entwicklung-Tab sichtbar", () => {
+    assert.equal(settingsViewSource.includes("makeDevTabButton(\"Lizenz / bearbeiten\", \"license\")"), false);
+    assert.equal(settingsViewSource.includes("{ key: \"license\", label: \"Lizenz / bearbeiten\", el: tabLicense }"), false);
   });
 
   await run("Lizenz / bearbeiten: Standardumfang enthaelt app/pdf/export", () => {

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -4658,6 +4658,45 @@ export default class SettingsView {
       },
     });
 
+    const openLicenseAdminPopup = () => {
+      const licenseAdminScreen = new LicenseAdminScreen();
+      openSettingsModal({
+        title: "Lizenzverwaltung",
+        content: [licenseAdminScreen.render()],
+        closeOnly: true,
+      });
+    };
+
+    const openAdminbereichPopup = () => {
+      const adminTiles = document.createElement("div");
+      adminTiles.style.display = "grid";
+      adminTiles.style.gridTemplateColumns = "repeat(auto-fill, minmax(220px, 1fr))";
+      adminTiles.style.gap = "10px";
+      adminTiles.style.maxWidth = "720px";
+      adminTiles.append(
+        mkTile({
+          titleText: "Lizenzverwaltung",
+          subText: "Kunden, Lizenzen, Produktumfang, Historie",
+          onClick: async () => {
+            openLicenseAdminPopup();
+          },
+        })
+      );
+      openSettingsModal({
+        title: "Adminbereich",
+        content: [adminTiles],
+        closeOnly: true,
+      });
+    };
+
+    const tileAdmin = mkTile({
+      titleText: "Adminbereich",
+      subText: "Adminmodule und Verwaltungswerkzeuge",
+      onClick: async () => {
+        openAdminbereichPopup();
+      },
+    });
+
     const tileDev = mkTile({
       titleText: "Entwicklung",
       subText: "Versionierung, Farben einstellen, DB-Diagnose",
@@ -4727,55 +4766,8 @@ export default class SettingsView {
         tabTools.style.gap = "10px";
         tabTools.append(printBox, topsLimitBox);
 
-        const openLicenseAdminPopup = () => {
-          const licenseAdminScreen = new LicenseAdminScreen();
-          openSettingsModal({
-            title: "Lizenzverwaltung",
-            content: [licenseAdminScreen.render()],
-            closeOnly: true,
-          });
-        };
-
-        const openAdminbereichPopup = () => {
-          const adminTiles = document.createElement("div");
-          adminTiles.style.display = "grid";
-          adminTiles.style.gridTemplateColumns = "repeat(auto-fill, minmax(220px, 1fr))";
-          adminTiles.style.gap = "10px";
-          adminTiles.style.maxWidth = "720px";
-          adminTiles.append(
-            mkTile({
-              titleText: "Lizenzverwaltung",
-              subText: "Kunden, Lizenzen, Produktumfang, Historie",
-              onClick: async () => {
-                openLicenseAdminPopup();
-              },
-            })
-          );
-          openSettingsModal({
-            title: "Adminbereich",
-            content: [adminTiles],
-            closeOnly: true,
-          });
-        };
-
-        const devEntryTiles = document.createElement("div");
-        devEntryTiles.style.display = "grid";
-        devEntryTiles.style.gridTemplateColumns = "repeat(auto-fill, minmax(220px, 1fr))";
-        devEntryTiles.style.gap = "10px";
-        devEntryTiles.style.maxWidth = "720px";
-        devEntryTiles.append(
-          mkTile({
-            titleText: "Adminbereich",
-            subText: "Adminmodule und Verwaltungswerkzeuge",
-            onClick: async () => {
-              openAdminbereichPopup();
-            },
-          })
-        );
-
         const devTabs = [
           { key: "version", label: "Versionierung", el: tabVersion },
-          { key: "license", label: "Lizenz / bearbeiten", el: tabLicense },
           { key: "db", label: "DB-Diagnose", el: tabDb },
           { key: "dictation", label: "Diktieren", el: tabDictation },
           { key: "tools", label: "Druck / TOP-Liste", el: tabTools },
@@ -4813,14 +4805,13 @@ export default class SettingsView {
 
         devTabHead.append(
           makeDevTabButton("Versionierung", "version"),
-          makeDevTabButton("Lizenz / bearbeiten", "license"),
           makeDevTabButton("DB-Diagnose", "db"),
           makeDevTabButton("Diktieren", "dictation"),
           makeDevTabButton("Druck / TOP-Liste", "tools")
         );
 
-        devTabBody.append(tabVersion, tabLicense, tabDb, tabDictation, tabTools);
-        devTabWrap.append(devEntryTiles, devTabHead, devTabBody);
+        devTabBody.append(tabVersion, tabDb, tabDictation, tabTools);
+        devTabWrap.append(devTabHead, devTabBody);
         setDevTab("version");
 
         this._openSettingsModal({
@@ -4836,7 +4827,7 @@ export default class SettingsView {
       },
     });
 
-    tiles.append(tileUser, tilePrint, tileLicense);
+    tiles.append(tileUser, tilePrint, tileLicense, tileAdmin);
     (async () => {
       const api = window.bbmDb || {};
       if (typeof api.appIsPackaged !== "function") {


### PR DESCRIPTION
### Motivation
- Aktuell waren Adminbereich, Lizenzverwaltung und der Bereich „Lizenz / bearbeiten“ unübersichtlich und falsch innerhalb des Entwicklung-Popups platziert, was fachlich inkorrekt ist. 
- Ziel ist, den Adminbereich direkt auf oberster Einstellungen-Ebene als eigenen Einstieg anzubieten und die Lizenzverwaltung klar innerhalb dieses Adminbereichs zu verorten. 
- Bestehende Lizenz-UI und Lizenzlogik bleiben unangetastet; es soll nur die Sichtbarkeit/Verortung und die Einstiege bereinigt werden.

### Description
- `src/renderer/views/SettingsView.js` ergänzt `tileAdmin` als eigene Kachel in der Haupt-Einstellungen-Ansicht und implementiert ein separates `Adminbereich`-Popup mit der Kachel `Lizenzverwaltung`, die `LicenseAdminScreen` rendert. 
- Admin-Einstieg wurde aus dem Entwicklungspopup entfernt und die Entwicklung-Tabs so angepasst, dass es dort keinen Admin-/Lizenz-Einstieg oder -Tab mehr gibt. 
- `scripts/tests/lizenzverwaltungModule.test.cjs` wurde angepasst und erweitert, um die neue Verortung abzudecken und zu prüfen, dass die Entwicklung keinen Admin-Einstieg/Tab mehr enthält und dass `LicenseAdminScreen` weiterhin verfügbar ist. 
- `STATUS.md` wurde aktualisiert, um den erledigten Meilenstein (Paket 3) und die betroffenen Dateien zu dokumentieren.

### Testing
- Automatisierte Tests ausgeführt: `npm test` (gesamter Testlauf) und alle Tests sind grün. 
- Spezifische neue/angepasste Prüfungen in `scripts/tests/lizenzverwaltungModule.test.cjs` validieren: Adminbereich auf oberster Einstellungen-Ebene, kein Admin-Einstieg/Tab in Entwicklung, Adminbereich-Popup enthält Kachel Lizenzverwaltung, Lizenzverwaltung zeigt `LicenseAdminScreen`, und der alte Bereich „Lizenz / bearbeiten“ ist nicht mehr als Entwicklung-Tab sichtbar. 
- Branch / PR-Status: Base-Branch ist `main`, Ergebnis-Branch ist `work`, es wurde versucht einen Pull Request zu erstellen, aber kein PR-Link steht zur Verfügung (PR-Erstellung nicht möglich in dieser Umgebung) — Status: gestoppt – nicht veröffentlicht. 
- Geänderte Dateien (automatisiert ermittelt): `src/renderer/views/SettingsView.js`, `scripts/tests/lizenzverwaltungModule.test.cjs`, `STATUS.md`; Arbeitsbaum ist sauber (keine uncommitted Änderungen).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed332a37b08322bb4a382bcd389190)