### PR TITLE
Lizenzverwaltung: Produktumfang zentral strukturieren

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -362,3 +362,20 @@ Wichtig:
 - `AGENTS.md` = Hausordnung
 - `PLAN.md` = Bauablaufplan
 - `STATUS.md` = Bautagebuch / Ist-Stand
+
+#### Paket: Lizenzverwaltung Paket 3 (Produktumfang intern zentral strukturiert)
+- Status: erledigt
+- Beschreibung:
+  - zentrale Produktumfangs-Struktur `PRODUCT_SCOPE` im Modul `lizenzverwaltung` angelegt
+  - `createLicenseEditorSection` auf die zentrale Struktur umgestellt (Standardumfang, Zusatzfunktionen, Module)
+  - sichtbares Verhalten beibehalten: Standardumfang fix, mail/Dictate auswählbar, Module vorbereitet/deaktiviert
+  - Features-Ausgabe bleibt kompatibel mit internem `audio`-Key fuer Dictate
+- Betroffene Dateien:
+  - `src/renderer/modules/lizenzverwaltung/productScope.js`
+  - `src/renderer/modules/lizenzverwaltung/screens/createLicenseEditorSection.js`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine Lizenzdatei-Strukturreform, keine Modulfreischaltung und keine Sidebar-/Projektmodul-Aenderung

--- a/scripts/tests/audioModule.test.cjs
+++ b/scripts/tests/audioModule.test.cjs
@@ -66,8 +66,8 @@ async function runAudioModuleTests(run) {
   });
 
   await run("Lizenz-Editor zeigt audio fachlich als Dictate", () => {
-    assert.equal(licenseEditorSource.includes('const formatLicenseFeatureLabel = (feature) =>'), true);
-    assert.equal(licenseEditorSource.includes('normalizedFeature === "audio" ? "Dictate" : normalizedFeature'), true);
+    assert.equal(licenseEditorSource.includes('const formatLicenseFeatureLabel = formatProductScopeFeatureLabel;'), true);
+    assert.equal(licenseEditorSource.includes('formatProductScopeFeatureLabel'), true);
     assert.equal(licenseEditorSource.includes('document.createTextNode(formatLicenseFeatureLabel(feature))'), true);
     assert.equal(
       licenseEditorSource.includes(
@@ -75,7 +75,6 @@ async function runAudioModuleTests(run) {
       ),
       true
     );
-    assert.equal(licenseEditorSource.includes('checkbox.value = feature;'), true);
   });
 }
 

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -19,12 +19,19 @@ async function runLizenzverwaltungModuleTests(run) {
     {
       getProjektverwaltungModuleEntry,
     },
+    {
+      PRODUCT_SCOPE,
+      formatProductScopeFeatureLabel,
+      normalizeProductScopeFeatureKey,
+    },
   ] = await Promise.all([
     importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/lizenzverwaltung/index.js")),
     importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/projektverwaltung/index.js")),
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/lizenzverwaltung/productScope.js")),
   ]);
 
   const screenSource = read("src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js");
+  const productScopeSource = read("src/renderer/modules/lizenzverwaltung/productScope.js");
   const licenseEditorSource = read("src/renderer/modules/lizenzverwaltung/screens/createLicenseEditorSection.js");
   const moduleCatalogSource = read("src/renderer/app/modules/moduleCatalog.js");
   const projectWorkspaceSource = read("src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js");
@@ -93,32 +100,49 @@ async function runLizenzverwaltungModuleTests(run) {
   await run("Lizenz / bearbeiten: enthaelt Produktumfang statt flacher Feature-Zeile", () => {
     assert.equal(licenseEditorSource.includes("mkRow(\"Produktumfang\", productScopeWrap)"), true);
     assert.equal(licenseEditorSource.includes("mkRow(\"Features\", featureWrap)"), false);
-    assert.equal(licenseEditorSource.includes("Standardumfang"), true);
-    assert.equal(licenseEditorSource.includes("Zusatzfunktionen"), true);
-    assert.equal(licenseEditorSource.includes("Module"), true);
+    assert.equal(licenseEditorSource.includes("Standardumfang"), false);
+    assert.equal(licenseEditorSource.includes("Zusatzfunktionen"), false);
+    assert.equal(licenseEditorSource.includes("Module"), false);
+  });
+
+  await run("Lizenzverwaltung: Produktumfang zentral im Modul definiert", () => {
+    assert.equal(productScopeSource.includes("export const PRODUCT_SCOPE"), true);
+    assert.equal(productScopeSource.includes("standardumfang"), true);
+    assert.equal(productScopeSource.includes("zusatzfunktionen"), true);
+    assert.equal(productScopeSource.includes("module"), true);
   });
 
   await run("Lizenz / bearbeiten: Standardumfang enthaelt app/pdf/export", () => {
-    assert.equal(licenseEditorSource.includes("const standardFeatureInputs = [\"app\", \"pdf\", \"export\"]"), true);
-    assert.equal(licenseEditorSource.includes("Immer enthalten, nicht abwaehlbar."), true);
+    const standardKeys = PRODUCT_SCOPE.standardumfang.entries.map((entry) => entry.key);
+    assert.deepEqual(standardKeys, ["app", "pdf", "export"]);
+    assert.equal(PRODUCT_SCOPE.standardumfang.note, "Immer enthalten, nicht abwaehlbar.");
   });
 
   await run("Lizenz / bearbeiten: Zusatzfunktionen enthaelt mail/Dictate (audio-kompatibel)", () => {
-    assert.equal(licenseEditorSource.includes("const optionalFeatureInputs = [\"mail\", \"audio\"]"), true);
-    assert.equal(licenseEditorSource.includes("return normalizedFeature === \"audio\" ? \"Dictate\" : normalizedFeature;"), true);
-    assert.equal(licenseEditorSource.includes("if (normalized === \"dictate\") return \"audio\";"), true);
+    const optionalKeys = PRODUCT_SCOPE.zusatzfunktionen.entries.map((entry) => entry.key);
+    const optionalLabels = PRODUCT_SCOPE.zusatzfunktionen.entries.map((entry) => entry.label);
+    assert.deepEqual(optionalKeys, ["mail", "audio"]);
+    assert.deepEqual(optionalLabels, ["mail", "Dictate"]);
+    assert.equal(formatProductScopeFeatureLabel("audio"), "Dictate");
+    assert.equal(normalizeProductScopeFeatureKey("Dictate"), "audio");
   });
 
   await run("Lizenz / bearbeiten: zeigt nicht audio und Dictate parallel an", () => {
-    assert.equal(licenseEditorSource.includes("mkFeatureInput(\"Dictate\""), false);
-    assert.equal(licenseEditorSource.includes("mkFeatureInput(\"audio\""), false);
-    assert.equal(licenseEditorSource.includes("return normalizedFeature === \"audio\" ? \"Dictate\" : normalizedFeature;"), true);
+    assert.equal(PRODUCT_SCOPE.zusatzfunktionen.entries.filter((entry) => entry.label === "Dictate").length, 1);
+    assert.equal(PRODUCT_SCOPE.zusatzfunktionen.entries.filter((entry) => entry.label === "audio").length, 0);
   });
 
   await run("Lizenz / bearbeiten: Module enthaelt Protokoll/Dummy als vorbereitete Eintraege", () => {
-    assert.equal(licenseEditorSource.includes("const moduleFeatureInputs = [\"Protokoll\", \"Dummy\"]"), true);
-    assert.equal(licenseEditorSource.includes("Vorbereitet, noch nicht aktiv angebunden."), true);
-    assert.equal(licenseEditorSource.includes("hint: \"(vorbereitet)\""), true);
+    const moduleLabels = PRODUCT_SCOPE.module.entries.map((entry) => entry.label);
+    assert.deepEqual(moduleLabels, ["Protokoll", "Dummy"]);
+    assert.equal(PRODUCT_SCOPE.module.note, "Vorbereitet, noch nicht aktiv angebunden.");
+  });
+
+  await run("Lizenz / bearbeiten: createLicenseEditorSection nutzt zentrale Produktumfang-Struktur", () => {
+    assert.equal(licenseEditorSource.includes('from "../productScope.js"'), true);
+    assert.equal(licenseEditorSource.includes("PRODUCT_SCOPE.standardumfang.entries"), true);
+    assert.equal(licenseEditorSource.includes("PRODUCT_SCOPE.zusatzfunktionen.entries"), true);
+    assert.equal(licenseEditorSource.includes("PRODUCT_SCOPE.module.entries"), true);
   });
 }
 

--- a/src/renderer/modules/lizenzverwaltung/productScope.js
+++ b/src/renderer/modules/lizenzverwaltung/productScope.js
@@ -1,0 +1,37 @@
+export const PRODUCT_SCOPE = {
+  standardumfang: {
+    title: "Standardumfang",
+    note: "Immer enthalten, nicht abwaehlbar.",
+    entries: [
+      { key: "app", label: "app", alwaysIncluded: true },
+      { key: "pdf", label: "pdf", alwaysIncluded: true },
+      { key: "export", label: "export", alwaysIncluded: true },
+    ],
+  },
+  zusatzfunktionen: {
+    title: "Zusatzfunktionen",
+    entries: [
+      { key: "mail", label: "mail", defaultEnabled: true },
+      { key: "audio", label: "Dictate", defaultEnabled: false, aliases: ["dictate"] },
+    ],
+  },
+  module: {
+    title: "Module",
+    note: "Vorbereitet, noch nicht aktiv angebunden.",
+    entries: [
+      { key: "protokoll", label: "Protokoll", preparedOnly: true },
+      { key: "dummy", label: "Dummy", preparedOnly: true },
+    ],
+  },
+};
+
+export function normalizeProductScopeFeatureKey(feature) {
+  const normalized = String(feature || "").trim().toLowerCase();
+  if (normalized === "dictate") return "audio";
+  return normalized;
+}
+
+export function formatProductScopeFeatureLabel(feature) {
+  const normalizedFeature = normalizeProductScopeFeatureKey(feature);
+  return normalizedFeature === "audio" ? "Dictate" : normalizedFeature;
+}

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseEditorSection.js
@@ -1,3 +1,9 @@
+import {
+  PRODUCT_SCOPE,
+  formatProductScopeFeatureLabel,
+  normalizeProductScopeFeatureKey,
+} from "../productScope.js";
+
 export function createLicenseEditorSection({
   mkRow,
   applyPopupCardStyle,
@@ -134,16 +140,8 @@ export function createLicenseEditorSection({
   productScopeWrap.style.display = "grid";
   productScopeWrap.style.gap = "8px";
 
-  const formatLicenseFeatureLabel = (feature) => {
-    const normalizedFeature = String(feature || "").trim();
-    return normalizedFeature === "audio" ? "Dictate" : normalizedFeature;
-  };
-
-  const normalizeLicenseFeatureKey = (feature) => {
-    const normalized = String(feature || "").trim().toLowerCase();
-    if (normalized === "dictate") return "audio";
-    return normalized;
-  };
+  const formatLicenseFeatureLabel = formatProductScopeFeatureLabel;
+  const normalizeLicenseFeatureKey = normalizeProductScopeFeatureKey;
 
   const mkScopeGroup = (title, note = "") => {
     const box = document.createElement("div");
@@ -199,25 +197,27 @@ export function createLicenseEditorSection({
     return checkbox;
   };
 
-  const standardScope = mkScopeGroup("Standardumfang", "Immer enthalten, nicht abwaehlbar.");
-  const optionalScope = mkScopeGroup("Zusatzfunktionen");
-  const moduleScope = mkScopeGroup("Module", "Vorbereitet, noch nicht aktiv angebunden.");
+  const standardScope = mkScopeGroup(PRODUCT_SCOPE.standardumfang.title, PRODUCT_SCOPE.standardumfang.note);
+  const optionalScope = mkScopeGroup(PRODUCT_SCOPE.zusatzfunktionen.title);
+  const moduleScope = mkScopeGroup(PRODUCT_SCOPE.module.title, PRODUCT_SCOPE.module.note);
 
-  const standardFeatureInputs = ["app", "pdf", "export"].map((feature) => {
-    const checkbox = mkFeatureInput(feature, { checked: true, disabled: true });
+  const standardFeatureInputs = PRODUCT_SCOPE.standardumfang.entries.map((entry) => {
+    const checkbox = mkFeatureInput(entry.key, { checked: true, disabled: true });
+    checkbox.value = entry.key;
     standardScope.row.appendChild(checkbox.parentElement);
     return checkbox;
   });
 
-  const optionalFeatureInputs = ["mail", "audio"].map((feature) => {
-    const checkbox = mkFeatureInput(feature, { checked: feature !== "audio" });
+  const optionalFeatureInputs = PRODUCT_SCOPE.zusatzfunktionen.entries.map((entry) => {
+    const checkbox = mkFeatureInput(entry.key, { checked: !!entry.defaultEnabled });
+    checkbox.value = entry.key;
     optionalScope.row.appendChild(checkbox.parentElement);
     return checkbox;
   });
 
-  const moduleFeatureInputs = ["Protokoll", "Dummy"].map((moduleLabel) => {
-    const checkbox = mkFeatureInput(moduleLabel, { checked: false, disabled: true, hint: "(vorbereitet)" });
-    checkbox.value = moduleLabel.toLowerCase();
+  const moduleFeatureInputs = PRODUCT_SCOPE.module.entries.map((entry) => {
+    const checkbox = mkFeatureInput(entry.label, { checked: false, disabled: true, hint: "(vorbereitet)" });
+    checkbox.value = entry.key;
     moduleScope.row.appendChild(checkbox.parentElement);
     return checkbox;
   });


### PR DESCRIPTION
### Motivation
- Prepare the license/product-scope data as a central, module-local structure so the UI no longer hardcodes the product lists and to keep future modularization options small and local. 
- Keep existing visible behavior unchanged: `Standardumfang` always present, `Zusatzfunktionen` optionally toggleable, `Module` shown as prepared but not activated. 

### Description
- Added `src/renderer/modules/lizenzverwaltung/productScope.js` exporting `PRODUCT_SCOPE` plus `normalizeProductScopeFeatureKey` and `formatProductScopeFeatureLabel` for central definitions of `Standardumfang` (app/pdf/export), `Zusatzfunktionen` (mail/Dictate with internal `audio` key) and `Module` (Protokoll, Dummy, prepared). 
- Updated `createLicenseEditorSection` to import and use `PRODUCT_SCOPE` and the formatting/normalization helpers instead of inline hardcoded lists so the UI consumes a single source of truth while keeping behavior (fixed standard features, selectable mail/Dictate, disabled prepared modules). 
- Adjusted tests: extended `scripts/tests/lizenzverwaltungModule.test.cjs` to assert the central structure and its usage, and adapted `scripts/tests/audioModule.test.cjs` to expect the new label usage. 
- Updated `STATUS.md` with the new package entry describing the change and scope. 
- Note: attempted PR creation against `main` from branch `work` could not be published in this environment due to missing remote/CLI support, so no PR link was produced. 

### Testing
- Ran `npm test`; all automated tests passed (test suite green). 
- Updated/added assertions in `scripts/tests/lizenzverwaltungModule.test.cjs` and adapted `scripts/tests/audioModule.test.cjs`; those tests passed as part of the full test run. 
- No other automated checks were run in this mini-package.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4106b3808322acfbafe92a4ad6fa)