### PR TITLE
Lizenzverwaltung Paket 4: Kunden- und Lizenzdatensatz vorbereiten

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -51,6 +51,12 @@ Sie ergänzt:
   - `LicenseAdminScreen` enthaelt jetzt den Einstieg `Lizenz erstellen / bearbeiten`
   - der Einstieg oeffnet die verschobene UI im Adminbereich
   - `SettingsView` bleibt Host/Einstieg und zeigt keinen sichtbaren Entwicklungs-Tab `Lizenz / bearbeiten`
+
+- Lizenzverwaltung Paket 4 (Datensatz-Vorbereitung) ist umgesetzt:
+  - zentrale Datei `licenseRecords.js` fuer Kunden- und Lizenzdatensatz vorbereitet
+  - Feldlisten, Default-Strukturen und Normalisierungsfunktionen fuer Kunde/Lizenz vorhanden
+  - `LicenseAdminScreen` zeigt die Bereiche `Kunden` und `Lizenzen` mit aussagekraeftigeren vorbereiteten Feldhinweisen
+  - bestehende Lizenz-erstellen-/bearbeiten-UI und Produktumfangsstruktur bleiben unveraendert nutzbar
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.
@@ -292,6 +298,28 @@ Sie ergänzt:
   - keine neue Kundenverwaltung, Historie oder Produktumfang-Datenstruktur eingefuehrt
   - keine Projektmodul-, Sidebar-, Whisper-, Diktier- oder Lizenzdatei-Logik-Aenderung
 
+
+#### Paket: Lizenzverwaltung Paket 4 (Kunden- und Lizenzdatensatz vorbereiten)
+- Status: erledigt
+- Beschreibung:
+  - zentrale Datei `src/renderer/modules/lizenzverwaltung/licenseRecords.js` mit Feldlisten fuer Kunde und Lizenz angelegt
+  - Default-Strukturen und kleine Normalisierungsfunktionen fuer beide Datensaetze eingefuehrt
+  - `LicenseAdminScreen` zeigt die Bereiche `Kunden` und `Lizenzen` weiter als vorbereitete Bereiche, aber mit Feldhinweisen
+  - bestehende Lizenz-erstellen-/bearbeiten-UI bleibt unveraendert als Einstieg nutzbar
+- Betroffene Dateien:
+  - `src/renderer/modules/lizenzverwaltung/licenseRecords.js`
+  - `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`
+  - `src/renderer/modules/lizenzverwaltung/index.js`
+  - `src/renderer/modules/lizenzverwaltung/README.md`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine neue Datenbank/Persistenz
+  - Keine Kundenverwaltung/Historie implementiert
+  - Keine Projektmodul-/Sidebar-/Whisper-Aenderung
+
 ## Offene Meilensteine
 1. Weitere kleine Altpfade im Modul `Protokoll` abbauen
 
@@ -326,11 +354,11 @@ Hinweis: Der Meilenstein „Projektverwaltung / Projekt-Arbeitsbereich“ ist ab
 ## Aktuell nächster sinnvoller Schritt
 Der naechste sinnvolle kleine Schritt nach diesem Paket ist:
 
-### Lizenzverwaltung Paket 4 vorbereiten
+### Lizenzverwaltung Paket 5 vorbereiten
 - Ziel:
-  - Adminbereich-Popup in kleinen Schritten um weitere echte Adminbereiche erweiterbar halten, ohne neue Lizenzlogik freizuschalten
+  - bestehende Lizenz laden, aendern und neu ausgeben als naechsten kleinen Adminschritt vorbereiten
 - Wichtig:
-  - weiterhin keine tiefgreifende Umstellung der Lizenzdatei-Erzeugung oder Kundenverwaltung
+  - Kundenverwaltung/Historie weiter nicht vorziehen
   - Audio / Diktat bleibt Maschinenraum ohne Projektmodul- oder Sidebar-Eintrag
 
 ---

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -15,6 +15,13 @@ async function runLizenzverwaltungModuleTests(run) {
       LIZENZVERWALTUNG_WORK_SCREEN_ID,
       LicenseAdminScreen,
       createLicenseEditorSection,
+      CUSTOMER_RECORD_FIELDS,
+      LICENSE_RECORD_FIELDS,
+      LICENSE_MODES,
+      createDefaultCustomerRecord,
+      createDefaultLicenseRecord,
+      normalizeCustomerRecord,
+      normalizeLicenseRecord,
     },
     {
       getProjektverwaltungModuleEntry,
@@ -32,6 +39,7 @@ async function runLizenzverwaltungModuleTests(run) {
 
   const screenSource = read("src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js");
   const productScopeSource = read("src/renderer/modules/lizenzverwaltung/productScope.js");
+  const licenseRecordsSource = read("src/renderer/modules/lizenzverwaltung/licenseRecords.js");
   const licenseEditorSource = read("src/renderer/modules/lizenzverwaltung/screens/createLicenseEditorSection.js");
   const moduleCatalogSource = read("src/renderer/app/modules/moduleCatalog.js");
   const projectWorkspaceSource = read("src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js");
@@ -49,6 +57,86 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(entry.screens?.licenseAdmin, LicenseAdminScreen);
   });
 
+
+  await run("Lizenzverwaltung: Kundendatensatz zentral vorbereitet", () => {
+    const customerKeys = CUSTOMER_RECORD_FIELDS.map((entry) => entry.key);
+    assert.deepEqual(customerKeys, [
+      "customerNumber",
+      "companyName",
+      "contactPerson",
+      "email",
+      "phone",
+      "notes",
+    ]);
+
+    const customerLabels = CUSTOMER_RECORD_FIELDS.map((entry) => entry.label);
+    assert.deepEqual(customerLabels, [
+      "Kundennummer",
+      "Firma / Kundenname",
+      "Ansprechpartner",
+      "E-Mail",
+      "Telefon",
+      "Notizen",
+    ]);
+
+    assert.equal(typeof createDefaultCustomerRecord, "function");
+    assert.equal(typeof normalizeCustomerRecord, "function");
+    assert.equal(licenseRecordsSource.includes("CUSTOMER_RECORD_FIELDS"), true);
+  });
+
+  await run("Lizenzverwaltung: Lizenzdatensatz zentral vorbereitet", () => {
+    const licenseKeys = LICENSE_RECORD_FIELDS.map((entry) => entry.key);
+    assert.deepEqual(licenseKeys, [
+      "licenseId",
+      "customerNumber",
+      "productScope",
+      "validFrom",
+      "validUntil",
+      "licenseMode",
+      "machineId",
+      "notes",
+    ]);
+
+    const licenseLabels = LICENSE_RECORD_FIELDS.map((entry) => entry.label);
+    assert.deepEqual(licenseLabels, [
+      "Lizenz-ID",
+      "Kunde",
+      "Produktumfang",
+      "gueltig von",
+      "gueltig bis",
+      "Lizenzmodus",
+      "Machine-ID",
+      "Notizen",
+    ]);
+
+    assert.deepEqual(LICENSE_MODES.map((entry) => entry.label), ["Soft-Lizenz", "Vollversion"]);
+    assert.equal(typeof createDefaultLicenseRecord, "function");
+    assert.equal(typeof normalizeLicenseRecord, "function");
+    assert.equal(licenseRecordsSource.includes("LICENSE_RECORD_FIELDS"), true);
+  });
+
+  await run("Lizenzverwaltung: Datensatz-Normalisierung bleibt minimal und robust", () => {
+    const normalizedCustomer = normalizeCustomerRecord({
+      customerNumber: "  K-100  ",
+      companyName: "  Musterbau GmbH  ",
+      email: "  info@example.org  ",
+    });
+    assert.equal(normalizedCustomer.customerNumber, "K-100");
+    assert.equal(normalizedCustomer.companyName, "Musterbau GmbH");
+    assert.equal(normalizedCustomer.email, "info@example.org");
+
+    const normalizedLicense = normalizeLicenseRecord({
+      licenseId: "  LIC-1  ",
+      customerNumber: "  K-100  ",
+      licenseMode: "FULL",
+      productScope: { zusatzfunktionen: ["mail"] },
+    });
+    assert.equal(normalizedLicense.licenseId, "LIC-1");
+    assert.equal(normalizedLicense.customerNumber, "K-100");
+    assert.equal(normalizedLicense.licenseMode, "full");
+    assert.deepEqual(normalizedLicense.productScope.zusatzfunktionen, ["mail"]);
+    assert.deepEqual(normalizedLicense.productScope.standardumfang, []);
+  });
   await run("Lizenzverwaltung: Skeleton enthaelt Einstieg und Platzhalterbereiche", () => {
     assert.equal(screenSource.includes("Lizenzverwaltung"), true);
     assert.equal(screenSource.includes("Admin-/Mutter-App-Modul"), true);
@@ -56,6 +144,9 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Lizenz erstellen / bearbeiten"), true);
     assert.equal(screenSource.includes("Kunden"), true);
     assert.equal(screenSource.includes("Lizenzen"), true);
+    assert.equal(screenSource.includes("Vorbereitete Felder:"), true);
+    assert.equal(screenSource.includes("CUSTOMER_RECORD_FIELDS"), true);
+    assert.equal(screenSource.includes("LICENSE_RECORD_FIELDS"), true);
     assert.equal(screenSource.includes("Produktumfang"), true);
     assert.equal(screenSource.includes("Historie"), true);
   });

--- a/src/renderer/modules/lizenzverwaltung/README.md
+++ b/src/renderer/modules/lizenzverwaltung/README.md
@@ -10,3 +10,5 @@ Status:
 Enthaelt:
 - `screens/LicenseAdminScreen.js` als einfacher Admin-Skeleton-Screen
 - `index.js` als Modul-Einstieg
+
+- `licenseRecords.js` als zentrale Feldlisten/Defaults/Normalisierung fuer Kunden- und Lizenzdatensaetze

--- a/src/renderer/modules/lizenzverwaltung/index.js
+++ b/src/renderer/modules/lizenzverwaltung/index.js
@@ -20,3 +20,5 @@ export function getLizenzverwaltungModuleEntry() {
 
 export { LicenseAdminScreen, createLicenseEditorSection, LIZENZVERWALTUNG_WORK_SCREEN_ID };
 export * from "./screens/index.js";
+export * from "./productScope.js";
+export * from "./licenseRecords.js";

--- a/src/renderer/modules/lizenzverwaltung/licenseRecords.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseRecords.js
@@ -1,0 +1,93 @@
+export const CUSTOMER_RECORD_FIELDS = Object.freeze([
+  Object.freeze({ key: "customerNumber", label: "Kundennummer", required: true }),
+  Object.freeze({ key: "companyName", label: "Firma / Kundenname", required: true }),
+  Object.freeze({ key: "contactPerson", label: "Ansprechpartner", required: true }),
+  Object.freeze({ key: "email", label: "E-Mail", required: true }),
+  Object.freeze({ key: "phone", label: "Telefon", required: false }),
+  Object.freeze({ key: "notes", label: "Notizen", required: false }),
+]);
+
+export const LICENSE_RECORD_FIELDS = Object.freeze([
+  Object.freeze({ key: "licenseId", label: "Lizenz-ID", required: true }),
+  Object.freeze({ key: "customerNumber", label: "Kunde", required: true }),
+  Object.freeze({ key: "productScope", label: "Produktumfang", required: true }),
+  Object.freeze({ key: "validFrom", label: "gueltig von", required: true }),
+  Object.freeze({ key: "validUntil", label: "gueltig bis", required: true }),
+  Object.freeze({ key: "licenseMode", label: "Lizenzmodus", required: true }),
+  Object.freeze({ key: "machineId", label: "Machine-ID", required: false }),
+  Object.freeze({ key: "notes", label: "Notizen", required: false }),
+]);
+
+export const LICENSE_MODES = Object.freeze([
+  Object.freeze({ key: "soft", label: "Soft-Lizenz" }),
+  Object.freeze({ key: "full", label: "Vollversion" }),
+]);
+
+export function createDefaultCustomerRecord(overrides = {}) {
+  return {
+    customerNumber: "",
+    companyName: "",
+    contactPerson: "",
+    email: "",
+    phone: "",
+    notes: "",
+    ...overrides,
+  };
+}
+
+export function createDefaultLicenseRecord(overrides = {}) {
+  return {
+    licenseId: "",
+    customerNumber: "",
+    productScope: {
+      standardumfang: [],
+      zusatzfunktionen: [],
+      module: [],
+    },
+    validFrom: "",
+    validUntil: "",
+    licenseMode: "soft",
+    machineId: "",
+    notes: "",
+    ...overrides,
+  };
+}
+
+export function normalizeCustomerRecord(input = {}) {
+  const base = createDefaultCustomerRecord();
+  return {
+    customerNumber: String(input.customerNumber ?? base.customerNumber).trim(),
+    companyName: String(input.companyName ?? base.companyName).trim(),
+    contactPerson: String(input.contactPerson ?? base.contactPerson).trim(),
+    email: String(input.email ?? base.email).trim(),
+    phone: String(input.phone ?? base.phone).trim(),
+    notes: String(input.notes ?? base.notes).trim(),
+  };
+}
+
+export function normalizeLicenseRecord(input = {}) {
+  const base = createDefaultLicenseRecord();
+  const mode = String(input.licenseMode ?? base.licenseMode).trim().toLowerCase();
+  const normalizedMode = LICENSE_MODES.some((entry) => entry.key === mode) ? mode : base.licenseMode;
+
+  return {
+    licenseId: String(input.licenseId ?? base.licenseId).trim(),
+    customerNumber: String(input.customerNumber ?? base.customerNumber).trim(),
+    productScope: {
+      standardumfang: Array.isArray(input?.productScope?.standardumfang)
+        ? [...input.productScope.standardumfang]
+        : [...base.productScope.standardumfang],
+      zusatzfunktionen: Array.isArray(input?.productScope?.zusatzfunktionen)
+        ? [...input.productScope.zusatzfunktionen]
+        : [...base.productScope.zusatzfunktionen],
+      module: Array.isArray(input?.productScope?.module)
+        ? [...input.productScope.module]
+        : [...base.productScope.module],
+    },
+    validFrom: String(input.validFrom ?? base.validFrom).trim(),
+    validUntil: String(input.validUntil ?? base.validUntil).trim(),
+    licenseMode: normalizedMode,
+    machineId: String(input.machineId ?? base.machineId).trim(),
+    notes: String(input.notes ?? base.notes).trim(),
+  };
+}

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -1,3 +1,5 @@
+import { CUSTOMER_RECORD_FIELDS, LICENSE_RECORD_FIELDS } from "../licenseRecords.js";
+
 function buildSectionCard({ title, hint = "", actionLabel = "", onClick = null }) {
   const card = document.createElement("section");
   card.style.border = "1px solid var(--card-border)";
@@ -35,6 +37,10 @@ function buildSectionCard({ title, hint = "", actionLabel = "", onClick = null }
   return card;
 }
 
+function buildPreparedFieldHint(fields) {
+  return `Vorbereitete Felder: ${fields.map((field) => field.label).join(", ")}.`;
+}
+
 export default class LicenseAdminScreen {
   constructor({ onOpenLicenseEditor } = {}) {
     this.onOpenLicenseEditor = onOpenLicenseEditor;
@@ -70,8 +76,14 @@ export default class LicenseAdminScreen {
         actionLabel: "Oeffnen",
         onClick: this.onOpenLicenseEditor,
       }),
-      buildSectionCard({ title: "Kunden" }),
-      buildSectionCard({ title: "Lizenzen" }),
+      buildSectionCard({
+        title: "Kunden",
+        hint: buildPreparedFieldHint(CUSTOMER_RECORD_FIELDS),
+      }),
+      buildSectionCard({
+        title: "Lizenzen",
+        hint: buildPreparedFieldHint(LICENSE_RECORD_FIELDS),
+      }),
       buildSectionCard({ title: "Produktumfang" }),
       buildSectionCard({ title: "Historie" })
     );


### PR DESCRIPTION
### Motivation
- Vorbereitung der fachlichen Datensatzstrukturen für Kunde und Lizenz im Modul `src/renderer/modules/lizenzverwaltung/`, ohne Persistenz oder Kundenverwaltung zu bauen.
- Schaffen einer zentralen Stelle für Feldlisten, Default-Objekte und Normalisierungsfunktionen, damit spätere Schritte (UI, Persistenz, Historie) konsistent aufbaubar sind.
- Sicherstellen, dass die existierende Lizenz-Erstellen/-Bearbeiten-UI weiter funktioniert und das Modul kein Projektmodul wird.

### Description
- Neue Datei `src/renderer/modules/lizenzverwaltung/licenseRecords.js` hinzugefügt mit Felddefinitionen (`CUSTOMER_RECORD_FIELDS`, `LICENSE_RECORD_FIELDS`), Default-Erzeugern (`createDefaultCustomerRecord`, `createDefaultLicenseRecord`), Normalisierern (`normalizeCustomerRecord`, `normalizeLicenseRecord`) und `LICENSE_MODES`.
- Modul-Exports erweitert: `index.js` exportiert nun zentral auch `productScope.js` und `licenseRecords.js`, so sind die Strukturen modulweit zugreifbar.
- `LicenseAdminScreen` (in `screens/LicenseAdminScreen.js`) ergänzt, die Karten für `Kunden` und `Lizenzen` zeigen jetzt aussagekräftige vorbereitete Feldhinweise basierend auf den zentralen Struktur-Definitionen; bestehende Einstiege zur Lizenz-Erstellung/-Bearbeitung bleiben unverändert.
- Tests und Dokumentation angepasst: `scripts/tests/lizenzverwaltungModule.test.cjs` erweitert, `README.md` und `STATUS.md` aktualisiert; es wurden keine Datenbank-, Persistenz-, Historie- oder Projektmodul-Änderungen vorgenommen.

### Testing
- Ausgeführt: `npm test` (gesamter Testlauf) und die erweiterte Testsammlung `scripts/tests/lizenzverwaltungModule.test.cjs`.
- Ergebnis: Alle Tests liefen grün (keine fehlgeschlagenen Tests).
- Geprüft: zentrale Feldlisten, Default-/Normalisierungsfunktionen und die Anzeigehinweise im `LicenseAdminScreen` werden wie erwartet exportiert und verwendet.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed442b5fec8322af8cbc14723c871b)