### PR TITLE
Lizenzverwaltung: Kundenmaske im Adminbereich vorbereiten

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -57,6 +57,11 @@ Sie ergänzt:
   - Feldlisten, Default-Strukturen und Normalisierungsfunktionen fuer Kunde/Lizenz vorhanden
   - `LicenseAdminScreen` zeigt die Bereiche `Kunden` und `Lizenzen` mit aussagekraeftigeren vorbereiteten Feldhinweisen
   - bestehende Lizenz-erstellen-/bearbeiten-UI und Produktumfangsstruktur bleiben unveraendert nutzbar
+- Lizenzverwaltung naechstes Paket ist umgesetzt:
+  - Kachel `Kunden` im `LicenseAdminScreen` oeffnet jetzt eine einfache vorbereitete Kundenmaske
+  - Kundenmaske nutzt `CUSTOMER_RECORD_FIELDS` und bietet die Felder Kundennummer, Firma/Kundenname, Ansprechpartner, E-Mail, Telefon, Notizen
+  - Kundenmaske bietet `Neu / leeren` und `Pruefen`; Pruefen validiert nur lokal Pflichtfelder ohne Speicherung, Datenbank oder Persistenz
+  - `SettingsView` bleibt Host/Einstieg und oeffnet die Kundenmaske nur ueber den Adminbereich
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.
@@ -318,6 +323,30 @@ Sie ergänzt:
 - Hinweise:
   - Keine neue Datenbank/Persistenz
   - Keine Kundenverwaltung/Historie implementiert
+  - Keine Projektmodul-/Sidebar-/Whisper-Aenderung
+
+#### Paket: Lizenzverwaltung naechstes Paket (Kunden-UI als vorbereitete Maske)
+- Status: erledigt
+- Beschreibung:
+  - neue Moduldatei `src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js` angelegt
+  - Kundenmaske mit Ueberschrift `Kunden`, Hinweis `vorbereitet, noch ohne Speicherung` und allen vorbereiteten Kundenfeldern aus `CUSTOMER_RECORD_FIELDS` umgesetzt
+  - Buttons `Neu / leeren` und `Pruefen` ergaenzt; Pruefen validiert lokal die Pflichtfelder ohne Speicherung/Persistenz
+  - `LicenseAdminScreen` um den Einstieg fuer die Kundenmaske erweitert
+  - `SettingsView` bleibt Host/Einstieg und oeffnet die Kundenmaske im Adminbereich
+  - Testvertrag fuer Modul-Export, Feldnutzung, Buttons, Kunden-Einstieg und Nicht-Projektmodul-Verhalten erweitert
+- Betroffene Dateien:
+  - `src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js`
+  - `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`
+  - `src/renderer/modules/lizenzverwaltung/screens/index.js`
+  - `src/renderer/modules/lizenzverwaltung/index.js`
+  - `src/renderer/views/SettingsView.js`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine Datenbank/Persistenz/Kundenliste/Historie implementiert
+  - Keine Lizenzdatei- oder Produktumfang-Logik geaendert
   - Keine Projektmodul-/Sidebar-/Whisper-Aenderung
 
 ## Offene Meilensteine

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -14,6 +14,7 @@ async function runLizenzverwaltungModuleTests(run) {
       LIZENZVERWALTUNG_MODULE_ID,
       LIZENZVERWALTUNG_WORK_SCREEN_ID,
       LicenseAdminScreen,
+      createCustomerEditorSection,
       createLicenseEditorSection,
       CUSTOMER_RECORD_FIELDS,
       LICENSE_RECORD_FIELDS,
@@ -41,6 +42,7 @@ async function runLizenzverwaltungModuleTests(run) {
   const productScopeSource = read("src/renderer/modules/lizenzverwaltung/productScope.js");
   const licenseRecordsSource = read("src/renderer/modules/lizenzverwaltung/licenseRecords.js");
   const licenseEditorSource = read("src/renderer/modules/lizenzverwaltung/screens/createLicenseEditorSection.js");
+  const customerEditorSource = read("src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js");
   const moduleCatalogSource = read("src/renderer/app/modules/moduleCatalog.js");
   const projectWorkspaceSource = read("src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js");
   const settingsViewSource = read("src/renderer/views/SettingsView.js");
@@ -51,6 +53,7 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(LIZENZVERWALTUNG_MODULE_ID, "lizenzverwaltung");
     assert.equal(LIZENZVERWALTUNG_WORK_SCREEN_ID, "licenseAdmin");
     assert.equal(typeof LicenseAdminScreen, "function");
+    assert.equal(typeof createCustomerEditorSection, "function");
     assert.equal(typeof createLicenseEditorSection, "function");
     assert.equal(entry.moduleId, "lizenzverwaltung");
     assert.equal(entry.workScreenId, "licenseAdmin");
@@ -143,6 +146,7 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Umsetzung erfolgt schrittweise"), true);
     assert.equal(screenSource.includes("Lizenz erstellen / bearbeiten"), true);
     assert.equal(screenSource.includes("Kunden"), true);
+    assert.equal(screenSource.includes('actionLabel: "Oeffnen"'), true);
     assert.equal(screenSource.includes("Lizenzen"), true);
     assert.equal(screenSource.includes("Vorbereitete Felder:"), true);
     assert.equal(screenSource.includes("CUSTOMER_RECORD_FIELDS"), true);
@@ -151,6 +155,28 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Historie"), true);
   });
 
+
+  await run("Kunden-UI: nutzt CUSTOMER_RECORD_FIELDS und enthaelt alle Kundenfelder", () => {
+    assert.equal(customerEditorSource.includes('from "../licenseRecords.js"'), true);
+    assert.equal(customerEditorSource.includes("CUSTOMER_RECORD_FIELDS"), true);
+    assert.equal(customerEditorSource.includes("createDefaultCustomerRecord"), true);
+    assert.equal(customerEditorSource.includes("normalizeCustomerRecord"), true);
+    assert.deepEqual(CUSTOMER_RECORD_FIELDS.map((entry) => entry.label), [
+      "Kundennummer",
+      "Firma / Kundenname",
+      "Ansprechpartner",
+      "E-Mail",
+      "Telefon",
+      "Notizen",
+    ]);
+  });
+
+  await run("Kunden-UI: bietet Neu / leeren und Pruefen", () => {
+    assert.equal(customerEditorSource.includes("Neu / leeren"), true);
+    assert.equal(customerEditorSource.includes("Pruefen"), true);
+    assert.equal(customerEditorSource.includes("ohne Speicherung"), true);
+    assert.equal(customerEditorSource.includes("Keine Speicherung"), true);
+  });
   await run("Lizenzverwaltung: bleibt Adminbereich und erscheint nicht als Projektmodul", () => {
     const projektEntry = getProjektverwaltungModuleEntry();
 
@@ -185,6 +211,7 @@ async function runLizenzverwaltungModuleTests(run) {
   await run("LicenseAdminScreen enthaelt Einstieg Lizenz erstellen / bearbeiten", () => {
     assert.equal(settingsViewSource.includes("new LicenseAdminScreen({"), true);
     assert.equal(settingsViewSource.includes("onOpenLicenseEditor: openLicenseEditorPopup"), true);
+    assert.equal(settingsViewSource.includes("onOpenCustomerEditor: openCustomerEditorPopup"), true);
     assert.equal(settingsViewSource.includes("title: \"Lizenz erstellen / bearbeiten\""), true);
   });
 

--- a/src/renderer/modules/lizenzverwaltung/index.js
+++ b/src/renderer/modules/lizenzverwaltung/index.js
@@ -1,4 +1,9 @@
-import { LicenseAdminScreen, createLicenseEditorSection, LIZENZVERWALTUNG_WORK_SCREEN_ID } from "./screens/index.js";
+import {
+  LicenseAdminScreen,
+  createCustomerEditorSection,
+  createLicenseEditorSection,
+  LIZENZVERWALTUNG_WORK_SCREEN_ID,
+} from "./screens/index.js";
 
 export const LIZENZVERWALTUNG_MODULE_ID = "lizenzverwaltung";
 export const LIZENZVERWALTUNG_MODULE_LABEL = "Lizenzverwaltung";
@@ -18,7 +23,12 @@ export function getLizenzverwaltungModuleEntry() {
   });
 }
 
-export { LicenseAdminScreen, createLicenseEditorSection, LIZENZVERWALTUNG_WORK_SCREEN_ID };
+export {
+  LicenseAdminScreen,
+  createCustomerEditorSection,
+  createLicenseEditorSection,
+  LIZENZVERWALTUNG_WORK_SCREEN_ID,
+};
 export * from "./screens/index.js";
 export * from "./productScope.js";
 export * from "./licenseRecords.js";

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -42,8 +42,9 @@ function buildPreparedFieldHint(fields) {
 }
 
 export default class LicenseAdminScreen {
-  constructor({ onOpenLicenseEditor } = {}) {
+  constructor({ onOpenLicenseEditor, onOpenCustomerEditor } = {}) {
     this.onOpenLicenseEditor = onOpenLicenseEditor;
+    this.onOpenCustomerEditor = onOpenCustomerEditor;
   }
 
   render() {
@@ -79,6 +80,8 @@ export default class LicenseAdminScreen {
       buildSectionCard({
         title: "Kunden",
         hint: buildPreparedFieldHint(CUSTOMER_RECORD_FIELDS),
+        actionLabel: "Oeffnen",
+        onClick: this.onOpenCustomerEditor,
       }),
       buildSectionCard({
         title: "Lizenzen",

--- a/src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js
@@ -1,0 +1,140 @@
+import {
+  CUSTOMER_RECORD_FIELDS,
+  createDefaultCustomerRecord,
+  normalizeCustomerRecord,
+} from "../licenseRecords.js";
+
+export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
+  const model = createDefaultCustomerRecord();
+  const fieldInputs = new Map();
+
+  const card = document.createElement("div");
+  if (typeof applyPopupCardStyle === "function") {
+    applyPopupCardStyle(card);
+  }
+  card.style.display = "grid";
+  card.style.gap = "10px";
+
+  const title = document.createElement("h3");
+  title.textContent = "Kunden";
+  title.style.margin = "0";
+
+  const hint = document.createElement("p");
+  hint.textContent = "vorbereitet, noch ohne Speicherung";
+  hint.style.margin = "0";
+  hint.style.fontSize = "12px";
+  hint.style.opacity = "0.8";
+
+  const form = document.createElement("div");
+  form.style.display = "grid";
+  form.style.gap = "8px";
+
+  const message = document.createElement("div");
+  message.style.fontSize = "12px";
+  message.style.padding = "8px";
+  message.style.borderRadius = "8px";
+  message.style.background = "#f8fafc";
+  message.style.border = "1px solid rgba(0,0,0,0.08)";
+  message.textContent = "Noch keine Pruefung ausgefuehrt.";
+
+  const updateModelFromInputs = () => {
+    for (const field of CUSTOMER_RECORD_FIELDS) {
+      const input = fieldInputs.get(field.key);
+      if (!input) continue;
+      model[field.key] = String(input.value || "");
+    }
+  };
+
+  const applyModelToInputs = () => {
+    for (const field of CUSTOMER_RECORD_FIELDS) {
+      const input = fieldInputs.get(field.key);
+      if (!input) continue;
+      input.value = model[field.key] || "";
+      input.style.borderColor = "";
+    }
+  };
+
+  const runValidation = () => {
+    updateModelFromInputs();
+    const normalized = normalizeCustomerRecord(model);
+    const missingRequired = CUSTOMER_RECORD_FIELDS.filter(
+      (field) => field.required && !String(normalized[field.key] || "").trim()
+    );
+
+    for (const field of CUSTOMER_RECORD_FIELDS) {
+      const input = fieldInputs.get(field.key);
+      if (!input) continue;
+      const isMissing = missingRequired.some((entry) => entry.key === field.key);
+      input.style.borderColor = isMissing ? "#dc2626" : "";
+    }
+
+    if (missingRequired.length > 0) {
+      message.textContent = `Pruefung fehlgeschlagen: Pflichtfelder fehlen (${missingRequired
+        .map((field) => field.label)
+        .join(", ")}).`;
+      message.style.background = "#fef2f2";
+      message.style.borderColor = "rgba(220, 38, 38, 0.35)";
+      return false;
+    }
+
+    message.textContent = "Pruefung erfolgreich: Pflichtfelder sind befuellt. Keine Speicherung erfolgt.";
+    message.style.background = "#f0fdf4";
+    message.style.borderColor = "rgba(34, 197, 94, 0.35)";
+    return true;
+  };
+
+  CUSTOMER_RECORD_FIELDS.forEach((field) => {
+    const row = document.createElement("label");
+    row.style.display = "grid";
+    row.style.gap = "4px";
+
+    const label = document.createElement("span");
+    label.textContent = field.required ? `${field.label} *` : field.label;
+    label.style.fontSize = "12px";
+    label.style.fontWeight = "600";
+
+    const input = field.key === "notes" ? document.createElement("textarea") : document.createElement("input");
+    if (field.key !== "notes") {
+      input.type = field.key === "email" ? "email" : "text";
+    }
+    if (field.key === "notes") {
+      input.rows = 4;
+    }
+    input.style.width = "100%";
+    input.style.boxSizing = "border-box";
+
+    row.append(label, input);
+    form.appendChild(row);
+    fieldInputs.set(field.key, input);
+  });
+
+  const buttons = document.createElement("div");
+  buttons.style.display = "flex";
+  buttons.style.gap = "8px";
+
+  const btnReset = document.createElement("button");
+  btnReset.type = "button";
+  btnReset.textContent = "Neu / leeren";
+  if (typeof applyPopupButtonStyle === "function") applyPopupButtonStyle(btnReset);
+  btnReset.onclick = () => {
+    Object.assign(model, createDefaultCustomerRecord());
+    applyModelToInputs();
+    message.textContent = "Formular geleert. Noch ohne Speicherung.";
+    message.style.background = "#f8fafc";
+    message.style.borderColor = "rgba(0,0,0,0.08)";
+  };
+
+  const btnValidate = document.createElement("button");
+  btnValidate.type = "button";
+  btnValidate.textContent = "Pruefen";
+  if (typeof applyPopupButtonStyle === "function") applyPopupButtonStyle(btnValidate);
+  btnValidate.onclick = () => {
+    runValidation();
+  };
+
+  buttons.append(btnReset, btnValidate);
+
+  applyModelToInputs();
+  card.append(title, hint, form, buttons, message);
+  return card;
+}

--- a/src/renderer/modules/lizenzverwaltung/screens/index.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/index.js
@@ -2,3 +2,4 @@ export { default as LicenseAdminScreen } from "./LicenseAdminScreen.js";
 export { createLicenseEditorSection } from "./createLicenseEditorSection.js";
 
 export const LIZENZVERWALTUNG_WORK_SCREEN_ID = "licenseAdmin";
+export { createCustomerEditorSection } from "./createCustomerEditorSection.js";

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -13,7 +13,11 @@ import {
   parseCssColor,
 } from "../theme/themes.js";
 import { createDictationDevSection } from "../modules/audio/index.js";
-import { LicenseAdminScreen, createLicenseEditorSection } from "../modules/lizenzverwaltung/index.js";
+import {
+  LicenseAdminScreen,
+  createCustomerEditorSection,
+  createLicenseEditorSection,
+} from "../modules/lizenzverwaltung/index.js";
 
 const DEFAULT_V2_PRE_REMARKS_TEXT =
   "folgende Punkte gelten als fest vereinbart, Diesen Text anpassen unter Einstellungen - Druckeinstellungen - Vorbemergung";
@@ -4025,9 +4029,23 @@ export default class SettingsView {
       });
     };
 
+
+    const openCustomerEditorPopup = () => {
+      const customerEditor = createCustomerEditorSection({
+        applyPopupCardStyle,
+        applyPopupButtonStyle,
+      });
+      openSettingsModal({
+        title: "Kunden",
+        content: [customerEditor],
+        closeOnly: true,
+      });
+    };
+
     const openLicenseAdminPopup = () => {
       const licenseAdminScreen = new LicenseAdminScreen({
         onOpenLicenseEditor: openLicenseEditorPopup,
+        onOpenCustomerEditor: openCustomerEditorPopup,
       });
       openSettingsModal({
         title: "Lizenzverwaltung",


### PR DESCRIPTION
### Motivation
- Vorbereitung des nächsten Lizenzverwaltungs-Pakets durch Bereitstellung einer einfachen, nicht-persistenten Kundenmaske im Adminbereich.
- Ziel ist eine kleine, reviewbare Ergänzung im Modul `lizenzverwaltung`, ohne Datenbank-, Sidebar- oder Projektmodul-Änderungen.

### Description
- Neue UI-Funktion `createCustomerEditorSection` unter `src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js` implementiert, die Felder aus `CUSTOMER_RECORD_FIELDS` anzeigt und lokale Validierung bietet.
- `LicenseAdminScreen` erweitert, so dass die Kachel „Kunden“ jetzt einen `Oeffnen`-Button hat und per Callback die Kundenmaske öffnet (`src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`).
- Modul-Exports ergänzt (`screens/index.js`, `index.js`) und `SettingsView` so angepasst, dass der Adminbereich die Kundenmaske per Popup öffnet (`src/renderer/views/SettingsView.js`).
- Tests ergänzt/angepasst in `scripts/tests/lizenzverwaltungModule.test.cjs` und Statusdokumentation in `STATUS.md` aktualisiert.

### Testing
- `npm test` ausgeführt; alle automatisierten Tests liefen erfolgreich und die Test-Suite meldet "Alle Tests bestanden.".
- Spezifische Ergänzungen wurden durch die erweiterten Modul-Tests in `scripts/tests/lizenzverwaltungModule.test.cjs` abgedeckt und bestanden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd3a041648322938720dee5bb3ed3)