### PR TITLE
Lizenzverwaltung: vorbereitete Lizenzen‑Maske im Adminbereich hinzufügen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -62,6 +62,11 @@ Sie ergänzt:
   - Kundenmaske nutzt `CUSTOMER_RECORD_FIELDS` und bietet die Felder Kundennummer, Firma/Kundenname, Ansprechpartner, E-Mail, Telefon, Notizen
   - Kundenmaske bietet `Neu / leeren` und `Pruefen`; Pruefen validiert nur lokal Pflichtfelder ohne Speicherung, Datenbank oder Persistenz
   - `SettingsView` bleibt Host/Einstieg und oeffnet die Kundenmaske nur ueber den Adminbereich
+- Lizenzverwaltung naechstes Paket ist umgesetzt:
+  - Kachel `Lizenzen` im `LicenseAdminScreen` oeffnet jetzt eine einfache vorbereitete Lizenzen-Maske
+  - Lizenzen-Maske nutzt `LICENSE_RECORD_FIELDS` und `LICENSE_MODES` und bietet die Felder Lizenz-ID, Kunde, Produktumfang, gueltig von, gueltig bis, Lizenzmodus, Machine-ID, Notizen
+  - Lizenzen-Maske bietet `Neu / leeren` und `Pruefen`; Pruefen validiert nur lokal Pflichtfelder ohne Speicherung, Datenbank oder Persistenz
+  - `SettingsView` bleibt Host/Einstieg und oeffnet die Lizenzen-Maske nur ueber den Adminbereich
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.
@@ -348,6 +353,32 @@ Sie ergänzt:
   - Keine Datenbank/Persistenz/Kundenliste/Historie implementiert
   - Keine Lizenzdatei- oder Produktumfang-Logik geaendert
   - Keine Projektmodul-/Sidebar-/Whisper-Aenderung
+
+
+#### Paket: Lizenzverwaltung naechstes Paket (Lizenzen-UI als vorbereitete Maske)
+- Status: erledigt
+- Beschreibung:
+  - neue Moduldatei `src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js` angelegt
+  - Lizenzen-Maske mit Ueberschrift `Lizenzen`, Hinweis `vorbereitet, noch ohne Speicherung` und allen vorbereiteten Lizenzfeldern aus `LICENSE_RECORD_FIELDS` umgesetzt
+  - Lizenzmodus wird ueber `LICENSE_MODES` gerendert
+  - Buttons `Neu / leeren` und `Pruefen` ergaenzt; Pruefen validiert lokal Pflichtfelder ohne Speicherung/Persistenz
+  - `LicenseAdminScreen` um den Einstieg fuer die Lizenzen-Maske erweitert
+  - `SettingsView` bleibt Host/Einstieg und oeffnet die Lizenzen-Maske im Adminbereich
+  - Testvertrag fuer Modul-Export, Feldnutzung, LICENSE_MODES, Buttons und Lizenzen-Einstieg erweitert
+- Betroffene Dateien:
+  - `src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js`
+  - `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`
+  - `src/renderer/modules/lizenzverwaltung/screens/index.js`
+  - `src/renderer/modules/lizenzverwaltung/index.js`
+  - `src/renderer/modules/lizenzverwaltung/README.md`
+  - `src/renderer/views/SettingsView.js`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine Datenbank/Persistenz/Lizenzenliste/Historie implementiert
+  - Keine Lizenzdatei-/Produktumfang-/Projektmodul-/Sidebar-/Whisper-Aenderung
 
 ## Offene Meilensteine
 1. Weitere kleine Altpfade im Modul `Protokoll` abbauen

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -16,6 +16,7 @@ async function runLizenzverwaltungModuleTests(run) {
       LicenseAdminScreen,
       createCustomerEditorSection,
       createLicenseEditorSection,
+      createLicenseRecordEditorSection,
       CUSTOMER_RECORD_FIELDS,
       LICENSE_RECORD_FIELDS,
       LICENSE_MODES,
@@ -43,6 +44,7 @@ async function runLizenzverwaltungModuleTests(run) {
   const licenseRecordsSource = read("src/renderer/modules/lizenzverwaltung/licenseRecords.js");
   const licenseEditorSource = read("src/renderer/modules/lizenzverwaltung/screens/createLicenseEditorSection.js");
   const customerEditorSource = read("src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js");
+  const licenseRecordEditorSource = read("src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js");
   const moduleCatalogSource = read("src/renderer/app/modules/moduleCatalog.js");
   const projectWorkspaceSource = read("src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js");
   const settingsViewSource = read("src/renderer/views/SettingsView.js");
@@ -55,6 +57,7 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(typeof LicenseAdminScreen, "function");
     assert.equal(typeof createCustomerEditorSection, "function");
     assert.equal(typeof createLicenseEditorSection, "function");
+    assert.equal(typeof createLicenseRecordEditorSection, "function");
     assert.equal(entry.moduleId, "lizenzverwaltung");
     assert.equal(entry.workScreenId, "licenseAdmin");
     assert.equal(entry.screens?.licenseAdmin, LicenseAdminScreen);
@@ -148,6 +151,7 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Kunden"), true);
     assert.equal(screenSource.includes('actionLabel: "Oeffnen"'), true);
     assert.equal(screenSource.includes("Lizenzen"), true);
+    assert.equal(screenSource.includes("onOpenLicenseRecordEditor"), true);
     assert.equal(screenSource.includes("Vorbereitete Felder:"), true);
     assert.equal(screenSource.includes("CUSTOMER_RECORD_FIELDS"), true);
     assert.equal(screenSource.includes("LICENSE_RECORD_FIELDS"), true);
@@ -177,6 +181,33 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(customerEditorSource.includes("ohne Speicherung"), true);
     assert.equal(customerEditorSource.includes("Keine Speicherung"), true);
   });
+
+  await run("Lizenzen-UI: nutzt LICENSE_RECORD_FIELDS und enthaelt alle Lizenzfelder", () => {
+    assert.equal(licenseRecordEditorSource.includes('from "../licenseRecords.js"'), true);
+    assert.equal(licenseRecordEditorSource.includes("LICENSE_RECORD_FIELDS"), true);
+    assert.equal(licenseRecordEditorSource.includes("LICENSE_MODES"), true);
+    assert.equal(licenseRecordEditorSource.includes("createDefaultLicenseRecord"), true);
+    assert.equal(licenseRecordEditorSource.includes("normalizeLicenseRecord"), true);
+    assert.deepEqual(LICENSE_RECORD_FIELDS.map((entry) => entry.label), [
+      "Lizenz-ID",
+      "Kunde",
+      "Produktumfang",
+      "gueltig von",
+      "gueltig bis",
+      "Lizenzmodus",
+      "Machine-ID",
+      "Notizen",
+    ]);
+  });
+
+  await run("Lizenzen-UI: bietet Neu / leeren und Pruefen", () => {
+    assert.equal(licenseRecordEditorSource.includes("Lizenzen"), true);
+    assert.equal(licenseRecordEditorSource.includes("vorbereitet, noch ohne Speicherung"), true);
+    assert.equal(licenseRecordEditorSource.includes("Neu / leeren"), true);
+    assert.equal(licenseRecordEditorSource.includes("Pruefen"), true);
+    assert.equal(licenseRecordEditorSource.includes("Keine Speicherung"), true);
+  });
+
   await run("Lizenzverwaltung: bleibt Adminbereich und erscheint nicht als Projektmodul", () => {
     const projektEntry = getProjektverwaltungModuleEntry();
 

--- a/src/renderer/modules/lizenzverwaltung/README.md
+++ b/src/renderer/modules/lizenzverwaltung/README.md
@@ -12,3 +12,4 @@ Enthaelt:
 - `index.js` als Modul-Einstieg
 
 - `licenseRecords.js` als zentrale Feldlisten/Defaults/Normalisierung fuer Kunden- und Lizenzdatensaetze
+- `screens/createLicenseRecordEditorSection.js` als einfache vorbereitete Lizenzen-Maske ohne Persistenz

--- a/src/renderer/modules/lizenzverwaltung/index.js
+++ b/src/renderer/modules/lizenzverwaltung/index.js
@@ -2,6 +2,7 @@ import {
   LicenseAdminScreen,
   createCustomerEditorSection,
   createLicenseEditorSection,
+  createLicenseRecordEditorSection,
   LIZENZVERWALTUNG_WORK_SCREEN_ID,
 } from "./screens/index.js";
 
@@ -27,6 +28,7 @@ export {
   LicenseAdminScreen,
   createCustomerEditorSection,
   createLicenseEditorSection,
+  createLicenseRecordEditorSection,
   LIZENZVERWALTUNG_WORK_SCREEN_ID,
 };
 export * from "./screens/index.js";

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -42,9 +42,10 @@ function buildPreparedFieldHint(fields) {
 }
 
 export default class LicenseAdminScreen {
-  constructor({ onOpenLicenseEditor, onOpenCustomerEditor } = {}) {
+  constructor({ onOpenLicenseEditor, onOpenCustomerEditor, onOpenLicenseRecordEditor } = {}) {
     this.onOpenLicenseEditor = onOpenLicenseEditor;
     this.onOpenCustomerEditor = onOpenCustomerEditor;
+    this.onOpenLicenseRecordEditor = onOpenLicenseRecordEditor;
   }
 
   render() {
@@ -86,6 +87,8 @@ export default class LicenseAdminScreen {
       buildSectionCard({
         title: "Lizenzen",
         hint: buildPreparedFieldHint(LICENSE_RECORD_FIELDS),
+        actionLabel: "Oeffnen",
+        onClick: this.onOpenLicenseRecordEditor,
       }),
       buildSectionCard({ title: "Produktumfang" }),
       buildSectionCard({ title: "Historie" })

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
@@ -1,0 +1,173 @@
+import {
+  LICENSE_MODES,
+  LICENSE_RECORD_FIELDS,
+  createDefaultLicenseRecord,
+  normalizeLicenseRecord,
+} from "../licenseRecords.js";
+
+export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
+  const model = createDefaultLicenseRecord();
+  const fieldInputs = new Map();
+
+  const card = document.createElement("div");
+  if (typeof applyPopupCardStyle === "function") {
+    applyPopupCardStyle(card);
+  }
+  card.style.display = "grid";
+  card.style.gap = "10px";
+
+  const title = document.createElement("h3");
+  title.textContent = "Lizenzen";
+  title.style.margin = "0";
+
+  const hint = document.createElement("p");
+  hint.textContent = "vorbereitet, noch ohne Speicherung";
+  hint.style.margin = "0";
+  hint.style.fontSize = "12px";
+  hint.style.opacity = "0.8";
+
+  const form = document.createElement("div");
+  form.style.display = "grid";
+  form.style.gap = "8px";
+
+  const message = document.createElement("div");
+  message.style.fontSize = "12px";
+  message.style.padding = "8px";
+  message.style.borderRadius = "8px";
+  message.style.background = "#f8fafc";
+  message.style.border = "1px solid rgba(0,0,0,0.08)";
+  message.textContent = "Noch keine Pruefung ausgefuehrt.";
+
+  const updateModelFromInputs = () => {
+    for (const field of LICENSE_RECORD_FIELDS) {
+      const input = fieldInputs.get(field.key);
+      if (!input) continue;
+
+      if (field.key === "productScope") {
+        model.productScope = {
+          standardumfang: [],
+          zusatzfunktionen: [],
+          module: [],
+          _display: String(input.value || ""),
+        };
+        continue;
+      }
+
+      model[field.key] = String(input.value || "");
+    }
+  };
+
+  const applyModelToInputs = () => {
+    for (const field of LICENSE_RECORD_FIELDS) {
+      const input = fieldInputs.get(field.key);
+      if (!input) continue;
+
+      if (field.key === "productScope") {
+        input.value = String(model.productScope?._display || "");
+      } else {
+        input.value = model[field.key] || "";
+      }
+      input.style.borderColor = "";
+    }
+  };
+
+  const runValidation = () => {
+    updateModelFromInputs();
+    const normalized = normalizeLicenseRecord(model);
+
+    const missingRequired = LICENSE_RECORD_FIELDS.filter((field) => {
+      if (!field.required) return false;
+      if (field.key === "productScope") {
+        return !String(model.productScope?._display || "").trim();
+      }
+      return !String(normalized[field.key] || "").trim();
+    });
+
+    for (const field of LICENSE_RECORD_FIELDS) {
+      const input = fieldInputs.get(field.key);
+      if (!input) continue;
+      const isMissing = missingRequired.some((entry) => entry.key === field.key);
+      input.style.borderColor = isMissing ? "#dc2626" : "";
+    }
+
+    if (missingRequired.length > 0) {
+      message.textContent = `Pruefung fehlgeschlagen: Pflichtfelder fehlen (${missingRequired
+        .map((field) => field.label)
+        .join(", ")}).`;
+      message.style.background = "#fef2f2";
+      message.style.borderColor = "rgba(220, 38, 38, 0.35)";
+      return false;
+    }
+
+    message.textContent = "Pruefung erfolgreich: Pflichtfelder sind befuellt. Keine Speicherung erfolgt.";
+    message.style.background = "#f0fdf4";
+    message.style.borderColor = "rgba(34, 197, 94, 0.35)";
+    return true;
+  };
+
+  LICENSE_RECORD_FIELDS.forEach((field) => {
+    const row = document.createElement("label");
+    row.style.display = "grid";
+    row.style.gap = "4px";
+
+    const label = document.createElement("span");
+    label.textContent = field.required ? `${field.label} *` : field.label;
+    label.style.fontSize = "12px";
+    label.style.fontWeight = "600";
+
+    let input;
+    if (field.key === "notes") {
+      input = document.createElement("textarea");
+      input.rows = 4;
+    } else if (field.key === "licenseMode") {
+      input = document.createElement("select");
+      LICENSE_MODES.forEach((mode) => {
+        const option = document.createElement("option");
+        option.value = mode.key;
+        option.textContent = mode.label;
+        input.appendChild(option);
+      });
+    } else {
+      input = document.createElement("input");
+      input.type = field.key === "validFrom" || field.key === "validUntil" ? "date" : "text";
+    }
+
+    input.style.width = "100%";
+    input.style.boxSizing = "border-box";
+
+    row.append(label, input);
+    form.appendChild(row);
+    fieldInputs.set(field.key, input);
+  });
+
+  const buttons = document.createElement("div");
+  buttons.style.display = "flex";
+  buttons.style.gap = "8px";
+
+  const btnReset = document.createElement("button");
+  btnReset.type = "button";
+  btnReset.textContent = "Neu / leeren";
+  if (typeof applyPopupButtonStyle === "function") applyPopupButtonStyle(btnReset);
+  btnReset.onclick = () => {
+    Object.assign(model, createDefaultLicenseRecord());
+    model.productScope._display = "";
+    applyModelToInputs();
+    message.textContent = "Formular geleert. Noch ohne Speicherung.";
+    message.style.background = "#f8fafc";
+    message.style.borderColor = "rgba(0,0,0,0.08)";
+  };
+
+  const btnValidate = document.createElement("button");
+  btnValidate.type = "button";
+  btnValidate.textContent = "Pruefen";
+  if (typeof applyPopupButtonStyle === "function") applyPopupButtonStyle(btnValidate);
+  btnValidate.onclick = () => {
+    runValidation();
+  };
+
+  buttons.append(btnReset, btnValidate);
+
+  applyModelToInputs();
+  card.append(title, hint, form, buttons, message);
+  return card;
+}

--- a/src/renderer/modules/lizenzverwaltung/screens/index.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/index.js
@@ -3,3 +3,4 @@ export { createLicenseEditorSection } from "./createLicenseEditorSection.js";
 
 export const LIZENZVERWALTUNG_WORK_SCREEN_ID = "licenseAdmin";
 export { createCustomerEditorSection } from "./createCustomerEditorSection.js";
+export { createLicenseRecordEditorSection } from "./createLicenseRecordEditorSection.js";

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -17,6 +17,7 @@ import {
   LicenseAdminScreen,
   createCustomerEditorSection,
   createLicenseEditorSection,
+  createLicenseRecordEditorSection,
 } from "../modules/lizenzverwaltung/index.js";
 
 const DEFAULT_V2_PRE_REMARKS_TEXT =
@@ -4042,10 +4043,24 @@ export default class SettingsView {
       });
     };
 
+
+    const openLicenseRecordEditorPopup = () => {
+      const licenseRecordEditor = createLicenseRecordEditorSection({
+        applyPopupCardStyle,
+        applyPopupButtonStyle,
+      });
+      openSettingsModal({
+        title: "Lizenzen",
+        content: [licenseRecordEditor],
+        closeOnly: true,
+      });
+    };
+
     const openLicenseAdminPopup = () => {
       const licenseAdminScreen = new LicenseAdminScreen({
         onOpenLicenseEditor: openLicenseEditorPopup,
         onOpenCustomerEditor: openCustomerEditorPopup,
+        onOpenLicenseRecordEditor: openLicenseRecordEditorPopup,
       });
       openSettingsModal({
         title: "Lizenzverwaltung",


### PR DESCRIPTION
### Motivation
- Vorbereitung des nächsten Lizenzverwaltungs‑Pakets: die Admin‑Kachel „Lizenzen“ soll eine einfache, vorbereitete Lizenzmaske öffnen, damit die UI‑Basis vorhanden ist ohne Persistenz oder Datenbanklogik.
- Wiederverwendung vorhandener Felddefinitionen und Modi aus `licenseRecords.js`, um Konsistenz zu wahren und keine fachliche Logik zu ändern.

### Description
- Neue UI‑Komponente `createLicenseRecordEditorSection.js` unter `src/renderer/modules/lizenzverwaltung/screens/` angelegt, die die Überschrift, Hinweis, alle Felder aus `LICENSE_RECORD_FIELDS`, die Auswahl für `LICENSE_MODES` sowie die Buttons `Neu / leeren` und `Pruefen` bereitstellt.
- `LicenseAdminScreen` erweitert, sodass die Kachel „Lizenzen“ eine `Oeffnen`‑Schaltfläche hat und den neuen Editor über einen `onOpenLicenseRecordEditor`‑Callback öffnet.
- Modul‑Exports und Screen‑Index angepasst (`screens/index.js`, `index.js`) und `SettingsView` so verdrahtet, dass das Admin‑Popup die neue Maske öffnet (Host/Einstieg bleibt unverändert).
- Tests ergänzt/angepasst (`scripts/tests/lizenzverwaltungModule.test.cjs`) sowie Doku/Status aktualisiert (`README.md`, `STATUS.md`) um das abgeschlossene Mini‑Paket zu dokumentieren.

### Testing
- Automatischer Testlauf ausgeführt mit `npm test`, alle Tests sind grün.
- Erweiterte Tests prüfen, dass das Modul die neue Lizenzen‑UI exportiert, die UI `LICENSE_RECORD_FIELDS` und `LICENSE_MODES` nutzt, alle Lizenzfelder enthält und die Buttons `Neu / leeren` und `Pruefen` vorhanden sind, und dass der Einstieg im `LicenseAdminScreen` vorhanden ist; diese Tests bestehen.
- `git status` wurde geprüft und die Arbeitsbranch‑Änderungen sind committed; der PR wurde über das Projekt‑Tool angestoßen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edd69d5d7c8322a108fbf02ea5d4c2)