### PR TITLE
Lizenzverwaltung: Produktumfang‑Maske im Adminbereich vorbereiten

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -67,6 +67,12 @@ Sie ergänzt:
   - Lizenzen-Maske nutzt `LICENSE_RECORD_FIELDS` und `LICENSE_MODES` und bietet die Felder Lizenz-ID, Kunde, Produktumfang, gueltig von, gueltig bis, Lizenzmodus, Machine-ID, Notizen
   - Lizenzen-Maske bietet `Neu / leeren` und `Pruefen`; Pruefen validiert nur lokal Pflichtfelder ohne Speicherung, Datenbank oder Persistenz
   - `SettingsView` bleibt Host/Einstieg und oeffnet die Lizenzen-Maske nur ueber den Adminbereich
+- Lizenzverwaltung naechstes Paket ist umgesetzt:
+  - Kachel `Produktumfang` im `LicenseAdminScreen` oeffnet jetzt eine einfache vorbereitete Produktumfang-Maske
+  - Produktumfang-Maske nutzt `PRODUCT_SCOPE` und zeigt `Standardumfang` (app, pdf, export), `Zusatzfunktionen` (mail, Dictate) und `Module` (Protokoll, Dummy)
+  - `Standardumfang` bleibt sichtbar und nicht abwaehlbar; `Zusatzfunktionen` sind auswählbar; `Module` bleiben vorbereitet und noch nicht aktiv angebunden
+  - Produktumfang-Maske bietet `Neu / leeren` und `Pruefen`; Pruefen validiert nur lokal auf app/pdf/export ohne Speicherung, Datenbank oder Persistenz
+  - `SettingsView` bleibt Host/Einstieg und oeffnet die Produktumfang-Maske nur ueber den Adminbereich
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -16,6 +16,7 @@ async function runLizenzverwaltungModuleTests(run) {
       LicenseAdminScreen,
       createCustomerEditorSection,
       createLicenseEditorSection,
+      createProductScopeEditorSection,
       createLicenseRecordEditorSection,
       CUSTOMER_RECORD_FIELDS,
       LICENSE_RECORD_FIELDS,
@@ -45,6 +46,9 @@ async function runLizenzverwaltungModuleTests(run) {
   const licenseEditorSource = read("src/renderer/modules/lizenzverwaltung/screens/createLicenseEditorSection.js");
   const customerEditorSource = read("src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js");
   const licenseRecordEditorSource = read("src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js");
+  const productScopeEditorSource = read(
+    "src/renderer/modules/lizenzverwaltung/screens/createProductScopeEditorSection.js"
+  );
   const moduleCatalogSource = read("src/renderer/app/modules/moduleCatalog.js");
   const projectWorkspaceSource = read("src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js");
   const settingsViewSource = read("src/renderer/views/SettingsView.js");
@@ -57,6 +61,7 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(typeof LicenseAdminScreen, "function");
     assert.equal(typeof createCustomerEditorSection, "function");
     assert.equal(typeof createLicenseEditorSection, "function");
+    assert.equal(typeof createProductScopeEditorSection, "function");
     assert.equal(typeof createLicenseRecordEditorSection, "function");
     assert.equal(entry.moduleId, "lizenzverwaltung");
     assert.equal(entry.workScreenId, "licenseAdmin");
@@ -208,6 +213,34 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordEditorSource.includes("Keine Speicherung"), true);
   });
 
+  await run("Produktumfang-UI: nutzt PRODUCT_SCOPE und enthaelt Gruppen", () => {
+    assert.equal(productScopeEditorSource.includes('from "../productScope.js"'), true);
+    assert.equal(productScopeEditorSource.includes("PRODUCT_SCOPE.standardumfang"), true);
+    assert.equal(productScopeEditorSource.includes("PRODUCT_SCOPE.zusatzfunktionen"), true);
+    assert.equal(productScopeEditorSource.includes("PRODUCT_SCOPE.module"), true);
+    assert.equal(PRODUCT_SCOPE.standardumfang.title, "Standardumfang");
+    assert.equal(PRODUCT_SCOPE.zusatzfunktionen.title, "Zusatzfunktionen");
+    assert.equal(PRODUCT_SCOPE.module.title, "Module");
+  });
+
+  await run("Produktumfang-UI: enthaelt app, pdf, export, mail, Dictate, Protokoll, Dummy", () => {
+    const standardLabels = PRODUCT_SCOPE.standardumfang.entries.map((entry) => entry.label);
+    const optionalLabels = PRODUCT_SCOPE.zusatzfunktionen.entries.map((entry) => entry.label);
+    const moduleLabels = PRODUCT_SCOPE.module.entries.map((entry) => entry.label);
+    assert.deepEqual(standardLabels, ["app", "pdf", "export"]);
+    assert.deepEqual(optionalLabels, ["mail", "Dictate"]);
+    assert.deepEqual(moduleLabels, ["Protokoll", "Dummy"]);
+  });
+
+  await run("Produktumfang-UI: bietet Neu / leeren und Pruefen mit lokaler Standardumfang-Pruefung", () => {
+    assert.equal(productScopeEditorSource.includes("Produktumfang"), true);
+    assert.equal(productScopeEditorSource.includes("vorbereitet, noch ohne Speicherung"), true);
+    assert.equal(productScopeEditorSource.includes("Neu / leeren"), true);
+    assert.equal(productScopeEditorSource.includes("Pruefen"), true);
+    assert.equal(productScopeEditorSource.includes("Standardumfang muss app, pdf und export enthalten"), true);
+    assert.equal(productScopeEditorSource.includes("Keine Speicherung"), true);
+  });
+
   await run("Lizenzverwaltung: bleibt Adminbereich und erscheint nicht als Projektmodul", () => {
     const projektEntry = getProjektverwaltungModuleEntry();
 
@@ -244,6 +277,16 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(settingsViewSource.includes("onOpenLicenseEditor: openLicenseEditorPopup"), true);
     assert.equal(settingsViewSource.includes("onOpenCustomerEditor: openCustomerEditorPopup"), true);
     assert.equal(settingsViewSource.includes("title: \"Lizenz erstellen / bearbeiten\""), true);
+  });
+
+  await run("LicenseAdminScreen enthaelt Einstieg fuer Produktumfang", () => {
+    assert.equal(screenSource.includes("onOpenProductScopeEditor"), true);
+    assert.equal(screenSource.includes("title: \"Produktumfang\""), true);
+    assert.equal(screenSource.includes("hint: \"vorbereitet, noch ohne Speicherung\""), true);
+    assert.equal(screenSource.includes("actionLabel: \"Oeffnen\""), true);
+    assert.equal(settingsViewSource.includes("createProductScopeEditorSection"), true);
+    assert.equal(settingsViewSource.includes("const openProductScopeEditorPopup = () =>"), true);
+    assert.equal(settingsViewSource.includes("onOpenProductScopeEditor: openProductScopeEditorPopup"), true);
   });
 
   await run("Lizenz / bearbeiten: enthaelt Produktumfang statt flacher Feature-Zeile", () => {

--- a/src/renderer/modules/lizenzverwaltung/index.js
+++ b/src/renderer/modules/lizenzverwaltung/index.js
@@ -2,6 +2,7 @@ import {
   LicenseAdminScreen,
   createCustomerEditorSection,
   createLicenseEditorSection,
+  createProductScopeEditorSection,
   createLicenseRecordEditorSection,
   LIZENZVERWALTUNG_WORK_SCREEN_ID,
 } from "./screens/index.js";
@@ -28,6 +29,7 @@ export {
   LicenseAdminScreen,
   createCustomerEditorSection,
   createLicenseEditorSection,
+  createProductScopeEditorSection,
   createLicenseRecordEditorSection,
   LIZENZVERWALTUNG_WORK_SCREEN_ID,
 };

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -42,10 +42,16 @@ function buildPreparedFieldHint(fields) {
 }
 
 export default class LicenseAdminScreen {
-  constructor({ onOpenLicenseEditor, onOpenCustomerEditor, onOpenLicenseRecordEditor } = {}) {
+  constructor({
+    onOpenLicenseEditor,
+    onOpenCustomerEditor,
+    onOpenLicenseRecordEditor,
+    onOpenProductScopeEditor,
+  } = {}) {
     this.onOpenLicenseEditor = onOpenLicenseEditor;
     this.onOpenCustomerEditor = onOpenCustomerEditor;
     this.onOpenLicenseRecordEditor = onOpenLicenseRecordEditor;
+    this.onOpenProductScopeEditor = onOpenProductScopeEditor;
   }
 
   render() {
@@ -90,7 +96,12 @@ export default class LicenseAdminScreen {
         actionLabel: "Oeffnen",
         onClick: this.onOpenLicenseRecordEditor,
       }),
-      buildSectionCard({ title: "Produktumfang" }),
+      buildSectionCard({
+        title: "Produktumfang",
+        hint: "vorbereitet, noch ohne Speicherung",
+        actionLabel: "Oeffnen",
+        onClick: this.onOpenProductScopeEditor,
+      }),
       buildSectionCard({ title: "Historie" })
     );
 

--- a/src/renderer/modules/lizenzverwaltung/screens/createProductScopeEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createProductScopeEditorSection.js
@@ -1,0 +1,185 @@
+import { PRODUCT_SCOPE } from "../productScope.js";
+
+const REQUIRED_STANDARD_SCOPE_KEYS = Object.freeze(["app", "pdf", "export"]);
+
+export function createProductScopeEditorSection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
+  const model = {
+    standardumfang: [...REQUIRED_STANDARD_SCOPE_KEYS],
+    zusatzfunktionen: PRODUCT_SCOPE.zusatzfunktionen.entries
+      .filter((entry) => entry.defaultEnabled)
+      .map((entry) => entry.key),
+    module: [],
+  };
+
+  const optionalFeatureChecks = new Map();
+  const message = document.createElement("div");
+  message.style.fontSize = "12px";
+  message.style.padding = "8px";
+  message.style.borderRadius = "8px";
+  message.style.background = "#f8fafc";
+  message.style.border = "1px solid rgba(0,0,0,0.08)";
+  message.textContent = "Noch keine Pruefung ausgefuehrt.";
+
+  const card = document.createElement("div");
+  if (typeof applyPopupCardStyle === "function") {
+    applyPopupCardStyle(card);
+  }
+  card.style.display = "grid";
+  card.style.gap = "10px";
+
+  const title = document.createElement("h3");
+  title.textContent = "Produktumfang";
+  title.style.margin = "0";
+
+  const hint = document.createElement("p");
+  hint.textContent = "vorbereitet, noch ohne Speicherung";
+  hint.style.margin = "0";
+  hint.style.fontSize = "12px";
+  hint.style.opacity = "0.8";
+
+  const groupsWrap = document.createElement("div");
+  groupsWrap.style.display = "grid";
+  groupsWrap.style.gap = "12px";
+
+  const renderReadonlyGroup = ({ title: groupTitle, note = "", entries = [] }) => {
+    const section = document.createElement("section");
+    section.style.display = "grid";
+    section.style.gap = "8px";
+
+    const heading = document.createElement("h4");
+    heading.textContent = groupTitle;
+    heading.style.margin = "0";
+
+    section.appendChild(heading);
+
+    if (note) {
+      const noteEl = document.createElement("p");
+      noteEl.textContent = note;
+      noteEl.style.margin = "0";
+      noteEl.style.fontSize = "12px";
+      noteEl.style.opacity = "0.8";
+      section.appendChild(noteEl);
+    }
+
+    entries.forEach((entry) => {
+      const row = document.createElement("label");
+      row.style.display = "flex";
+      row.style.alignItems = "center";
+      row.style.gap = "8px";
+
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.checked = true;
+      checkbox.disabled = true;
+
+      const text = document.createElement("span");
+      text.textContent = entry.label;
+
+      row.append(checkbox, text);
+      section.appendChild(row);
+    });
+
+    return section;
+  };
+
+  const renderSelectableGroup = ({ title: groupTitle, entries = [] }) => {
+    const section = document.createElement("section");
+    section.style.display = "grid";
+    section.style.gap = "8px";
+
+    const heading = document.createElement("h4");
+    heading.textContent = groupTitle;
+    heading.style.margin = "0";
+    section.appendChild(heading);
+
+    entries.forEach((entry) => {
+      const row = document.createElement("label");
+      row.style.display = "flex";
+      row.style.alignItems = "center";
+      row.style.gap = "8px";
+
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.checked = model.zusatzfunktionen.includes(entry.key);
+      checkbox.onchange = () => {
+        if (checkbox.checked) {
+          if (!model.zusatzfunktionen.includes(entry.key)) {
+            model.zusatzfunktionen.push(entry.key);
+          }
+        } else {
+          model.zusatzfunktionen = model.zusatzfunktionen.filter((key) => key !== entry.key);
+        }
+      };
+      optionalFeatureChecks.set(entry.key, checkbox);
+
+      const text = document.createElement("span");
+      text.textContent = entry.label;
+
+      row.append(checkbox, text);
+      section.appendChild(row);
+    });
+
+    return section;
+  };
+
+  groupsWrap.append(
+    renderReadonlyGroup(PRODUCT_SCOPE.standardumfang),
+    renderSelectableGroup(PRODUCT_SCOPE.zusatzfunktionen),
+    renderReadonlyGroup(PRODUCT_SCOPE.module)
+  );
+
+  const runValidation = () => {
+    const hasRequiredStandardumfang = REQUIRED_STANDARD_SCOPE_KEYS.every((key) =>
+      model.standardumfang.includes(key)
+    );
+
+    if (!hasRequiredStandardumfang) {
+      message.textContent =
+        "Pruefung fehlgeschlagen: Standardumfang muss app, pdf und export enthalten.";
+      message.style.background = "#fef2f2";
+      message.style.borderColor = "rgba(220, 38, 38, 0.35)";
+      return false;
+    }
+
+    message.textContent =
+      "Pruefung erfolgreich: Standardumfang enthaelt app, pdf, export. Keine Speicherung erfolgt.";
+    message.style.background = "#f0fdf4";
+    message.style.borderColor = "rgba(34, 197, 94, 0.35)";
+    return true;
+  };
+
+  const buttons = document.createElement("div");
+  buttons.style.display = "flex";
+  buttons.style.gap = "8px";
+
+  const btnReset = document.createElement("button");
+  btnReset.type = "button";
+  btnReset.textContent = "Neu / leeren";
+  if (typeof applyPopupButtonStyle === "function") applyPopupButtonStyle(btnReset);
+  btnReset.onclick = () => {
+    model.standardumfang = [...REQUIRED_STANDARD_SCOPE_KEYS];
+    model.zusatzfunktionen = PRODUCT_SCOPE.zusatzfunktionen.entries
+      .filter((entry) => entry.defaultEnabled)
+      .map((entry) => entry.key);
+
+    optionalFeatureChecks.forEach((checkbox, key) => {
+      checkbox.checked = model.zusatzfunktionen.includes(key);
+    });
+
+    message.textContent = "Formular geleert. Noch ohne Speicherung.";
+    message.style.background = "#f8fafc";
+    message.style.borderColor = "rgba(0,0,0,0.08)";
+  };
+
+  const btnValidate = document.createElement("button");
+  btnValidate.type = "button";
+  btnValidate.textContent = "Pruefen";
+  if (typeof applyPopupButtonStyle === "function") applyPopupButtonStyle(btnValidate);
+  btnValidate.onclick = () => {
+    runValidation();
+  };
+
+  buttons.append(btnReset, btnValidate);
+  card.append(title, hint, groupsWrap, buttons, message);
+  return card;
+}

--- a/src/renderer/modules/lizenzverwaltung/screens/index.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/index.js
@@ -1,5 +1,6 @@
 export { default as LicenseAdminScreen } from "./LicenseAdminScreen.js";
 export { createLicenseEditorSection } from "./createLicenseEditorSection.js";
+export { createProductScopeEditorSection } from "./createProductScopeEditorSection.js";
 
 export const LIZENZVERWALTUNG_WORK_SCREEN_ID = "licenseAdmin";
 export { createCustomerEditorSection } from "./createCustomerEditorSection.js";

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -17,6 +17,7 @@ import {
   LicenseAdminScreen,
   createCustomerEditorSection,
   createLicenseEditorSection,
+  createProductScopeEditorSection,
   createLicenseRecordEditorSection,
 } from "../modules/lizenzverwaltung/index.js";
 
@@ -4056,11 +4057,24 @@ export default class SettingsView {
       });
     };
 
+    const openProductScopeEditorPopup = () => {
+      const productScopeEditor = createProductScopeEditorSection({
+        applyPopupCardStyle,
+        applyPopupButtonStyle,
+      });
+      openSettingsModal({
+        title: "Produktumfang",
+        content: [productScopeEditor],
+        closeOnly: true,
+      });
+    };
+
     const openLicenseAdminPopup = () => {
       const licenseAdminScreen = new LicenseAdminScreen({
         onOpenLicenseEditor: openLicenseEditorPopup,
         onOpenCustomerEditor: openCustomerEditorPopup,
         onOpenLicenseRecordEditor: openLicenseRecordEditorPopup,
+        onOpenProductScopeEditor: openProductScopeEditorPopup,
       });
       openSettingsModal({
         title: "Lizenzverwaltung",


### PR DESCRIPTION
### Motivation
- Vorbereitung des nächsten Lizenzverwaltungs‑Pakets: die bisherige Platzhalter‑Kachel „Produktumfang“ im Adminbereich soll eine einfache, vorbereitete UI öffnen, ohne Persistenz oder Datenbankänderungen.

### Description
- Neue UI‑Sektion `createProductScopeEditorSection` angelegt unter `src/renderer/modules/lizenzverwaltung/screens/createProductScopeEditorSection.js`, die `PRODUCT_SCOPE` nutzt und die Gruppen Standardumfang, Zusatzfunktionen und Module darstellt; Standardumfang ist sichtbar und nicht abwählbar, Zusatzfunktionen sind auswählbar, Module sind vorbereitet und nicht aktiv angebunden.
- `LicenseAdminScreen` erweitert, so dass die Kachel „Produktumfang“ jetzt einen `Oeffnen`‑Einstieg hat und die neue Maske öffnen kann.
- `SettingsView` verdrahtet den Admin‑Popup‑Einstieg zur neuen Produktumfang‑Maske und bleibt weiterhin nur Host/Einstieg (keine fachliche Erweiterung dort).
- Modul‑Exporte aktualisiert (`screens/index.js`, `index.js`) und Tests erweitert/angeglichen; `STATUS.md` entsprechend aktualisiert.
- Geänderte Dateien: `src/renderer/modules/lizenzverwaltung/screens/createProductScopeEditorSection.js`, `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`, `src/renderer/views/SettingsView.js`, `src/renderer/modules/lizenzverwaltung/screens/index.js`, `src/renderer/modules/lizenzverwaltung/index.js`, `scripts/tests/lizenzverwaltungModule.test.cjs`, `STATUS.md`.

### Testing
- `node scripts/test.cjs --match lizenzverwaltungModule` ausgeführt und erfolgreich (alle zugehörigen Tests grün).
- `npm test` ausgeführt und erfolgreich (gesamte Test-Suite grün).
- Base-Branch: `main`.
- Ergebnis-Branch: `work`.
- Pull-Request-Link: nicht verfügbar (in dieser Sitzung kein PR‑Link geliefert).
- `git status`: sauber auf Branch `work` (keine ungestagten Änderungen).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eddbc283208322ba6ab723039e346e)