### PR TITLE
Lizenzverwaltung: Historie-Maske im Adminbereich vorbereiten

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -73,6 +73,11 @@ Sie ergänzt:
   - `Standardumfang` bleibt sichtbar und nicht abwaehlbar; `Zusatzfunktionen` sind auswählbar; `Module` bleiben vorbereitet und noch nicht aktiv angebunden
   - Produktumfang-Maske bietet `Neu / leeren` und `Pruefen`; Pruefen validiert nur lokal auf app/pdf/export ohne Speicherung, Datenbank oder Persistenz
   - `SettingsView` bleibt Host/Einstieg und oeffnet die Produktumfang-Maske nur ueber den Adminbereich
+- Lizenzverwaltung naechstes Paket ist umgesetzt:
+  - Kachel `Historie` im `LicenseAdminScreen` oeffnet jetzt eine einfache vorbereitete Historie-Maske
+  - Historie-Maske nutzt `LICENSE_HISTORY_FIELDS` und zeigt `erzeugt am`, `Lizenz-ID`, `Kunde`, `Produktumfang`, `gueltig bis`, `Datei / Ausgabeort`, `Notizen`
+  - Historie-Maske bietet `Neu / leeren` und `Pruefen`; Pruefen validiert nur lokal Pflichtfelder ohne Speicherung, Datenbank oder Persistenz
+  - `SettingsView` bleibt Host/Einstieg und oeffnet die Historie-Maske nur ueber den Adminbereich
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -18,13 +18,17 @@ async function runLizenzverwaltungModuleTests(run) {
       createLicenseEditorSection,
       createProductScopeEditorSection,
       createLicenseRecordEditorSection,
+      createLicenseHistorySection,
       CUSTOMER_RECORD_FIELDS,
       LICENSE_RECORD_FIELDS,
+      LICENSE_HISTORY_FIELDS,
       LICENSE_MODES,
       createDefaultCustomerRecord,
       createDefaultLicenseRecord,
+      createDefaultLicenseHistoryRecord,
       normalizeCustomerRecord,
       normalizeLicenseRecord,
+      normalizeLicenseHistoryRecord,
     },
     {
       getProjektverwaltungModuleEntry,
@@ -49,6 +53,9 @@ async function runLizenzverwaltungModuleTests(run) {
   const productScopeEditorSource = read(
     "src/renderer/modules/lizenzverwaltung/screens/createProductScopeEditorSection.js"
   );
+  const licenseHistoryEditorSource = read(
+    "src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js"
+  );
   const moduleCatalogSource = read("src/renderer/app/modules/moduleCatalog.js");
   const projectWorkspaceSource = read("src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js");
   const settingsViewSource = read("src/renderer/views/SettingsView.js");
@@ -63,6 +70,7 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(typeof createLicenseEditorSection, "function");
     assert.equal(typeof createProductScopeEditorSection, "function");
     assert.equal(typeof createLicenseRecordEditorSection, "function");
+    assert.equal(typeof createLicenseHistorySection, "function");
     assert.equal(entry.moduleId, "lizenzverwaltung");
     assert.equal(entry.workScreenId, "licenseAdmin");
     assert.equal(entry.screens?.licenseAdmin, LicenseAdminScreen);
@@ -147,6 +155,32 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(normalizedLicense.licenseMode, "full");
     assert.deepEqual(normalizedLicense.productScope.zusatzfunktionen, ["mail"]);
     assert.deepEqual(normalizedLicense.productScope.standardumfang, []);
+  });
+
+  await run("Lizenzverwaltung: Historien-Datensatz zentral vorbereitet", () => {
+    const historyKeys = LICENSE_HISTORY_FIELDS.map((entry) => entry.key);
+    assert.deepEqual(historyKeys, [
+      "createdAt",
+      "licenseId",
+      "customer",
+      "productScope",
+      "validUntil",
+      "outputPath",
+      "notes",
+    ]);
+    const historyLabels = LICENSE_HISTORY_FIELDS.map((entry) => entry.label);
+    assert.deepEqual(historyLabels, [
+      "erzeugt am",
+      "Lizenz-ID",
+      "Kunde",
+      "Produktumfang",
+      "gueltig bis",
+      "Datei / Ausgabeort",
+      "Notizen",
+    ]);
+    assert.equal(typeof createDefaultLicenseHistoryRecord, "function");
+    assert.equal(typeof normalizeLicenseHistoryRecord, "function");
+    assert.equal(licenseRecordsSource.includes("LICENSE_HISTORY_FIELDS"), true);
   });
   await run("Lizenzverwaltung: Skeleton enthaelt Einstieg und Platzhalterbereiche", () => {
     assert.equal(screenSource.includes("Lizenzverwaltung"), true);
@@ -241,6 +275,24 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(productScopeEditorSource.includes("Keine Speicherung"), true);
   });
 
+  await run("Historie-UI: enthaelt vorbereitete Felder und lokale Validierung", () => {
+    assert.equal(licenseHistoryEditorSource.includes("Historie"), true);
+    assert.equal(licenseHistoryEditorSource.includes("vorbereitet, noch ohne Speicherung"), true);
+    assert.equal(licenseHistoryEditorSource.includes("LICENSE_HISTORY_FIELDS"), true);
+    assert.deepEqual(LICENSE_HISTORY_FIELDS.map((entry) => entry.label), [
+      "erzeugt am",
+      "Lizenz-ID",
+      "Kunde",
+      "Produktumfang",
+      "gueltig bis",
+      "Datei / Ausgabeort",
+      "Notizen",
+    ]);
+    assert.equal(licenseHistoryEditorSource.includes("Neu / leeren"), true);
+    assert.equal(licenseHistoryEditorSource.includes("Pruefen"), true);
+    assert.equal(licenseHistoryEditorSource.includes("Keine Speicherung"), true);
+  });
+
   await run("Lizenzverwaltung: bleibt Adminbereich und erscheint nicht als Projektmodul", () => {
     const projektEntry = getProjektverwaltungModuleEntry();
 
@@ -287,6 +339,15 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(settingsViewSource.includes("createProductScopeEditorSection"), true);
     assert.equal(settingsViewSource.includes("const openProductScopeEditorPopup = () =>"), true);
     assert.equal(settingsViewSource.includes("onOpenProductScopeEditor: openProductScopeEditorPopup"), true);
+  });
+
+  await run("LicenseAdminScreen enthaelt Einstieg fuer Historie", () => {
+    assert.equal(screenSource.includes("onOpenLicenseHistory"), true);
+    assert.equal(screenSource.includes("title: \"Historie\""), true);
+    assert.equal(screenSource.includes("hint: \"vorbereitet, noch ohne Speicherung\""), true);
+    assert.equal(settingsViewSource.includes("createLicenseHistorySection"), true);
+    assert.equal(settingsViewSource.includes("const openLicenseHistoryPopup = () =>"), true);
+    assert.equal(settingsViewSource.includes("onOpenLicenseHistory: openLicenseHistoryPopup"), true);
   });
 
   await run("Lizenz / bearbeiten: enthaelt Produktumfang statt flacher Feature-Zeile", () => {

--- a/src/renderer/modules/lizenzverwaltung/index.js
+++ b/src/renderer/modules/lizenzverwaltung/index.js
@@ -4,6 +4,7 @@ import {
   createLicenseEditorSection,
   createProductScopeEditorSection,
   createLicenseRecordEditorSection,
+  createLicenseHistorySection,
   LIZENZVERWALTUNG_WORK_SCREEN_ID,
 } from "./screens/index.js";
 
@@ -31,6 +32,7 @@ export {
   createLicenseEditorSection,
   createProductScopeEditorSection,
   createLicenseRecordEditorSection,
+  createLicenseHistorySection,
   LIZENZVERWALTUNG_WORK_SCREEN_ID,
 };
 export * from "./screens/index.js";

--- a/src/renderer/modules/lizenzverwaltung/licenseRecords.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseRecords.js
@@ -23,6 +23,16 @@ export const LICENSE_MODES = Object.freeze([
   Object.freeze({ key: "full", label: "Vollversion" }),
 ]);
 
+export const LICENSE_HISTORY_FIELDS = Object.freeze([
+  Object.freeze({ key: "createdAt", label: "erzeugt am", required: true }),
+  Object.freeze({ key: "licenseId", label: "Lizenz-ID", required: true }),
+  Object.freeze({ key: "customer", label: "Kunde", required: true }),
+  Object.freeze({ key: "productScope", label: "Produktumfang", required: true }),
+  Object.freeze({ key: "validUntil", label: "gueltig bis", required: true }),
+  Object.freeze({ key: "outputPath", label: "Datei / Ausgabeort", required: true }),
+  Object.freeze({ key: "notes", label: "Notizen", required: false }),
+]);
+
 export function createDefaultCustomerRecord(overrides = {}) {
   return {
     customerNumber: "",
@@ -48,6 +58,19 @@ export function createDefaultLicenseRecord(overrides = {}) {
     validUntil: "",
     licenseMode: "soft",
     machineId: "",
+    notes: "",
+    ...overrides,
+  };
+}
+
+export function createDefaultLicenseHistoryRecord(overrides = {}) {
+  return {
+    createdAt: "",
+    licenseId: "",
+    customer: "",
+    productScope: "",
+    validUntil: "",
+    outputPath: "",
     notes: "",
     ...overrides,
   };
@@ -88,6 +111,19 @@ export function normalizeLicenseRecord(input = {}) {
     validUntil: String(input.validUntil ?? base.validUntil).trim(),
     licenseMode: normalizedMode,
     machineId: String(input.machineId ?? base.machineId).trim(),
+    notes: String(input.notes ?? base.notes).trim(),
+  };
+}
+
+export function normalizeLicenseHistoryRecord(input = {}) {
+  const base = createDefaultLicenseHistoryRecord();
+  return {
+    createdAt: String(input.createdAt ?? base.createdAt).trim(),
+    licenseId: String(input.licenseId ?? base.licenseId).trim(),
+    customer: String(input.customer ?? base.customer).trim(),
+    productScope: String(input.productScope ?? base.productScope).trim(),
+    validUntil: String(input.validUntil ?? base.validUntil).trim(),
+    outputPath: String(input.outputPath ?? base.outputPath).trim(),
     notes: String(input.notes ?? base.notes).trim(),
   };
 }

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -47,11 +47,13 @@ export default class LicenseAdminScreen {
     onOpenCustomerEditor,
     onOpenLicenseRecordEditor,
     onOpenProductScopeEditor,
+    onOpenLicenseHistory,
   } = {}) {
     this.onOpenLicenseEditor = onOpenLicenseEditor;
     this.onOpenCustomerEditor = onOpenCustomerEditor;
     this.onOpenLicenseRecordEditor = onOpenLicenseRecordEditor;
     this.onOpenProductScopeEditor = onOpenProductScopeEditor;
+    this.onOpenLicenseHistory = onOpenLicenseHistory;
   }
 
   render() {
@@ -102,7 +104,12 @@ export default class LicenseAdminScreen {
         actionLabel: "Oeffnen",
         onClick: this.onOpenProductScopeEditor,
       }),
-      buildSectionCard({ title: "Historie" })
+      buildSectionCard({
+        title: "Historie",
+        hint: "vorbereitet, noch ohne Speicherung",
+        actionLabel: "Oeffnen",
+        onClick: this.onOpenLicenseHistory,
+      })
     );
 
     root.append(title, adminHint, rolloutHint, grid);

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js
@@ -1,0 +1,141 @@
+import {
+  LICENSE_HISTORY_FIELDS,
+  createDefaultLicenseHistoryRecord,
+  normalizeLicenseHistoryRecord,
+} from "../licenseRecords.js";
+
+export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
+  const model = createDefaultLicenseHistoryRecord();
+  const fieldInputs = new Map();
+
+  const card = document.createElement("div");
+  if (typeof applyPopupCardStyle === "function") {
+    applyPopupCardStyle(card);
+  }
+  card.style.display = "grid";
+  card.style.gap = "10px";
+
+  const title = document.createElement("h3");
+  title.textContent = "Historie";
+  title.style.margin = "0";
+
+  const hint = document.createElement("p");
+  hint.textContent = "vorbereitet, noch ohne Speicherung";
+  hint.style.margin = "0";
+  hint.style.fontSize = "12px";
+  hint.style.opacity = "0.8";
+
+  const form = document.createElement("div");
+  form.style.display = "grid";
+  form.style.gap = "8px";
+
+  const message = document.createElement("div");
+  message.style.fontSize = "12px";
+  message.style.padding = "8px";
+  message.style.borderRadius = "8px";
+  message.style.background = "#f8fafc";
+  message.style.border = "1px solid rgba(0,0,0,0.08)";
+  message.textContent = "Noch keine Pruefung ausgefuehrt.";
+
+  const updateModelFromInputs = () => {
+    for (const field of LICENSE_HISTORY_FIELDS) {
+      const input = fieldInputs.get(field.key);
+      if (!input) continue;
+      model[field.key] = String(input.value || "");
+    }
+  };
+
+  const applyModelToInputs = () => {
+    for (const field of LICENSE_HISTORY_FIELDS) {
+      const input = fieldInputs.get(field.key);
+      if (!input) continue;
+      input.value = model[field.key] || "";
+      input.style.borderColor = "";
+    }
+  };
+
+  const runValidation = () => {
+    updateModelFromInputs();
+    const normalized = normalizeLicenseHistoryRecord(model);
+    const missingRequired = LICENSE_HISTORY_FIELDS.filter(
+      (field) => field.required && !String(normalized[field.key] || "").trim()
+    );
+
+    for (const field of LICENSE_HISTORY_FIELDS) {
+      const input = fieldInputs.get(field.key);
+      if (!input) continue;
+      const isMissing = missingRequired.some((entry) => entry.key === field.key);
+      input.style.borderColor = isMissing ? "#dc2626" : "";
+    }
+
+    if (missingRequired.length > 0) {
+      message.textContent = `Pruefung fehlgeschlagen: Pflichtfelder fehlen (${missingRequired
+        .map((field) => field.label)
+        .join(", ")}).`;
+      message.style.background = "#fef2f2";
+      message.style.borderColor = "rgba(220, 38, 38, 0.35)";
+      return false;
+    }
+
+    message.textContent = "Pruefung erfolgreich: Pflichtfelder sind befuellt. Keine Speicherung erfolgt.";
+    message.style.background = "#f0fdf4";
+    message.style.borderColor = "rgba(34, 197, 94, 0.35)";
+    return true;
+  };
+
+  LICENSE_HISTORY_FIELDS.forEach((field) => {
+    const row = document.createElement("label");
+    row.style.display = "grid";
+    row.style.gap = "4px";
+
+    const label = document.createElement("span");
+    label.textContent = field.required ? `${field.label} *` : field.label;
+    label.style.fontSize = "12px";
+    label.style.fontWeight = "600";
+
+    const input = field.key === "notes" ? document.createElement("textarea") : document.createElement("input");
+    if (field.key !== "notes") {
+      input.type = field.key === "validUntil" ? "date" : "text";
+    }
+    if (field.key === "notes") {
+      input.rows = 4;
+    }
+
+    input.style.width = "100%";
+    input.style.boxSizing = "border-box";
+
+    row.append(label, input);
+    form.appendChild(row);
+    fieldInputs.set(field.key, input);
+  });
+
+  const buttons = document.createElement("div");
+  buttons.style.display = "flex";
+  buttons.style.gap = "8px";
+
+  const btnReset = document.createElement("button");
+  btnReset.type = "button";
+  btnReset.textContent = "Neu / leeren";
+  if (typeof applyPopupButtonStyle === "function") applyPopupButtonStyle(btnReset);
+  btnReset.onclick = () => {
+    Object.assign(model, createDefaultLicenseHistoryRecord());
+    applyModelToInputs();
+    message.textContent = "Formular geleert. Noch ohne Speicherung.";
+    message.style.background = "#f8fafc";
+    message.style.borderColor = "rgba(0,0,0,0.08)";
+  };
+
+  const btnValidate = document.createElement("button");
+  btnValidate.type = "button";
+  btnValidate.textContent = "Pruefen";
+  if (typeof applyPopupButtonStyle === "function") applyPopupButtonStyle(btnValidate);
+  btnValidate.onclick = () => {
+    runValidation();
+  };
+
+  buttons.append(btnReset, btnValidate);
+
+  applyModelToInputs();
+  card.append(title, hint, form, buttons, message);
+  return card;
+}

--- a/src/renderer/modules/lizenzverwaltung/screens/index.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/index.js
@@ -1,6 +1,7 @@
 export { default as LicenseAdminScreen } from "./LicenseAdminScreen.js";
 export { createLicenseEditorSection } from "./createLicenseEditorSection.js";
 export { createProductScopeEditorSection } from "./createProductScopeEditorSection.js";
+export { createLicenseHistorySection } from "./createLicenseHistorySection.js";
 
 export const LIZENZVERWALTUNG_WORK_SCREEN_ID = "licenseAdmin";
 export { createCustomerEditorSection } from "./createCustomerEditorSection.js";

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -19,6 +19,7 @@ import {
   createLicenseEditorSection,
   createProductScopeEditorSection,
   createLicenseRecordEditorSection,
+  createLicenseHistorySection,
 } from "../modules/lizenzverwaltung/index.js";
 
 const DEFAULT_V2_PRE_REMARKS_TEXT =
@@ -4069,12 +4070,25 @@ export default class SettingsView {
       });
     };
 
+    const openLicenseHistoryPopup = () => {
+      const licenseHistoryEditor = createLicenseHistorySection({
+        applyPopupCardStyle,
+        applyPopupButtonStyle,
+      });
+      openSettingsModal({
+        title: "Historie",
+        content: [licenseHistoryEditor],
+        closeOnly: true,
+      });
+    };
+
     const openLicenseAdminPopup = () => {
       const licenseAdminScreen = new LicenseAdminScreen({
         onOpenLicenseEditor: openLicenseEditorPopup,
         onOpenCustomerEditor: openCustomerEditorPopup,
         onOpenLicenseRecordEditor: openLicenseRecordEditorPopup,
         onOpenProductScopeEditor: openProductScopeEditorPopup,
+        onOpenLicenseHistory: openLicenseHistoryPopup,
       });
       openSettingsModal({
         title: "Lizenzverwaltung",


### PR DESCRIPTION
### Motivation
- Nächstes Paket der Lizenzverwaltung vorbereitet: die bisherige Platzhalter-Kachel „Historie“ im Adminbereich soll eine einfache, vorbereitete Historie-Maske öffnen, ohne Speicherung oder Datenbankzugriff.

### Description
- Ergänzt zentrale Historien-Feldstruktur und Helfer in `licenseRecords.js` (`LICENSE_HISTORY_FIELDS`, `createDefaultLicenseHistoryRecord`, `normalizeLicenseHistoryRecord`).
- Neue UI-Komponente `createLicenseHistorySection` angelegt unter `src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js` mit Überschrift, Hinweis, vorbereiteten Feldern (`erzeugt am`, `Lizenz-ID`, `Kunde`, `Produktumfang`, `gueltig bis`, `Datei / Ausgabeort`, `Notizen`) sowie den Buttons `Neu / leeren` und `Pruefen` (lokale Pflichtfeld-Validierung, keine Persistenz). 
- `LicenseAdminScreen` erweitert, damit die Kachel **Historie** jetzt einen echten `Oeffnen`-Einstieg nutzt, und `SettingsView` erhält ein `openLicenseHistoryPopup`, das die Maske im Adminbereich öffnet; Modul-Exports (`screens/index.js`, `index.js`) wurden angepasst. 
- Tests für das Lizenzverwaltungs-Paket erweitert und `STATUS.md` um den Meilenstein ergänzt.

### Testing
- Automatisierte Tests ausgeführt mit `npm test`, alle Tests sind grün und die neuen Assertions für die Historie-UI und die zentralen Felder bestehen. 
- Die Test-Suite prüft Export/Exportsignatur des Moduls, die Präsenz der Felddefinitionen und die UI-Inhalte/Buttons der neuen Historie-Maske, und alle Prüfungen wurden bestanden.
- Hinweis: In dieser Umgebung konnte kein GitHub-Pull-Request gegen `main` veröffentlicht werden, daher ist der Zustand lokal committed; Folge-Status: `gestoppt – nicht veröffentlicht`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede0f9f7c88322b08b67cf283994dc)