### PR TITLE
Prepare lizenzverwaltung storage service interface (in-memory async stub)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -78,6 +78,10 @@ Sie ergänzt:
   - Historie-Maske nutzt `LICENSE_HISTORY_FIELDS` und zeigt `erzeugt am`, `Lizenz-ID`, `Kunde`, `Produktumfang`, `gueltig bis`, `Datei / Ausgabeort`, `Notizen`
   - Historie-Maske bietet `Neu / leeren` und `Pruefen`; Pruefen validiert nur lokal Pflichtfelder ohne Speicherung, Datenbank oder Persistenz
   - `SettingsView` bleibt Host/Einstieg und oeffnet die Historie-Maske nur ueber den Adminbereich
+- Lizenzverwaltung naechstes Paket ist umgesetzt:
+  - zentrale Storage-Service-Schnittstelle `licenseStorageService.js` im Modul angelegt (In-Memory-Stub, async, ohne DB/IPC/Persistenz)
+  - Service nutzt `normalizeCustomerRecord`, `normalizeLicenseRecord` und `normalizeLicenseHistoryRecord` aus `licenseRecords.js`
+  - Export im Modul-Index ergaenzt; Tests decken Export, initiale Listen, Speichern mit Normalisierung und Promise-Kompatibilitaet ab
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -29,6 +29,12 @@ async function runLizenzverwaltungModuleTests(run) {
       normalizeCustomerRecord,
       normalizeLicenseRecord,
       normalizeLicenseHistoryRecord,
+      listCustomers,
+      saveCustomer,
+      listLicenses,
+      saveLicense,
+      listHistory,
+      addHistoryEntry,
     },
     {
       getProjektverwaltungModuleEntry,
@@ -155,6 +161,92 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(normalizedLicense.licenseMode, "full");
     assert.deepEqual(normalizedLicense.productScope.zusatzfunktionen, ["mail"]);
     assert.deepEqual(normalizedLicense.productScope.standardumfang, []);
+  });
+
+
+  await run("Lizenzverwaltung: Storage-Service wird exportiert und ist Promise-kompatibel", async () => {
+    assert.equal(typeof listCustomers, "function");
+    assert.equal(typeof saveCustomer, "function");
+    assert.equal(typeof listLicenses, "function");
+    assert.equal(typeof saveLicense, "function");
+    assert.equal(typeof listHistory, "function");
+    assert.equal(typeof addHistoryEntry, "function");
+
+    assert.equal(listCustomers.constructor.name, "AsyncFunction");
+    assert.equal(saveCustomer.constructor.name, "AsyncFunction");
+    assert.equal(listLicenses.constructor.name, "AsyncFunction");
+    assert.equal(saveLicense.constructor.name, "AsyncFunction");
+    assert.equal(listHistory.constructor.name, "AsyncFunction");
+    assert.equal(addHistoryEntry.constructor.name, "AsyncFunction");
+
+    assert.equal(typeof listCustomers().then, "function");
+    assert.equal(typeof listLicenses().then, "function");
+    assert.equal(typeof listHistory().then, "function");
+  });
+
+  await run("Lizenzverwaltung: listCustomers liefert initial eine Liste", async () => {
+    const customers = await listCustomers();
+    assert.equal(Array.isArray(customers), true);
+    assert.equal(customers.length, 0);
+  });
+
+  await run("Lizenzverwaltung: saveCustomer normalisiert und speichert im Stub", async () => {
+    const record = await saveCustomer({
+      customerNumber: "  K-200  ",
+      companyName: "  Beispiel GmbH  ",
+      contactPerson: "  Max Mustermann  ",
+      email: "  kontakt@example.org  ",
+    });
+
+    assert.equal(record.customerNumber, "K-200");
+    assert.equal(record.companyName, "Beispiel GmbH");
+
+    const customers = await listCustomers();
+    assert.equal(customers.some((entry) => entry.customerNumber === "K-200"), true);
+  });
+
+  await run("Lizenzverwaltung: listLicenses liefert initial eine Liste", async () => {
+    const licenses = await listLicenses();
+    assert.equal(Array.isArray(licenses), true);
+    assert.equal(licenses.length, 0);
+  });
+
+  await run("Lizenzverwaltung: saveLicense normalisiert und speichert im Stub", async () => {
+    const record = await saveLicense({
+      licenseId: "  LIC-200  ",
+      customerNumber: "  K-200  ",
+      licenseMode: "FULL",
+      productScope: { zusatzfunktionen: ["mail"] },
+    });
+
+    assert.equal(record.licenseId, "LIC-200");
+    assert.equal(record.licenseMode, "full");
+
+    const licenses = await listLicenses();
+    assert.equal(licenses.some((entry) => entry.licenseId === "LIC-200"), true);
+  });
+
+  await run("Lizenzverwaltung: listHistory liefert initial eine Liste", async () => {
+    const history = await listHistory();
+    assert.equal(Array.isArray(history), true);
+    assert.equal(history.length, 0);
+  });
+
+  await run("Lizenzverwaltung: addHistoryEntry normalisiert und speichert im Stub", async () => {
+    const record = await addHistoryEntry({
+      createdAt: "  2026-04-26  ",
+      licenseId: "  LIC-200  ",
+      customer: "  Beispiel GmbH  ",
+      productScope: "  app,pdf,export  ",
+      validUntil: "  2027-04-26  ",
+      outputPath: "  /tmp/license.json  ",
+    });
+
+    assert.equal(record.createdAt, "2026-04-26");
+    assert.equal(record.licenseId, "LIC-200");
+
+    const history = await listHistory();
+    assert.equal(history.some((entry) => entry.licenseId === "LIC-200"), true);
   });
 
   await run("Lizenzverwaltung: Historien-Datensatz zentral vorbereitet", () => {

--- a/src/renderer/modules/lizenzverwaltung/index.js
+++ b/src/renderer/modules/lizenzverwaltung/index.js
@@ -38,3 +38,4 @@ export {
 export * from "./screens/index.js";
 export * from "./productScope.js";
 export * from "./licenseRecords.js";
+export * from "./licenseStorageService.js";

--- a/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
@@ -1,0 +1,41 @@
+import {
+  normalizeCustomerRecord,
+  normalizeLicenseRecord,
+  normalizeLicenseHistoryRecord,
+} from "./licenseRecords.js";
+
+const storage = {
+  customers: [],
+  licenses: [],
+  history: [],
+};
+
+export async function listCustomers() {
+  return [...storage.customers];
+}
+
+export async function saveCustomer(customer) {
+  const record = normalizeCustomerRecord(customer);
+  storage.customers.push(record);
+  return record;
+}
+
+export async function listLicenses() {
+  return [...storage.licenses];
+}
+
+export async function saveLicense(license) {
+  const record = normalizeLicenseRecord(license);
+  storage.licenses.push(record);
+  return record;
+}
+
+export async function listHistory() {
+  return [...storage.history];
+}
+
+export async function addHistoryEntry(entry) {
+  const record = normalizeLicenseHistoryRecord(entry);
+  storage.history.push(record);
+  return record;
+}


### PR DESCRIPTION
### Motivation
- Die UI-Logik der Lizenzverwaltung soll von der späteren Persistenz entkoppelt werden, indem eine zentrale Service-Schnittstelle vorbereitet wird.
- Schrittweise Vorbereitung einer austauschbaren async/Promise-kompatiblen Storage-API, damit spätere DB- oder IPC-Anbindungen ohne UI-Änderungen möglich sind.

### Description
- Neue Datei `src/renderer/modules/lizenzverwaltung/licenseStorageService.js` angelegt, die als In-Memory-Stub async-Funktionen `listCustomers`, `saveCustomer`, `listLicenses`, `saveLicense`, `listHistory` und `addHistoryEntry` bereitstellt.
- Die Save-/Add-Funktionen nutzen die vorhandenen Normalisierer `normalizeCustomerRecord`, `normalizeLicenseRecord` und `normalizeLicenseHistoryRecord` aus `licenseRecords.js`.
- Modul-Export in `src/renderer/modules/lizenzverwaltung/index.js` um `export * from "./licenseStorageService.js";` erweitert, sodass der Service über das Modul verfügbar ist.
- Tests in `scripts/tests/lizenzverwaltungModule.test.cjs` erweitert, um Export, Promise-/Async-Kompatibilität, initiale Listen (leer), sowie Save+Normalisierung für Kunde/Lizenz/Historie abzudecken, und `STATUS.md` entsprechend aktualisiert.

### Testing
- Ausgeführt: `npm test`, alle Tests waren erfolgreich (siehe Testlauf: alle Tests bestanden).
- Erweiterte Tests: `scripts/tests/lizenzverwaltungModule.test.cjs` prüft jetzt Service-Export, dass Service-Funktionen `AsyncFunction` sind, initial leere Arrays zurückgeben und dass `saveCustomer`, `saveLicense` und `addHistoryEntry` normalisieren und in den In-Memory-Stub schreiben. 
- Ergebnis: Testlauf grün, keine regressionsbedingten Fehler festgestellt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edef51e63c8322a4ef650dd07925de)