### PR TITLE
Lizenzverwaltung: 'Merken'-Buttons an In-Memory-Storage anbinden

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -82,6 +82,10 @@ Sie ergänzt:
   - zentrale Storage-Service-Schnittstelle `licenseStorageService.js` im Modul angelegt (In-Memory-Stub, async, ohne DB/IPC/Persistenz)
   - Service nutzt `normalizeCustomerRecord`, `normalizeLicenseRecord` und `normalizeLicenseHistoryRecord` aus `licenseRecords.js`
   - Export im Modul-Index ergaenzt; Tests decken Export, initiale Listen, Speichern mit Normalisierung und Promise-Kompatibilitaet ab
+- Lizenzverwaltung naechstes Paket ist umgesetzt:
+  - vorbereitete Masken `Kunden`, `Lizenzen` und `Historie` enthalten zusaetzlich den Button `Merken`
+  - `Merken` validiert lokal und ruft danach den In-Memory-Storage-Service auf (`saveCustomer`, `saveLicense`, `addHistoryEntry`)
+  - Erfolgsmeldung in allen drei Masken: nur temporaer/In-Memory gemerkt, keine dauerhafte Speicherung
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -309,8 +309,12 @@ async function runLizenzverwaltungModuleTests(run) {
   await run("Kunden-UI: bietet Neu / leeren und Pruefen", () => {
     assert.equal(customerEditorSource.includes("Neu / leeren"), true);
     assert.equal(customerEditorSource.includes("Pruefen"), true);
+    assert.equal(customerEditorSource.includes("Merken"), true);
     assert.equal(customerEditorSource.includes("ohne Speicherung"), true);
     assert.equal(customerEditorSource.includes("Keine Speicherung"), true);
+    assert.equal(customerEditorSource.includes("saveCustomer"), true);
+    assert.equal(customerEditorSource.includes("temporaer gemerkt"), true);
+    assert.equal(customerEditorSource.includes("nur In-Memory-Storage-Service"), true);
   });
 
   await run("Lizenzen-UI: nutzt LICENSE_RECORD_FIELDS und enthaelt alle Lizenzfelder", () => {
@@ -336,7 +340,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordEditorSource.includes("vorbereitet, noch ohne Speicherung"), true);
     assert.equal(licenseRecordEditorSource.includes("Neu / leeren"), true);
     assert.equal(licenseRecordEditorSource.includes("Pruefen"), true);
+    assert.equal(licenseRecordEditorSource.includes("Merken"), true);
     assert.equal(licenseRecordEditorSource.includes("Keine Speicherung"), true);
+    assert.equal(licenseRecordEditorSource.includes("saveLicense"), true);
+    assert.equal(licenseRecordEditorSource.includes("temporaer gemerkt"), true);
+    assert.equal(licenseRecordEditorSource.includes("nur In-Memory-Storage-Service"), true);
   });
 
   await run("Produktumfang-UI: nutzt PRODUCT_SCOPE und enthaelt Gruppen", () => {
@@ -382,7 +390,11 @@ async function runLizenzverwaltungModuleTests(run) {
     ]);
     assert.equal(licenseHistoryEditorSource.includes("Neu / leeren"), true);
     assert.equal(licenseHistoryEditorSource.includes("Pruefen"), true);
+    assert.equal(licenseHistoryEditorSource.includes("Merken"), true);
     assert.equal(licenseHistoryEditorSource.includes("Keine Speicherung"), true);
+    assert.equal(licenseHistoryEditorSource.includes("addHistoryEntry"), true);
+    assert.equal(licenseHistoryEditorSource.includes("temporaer gemerkt"), true);
+    assert.equal(licenseHistoryEditorSource.includes("nur In-Memory-Storage-Service"), true);
   });
 
   await run("Lizenzverwaltung: bleibt Adminbereich und erscheint nicht als Projektmodul", () => {

--- a/src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js
@@ -3,6 +3,7 @@ import {
   createDefaultCustomerRecord,
   normalizeCustomerRecord,
 } from "../licenseRecords.js";
+import { saveCustomer } from "../licenseStorageService.js";
 
 export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
   const model = createDefaultCustomerRecord();
@@ -132,7 +133,22 @@ export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupBut
     runValidation();
   };
 
-  buttons.append(btnReset, btnValidate);
+  const btnRemember = document.createElement("button");
+  btnRemember.type = "button";
+  btnRemember.textContent = "Merken";
+  if (typeof applyPopupButtonStyle === "function") applyPopupButtonStyle(btnRemember);
+  btnRemember.onclick = async () => {
+    const isValid = runValidation();
+    if (!isValid) return;
+
+    await saveCustomer(model);
+    message.textContent =
+      "Datensatz temporaer gemerkt, noch keine dauerhafte Speicherung (nur In-Memory-Storage-Service).";
+    message.style.background = "#f0fdf4";
+    message.style.borderColor = "rgba(34, 197, 94, 0.35)";
+  };
+
+  buttons.append(btnReset, btnValidate, btnRemember);
 
   applyModelToInputs();
   card.append(title, hint, form, buttons, message);

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js
@@ -3,6 +3,7 @@ import {
   createDefaultLicenseHistoryRecord,
   normalizeLicenseHistoryRecord,
 } from "../licenseRecords.js";
+import { addHistoryEntry } from "../licenseStorageService.js";
 
 export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
   const model = createDefaultLicenseHistoryRecord();
@@ -133,7 +134,22 @@ export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupBut
     runValidation();
   };
 
-  buttons.append(btnReset, btnValidate);
+  const btnRemember = document.createElement("button");
+  btnRemember.type = "button";
+  btnRemember.textContent = "Merken";
+  if (typeof applyPopupButtonStyle === "function") applyPopupButtonStyle(btnRemember);
+  btnRemember.onclick = async () => {
+    const isValid = runValidation();
+    if (!isValid) return;
+
+    await addHistoryEntry(model);
+    message.textContent =
+      "Datensatz temporaer gemerkt, noch keine dauerhafte Speicherung (nur In-Memory-Storage-Service).";
+    message.style.background = "#f0fdf4";
+    message.style.borderColor = "rgba(34, 197, 94, 0.35)";
+  };
+
+  buttons.append(btnReset, btnValidate, btnRemember);
 
   applyModelToInputs();
   card.append(title, hint, form, buttons, message);

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
@@ -4,6 +4,7 @@ import {
   createDefaultLicenseRecord,
   normalizeLicenseRecord,
 } from "../licenseRecords.js";
+import { saveLicense } from "../licenseStorageService.js";
 
 export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
   const model = createDefaultLicenseRecord();
@@ -165,7 +166,22 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
     runValidation();
   };
 
-  buttons.append(btnReset, btnValidate);
+  const btnRemember = document.createElement("button");
+  btnRemember.type = "button";
+  btnRemember.textContent = "Merken";
+  if (typeof applyPopupButtonStyle === "function") applyPopupButtonStyle(btnRemember);
+  btnRemember.onclick = async () => {
+    const isValid = runValidation();
+    if (!isValid) return;
+
+    await saveLicense(model);
+    message.textContent =
+      "Datensatz temporaer gemerkt, noch keine dauerhafte Speicherung (nur In-Memory-Storage-Service).";
+    message.style.background = "#f0fdf4";
+    message.style.borderColor = "rgba(34, 197, 94, 0.35)";
+  };
+
+  buttons.append(btnReset, btnValidate, btnRemember);
 
   applyModelToInputs();
   card.append(title, hint, form, buttons, message);


### PR DESCRIPTION
### Motivation
- Ermöglichen, dass die vorbereiteten Masken `Kunden`, `Lizenzen` und `Historie` nach lokaler Validierung geprüfte Datensätze temporär im vorhandenen In-Memory-Storage-Service merken können, ohne persistente Speicherung oder DB/IPC-Änderungen einzuführen.
- Bestehendes Verhalten behalten: der vorhandene Button `Pruefen` bleibt unverändert und die Änderung soll nur eine temporäre, klar gekennzeichnete Merken-Option ergänzen.

### Description
- In die drei Editor-Screens wurden die Storage-Stub-Funktionen importiert und jeweils ein zusätzlicher Button `Merken` ergänzt, der zuerst die vorhandene lokale Validierung ausführt und bei Erfolg dann `saveCustomer(...)`, `saveLicense(...)` bzw. `addHistoryEntry(...)` aufruft.
- Die Erfolgsmeldung in allen drei Masken wurde präzisiert auf: `Datensatz temporaer gemerkt, noch keine dauerhafte Speicherung (nur In-Memory-Storage-Service).`.
- Modultests in `scripts/tests/lizenzverwaltungModule.test.cjs` wurden erweitert, um Existenz des `Merken`-Buttons, Aufrufe der Storage-Funktionen und die temporäre Meldung zu prüfen.
- Aktualisierte Dateien: `src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js`, `src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js`, `src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js`, `scripts/tests/lizenzverwaltungModule.test.cjs`, `STATUS.md`.

### Testing
- Ausgeführt: `npm test` and alle Tests sind grün gelaufen (keine fehlschläge). 
- Die angepassten Tests prüfen nun, dass `Merken` in den drei Masken vorhanden ist, die jeweiligen Storage-Funktionen (`saveCustomer`, `saveLicense`, `addHistoryEntry`) referenziert werden und die Hinweistexte die temporäre/In-Memory-Natur der Speicherung deutlich machen.
- Es wurden keine weiteren automatischen Prüfungen (Build/CI) benötigt; die Modul-Tests liefen lokal erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf15d8e3083228bd1ea3de2753e33)