### PR TITLE
Lizenzverwaltung: In-Memory-Listenansichten für Kunden, Lizenzen und Historie

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -86,6 +86,11 @@ Sie ergänzt:
   - vorbereitete Masken `Kunden`, `Lizenzen` und `Historie` enthalten zusaetzlich den Button `Merken`
   - `Merken` validiert lokal und ruft danach den In-Memory-Storage-Service auf (`saveCustomer`, `saveLicense`, `addHistoryEntry`)
   - Erfolgsmeldung in allen drei Masken: nur temporaer/In-Memory gemerkt, keine dauerhafte Speicherung
+- Lizenzverwaltung naechstes Paket ist umgesetzt:
+  - Kunden-, Lizenzen- und Historie-Maske zeigen unterhalb der Buttons einfache In-Memory-Listenansichten
+  - Listen werden ueber `listCustomers`, `listLicenses` und `listHistory` geladen
+  - Nach erfolgreichem `Merken` wird die jeweilige Liste sofort aktualisiert (ohne Persistenz, nur im laufenden App-Prozess)
+  - Leerer Zustand ist in allen drei Masken sichtbar
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.
@@ -433,7 +438,7 @@ Hinweis: Der Meilenstein „Projektverwaltung / Projekt-Arbeitsbereich“ ist ab
 ## Aktuell nächster sinnvoller Schritt
 Der naechste sinnvolle kleine Schritt nach diesem Paket ist:
 
-### Lizenzverwaltung Paket 5 vorbereiten
+### Lizenzverwaltung Paket 6 vorbereiten
 - Ziel:
   - bestehende Lizenz laden, aendern und neu ausgeben als naechsten kleinen Adminschritt vorbereiten
 - Wichtig:

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -313,8 +313,13 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(customerEditorSource.includes("ohne Speicherung"), true);
     assert.equal(customerEditorSource.includes("Keine Speicherung"), true);
     assert.equal(customerEditorSource.includes("saveCustomer"), true);
+    assert.equal(customerEditorSource.includes("listCustomers"), true);
     assert.equal(customerEditorSource.includes("temporaer gemerkt"), true);
     assert.equal(customerEditorSource.includes("nur In-Memory-Storage-Service"), true);
+    assert.equal(customerEditorSource.includes("Temporär gemerkte Kunden"), true);
+    assert.equal(customerEditorSource.includes("Noch keine temporär gemerkten Kunden."), true);
+    assert.equal(customerEditorSource.includes("refreshRememberedCustomers"), true);
+    assert.equal(customerEditorSource.includes("await refreshRememberedCustomers();"), true);
   });
 
   await run("Lizenzen-UI: nutzt LICENSE_RECORD_FIELDS und enthaelt alle Lizenzfelder", () => {
@@ -343,8 +348,13 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordEditorSource.includes("Merken"), true);
     assert.equal(licenseRecordEditorSource.includes("Keine Speicherung"), true);
     assert.equal(licenseRecordEditorSource.includes("saveLicense"), true);
+    assert.equal(licenseRecordEditorSource.includes("listLicenses"), true);
     assert.equal(licenseRecordEditorSource.includes("temporaer gemerkt"), true);
     assert.equal(licenseRecordEditorSource.includes("nur In-Memory-Storage-Service"), true);
+    assert.equal(licenseRecordEditorSource.includes("Temporär gemerkte Lizenzen"), true);
+    assert.equal(licenseRecordEditorSource.includes("Noch keine temporär gemerkten Lizenzen."), true);
+    assert.equal(licenseRecordEditorSource.includes("refreshRememberedLicenses"), true);
+    assert.equal(licenseRecordEditorSource.includes("await refreshRememberedLicenses();"), true);
   });
 
   await run("Produktumfang-UI: nutzt PRODUCT_SCOPE und enthaelt Gruppen", () => {
@@ -393,8 +403,13 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseHistoryEditorSource.includes("Merken"), true);
     assert.equal(licenseHistoryEditorSource.includes("Keine Speicherung"), true);
     assert.equal(licenseHistoryEditorSource.includes("addHistoryEntry"), true);
+    assert.equal(licenseHistoryEditorSource.includes("listHistory"), true);
     assert.equal(licenseHistoryEditorSource.includes("temporaer gemerkt"), true);
     assert.equal(licenseHistoryEditorSource.includes("nur In-Memory-Storage-Service"), true);
+    assert.equal(licenseHistoryEditorSource.includes("Temporär gemerkte Historie"), true);
+    assert.equal(licenseHistoryEditorSource.includes("Noch keine temporär gemerkte Historie."), true);
+    assert.equal(licenseHistoryEditorSource.includes("refreshRememberedHistory"), true);
+    assert.equal(licenseHistoryEditorSource.includes("await refreshRememberedHistory();"), true);
   });
 
   await run("Lizenzverwaltung: bleibt Adminbereich und erscheint nicht als Projektmodul", () => {

--- a/src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js
@@ -3,7 +3,7 @@ import {
   createDefaultCustomerRecord,
   normalizeCustomerRecord,
 } from "../licenseRecords.js";
-import { saveCustomer } from "../licenseStorageService.js";
+import { listCustomers, saveCustomer } from "../licenseStorageService.js";
 
 export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
   const model = createDefaultCustomerRecord();
@@ -37,6 +37,36 @@ export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupBut
   message.style.background = "#f8fafc";
   message.style.border = "1px solid rgba(0,0,0,0.08)";
   message.textContent = "Noch keine Pruefung ausgefuehrt.";
+
+  const listWrap = document.createElement("div");
+  listWrap.style.display = "grid";
+  listWrap.style.gap = "6px";
+
+  const listTitle = document.createElement("h4");
+  listTitle.textContent = "Temporär gemerkte Kunden";
+  listTitle.style.margin = "0";
+  listTitle.style.fontSize = "13px";
+
+  const listContent = document.createElement("div");
+  listContent.style.fontSize = "12px";
+  listContent.style.display = "grid";
+  listContent.style.gap = "4px";
+
+  const refreshRememberedCustomers = async () => {
+    const customers = await listCustomers();
+    listContent.replaceChildren();
+
+    if (!Array.isArray(customers) || customers.length < 1) {
+      listContent.textContent = "Noch keine temporär gemerkten Kunden.";
+      return;
+    }
+
+    customers.forEach((entry) => {
+      const row = document.createElement("div");
+      row.textContent = `${entry.customerNumber || "-"} | ${entry.companyName || "-"} | ${entry.email || "-"}`;
+      listContent.appendChild(row);
+    });
+  };
 
   const updateModelFromInputs = () => {
     for (const field of CUSTOMER_RECORD_FIELDS) {
@@ -142,6 +172,7 @@ export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupBut
     if (!isValid) return;
 
     await saveCustomer(model);
+    await refreshRememberedCustomers();
     message.textContent =
       "Datensatz temporaer gemerkt, noch keine dauerhafte Speicherung (nur In-Memory-Storage-Service).";
     message.style.background = "#f0fdf4";
@@ -151,6 +182,8 @@ export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupBut
   buttons.append(btnReset, btnValidate, btnRemember);
 
   applyModelToInputs();
-  card.append(title, hint, form, buttons, message);
+  listWrap.append(listTitle, listContent);
+  card.append(title, hint, form, buttons, message, listWrap);
+  refreshRememberedCustomers();
   return card;
 }

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js
@@ -3,7 +3,7 @@ import {
   createDefaultLicenseHistoryRecord,
   normalizeLicenseHistoryRecord,
 } from "../licenseRecords.js";
-import { addHistoryEntry } from "../licenseStorageService.js";
+import { addHistoryEntry, listHistory } from "../licenseStorageService.js";
 
 export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
   const model = createDefaultLicenseHistoryRecord();
@@ -37,6 +37,36 @@ export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupBut
   message.style.background = "#f8fafc";
   message.style.border = "1px solid rgba(0,0,0,0.08)";
   message.textContent = "Noch keine Pruefung ausgefuehrt.";
+
+  const listWrap = document.createElement("div");
+  listWrap.style.display = "grid";
+  listWrap.style.gap = "6px";
+
+  const listTitle = document.createElement("h4");
+  listTitle.textContent = "Temporär gemerkte Historie";
+  listTitle.style.margin = "0";
+  listTitle.style.fontSize = "13px";
+
+  const listContent = document.createElement("div");
+  listContent.style.fontSize = "12px";
+  listContent.style.display = "grid";
+  listContent.style.gap = "4px";
+
+  const refreshRememberedHistory = async () => {
+    const history = await listHistory();
+    listContent.replaceChildren();
+
+    if (!Array.isArray(history) || history.length < 1) {
+      listContent.textContent = "Noch keine temporär gemerkte Historie.";
+      return;
+    }
+
+    history.forEach((entry) => {
+      const row = document.createElement("div");
+      row.textContent = `${entry.createdAt || "-"} | ${entry.licenseId || "-"} | ${entry.customer || "-"} | ${entry.validUntil || "-"}`;
+      listContent.appendChild(row);
+    });
+  };
 
   const updateModelFromInputs = () => {
     for (const field of LICENSE_HISTORY_FIELDS) {
@@ -143,6 +173,7 @@ export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupBut
     if (!isValid) return;
 
     await addHistoryEntry(model);
+    await refreshRememberedHistory();
     message.textContent =
       "Datensatz temporaer gemerkt, noch keine dauerhafte Speicherung (nur In-Memory-Storage-Service).";
     message.style.background = "#f0fdf4";
@@ -152,6 +183,8 @@ export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupBut
   buttons.append(btnReset, btnValidate, btnRemember);
 
   applyModelToInputs();
-  card.append(title, hint, form, buttons, message);
+  listWrap.append(listTitle, listContent);
+  card.append(title, hint, form, buttons, message, listWrap);
+  refreshRememberedHistory();
   return card;
 }

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
@@ -4,7 +4,7 @@ import {
   createDefaultLicenseRecord,
   normalizeLicenseRecord,
 } from "../licenseRecords.js";
-import { saveLicense } from "../licenseStorageService.js";
+import { listLicenses, saveLicense } from "../licenseStorageService.js";
 
 export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
   const model = createDefaultLicenseRecord();
@@ -38,6 +38,36 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
   message.style.background = "#f8fafc";
   message.style.border = "1px solid rgba(0,0,0,0.08)";
   message.textContent = "Noch keine Pruefung ausgefuehrt.";
+
+  const listWrap = document.createElement("div");
+  listWrap.style.display = "grid";
+  listWrap.style.gap = "6px";
+
+  const listTitle = document.createElement("h4");
+  listTitle.textContent = "Temporär gemerkte Lizenzen";
+  listTitle.style.margin = "0";
+  listTitle.style.fontSize = "13px";
+
+  const listContent = document.createElement("div");
+  listContent.style.fontSize = "12px";
+  listContent.style.display = "grid";
+  listContent.style.gap = "4px";
+
+  const refreshRememberedLicenses = async () => {
+    const licenses = await listLicenses();
+    listContent.replaceChildren();
+
+    if (!Array.isArray(licenses) || licenses.length < 1) {
+      listContent.textContent = "Noch keine temporär gemerkten Lizenzen.";
+      return;
+    }
+
+    licenses.forEach((entry) => {
+      const row = document.createElement("div");
+      row.textContent = `${entry.licenseId || "-"} | ${entry.customerNumber || "-"} | ${entry.validUntil || "-"} | ${entry.licenseMode || "-"}`;
+      listContent.appendChild(row);
+    });
+  };
 
   const updateModelFromInputs = () => {
     for (const field of LICENSE_RECORD_FIELDS) {
@@ -175,6 +205,7 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
     if (!isValid) return;
 
     await saveLicense(model);
+    await refreshRememberedLicenses();
     message.textContent =
       "Datensatz temporaer gemerkt, noch keine dauerhafte Speicherung (nur In-Memory-Storage-Service).";
     message.style.background = "#f0fdf4";
@@ -184,6 +215,8 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
   buttons.append(btnReset, btnValidate, btnRemember);
 
   applyModelToInputs();
-  card.append(title, hint, form, buttons, message);
+  listWrap.append(listTitle, listContent);
+  card.append(title, hint, form, buttons, message, listWrap);
+  refreshRememberedLicenses();
   return card;
 }


### PR DESCRIPTION
### Motivation
- Nutzer soll nach „Merken“ während desselben App-Laufs sofort sehen können, welche Datensätze temporär im In‑Memory-Storage-Service abgelegt wurden, ohne Persistenz oder IPC zu verändern.

### Description
- Ergänzt einfache Listenansichten unterhalb der Buttons in den Masken `Kunden`, `Lizenzen` und `Historie`, geladen über `listCustomers()`, `listLicenses()` bzw. `listHistory()` und mit sichtbarem Leerzustand.
- Die Masken rufen die jeweilige `list*()`-Funktion nach einem erfolgreichen `Merken` auf, verwenden lokale `refreshRemembered*()`-Funktionen und zeigen die geforderten Felder (Kundennummer / Firma / E‑Mail; Lizenz‑ID / Kunde / gültig bis / Lizenzmodus; erzeugt am / Lizenz‑ID / Kunde / gültig bis).
- Tests in `scripts/tests/lizenzverwaltungModule.test.cjs` wurden erweitert, um die Verwendung von `listCustomers`/`listLicenses`/`listHistory`, die Sichtbarkeit der Listentitel und die Anzeige leerer Zustände sowie die Aufrufe zur Aktualisierung nach `Merken` zu prüfen.
- Dokumentation/Status aktualisiert (`STATUS.md`) und Änderungen in den folgenden Dateien umgesetzt: `createCustomerEditorSection.js`, `createLicenseRecordEditorSection.js`, `createLicenseHistorySection.js`, `scripts/tests/lizenzverwaltungModule.test.cjs`, `STATUS.md`.

### Testing
- Ausgeführt: `npm test`; alle Tests verliefen erfolgreich (Ausgabe: "Alle Tests bestanden.").
- Geänderte Dateien: `src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js`, `src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js`, `src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js`, `scripts/tests/lizenzverwaltungModule.test.cjs`, `STATUS.md`.
- Git/PR-Status: Ziel-Base-Branch laut Auftrag: `main`; Ergebnis-Branch lokal: `work`; kein PR-Link vorhanden, weil kein Remote/Publishing konfiguriert wurde; lokaler Git-Status: auf Branch `work`, Working Tree sauber.
- Abschlussstatus: kein veröffentlichter Pull Request möglich -> `gestoppt – nicht veröffentlicht`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf7274c088322a735eab67aa734d2)