### PR TITLE
Lizenzverwaltung: In-Memory-Listenansichten für Kunden, Lizenzen und Historie

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -486,3 +486,23 @@ Wichtig:
   - `siehe aktuellen Branch-Commit`
 - Hinweise:
   - Keine Lizenzdatei-Strukturreform, keine Modulfreischaltung und keine Sidebar-/Projektmodul-Aenderung
+
+#### Paket: Lizenzverwaltung naechstes Paket (In-Memory-Listen in Kunden/Lizenzen/Historie)
+- Status: erledigt
+- Beschreibung:
+  - Kunden-, Lizenzen- und Historie-Maske zeigen unterhalb der Buttons jeweils eine einfache Liste mit temporaer gemerkten In-Memory-Datensaetzen
+  - Listen laden ueber `listCustomers`, `listLicenses` und `listHistory` beim Oeffnen der Maske
+  - Nach erfolgreichem `Merken` wird die jeweilige Liste direkt aktualisiert
+  - Leerer Zustand ist je Maske sichtbar (`Noch keine temporär gemerkten ...`)
+  - Bestehende Buttons `Pruefen` und `Merken` bleiben unveraendert im Ablauf
+- Betroffene Dateien:
+  - `src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js`
+  - `src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js`
+  - `src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine Datenbank/Persistenz/Dateischreiben/IPC
+  - Keine Lizenzdatei-Logik, keine Sidebar- oder Projektmodul-Aenderung

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -313,6 +313,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(customerEditorSource.includes("ohne Speicherung"), true);
     assert.equal(customerEditorSource.includes("Keine Speicherung"), true);
     assert.equal(customerEditorSource.includes("saveCustomer"), true);
+    assert.equal(customerEditorSource.includes("listCustomers"), true);
+    assert.equal(customerEditorSource.includes("refreshCustomerList"), true);
+    assert.equal(customerEditorSource.includes("Temporär gemerkte Kunden"), true);
+    assert.equal(customerEditorSource.includes("Noch keine temporär gemerkten Kunden."), true);
+    assert.equal(customerEditorSource.includes("await refreshCustomerList();"), true);
     assert.equal(customerEditorSource.includes("temporaer gemerkt"), true);
     assert.equal(customerEditorSource.includes("nur In-Memory-Storage-Service"), true);
   });
@@ -343,6 +348,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordEditorSource.includes("Merken"), true);
     assert.equal(licenseRecordEditorSource.includes("Keine Speicherung"), true);
     assert.equal(licenseRecordEditorSource.includes("saveLicense"), true);
+    assert.equal(licenseRecordEditorSource.includes("listLicenses"), true);
+    assert.equal(licenseRecordEditorSource.includes("refreshLicenseList"), true);
+    assert.equal(licenseRecordEditorSource.includes("Temporär gemerkte Lizenzen"), true);
+    assert.equal(licenseRecordEditorSource.includes("Noch keine temporär gemerkten Lizenzen."), true);
+    assert.equal(licenseRecordEditorSource.includes("await refreshLicenseList();"), true);
     assert.equal(licenseRecordEditorSource.includes("temporaer gemerkt"), true);
     assert.equal(licenseRecordEditorSource.includes("nur In-Memory-Storage-Service"), true);
   });
@@ -393,6 +403,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseHistoryEditorSource.includes("Merken"), true);
     assert.equal(licenseHistoryEditorSource.includes("Keine Speicherung"), true);
     assert.equal(licenseHistoryEditorSource.includes("addHistoryEntry"), true);
+    assert.equal(licenseHistoryEditorSource.includes("listHistory"), true);
+    assert.equal(licenseHistoryEditorSource.includes("refreshHistoryList"), true);
+    assert.equal(licenseHistoryEditorSource.includes("Temporär gemerkte Historie"), true);
+    assert.equal(licenseHistoryEditorSource.includes("Noch keine temporär gemerkte Historie."), true);
+    assert.equal(licenseHistoryEditorSource.includes("await refreshHistoryList();"), true);
     assert.equal(licenseHistoryEditorSource.includes("temporaer gemerkt"), true);
     assert.equal(licenseHistoryEditorSource.includes("nur In-Memory-Storage-Service"), true);
   });

--- a/src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js
@@ -3,7 +3,7 @@ import {
   createDefaultCustomerRecord,
   normalizeCustomerRecord,
 } from "../licenseRecords.js";
-import { saveCustomer } from "../licenseStorageService.js";
+import { listCustomers, saveCustomer } from "../licenseStorageService.js";
 
 export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
   const model = createDefaultCustomerRecord();
@@ -113,6 +113,42 @@ export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupBut
   buttons.style.display = "flex";
   buttons.style.gap = "8px";
 
+  const memoryListWrap = document.createElement("div");
+  memoryListWrap.style.display = "grid";
+  memoryListWrap.style.gap = "6px";
+
+  const memoryListTitle = document.createElement("h4");
+  memoryListTitle.textContent = "Temporär gemerkte Kunden";
+  memoryListTitle.style.margin = "0";
+  memoryListTitle.style.fontSize = "13px";
+
+  const memoryList = document.createElement("ul");
+  memoryList.style.margin = "0";
+  memoryList.style.paddingLeft = "18px";
+  memoryList.style.display = "grid";
+  memoryList.style.gap = "4px";
+
+  const renderCustomerList = (customers) => {
+    memoryList.innerHTML = "";
+    if (!Array.isArray(customers) || customers.length === 0) {
+      const empty = document.createElement("li");
+      empty.textContent = "Noch keine temporär gemerkten Kunden.";
+      memoryList.appendChild(empty);
+      return;
+    }
+
+    customers.forEach((entry) => {
+      const item = document.createElement("li");
+      item.textContent = `${entry.customerNumber || "—"} | ${entry.companyName || "—"} | ${entry.email || "—"}`;
+      memoryList.appendChild(item);
+    });
+  };
+
+  const refreshCustomerList = async () => {
+    const customers = await listCustomers();
+    renderCustomerList(customers);
+  };
+
   const btnReset = document.createElement("button");
   btnReset.type = "button";
   btnReset.textContent = "Neu / leeren";
@@ -142,6 +178,7 @@ export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupBut
     if (!isValid) return;
 
     await saveCustomer(model);
+    await refreshCustomerList();
     message.textContent =
       "Datensatz temporaer gemerkt, noch keine dauerhafte Speicherung (nur In-Memory-Storage-Service).";
     message.style.background = "#f0fdf4";
@@ -149,8 +186,10 @@ export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupBut
   };
 
   buttons.append(btnReset, btnValidate, btnRemember);
+  memoryListWrap.append(memoryListTitle, memoryList);
 
   applyModelToInputs();
-  card.append(title, hint, form, buttons, message);
+  void refreshCustomerList();
+  card.append(title, hint, form, buttons, memoryListWrap, message);
   return card;
 }

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js
@@ -3,7 +3,7 @@ import {
   createDefaultLicenseHistoryRecord,
   normalizeLicenseHistoryRecord,
 } from "../licenseRecords.js";
-import { addHistoryEntry } from "../licenseStorageService.js";
+import { addHistoryEntry, listHistory } from "../licenseStorageService.js";
 
 export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
   const model = createDefaultLicenseHistoryRecord();
@@ -114,6 +114,44 @@ export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupBut
   buttons.style.display = "flex";
   buttons.style.gap = "8px";
 
+  const memoryListWrap = document.createElement("div");
+  memoryListWrap.style.display = "grid";
+  memoryListWrap.style.gap = "6px";
+
+  const memoryListTitle = document.createElement("h4");
+  memoryListTitle.textContent = "Temporär gemerkte Historie";
+  memoryListTitle.style.margin = "0";
+  memoryListTitle.style.fontSize = "13px";
+
+  const memoryList = document.createElement("ul");
+  memoryList.style.margin = "0";
+  memoryList.style.paddingLeft = "18px";
+  memoryList.style.display = "grid";
+  memoryList.style.gap = "4px";
+
+  const renderHistoryList = (historyEntries) => {
+    memoryList.innerHTML = "";
+    if (!Array.isArray(historyEntries) || historyEntries.length === 0) {
+      const empty = document.createElement("li");
+      empty.textContent = "Noch keine temporär gemerkte Historie.";
+      memoryList.appendChild(empty);
+      return;
+    }
+
+    historyEntries.forEach((entry) => {
+      const item = document.createElement("li");
+      item.textContent = `${entry.createdAt || "—"} | ${entry.licenseId || "—"} | ${entry.customer || "—"} | ${
+        entry.validUntil || "—"
+      }`;
+      memoryList.appendChild(item);
+    });
+  };
+
+  const refreshHistoryList = async () => {
+    const historyEntries = await listHistory();
+    renderHistoryList(historyEntries);
+  };
+
   const btnReset = document.createElement("button");
   btnReset.type = "button";
   btnReset.textContent = "Neu / leeren";
@@ -143,6 +181,7 @@ export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupBut
     if (!isValid) return;
 
     await addHistoryEntry(model);
+    await refreshHistoryList();
     message.textContent =
       "Datensatz temporaer gemerkt, noch keine dauerhafte Speicherung (nur In-Memory-Storage-Service).";
     message.style.background = "#f0fdf4";
@@ -150,8 +189,10 @@ export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupBut
   };
 
   buttons.append(btnReset, btnValidate, btnRemember);
+  memoryListWrap.append(memoryListTitle, memoryList);
 
   applyModelToInputs();
-  card.append(title, hint, form, buttons, message);
+  void refreshHistoryList();
+  card.append(title, hint, form, buttons, memoryListWrap, message);
   return card;
 }

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
@@ -4,7 +4,7 @@ import {
   createDefaultLicenseRecord,
   normalizeLicenseRecord,
 } from "../licenseRecords.js";
-import { saveLicense } from "../licenseStorageService.js";
+import { listLicenses, saveLicense } from "../licenseStorageService.js";
 
 export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
   const model = createDefaultLicenseRecord();
@@ -145,6 +145,44 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
   buttons.style.display = "flex";
   buttons.style.gap = "8px";
 
+  const memoryListWrap = document.createElement("div");
+  memoryListWrap.style.display = "grid";
+  memoryListWrap.style.gap = "6px";
+
+  const memoryListTitle = document.createElement("h4");
+  memoryListTitle.textContent = "Temporär gemerkte Lizenzen";
+  memoryListTitle.style.margin = "0";
+  memoryListTitle.style.fontSize = "13px";
+
+  const memoryList = document.createElement("ul");
+  memoryList.style.margin = "0";
+  memoryList.style.paddingLeft = "18px";
+  memoryList.style.display = "grid";
+  memoryList.style.gap = "4px";
+
+  const renderLicenseList = (licenses) => {
+    memoryList.innerHTML = "";
+    if (!Array.isArray(licenses) || licenses.length === 0) {
+      const empty = document.createElement("li");
+      empty.textContent = "Noch keine temporär gemerkten Lizenzen.";
+      memoryList.appendChild(empty);
+      return;
+    }
+
+    licenses.forEach((entry) => {
+      const item = document.createElement("li");
+      item.textContent = `${entry.licenseId || "—"} | ${entry.customerNumber || "—"} | ${
+        entry.validUntil || "—"
+      } | ${entry.licenseMode || "—"}`;
+      memoryList.appendChild(item);
+    });
+  };
+
+  const refreshLicenseList = async () => {
+    const licenses = await listLicenses();
+    renderLicenseList(licenses);
+  };
+
   const btnReset = document.createElement("button");
   btnReset.type = "button";
   btnReset.textContent = "Neu / leeren";
@@ -175,6 +213,7 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
     if (!isValid) return;
 
     await saveLicense(model);
+    await refreshLicenseList();
     message.textContent =
       "Datensatz temporaer gemerkt, noch keine dauerhafte Speicherung (nur In-Memory-Storage-Service).";
     message.style.background = "#f0fdf4";
@@ -182,8 +221,10 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
   };
 
   buttons.append(btnReset, btnValidate, btnRemember);
+  memoryListWrap.append(memoryListTitle, memoryList);
 
   applyModelToInputs();
-  card.append(title, hint, form, buttons, message);
+  void refreshLicenseList();
+  card.append(title, hint, form, buttons, memoryListWrap, message);
   return card;
 }


### PR DESCRIPTION
### Motivation
- Vorbereitung des nächsten Lizenzverwaltungs-Pakets: der Benutzer soll nach „Merken“ im selben Lauf sehen können, welche Datensätze temporär im In-Memory-Storage-Service gespeichert wurden.
- Keine Persistenz oder Architekturänderung; nur eine sichtbare, temporäre In-Memory-Übersicht in den drei relevanten Masken.

### Description
- Ergänzt in den Masken `Kunden`, `Lizenzen` und `Historie` je einen einfachen Listenbereich unterhalb der Buttons, der temporär gemerkte Einträge anzeigt und beim Öffnen über `listCustomers()`, `listLicenses()` bzw. `listHistory()` geladen wird. Nach erfolgreichem `Merken` wird die jeweilige Liste aktualisiert.
- Anzeigen (mindestens): Kunden: `Kundennummer | Firma/Kundenname | E-Mail`; Lizenzen: `Lizenz-ID | Kunde | gueltig bis | Lizenzmodus`; Historie: `erzeugt am | Lizenz-ID | Kunde | gueltig bis`.
- Nutzung ausschließlich der bestehenden In-Memory-Service-Funktionen: `listCustomers`, `listLicenses`, `listHistory`, `saveCustomer`, `saveLicense`, `addHistoryEntry`; keine Datenbank, keine Persistenz, kein IPC, und keine Änderung der Lizenzdatei-Logik.
- Geänderte Dateien:
  - `src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js`
  - `src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js`
  - `src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js`
  - `scripts/tests/lizenzverwaltungModule.test.cjs` (Test-Vertragsprüfungen ergänzt)
  - `STATUS.md` (Paket-Fortschreibung)

### Testing
- Ausgeführt: `npm test`; Ergebnis: alle Tests bestanden (grün).
- Test-Ergänzungen in `scripts/tests/lizenzverwaltungModule.test.cjs` prüfen jetzt die Verwendung von `listCustomers` / `listLicenses` / `listHistory`, die Sichtbarkeit der neuen Listentitel, die leeren Zustände und das Vorhandensein von Calls/Refresh nach `Merken`.
- Es wurden keine weiteren automatisierten Tests modifiziert oder neue Persistenz-Tests eingeführt; bestehendes Verhalten außerhalb des beschriebenen UI-Views blieb unverändert.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf7cd58ac83229c71bd55e6a7c668)