### PR TITLE
Lizenzverwaltung: In-Memory-Listenansichten in Kunden/Lizenzen/Historie absichern

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -91,6 +91,9 @@ Sie ergänzt:
   - Listen werden ueber `listCustomers`, `listLicenses` und `listHistory` geladen
   - Nach erfolgreichem `Merken` wird die jeweilige Liste sofort aktualisiert (ohne Persistenz, nur im laufenden App-Prozess)
   - Leerer Zustand ist in allen drei Masken sichtbar
+- Lizenzverwaltung Neuversuch (In-Memory-Listenansichten) ist nachgezogen:
+  - Testnachweise in `scripts/tests/lizenzverwaltungModule.test.cjs` fuer Kunden/Lizenzen/Historie um Listenfelder und Refresh nach `Merken` ergaenzt
+  - Leerer Zustand und Adminbereich-Abgrenzung bleiben weiterhin abgesichert
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -318,7 +318,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(customerEditorSource.includes("nur In-Memory-Storage-Service"), true);
     assert.equal(customerEditorSource.includes("Temporär gemerkte Kunden"), true);
     assert.equal(customerEditorSource.includes("Noch keine temporär gemerkten Kunden."), true);
+    assert.equal(customerEditorSource.includes("entry.customerNumber"), true);
+    assert.equal(customerEditorSource.includes("entry.companyName"), true);
+    assert.equal(customerEditorSource.includes("entry.email"), true);
     assert.equal(customerEditorSource.includes("refreshRememberedCustomers"), true);
+    assert.equal(customerEditorSource.includes("refreshRememberedCustomers();"), true);
     assert.equal(customerEditorSource.includes("await refreshRememberedCustomers();"), true);
   });
 
@@ -353,7 +357,12 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordEditorSource.includes("nur In-Memory-Storage-Service"), true);
     assert.equal(licenseRecordEditorSource.includes("Temporär gemerkte Lizenzen"), true);
     assert.equal(licenseRecordEditorSource.includes("Noch keine temporär gemerkten Lizenzen."), true);
+    assert.equal(licenseRecordEditorSource.includes("entry.licenseId"), true);
+    assert.equal(licenseRecordEditorSource.includes("entry.customerNumber"), true);
+    assert.equal(licenseRecordEditorSource.includes("entry.validUntil"), true);
+    assert.equal(licenseRecordEditorSource.includes("entry.licenseMode"), true);
     assert.equal(licenseRecordEditorSource.includes("refreshRememberedLicenses"), true);
+    assert.equal(licenseRecordEditorSource.includes("refreshRememberedLicenses();"), true);
     assert.equal(licenseRecordEditorSource.includes("await refreshRememberedLicenses();"), true);
   });
 
@@ -408,7 +417,12 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseHistoryEditorSource.includes("nur In-Memory-Storage-Service"), true);
     assert.equal(licenseHistoryEditorSource.includes("Temporär gemerkte Historie"), true);
     assert.equal(licenseHistoryEditorSource.includes("Noch keine temporär gemerkte Historie."), true);
+    assert.equal(licenseHistoryEditorSource.includes("entry.createdAt"), true);
+    assert.equal(licenseHistoryEditorSource.includes("entry.licenseId"), true);
+    assert.equal(licenseHistoryEditorSource.includes("entry.customer"), true);
+    assert.equal(licenseHistoryEditorSource.includes("entry.validUntil"), true);
     assert.equal(licenseHistoryEditorSource.includes("refreshRememberedHistory"), true);
+    assert.equal(licenseHistoryEditorSource.includes("refreshRememberedHistory();"), true);
     assert.equal(licenseHistoryEditorSource.includes("await refreshRememberedHistory();"), true);
   });
 


### PR DESCRIPTION
### Motivation
- Sicherstellen, dass die vorbereiteten In-Memory-Listen in den Masken `Kunden`, `Lizenzen` und `Historie` sichtbar und prüfbar sind, sodass nach einem „Merken“ temporär gespeicherte Datensätze im laufenden App-Prozess sofort angezeigt werden.

### Description
- Erweiterte Tests in `scripts/tests/lizenzverwaltungModule.test.cjs`, die explizit prüfen, dass die Listenansichten vorhanden sind und die geforderten Mindestfelder anzeigen: Kunden: `customerNumber`, `companyName`, `email`; Lizenzen: `licenseId`, `customerNumber`, `validUntil`, `licenseMode`; Historie: `createdAt`, `licenseId`, `customer`, `validUntil`.
- `STATUS.md` aktualisiert, um den Neuversuch und die erweiterten Testnachweise zu dokumentieren; es wurden keine Änderungen an Persistenz, IPC, DB oder an der eigentlichen UI-Logik vorgenommen.

### Testing
- `npm test` ausgeführt und alle Tests sind grün, inklusive der erweiterten Lizenzverwaltungs-Tests.
- Geänderte Dateien in den Tests und Dokumentation: `scripts/tests/lizenzverwaltungModule.test.cjs` und `STATUS.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee11d4db048322b0593dc155628131)