### PR TITLE
docs: Bestandsaufnahme vorhandene Speicherung für Lizenzverwaltung

### DIFF
--- a/docs/modules/lizenzverwaltung.md
+++ b/docs/modules/lizenzverwaltung.md
@@ -153,6 +153,31 @@ Noch nicht festlegen:
 - keine Persistenz implementieren
 - keine Lizenzdatei-Strukturreform
 
+### Bestandsaufnahme vorhandene Speicherung
+1. Gefundene bestehende Speicherwege
+   - Hauptspeicherweg der App: lokale SQLite-Datenbank `app.db` unter `app.getPath("userData")` via `better-sqlite3`; darin liegen u. a. Projekte, Meetings, Tops, App-Settings, Projekt-Settings, Firmen/Personen, Audio- und Wörterbuchdaten.
+   - Dateibasierte Speicherung ist vorhanden:
+     - installierte Laufzeitlizenz als `license.json` unter `userData`
+     - Import/Export- und Arbeitsdateien als JSON/ZIP/PDF in Dateisystempfaden (u. a. Downloads/Temp/Projektordner).
+   - Renderer-seitig gibt es kleine `localStorage`-Nutzung für UI-Zustände/Fallbacks (z. B. UI-Modus, letztes Projekt, einzelne View-Settings).
+   - Aktuelles Lizenzverwaltungs-Modul (`licenseStorageService.js`) ist nur In-Memory (Arrays im Prozess) und derzeit nicht dauerhaft.
+
+2. Bewertung für Lizenzverwaltung
+   - Für Kunden-/Lizenz-/Historien-Daten ist In-Memory ungeeignet (kein Neustart-Überleben, kein belastbarer Admin-Bestand).
+   - `localStorage` ist für Admin-Fachdaten ungeeignet (Renderer-gebunden, nur für leichte UI-Zustände sinnvoll).
+   - Reine Dateiablage (einzelne JSON-Dateien) ist für Exporte/Transfer gut, aber für relationale Admin-Verwaltung (Kunde ↔ Lizenzen ↔ Historie) fehleranfälliger als strukturierte Tabellen.
+   - Der bestehende App-Speicherpfad über SQLite ist bereits produktiv etabliert und passt fachlich zum benötigten Datenmodell.
+
+3. Empfehlung für den nächsten technischen Schritt
+   - Als nächstes nur ein technisches Speicherkonzept festziehen (ohne Implementierung): Zielrichtung `app.db` mit klar getrennten Admin-Tabellen für Kunden, Lizenzen und Lizenzhistorie.
+   - Parallel Datenabgrenzung dokumentieren: welche Felder nur Admin-intern sind und welche Felder später in exportierte Lizenzdateien dürfen.
+   - Danach erst Migrations-/IPC-Schnitt planen (weiterhin noch ohne Persistenzbau in diesem Paket).
+
+4. Abgrenzung Kind-App / Admin-App
+   - Bleibt in der Admin-/Mutter-App: vollständige Kundenstammdaten, interne Notizen, Verlängerungs-/Neuausgabe-Historie, interne Bearbeitungsmetadaten.
+   - Darf in die Kind-App: nur prüfrelevante Lizenzdaten (z. B. Lizenz-ID, Gültigkeit, freigegebener Umfang, ggf. Binding/Machine-ID) plus Status/Import/Prüfung.
+   - Darf die Kind-App nicht mitbekommen: Kundenliste, Gesamt-Lizenzhistorie, interne Admin-Notizen, Daten anderer Kunden/Installationen.
+
 ### Abgrenzung
 Nicht Teil dieses Schritts:
 - Kunden speichern


### PR DESCRIPTION
### Motivation
- Kleines Doku-/Analyse-Paket zur Vorbereitung der Lizenzverwaltung: bestehende Speicherwege in der App erfassen, bewerten und eine fachlich sinnvolle nächste Richtungsentscheidung vorschlagen, ohne Persistenz zu bauen.

### Description
- Ergänzt `docs/modules/lizenzverwaltung.md` um den Abschnitt `Bestandsaufnahme vorhandene Speicherung`, der gefundene Speicherwege, eine Bewertung für die Lizenzverwaltung, eine Empfehlung für den nächsten technischen Schritt und die Abgrenzung Admin-App / Kind-App beschreibt (Datei: `docs/modules/lizenzverwaltung.md`).
- Die Analyse stützt sich auf vorhandene Implementierungen/Einträge im Repo, u. a. lokale SQLite-DB (`src/main/db/database.js`), Laufzeit-Lizenzdatei (`src/main/licensing/licenseStorage.js`), In-Memory-Stub im Renderer (`src/renderer/modules/lizenzverwaltung/licenseStorageService.js`) sowie IPC/Preload-Zugänge (`src/main/ipc/licenseIpc.js`, `src/main/preload.js`).

### Testing
- Keine automatisierten Tests ausgeführt; Paket ist reine Dokumentation/Analyse und ändert nur `docs/modules/lizenzverwaltung.md`.
- Manuelle Prüfungen: `git diff`/Dateiansicht zur Bestätigung, dass nur die Doku-Datei ergänzt wurde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee150e7a9c8322accea6dd17a46feb)