### PR TITLE
DB-Schema vorbereiten: Admin-Tabellen für Lizenzverwaltung

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -91,6 +91,10 @@ Sie ergänzt:
   - Listen werden ueber `listCustomers`, `listLicenses` und `listHistory` geladen
   - Nach erfolgreichem `Merken` wird die jeweilige Liste sofort aktualisiert (ohne Persistenz, nur im laufenden App-Prozess)
   - Leerer Zustand ist in allen drei Masken sichtbar
+- Lizenzverwaltung naechstes Paket ist umgesetzt:
+  - DB-Schema/Migration in `src/main/db/database.js` um getrennte Admin-Tabellen `license_customers`, `license_records`, `license_history` erweitert (nicht-destruktiv, ohne UI-/IPC-Umstellung)
+  - `licenseStorageService` bleibt bewusst In-Memory; keine Lizenzdatei-Logik und kein Projektmodul-Verhalten geändert
+
 - Lizenzverwaltung Neuversuch (In-Memory-Listenansichten) ist nachgezogen:
   - Testnachweise in `scripts/tests/lizenzverwaltungModule.test.cjs` fuer Kunden/Lizenzen/Historie um Listenfelder und Refresh nach `Merken` ergaenzt
   - Leerer Zustand und Adminbereich-Abgrenzung bleiben weiterhin abgesichert

--- a/docs/modules/lizenzverwaltung.md
+++ b/docs/modules/lizenzverwaltung.md
@@ -226,6 +226,10 @@ Sie ist nicht die vollständige Admin-Datenbank.
 4. Renderer-`licenseStorageService` von In-Memory auf IPC umstellen.
 5. Danach erst Masken wirklich dauerhaft speichern.
 
+Kurzstand (Paket DB-Schema/Migration):
+- Die Tabellen `license_customers`, `license_records` und `license_history` sind in `src/main/db/database.js` als nicht-destruktive Tabellenanlage vorbereitet.
+- `licenseStorageService` bleibt weiterhin In-Memory; UI und IPC wurden in diesem Paket nicht umgestellt.
+
 ### Abgrenzung
 Nicht Teil dieses Schritts:
 - Kunden speichern

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -65,6 +65,7 @@ async function runLizenzverwaltungModuleTests(run) {
   const moduleCatalogSource = read("src/renderer/app/modules/moduleCatalog.js");
   const projectWorkspaceSource = read("src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js");
   const settingsViewSource = read("src/renderer/views/SettingsView.js");
+  const databaseSource = read("src/main/db/database.js");
 
   await run("Lizenzverwaltung: Modul exportiert LicenseAdminScreen", () => {
     const entry = getLizenzverwaltungModuleEntry();
@@ -424,6 +425,44 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseHistoryEditorSource.includes("refreshRememberedHistory"), true);
     assert.equal(licenseHistoryEditorSource.includes("refreshRememberedHistory();"), true);
     assert.equal(licenseHistoryEditorSource.includes("await refreshRememberedHistory();"), true);
+  });
+
+  await run("Lizenzverwaltung DB-Schema: Tabellen fuer Admin-Lizenzdaten sind vorbereitet", () => {
+    assert.equal(databaseSource.includes("CREATE TABLE IF NOT EXISTS license_customers"), true);
+    assert.equal(databaseSource.includes("CREATE TABLE IF NOT EXISTS license_records"), true);
+    assert.equal(databaseSource.includes("CREATE TABLE IF NOT EXISTS license_history"), true);
+  });
+
+  await run("Lizenzverwaltung DB-Schema: product_scope_json ist fuer Lizenz und Historie vorhanden", () => {
+    assert.equal(databaseSource.includes("license_records"), true);
+    assert.equal(databaseSource.includes("product_scope_json TEXT NOT NULL"), true);
+    assert.equal(databaseSource.includes("license_history"), true);
+  });
+
+  await run("Lizenzverwaltung DB-Schema: Referenzen customer_id und license_record_id sind vorbereitet", () => {
+    assert.equal(databaseSource.includes("customer_id TEXT NOT NULL"), true);
+    assert.equal(
+      databaseSource.includes("FOREIGN KEY (customer_id) REFERENCES license_customers(id) ON DELETE RESTRICT"),
+      true
+    );
+    assert.equal(databaseSource.includes("license_record_id TEXT NOT NULL"), true);
+    assert.equal(
+      databaseSource.includes(
+        "FOREIGN KEY (license_record_id) REFERENCES license_records(id) ON DELETE RESTRICT"
+      ),
+      true
+    );
+  });
+
+  await run("Lizenzverwaltung: keine IPC-Umstellung und Renderer-Storage bleibt In-Memory", () => {
+    const storageServiceSource = read("src/renderer/modules/lizenzverwaltung/licenseStorageService.js");
+
+    assert.equal(storageServiceSource.includes("const storage = {"), true);
+    assert.equal(storageServiceSource.includes("customers: []"), true);
+    assert.equal(storageServiceSource.includes("licenses: []"), true);
+    assert.equal(storageServiceSource.includes("history: []"), true);
+    assert.equal(storageServiceSource.includes("ipcRenderer"), false);
+    assert.equal(storageServiceSource.includes("window.api"), false);
   });
 
   await run("Lizenzverwaltung: bleibt Adminbereich und erscheint nicht als Projektmodul", () => {

--- a/src/main/db/database.js
+++ b/src/main/db/database.js
@@ -1088,6 +1088,60 @@ function ensureAppSettingsSchema(dbConn) {
   }
 }
 
+
+function ensureLicenseAdminSchema(dbConn) {
+  if (!tableExists(dbConn, "license_customers")) {
+    dbConn.exec(`
+      CREATE TABLE IF NOT EXISTS license_customers (
+        id TEXT PRIMARY KEY,
+        customer_number TEXT NOT NULL,
+        company_name TEXT NOT NULL,
+        contact_person TEXT,
+        email TEXT,
+        phone TEXT,
+        notes TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+      );
+    `);
+  }
+
+  if (!tableExists(dbConn, "license_records")) {
+    dbConn.exec(`
+      CREATE TABLE IF NOT EXISTS license_records (
+        id TEXT PRIMARY KEY,
+        license_id TEXT NOT NULL,
+        customer_id TEXT NOT NULL,
+        product_scope_json TEXT NOT NULL,
+        valid_from TEXT,
+        valid_until TEXT,
+        license_mode TEXT,
+        machine_id TEXT,
+        notes TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+        FOREIGN KEY (customer_id) REFERENCES license_customers(id) ON DELETE RESTRICT
+      );
+    `);
+  }
+
+  if (!tableExists(dbConn, "license_history")) {
+    dbConn.exec(`
+      CREATE TABLE IF NOT EXISTS license_history (
+        id TEXT PRIMARY KEY,
+        license_record_id TEXT NOT NULL,
+        generated_at TEXT,
+        product_scope_json TEXT NOT NULL,
+        valid_until TEXT,
+        output_path TEXT,
+        notes TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+        FOREIGN KEY (license_record_id) REFERENCES license_records(id) ON DELETE RESTRICT
+      );
+    `);
+  }
+}
+
 function ensureDictionarySchema(dbConn) {
   if (!tableExists(dbConn, "dictionary_suggestions")) {
     dbConn.exec(`
@@ -1403,6 +1457,7 @@ function ensureSchema(dbConn) {
 
   ensureDictionarySchema(dbConn);
   ensureAppSettingsSchema(dbConn);
+  ensureLicenseAdminSchema(dbConn);
 }
 
 function initDatabase() {


### PR DESCRIPTION
### Motivation
- Vorbereitung des Datenbank-Schemas als ersten nicht-destruktiven Persistenzschritt für die Lizenzverwaltung, damit Kunden-, Lizenz- und Historien-Daten künftig sauber in `app.db` liegen können.
- Dabei soll das bestehende Verhalten stabil bleiben: keine UI-/IPC-Änderungen, `licenseStorageService` bleibt In-Memory und es werden keine bestehenden Tabellen oder Migrationen zerstört.

### Description
- `src/main/db/database.js` wurde um die Funktion `ensureLicenseAdminSchema(dbConn)` erweitert und in `ensureSchema` eingebunden, die nicht-destruktiv die Tabellen `license_customers`, `license_records` und `license_history` anlegt (inkl. Felder wie `product_scope_json`, `created_at`/`updated_at` und vorbereiteten FOREIGN KEYs mit `ON DELETE RESTRICT`).
- `product_scope_json` wird als TEXT/JSON-String-Feld umgesetzt und `created_at`/`updated_at` folgen dem bestehenden `strftime(...,'now')`-Stil; es wurden keine bestehenden Tabellen verändert.
- Tests in `scripts/tests/lizenzverwaltungModule.test.cjs` wurden ergänzt, um das Vorhandensein der neuen Tabellen, das Vorhandensein von `product_scope_json` und die vorbereiteten Referenzen zu prüfen, und um sicherzustellen, dass der Renderer-Storage weiterhin In-Memory ohne IPC bleibt.
- Dokumentation in `docs/modules/lizenzverwaltung.md` wurde kurz ergänzt (Kurzstand: DB-Schema/Migration vorbereitet) und `STATUS.md` minimal aktualisiert; keine UI-, IPC- oder Lizenzdatei-Logik wurde geändert.

### Testing
- `npm test` wurde ausgeführt und alle automatisierten Tests liefen grün, inklusive der neuen Assertions in `scripts/tests/lizenzverwaltungModule.test.cjs`.
- Ergänzte Tests prüfen explizit: Vorhandensein von `license_customers`, `license_records`, `license_history`, dass `product_scope_json` vorhanden ist, die vorbereiteten FOREIGN KEY-Verknüpfungen und dass `licenseStorageService` weiterhin In-Memory ohne IPC-Aufrufe bleibt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee26a285108322a1647c680c2c33e8)