### PR TITLE
Prepare Main-Process license admin service (list/save/history)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -94,6 +94,9 @@ Sie ergänzt:
 - Lizenzverwaltung naechstes Paket ist umgesetzt:
   - DB-Schema/Migration in `src/main/db/database.js` um getrennte Admin-Tabellen `license_customers`, `license_records`, `license_history` erweitert (nicht-destruktiv, ohne UI-/IPC-Umstellung)
   - `licenseStorageService` bleibt bewusst In-Memory; keine Lizenzdatei-Logik und kein Projektmodul-Verhalten geändert
+- Lizenzverwaltung naechstes Paket ist umgesetzt:
+  - Main-Process-Service `src/main/licensing/licenseAdminService.js` fuer Admin-Lizenzdaten vorbereitet (list/save fuer Kunden und Lizenzen, Historien-Read/Write)
+  - noch keine IPC-/Preload-Anbindung; Renderer-Storage bleibt In-Memory
 
 - Lizenzverwaltung Neuversuch (In-Memory-Listenansichten) ist nachgezogen:
   - Testnachweise in `scripts/tests/lizenzverwaltungModule.test.cjs` fuer Kunden/Lizenzen/Historie um Listenfelder und Refresh nach `Merken` ergaenzt

--- a/docs/modules/lizenzverwaltung.md
+++ b/docs/modules/lizenzverwaltung.md
@@ -229,6 +229,7 @@ Sie ist nicht die vollständige Admin-Datenbank.
 Kurzstand (Paket DB-Schema/Migration):
 - Die Tabellen `license_customers`, `license_records` und `license_history` sind in `src/main/db/database.js` als nicht-destruktive Tabellenanlage vorbereitet.
 - `licenseStorageService` bleibt weiterhin In-Memory; UI und IPC wurden in diesem Paket nicht umgestellt.
+- Main-Process-Service ist vorbereitet (`src/main/licensing/licenseAdminService.js`), aber noch nicht per IPC angebunden.
 
 ### Abgrenzung
 Nicht Teil dieses Schritts:

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -66,6 +66,9 @@ async function runLizenzverwaltungModuleTests(run) {
   const projectWorkspaceSource = read("src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js");
   const settingsViewSource = read("src/renderer/views/SettingsView.js");
   const databaseSource = read("src/main/db/database.js");
+  const licenseAdminServiceSource = read("src/main/licensing/licenseAdminService.js");
+  const preloadSource = read("src/main/preload.js");
+  const licenseIpcSource = read("src/main/ipc/licenseIpc.js");
 
   await run("Lizenzverwaltung: Modul exportiert LicenseAdminScreen", () => {
     const entry = getLizenzverwaltungModuleEntry();
@@ -454,6 +457,35 @@ async function runLizenzverwaltungModuleTests(run) {
     );
   });
 
+  await run("Lizenzverwaltung Main-Service: Datei existiert und exportiert die geplanten Funktionen", () => {
+    const service = require(path.join(process.cwd(), "src/main/licensing/licenseAdminService.js"));
+
+    assert.equal(typeof service.listCustomers, "function");
+    assert.equal(typeof service.saveCustomer, "function");
+    assert.equal(typeof service.listLicenses, "function");
+    assert.equal(typeof service.saveLicense, "function");
+    assert.equal(typeof service.listHistory, "function");
+    assert.equal(typeof service.addHistoryEntry, "function");
+  });
+
+  await run("Lizenzverwaltung Main-Service: nutzt database.js und Admin-Tabellen", () => {
+    assert.equal(licenseAdminServiceSource.includes('require("../db/database")'), true);
+    assert.equal(licenseAdminServiceSource.includes("license_customers"), true);
+    assert.equal(licenseAdminServiceSource.includes("license_records"), true);
+    assert.equal(licenseAdminServiceSource.includes("license_history"), true);
+  });
+
+  await run("Lizenzverwaltung Main-Service: speichert product_scope_json als JSON-String", () => {
+    assert.equal(licenseAdminServiceSource.includes("product_scope_json"), true);
+    assert.equal(licenseAdminServiceSource.includes("JSON.stringify"), true);
+    assert.equal(licenseAdminServiceSource.includes("JSON.parse"), true);
+  });
+
+  await run("Lizenzverwaltung Main-Service: bleibt im Main-Prozess ohne Renderer-Import", () => {
+    assert.equal(licenseAdminServiceSource.includes("../renderer"), false);
+    assert.equal(licenseAdminServiceSource.includes("licenseStorageService"), false);
+  });
+
   await run("Lizenzverwaltung: keine IPC-Umstellung und Renderer-Storage bleibt In-Memory", () => {
     const storageServiceSource = read("src/renderer/modules/lizenzverwaltung/licenseStorageService.js");
 
@@ -463,6 +495,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(storageServiceSource.includes("history: []"), true);
     assert.equal(storageServiceSource.includes("ipcRenderer"), false);
     assert.equal(storageServiceSource.includes("window.api"), false);
+  });
+
+  await run("Lizenzverwaltung: keine IPC-/Preload-Umstellung fuer Main-Service erfolgt", () => {
+    assert.equal(preloadSource.includes("licenseAdminService"), false);
+    assert.equal(licenseIpcSource.includes("licenseAdminService"), false);
   });
 
   await run("Lizenzverwaltung: bleibt Adminbereich und erscheint nicht als Projektmodul", () => {

--- a/src/main/licensing/licenseAdminService.js
+++ b/src/main/licensing/licenseAdminService.js
@@ -1,0 +1,264 @@
+const { randomUUID } = require("crypto");
+const { initDatabase } = require("../db/database");
+
+function _db() {
+  return initDatabase();
+}
+
+function _trimText(value) {
+  if (value === null || value === undefined) return "";
+  return String(value).trim();
+}
+
+function _optionalText(value) {
+  const trimmed = _trimText(value);
+  return trimmed || null;
+}
+
+function _nowIso() {
+  return new Date().toISOString();
+}
+
+function _normalizeProductScopeJson(input) {
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    if (!trimmed) return JSON.stringify({});
+    try {
+      const parsed = JSON.parse(trimmed);
+      return JSON.stringify(parsed || {});
+    } catch (_err) {
+      return JSON.stringify({ raw: trimmed });
+    }
+  }
+
+  if (!input || typeof input !== "object") {
+    return JSON.stringify({});
+  }
+
+  return JSON.stringify(input);
+}
+
+function _normalizeCustomerRecord(customer = {}) {
+  const id = _trimText(customer.id) || randomUUID();
+
+  return {
+    id,
+    customer_number: _trimText(customer.customer_number || customer.customerNumber),
+    company_name: _trimText(customer.company_name || customer.companyName),
+    contact_person: _optionalText(customer.contact_person || customer.contactPerson),
+    email: _optionalText(customer.email),
+    phone: _optionalText(customer.phone),
+    notes: _optionalText(customer.notes),
+  };
+}
+
+function _normalizeLicenseRecord(license = {}) {
+  const id = _trimText(license.id) || randomUUID();
+
+  return {
+    id,
+    license_id: _trimText(license.license_id || license.licenseId),
+    customer_id: _trimText(license.customer_id || license.customerId),
+    product_scope_json: _normalizeProductScopeJson(
+      license.product_scope_json !== undefined ? license.product_scope_json : license.productScope
+    ),
+    valid_from: _optionalText(license.valid_from || license.validFrom),
+    valid_until: _optionalText(license.valid_until || license.validUntil),
+    license_mode: _optionalText(license.license_mode || license.licenseMode),
+    machine_id: _optionalText(license.machine_id || license.machineId),
+    notes: _optionalText(license.notes),
+  };
+}
+
+function _normalizeHistoryEntry(entry = {}) {
+  const id = _trimText(entry.id) || randomUUID();
+
+  return {
+    id,
+    license_record_id: _trimText(entry.license_record_id || entry.licenseRecordId),
+    generated_at: _optionalText(entry.generated_at || entry.generatedAt),
+    product_scope_json: _normalizeProductScopeJson(
+      entry.product_scope_json !== undefined ? entry.product_scope_json : entry.productScope
+    ),
+    valid_until: _optionalText(entry.valid_until || entry.validUntil),
+    output_path: _optionalText(entry.output_path || entry.outputPath),
+    notes: _optionalText(entry.notes),
+  };
+}
+
+function listCustomers() {
+  return _db().prepare(`SELECT * FROM license_customers ORDER BY company_name COLLATE NOCASE, customer_number COLLATE NOCASE`).all();
+}
+
+function saveCustomer(customer = {}) {
+  const db = _db();
+  const record = _normalizeCustomerRecord(customer);
+  if (!record.customer_number) throw new Error("customer_number required");
+  if (!record.company_name) throw new Error("company_name required");
+
+  const existing = db.prepare(`SELECT id FROM license_customers WHERE id = ?`).get(record.id);
+  const now = _nowIso();
+
+  if (existing) {
+    db.prepare(
+      `
+      UPDATE license_customers
+      SET customer_number = ?,
+          company_name = ?,
+          contact_person = ?,
+          email = ?,
+          phone = ?,
+          notes = ?,
+          updated_at = ?
+      WHERE id = ?
+    `
+    ).run(
+      record.customer_number,
+      record.company_name,
+      record.contact_person,
+      record.email,
+      record.phone,
+      record.notes,
+      now,
+      record.id
+    );
+  } else {
+    db.prepare(
+      `
+      INSERT INTO license_customers (
+        id,
+        customer_number,
+        company_name,
+        contact_person,
+        email,
+        phone,
+        notes
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    `
+    ).run(
+      record.id,
+      record.customer_number,
+      record.company_name,
+      record.contact_person,
+      record.email,
+      record.phone,
+      record.notes
+    );
+  }
+
+  return db.prepare(`SELECT * FROM license_customers WHERE id = ?`).get(record.id);
+}
+
+function listLicenses() {
+  return _db().prepare(`SELECT * FROM license_records ORDER BY created_at DESC, license_id COLLATE NOCASE`).all();
+}
+
+function saveLicense(license = {}) {
+  const db = _db();
+  const record = _normalizeLicenseRecord(license);
+  if (!record.license_id) throw new Error("license_id required");
+  if (!record.customer_id) throw new Error("customer_id required");
+
+  const existing = db.prepare(`SELECT id FROM license_records WHERE id = ?`).get(record.id);
+  const now = _nowIso();
+
+  if (existing) {
+    db.prepare(
+      `
+      UPDATE license_records
+      SET license_id = ?,
+          customer_id = ?,
+          product_scope_json = ?,
+          valid_from = ?,
+          valid_until = ?,
+          license_mode = ?,
+          machine_id = ?,
+          notes = ?,
+          updated_at = ?
+      WHERE id = ?
+    `
+    ).run(
+      record.license_id,
+      record.customer_id,
+      record.product_scope_json,
+      record.valid_from,
+      record.valid_until,
+      record.license_mode,
+      record.machine_id,
+      record.notes,
+      now,
+      record.id
+    );
+  } else {
+    db.prepare(
+      `
+      INSERT INTO license_records (
+        id,
+        license_id,
+        customer_id,
+        product_scope_json,
+        valid_from,
+        valid_until,
+        license_mode,
+        machine_id,
+        notes
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `
+    ).run(
+      record.id,
+      record.license_id,
+      record.customer_id,
+      record.product_scope_json,
+      record.valid_from,
+      record.valid_until,
+      record.license_mode,
+      record.machine_id,
+      record.notes
+    );
+  }
+
+  return db.prepare(`SELECT * FROM license_records WHERE id = ?`).get(record.id);
+}
+
+function listHistory() {
+  return _db().prepare(`SELECT * FROM license_history ORDER BY created_at DESC`).all();
+}
+
+function addHistoryEntry(entry = {}) {
+  const db = _db();
+  const record = _normalizeHistoryEntry(entry);
+  if (!record.license_record_id) throw new Error("license_record_id required");
+
+  db.prepare(
+    `
+    INSERT INTO license_history (
+      id,
+      license_record_id,
+      generated_at,
+      product_scope_json,
+      valid_until,
+      output_path,
+      notes
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+  `
+  ).run(
+    record.id,
+    record.license_record_id,
+    record.generated_at,
+    record.product_scope_json,
+    record.valid_until,
+    record.output_path,
+    record.notes
+  );
+
+  return db.prepare(`SELECT * FROM license_history WHERE id = ?`).get(record.id);
+}
+
+module.exports = {
+  listCustomers,
+  saveCustomer,
+  listLicenses,
+  saveLicense,
+  listHistory,
+  addHistoryEntry,
+};


### PR DESCRIPTION
### Motivation
- Prepare a central Main-Process service layer for Admin license data so the Renderer can be connected later via IPC without changing current UI or persistence behavior.
- Ensure the new service works with the prepared DB tables `license_customers`, `license_records` and `license_history` defined in `database.js` and follows the existing non-destructive migration approach.

### Description
- Added `src/main/licensing/licenseAdminService.js` implementing `listCustomers()`, `saveCustomer(customer)`, `listLicenses()`, `saveLicense(license)`, `listHistory()`, and `addHistoryEntry(entry)` and exporting them for future IPC usage.
- The service uses `initDatabase()` from `src/main/db/database.js` for DB access and performs safe normalization: string trimming, ID generation with `randomUUID()` when missing, `updated_at` on updates, and storing `product_scope_json` as a JSON string.
- Tests and docs updated: extended `scripts/tests/lizenzverwaltungModule.test.cjs` to assert the Main-Service file, its exports, DB-table usage, JSON handling and absence of renderer imports or IPC/preload changes; and added a short note to `docs/modules/lizenzverwaltung.md` and a brief STATUS.md entry stating the Main-Service is prepared but not IPC-bound.
- No IPC, preload, renderer, UI, license-file logic, schema destructive changes, or new dependencies were introduced.

### Testing
- Ran `npm test`, all tests passed (see test run output: "Alle Tests bestanden." and detailed per-test OK lines).
- Added automated checks in `scripts/tests/lizenzverwaltungModule.test.cjs` verifying the Main-Service file exists, exports the required functions, references `database.js` and the admin tables, stores `product_scope_json` as JSON, contains no renderer imports, and confirmed no IPC/preload integration was added; these checks passed as part of the full test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3a080b0c8322a350267c3ae0a9ba)