### PR TITLE
Lizenzverwaltung: IPC-/Preload‑Schnitt für Admin‑Lizenzdaten vorbereiten

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -97,6 +97,9 @@ Sie ergänzt:
 - Lizenzverwaltung naechstes Paket ist umgesetzt:
   - Main-Process-Service `src/main/licensing/licenseAdminService.js` fuer Admin-Lizenzdaten vorbereitet (list/save fuer Kunden und Lizenzen, Historien-Read/Write)
   - noch keine IPC-/Preload-Anbindung; Renderer-Storage bleibt In-Memory
+- Lizenzverwaltung naechstes Paket ist umgesetzt:
+  - IPC-/Preload-Schnitt fuer Admin-Lizenzdaten ist vorbereitet (`license-admin:*` + `licenseAdmin*` im Preload)
+  - Renderer-`licenseStorageService` bleibt weiterhin In-Memory; keine UI-/Masken-Umstellung
 
 - Lizenzverwaltung Neuversuch (In-Memory-Listenansichten) ist nachgezogen:
   - Testnachweise in `scripts/tests/lizenzverwaltungModule.test.cjs` fuer Kunden/Lizenzen/Historie um Listenfelder und Refresh nach `Merken` ergaenzt

--- a/docs/modules/lizenzverwaltung.md
+++ b/docs/modules/lizenzverwaltung.md
@@ -230,6 +230,7 @@ Kurzstand (Paket DB-Schema/Migration):
 - Die Tabellen `license_customers`, `license_records` und `license_history` sind in `src/main/db/database.js` als nicht-destruktive Tabellenanlage vorbereitet.
 - `licenseStorageService` bleibt weiterhin In-Memory; UI und IPC wurden in diesem Paket nicht umgestellt.
 - Main-Process-Service ist vorbereitet (`src/main/licensing/licenseAdminService.js`), aber noch nicht per IPC angebunden.
+- IPC-/Preload-Schnitt ist vorbereitet; Renderer-`licenseStorageService` bleibt weiterhin In-Memory und wurde noch nicht umgestellt.
 
 ### Abgrenzung
 Nicht Teil dieses Schritts:

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -497,10 +497,49 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(storageServiceSource.includes("window.api"), false);
   });
 
-  await run("Lizenzverwaltung: keine IPC-/Preload-Umstellung fuer Main-Service erfolgt", () => {
-    assert.equal(preloadSource.includes("licenseAdminService"), false);
-    assert.equal(licenseIpcSource.includes("licenseAdminService"), false);
+  await run("Lizenzverwaltung: IPC-Handler fuer Admin-Lizenzkunden sind vorbereitet", () => {
+    assert.equal(licenseIpcSource.includes('ipcMain.handle("license-admin:list-customers"'), true);
+    assert.equal(licenseIpcSource.includes('ipcMain.handle("license-admin:save-customer"'), true);
   });
+
+  await run("Lizenzverwaltung: IPC-Handler fuer Admin-Lizenzen sind vorbereitet", () => {
+    assert.equal(licenseIpcSource.includes('ipcMain.handle("license-admin:list-records"'), true);
+    assert.equal(licenseIpcSource.includes('ipcMain.handle("license-admin:save-record"'), true);
+  });
+
+  await run("Lizenzverwaltung: IPC-Handler fuer Admin-Lizenzhistorie sind vorbereitet", () => {
+    assert.equal(licenseIpcSource.includes('ipcMain.handle("license-admin:list-history"'), true);
+    assert.equal(licenseIpcSource.includes('ipcMain.handle("license-admin:add-history-entry"'), true);
+  });
+
+  await run("Lizenzverwaltung: licenseAdminService wird in der Lizenz-IPC genutzt", () => {
+    assert.equal(licenseIpcSource.includes('require("../licensing/licenseAdminService")'), true);
+    assert.equal(licenseIpcSource.includes("licenseAdminService.listCustomers"), true);
+    assert.equal(licenseIpcSource.includes("licenseAdminService.saveCustomer"), true);
+    assert.equal(licenseIpcSource.includes("licenseAdminService.listLicenses"), true);
+    assert.equal(licenseIpcSource.includes("licenseAdminService.saveLicense"), true);
+    assert.equal(licenseIpcSource.includes("licenseAdminService.listHistory"), true);
+    assert.equal(licenseIpcSource.includes("licenseAdminService.addHistoryEntry"), true);
+  });
+
+  await run("Lizenzverwaltung: bestehende Lizenzdatei-/Status-IPC bleibt vorhanden", () => {
+    assert.equal(licenseIpcSource.includes('ipcMain.handle("license:get-status"'), true);
+    assert.equal(licenseIpcSource.includes('ipcMain.handle("license:get-installed"'), true);
+    assert.equal(licenseIpcSource.includes('ipcMain.handle("license:import"'), true);
+    assert.equal(licenseIpcSource.includes('ipcMain.handle("license:delete"'), true);
+  });
+
+  await run(
+    "Lizenzverwaltung: Preload-API enthaelt list/save fuer Admin-Lizenzkunden, -Lizenzen und -Historie",
+    () => {
+      assert.equal(preloadSource.includes("licenseAdminListLicenseCustomers"), true);
+      assert.equal(preloadSource.includes("licenseAdminSaveLicenseCustomer"), true);
+      assert.equal(preloadSource.includes("licenseAdminListLicenseRecords"), true);
+      assert.equal(preloadSource.includes("licenseAdminSaveLicenseRecord"), true);
+      assert.equal(preloadSource.includes("licenseAdminListLicenseHistory"), true);
+      assert.equal(preloadSource.includes("licenseAdminAddLicenseHistoryEntry"), true);
+    }
+  );
 
   await run("Lizenzverwaltung: bleibt Adminbereich und erscheint nicht als Projektmodul", () => {
     const projektEntry = getProjektverwaltungModuleEntry();

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -10,6 +10,7 @@ const { saveLicense, loadLicense, deleteLicense } = require("../licensing/licens
 const { getMachineId } = require("../licensing/deviceIdentity");
 const { verifyLicense } = require("../licensing/licenseVerifier");
 const { refreshStatus } = require("../licensing/licenseService");
+const licenseAdminService = require("../licensing/licenseAdminService");
 
 const LICENSE_FILE_FILTER = [
   {
@@ -596,10 +597,37 @@ function registerLicenseDevGeneratorIpc() {
   });
 }
 
+function registerLicenseAdminDataIpc() {
+  ipcMain.handle("license-admin:list-customers", async () => {
+    return licenseAdminService.listCustomers();
+  });
+
+  ipcMain.handle("license-admin:save-customer", async (_event, customer) => {
+    return licenseAdminService.saveCustomer(customer || {});
+  });
+
+  ipcMain.handle("license-admin:list-records", async () => {
+    return licenseAdminService.listLicenses();
+  });
+
+  ipcMain.handle("license-admin:save-record", async (_event, license) => {
+    return licenseAdminService.saveLicense(license || {});
+  });
+
+  ipcMain.handle("license-admin:list-history", async () => {
+    return licenseAdminService.listHistory();
+  });
+
+  ipcMain.handle("license-admin:add-history-entry", async (_event, entry) => {
+    return licenseAdminService.addHistoryEntry(entry || {});
+  });
+}
+
 function registerLicenseIpc() {
   registerLicenseStatusIpc();
   registerLicenseInstallationIpc();
   registerLicenseDevGeneratorIpc();
+  registerLicenseAdminDataIpc();
 }
 
 module.exports = {

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -203,6 +203,12 @@ contextBridge.exposeInMainWorld("bbmDb", {
   licenseLoadForEdit: (data) => ipcRenderer.invoke("license:load-for-edit", data),
   licenseGenerate: (data) => ipcRenderer.invoke("license:generate", data),
   licenseOpenOutputDir: (data) => ipcRenderer.invoke("license:open-output-dir", data),
+  licenseAdminListLicenseCustomers: () => ipcRenderer.invoke("license-admin:list-customers"),
+  licenseAdminSaveLicenseCustomer: (customer) => ipcRenderer.invoke("license-admin:save-customer", customer),
+  licenseAdminListLicenseRecords: () => ipcRenderer.invoke("license-admin:list-records"),
+  licenseAdminSaveLicenseRecord: (license) => ipcRenderer.invoke("license-admin:save-record", license),
+  licenseAdminListLicenseHistory: () => ipcRenderer.invoke("license-admin:list-history"),
+  licenseAdminAddLicenseHistoryEntry: (entry) => ipcRenderer.invoke("license-admin:add-history-entry", entry),
 
   // DEV: Audio Override Status
   devAudioUnlockStatus: () => ipcRenderer.invoke("dev:audioUnlockStatus"),


### PR DESCRIPTION
### Motivation
- Vorbereitung einer sauberen Main-/Preload‑Schnittstelle, damit Admin‑Lizenzdaten (Kunden, Lizenzen, Historie) später sicher vom Renderer genutzt werden können, ohne jetzt den Renderer oder die Lizenzdatei-/Lizenzstatus‑Logik umzubauen.

### Description
- Neue Admin‑IPC‑Handler `license-admin:*` wurden in `src/main/ipc/licenseIpc.js` ergänzt und binden die Funktionen aus `src/main/licensing/licenseAdminService.js` (list/save für Kunden, Records, History add/read).
- Preload‑API wurde erweitert (klar gekennzeichnete Namen) in `src/main/preload.js`: `licenseAdminListLicenseCustomers`, `licenseAdminSaveLicenseCustomer`, `licenseAdminListLicenseRecords`, `licenseAdminSaveLicenseRecord`, `licenseAdminListLicenseHistory`, `licenseAdminAddLicenseHistoryEntry`.
- Tests in `scripts/tests/lizenzverwaltungModule.test.cjs` wurden angepasst/ergänzt, um die neuen IPC‑Handler, Preload‑API und die Nutzung von `licenseAdminService` nachzuweisen, wobei bestehende Lizenzdatei-/Status‑IPC unverändert bleiben und der Renderer‑Storage weiterhin In‑Memory bleibt.
- Dokumentation kurz ergänzt in `docs/modules/lizenzverwaltung.md` und Statushinweis in `STATUS.md`, ohne ARCHITECTURE/PLAN aufzublähen oder UI/Renderer‑Speicher umzubauen.

### Testing
- Automatisierte Tests: `npm test` wurde ausgeführt und alle Tests sind grün (alle Tests bestanden).
- Die angepassten Tests für die Admin‑IPC/Preload‑Schnitt laufen erfolgreich und verifizieren die neuen Handler sowie die Unversehrtheit der bestehenden Lizenz‑IPC.
- Veröffentlichung/PR: In dieser Umgebung konnte kein Pull Request erstellt werden (kein GitHub CLI / Auth verfügbar); die Änderungen liegen auf dem lokalen Ergebnis‑Branch `work` und sind gegen `main` vorgesehen, wurden jedoch hier nicht als PR veröffentlicht.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3c9b95c083228aeb0846c5b6c16f)