### PR TITLE
Lizenzverwaltung: Renderer `licenseStorageService` auf Preload-/IPC umgestellt

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -99,7 +99,8 @@ Sie ergänzt:
   - noch keine IPC-/Preload-Anbindung; Renderer-Storage bleibt In-Memory
 - Lizenzverwaltung naechstes Paket ist umgesetzt:
   - IPC-/Preload-Schnitt fuer Admin-Lizenzdaten ist vorbereitet (`license-admin:*` + `licenseAdmin*` im Preload)
-  - Renderer-`licenseStorageService` bleibt weiterhin In-Memory; keine UI-/Masken-Umstellung
+  - Renderer-`licenseStorageService` nutzt jetzt die Preload-/IPC-Schnitt (`window.bbmDb.licenseAdmin*`) statt In-Memory
+  - Kunden, Lizenzen und Historie werden dadurch dauerhaft in `app.db` gespeichert; UI blieb minimal angepasst
 
 - Lizenzverwaltung Neuversuch (In-Memory-Listenansichten) ist nachgezogen:
   - Testnachweise in `scripts/tests/lizenzverwaltungModule.test.cjs` fuer Kunden/Lizenzen/Historie um Listenfelder und Refresh nach `Merken` ergaenzt

--- a/docs/modules/lizenzverwaltung.md
+++ b/docs/modules/lizenzverwaltung.md
@@ -228,9 +228,8 @@ Sie ist nicht die vollständige Admin-Datenbank.
 
 Kurzstand (Paket DB-Schema/Migration):
 - Die Tabellen `license_customers`, `license_records` und `license_history` sind in `src/main/db/database.js` als nicht-destruktive Tabellenanlage vorbereitet.
-- `licenseStorageService` bleibt weiterhin In-Memory; UI und IPC wurden in diesem Paket nicht umgestellt.
-- Main-Process-Service ist vorbereitet (`src/main/licensing/licenseAdminService.js`), aber noch nicht per IPC angebunden.
-- IPC-/Preload-Schnitt ist vorbereitet; Renderer-`licenseStorageService` bleibt weiterhin In-Memory und wurde noch nicht umgestellt.
+- Main-Process-Service ist vorbereitet und per IPC angebunden (`src/main/licensing/licenseAdminService.js`, `src/main/ipc/licenseIpc.js`, `src/main/preload.js`).
+- IPC-/Preload-Schnitt ist vorbereitet und angebunden; Renderer-`licenseStorageService` nutzt jetzt IPC/Preload, sodass Kunden, Lizenzen und Historie dauerhaft in `app.db` gespeichert werden.
 
 ### Abgrenzung
 Nicht Teil dieses Schritts:

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -8,6 +8,11 @@ function read(relPath) {
 }
 
 async function runLizenzverwaltungModuleTests(run) {
+  const originalWindow = global.window;
+  const restoreWindow = () => {
+    if (typeof originalWindow === "undefined") delete global.window;
+    else global.window = originalWindow;
+  };
   const [
     {
       getLizenzverwaltungModuleEntry,
@@ -169,6 +174,13 @@ async function runLizenzverwaltungModuleTests(run) {
 
 
   await run("Lizenzverwaltung: Storage-Service wird exportiert und ist Promise-kompatibel", async () => {
+    global.window = {
+      bbmDb: {
+        licenseAdminListLicenseCustomers: async () => [],
+        licenseAdminListLicenseRecords: async () => [],
+        licenseAdminListLicenseHistory: async () => [],
+      },
+    };
     assert.equal(typeof listCustomers, "function");
     assert.equal(typeof saveCustomer, "function");
     assert.equal(typeof listLicenses, "function");
@@ -186,15 +198,36 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(typeof listCustomers().then, "function");
     assert.equal(typeof listLicenses().then, "function");
     assert.equal(typeof listHistory().then, "function");
+    restoreWindow();
   });
 
-  await run("Lizenzverwaltung: listCustomers liefert initial eine Liste", async () => {
+  await run("Lizenzverwaltung: listCustomers nutzt licenseAdminListLicenseCustomers", async () => {
+    let calls = 0;
+    global.window = {
+      bbmDb: {
+        licenseAdminListLicenseCustomers: async () => {
+          calls += 1;
+          return [{ customerNumber: "K-200" }];
+        },
+      },
+    };
     const customers = await listCustomers();
     assert.equal(Array.isArray(customers), true);
-    assert.equal(customers.length, 0);
+    assert.equal(customers.length, 1);
+    assert.equal(calls, 1);
+    restoreWindow();
   });
 
-  await run("Lizenzverwaltung: saveCustomer normalisiert und speichert im Stub", async () => {
+  await run("Lizenzverwaltung: saveCustomer nutzt licenseAdminSaveLicenseCustomer", async () => {
+    let payload = null;
+    global.window = {
+      bbmDb: {
+        licenseAdminSaveLicenseCustomer: async (customer) => {
+          payload = customer;
+          return { ...customer, id: "customer-1" };
+        },
+      },
+    };
     const record = await saveCustomer({
       customerNumber: "  K-200  ",
       companyName: "  Beispiel GmbH  ",
@@ -204,18 +237,39 @@ async function runLizenzverwaltungModuleTests(run) {
 
     assert.equal(record.customerNumber, "K-200");
     assert.equal(record.companyName, "Beispiel GmbH");
-
-    const customers = await listCustomers();
-    assert.equal(customers.some((entry) => entry.customerNumber === "K-200"), true);
+    assert.equal(record.id, "customer-1");
+    assert.equal(payload.customerNumber, "K-200");
+    assert.equal(payload.companyName, "Beispiel GmbH");
+    restoreWindow();
   });
 
-  await run("Lizenzverwaltung: listLicenses liefert initial eine Liste", async () => {
+  await run("Lizenzverwaltung: listLicenses nutzt licenseAdminListLicenseRecords", async () => {
+    let calls = 0;
+    global.window = {
+      bbmDb: {
+        licenseAdminListLicenseRecords: async () => {
+          calls += 1;
+          return [{ licenseId: "LIC-200" }];
+        },
+      },
+    };
     const licenses = await listLicenses();
     assert.equal(Array.isArray(licenses), true);
-    assert.equal(licenses.length, 0);
+    assert.equal(licenses.length, 1);
+    assert.equal(calls, 1);
+    restoreWindow();
   });
 
-  await run("Lizenzverwaltung: saveLicense normalisiert und speichert im Stub", async () => {
+  await run("Lizenzverwaltung: saveLicense nutzt licenseAdminSaveLicenseRecord", async () => {
+    let payload = null;
+    global.window = {
+      bbmDb: {
+        licenseAdminSaveLicenseRecord: async (license) => {
+          payload = license;
+          return { ...license, id: "license-1" };
+        },
+      },
+    };
     const record = await saveLicense({
       licenseId: "  LIC-200  ",
       customerNumber: "  K-200  ",
@@ -225,18 +279,38 @@ async function runLizenzverwaltungModuleTests(run) {
 
     assert.equal(record.licenseId, "LIC-200");
     assert.equal(record.licenseMode, "full");
-
-    const licenses = await listLicenses();
-    assert.equal(licenses.some((entry) => entry.licenseId === "LIC-200"), true);
+    assert.equal(record.id, "license-1");
+    assert.equal(payload.licenseId, "LIC-200");
+    restoreWindow();
   });
 
-  await run("Lizenzverwaltung: listHistory liefert initial eine Liste", async () => {
+  await run("Lizenzverwaltung: listHistory nutzt licenseAdminListLicenseHistory", async () => {
+    let calls = 0;
+    global.window = {
+      bbmDb: {
+        licenseAdminListLicenseHistory: async () => {
+          calls += 1;
+          return [{ licenseId: "LIC-200" }];
+        },
+      },
+    };
     const history = await listHistory();
     assert.equal(Array.isArray(history), true);
-    assert.equal(history.length, 0);
+    assert.equal(history.length, 1);
+    assert.equal(calls, 1);
+    restoreWindow();
   });
 
-  await run("Lizenzverwaltung: addHistoryEntry normalisiert und speichert im Stub", async () => {
+  await run("Lizenzverwaltung: addHistoryEntry nutzt licenseAdminAddLicenseHistoryEntry", async () => {
+    let payload = null;
+    global.window = {
+      bbmDb: {
+        licenseAdminAddLicenseHistoryEntry: async (entry) => {
+          payload = entry;
+          return { ...entry, id: "history-1" };
+        },
+      },
+    };
     const record = await addHistoryEntry({
       createdAt: "  2026-04-26  ",
       licenseId: "  LIC-200  ",
@@ -248,9 +322,23 @@ async function runLizenzverwaltungModuleTests(run) {
 
     assert.equal(record.createdAt, "2026-04-26");
     assert.equal(record.licenseId, "LIC-200");
+    assert.equal(record.id, "history-1");
+    assert.equal(payload.createdAt, "2026-04-26");
+    restoreWindow();
+  });
 
-    const history = await listHistory();
-    assert.equal(history.some((entry) => entry.licenseId === "LIC-200"), true);
+  await run("Lizenzverwaltung: fehlende Preload-API erzeugt klare Fehlermeldung", async () => {
+    delete global.window;
+    await assert.rejects(
+      () => listCustomers(),
+      /Preload-API nicht verfügbar \(window\.bbmDb fehlt\)\. Speicherung nicht möglich\./
+    );
+    global.window = { bbmDb: {} };
+    await assert.rejects(
+      () => saveCustomer({ customerNumber: "K-1" }),
+      /Preload-API-Methode fehlt \(licenseAdminSaveLicenseCustomer\)\./
+    );
+    restoreWindow();
   });
 
   await run("Lizenzverwaltung: Historien-Datensatz zentral vorbereitet", () => {
@@ -318,10 +406,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(customerEditorSource.includes("Keine Speicherung"), true);
     assert.equal(customerEditorSource.includes("saveCustomer"), true);
     assert.equal(customerEditorSource.includes("listCustomers"), true);
-    assert.equal(customerEditorSource.includes("temporaer gemerkt"), true);
-    assert.equal(customerEditorSource.includes("nur In-Memory-Storage-Service"), true);
-    assert.equal(customerEditorSource.includes("Temporär gemerkte Kunden"), true);
-    assert.equal(customerEditorSource.includes("Noch keine temporär gemerkten Kunden."), true);
+    assert.equal(customerEditorSource.includes("temporaer gemerkt"), false);
+    assert.equal(customerEditorSource.includes("nur In-Memory-Storage-Service"), false);
+    assert.equal(customerEditorSource.includes("dauerhaft gespeichert"), true);
+    assert.equal(customerEditorSource.includes("Gespeicherte Kunden"), true);
+    assert.equal(customerEditorSource.includes("Noch keine gespeicherten Kunden."), true);
     assert.equal(customerEditorSource.includes("entry.customerNumber"), true);
     assert.equal(customerEditorSource.includes("entry.companyName"), true);
     assert.equal(customerEditorSource.includes("entry.email"), true);
@@ -357,10 +446,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordEditorSource.includes("Keine Speicherung"), true);
     assert.equal(licenseRecordEditorSource.includes("saveLicense"), true);
     assert.equal(licenseRecordEditorSource.includes("listLicenses"), true);
-    assert.equal(licenseRecordEditorSource.includes("temporaer gemerkt"), true);
-    assert.equal(licenseRecordEditorSource.includes("nur In-Memory-Storage-Service"), true);
-    assert.equal(licenseRecordEditorSource.includes("Temporär gemerkte Lizenzen"), true);
-    assert.equal(licenseRecordEditorSource.includes("Noch keine temporär gemerkten Lizenzen."), true);
+    assert.equal(licenseRecordEditorSource.includes("temporaer gemerkt"), false);
+    assert.equal(licenseRecordEditorSource.includes("nur In-Memory-Storage-Service"), false);
+    assert.equal(licenseRecordEditorSource.includes("dauerhaft gespeichert"), true);
+    assert.equal(licenseRecordEditorSource.includes("Gespeicherte Lizenzen"), true);
+    assert.equal(licenseRecordEditorSource.includes("Noch keine gespeicherten Lizenzen."), true);
     assert.equal(licenseRecordEditorSource.includes("entry.licenseId"), true);
     assert.equal(licenseRecordEditorSource.includes("entry.customerNumber"), true);
     assert.equal(licenseRecordEditorSource.includes("entry.validUntil"), true);
@@ -417,10 +507,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseHistoryEditorSource.includes("Keine Speicherung"), true);
     assert.equal(licenseHistoryEditorSource.includes("addHistoryEntry"), true);
     assert.equal(licenseHistoryEditorSource.includes("listHistory"), true);
-    assert.equal(licenseHistoryEditorSource.includes("temporaer gemerkt"), true);
-    assert.equal(licenseHistoryEditorSource.includes("nur In-Memory-Storage-Service"), true);
-    assert.equal(licenseHistoryEditorSource.includes("Temporär gemerkte Historie"), true);
-    assert.equal(licenseHistoryEditorSource.includes("Noch keine temporär gemerkte Historie."), true);
+    assert.equal(licenseHistoryEditorSource.includes("temporaer gemerkt"), false);
+    assert.equal(licenseHistoryEditorSource.includes("nur In-Memory-Storage-Service"), false);
+    assert.equal(licenseHistoryEditorSource.includes("dauerhaft gespeichert"), true);
+    assert.equal(licenseHistoryEditorSource.includes("Gespeicherte Historie"), true);
+    assert.equal(licenseHistoryEditorSource.includes("Noch keine gespeicherte Historie."), true);
     assert.equal(licenseHistoryEditorSource.includes("entry.createdAt"), true);
     assert.equal(licenseHistoryEditorSource.includes("entry.licenseId"), true);
     assert.equal(licenseHistoryEditorSource.includes("entry.customer"), true);
@@ -486,13 +577,20 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseAdminServiceSource.includes("licenseStorageService"), false);
   });
 
-  await run("Lizenzverwaltung: keine IPC-Umstellung und Renderer-Storage bleibt In-Memory", () => {
+  await run("Lizenzverwaltung: Renderer-Storage nutzt Preload-API statt In-Memory", () => {
     const storageServiceSource = read("src/renderer/modules/lizenzverwaltung/licenseStorageService.js");
 
-    assert.equal(storageServiceSource.includes("const storage = {"), true);
-    assert.equal(storageServiceSource.includes("customers: []"), true);
-    assert.equal(storageServiceSource.includes("licenses: []"), true);
-    assert.equal(storageServiceSource.includes("history: []"), true);
+    assert.equal(storageServiceSource.includes("const storage = {"), false);
+    assert.equal(storageServiceSource.includes("customers: []"), false);
+    assert.equal(storageServiceSource.includes("licenses: []"), false);
+    assert.equal(storageServiceSource.includes("history: []"), false);
+    assert.equal(storageServiceSource.includes("window.bbmDb"), true);
+    assert.equal(storageServiceSource.includes("licenseAdminListLicenseCustomers"), true);
+    assert.equal(storageServiceSource.includes("licenseAdminSaveLicenseCustomer"), true);
+    assert.equal(storageServiceSource.includes("licenseAdminListLicenseRecords"), true);
+    assert.equal(storageServiceSource.includes("licenseAdminSaveLicenseRecord"), true);
+    assert.equal(storageServiceSource.includes("licenseAdminListLicenseHistory"), true);
+    assert.equal(storageServiceSource.includes("licenseAdminAddLicenseHistoryEntry"), true);
     assert.equal(storageServiceSource.includes("ipcRenderer"), false);
     assert.equal(storageServiceSource.includes("window.api"), false);
   });

--- a/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
@@ -4,38 +4,54 @@ import {
   normalizeLicenseHistoryRecord,
 } from "./licenseRecords.js";
 
-const storage = {
-  customers: [],
-  licenses: [],
-  history: [],
-};
+function getLicenseAdminDbApi() {
+  const api = globalThis?.window?.bbmDb;
+  if (!api) {
+    throw new Error(
+      "Lizenzverwaltung: Preload-API nicht verfügbar (window.bbmDb fehlt). Speicherung nicht möglich."
+    );
+  }
+  return api;
+}
+
+function requireApiMethod(methodName) {
+  const api = getLicenseAdminDbApi();
+  const method = api[methodName];
+  if (typeof method !== "function") {
+    throw new Error(`Lizenzverwaltung: Preload-API-Methode fehlt (${methodName}).`);
+  }
+  return method;
+}
 
 export async function listCustomers() {
-  return [...storage.customers];
+  const list = requireApiMethod("licenseAdminListLicenseCustomers");
+  return list();
 }
 
 export async function saveCustomer(customer) {
   const record = normalizeCustomerRecord(customer);
-  storage.customers.push(record);
-  return record;
+  const save = requireApiMethod("licenseAdminSaveLicenseCustomer");
+  return save(record);
 }
 
 export async function listLicenses() {
-  return [...storage.licenses];
+  const list = requireApiMethod("licenseAdminListLicenseRecords");
+  return list();
 }
 
 export async function saveLicense(license) {
   const record = normalizeLicenseRecord(license);
-  storage.licenses.push(record);
-  return record;
+  const save = requireApiMethod("licenseAdminSaveLicenseRecord");
+  return save(record);
 }
 
 export async function listHistory() {
-  return [...storage.history];
+  const list = requireApiMethod("licenseAdminListLicenseHistory");
+  return list();
 }
 
 export async function addHistoryEntry(entry) {
   const record = normalizeLicenseHistoryRecord(entry);
-  storage.history.push(record);
-  return record;
+  const add = requireApiMethod("licenseAdminAddLicenseHistoryEntry");
+  return add(record);
 }

--- a/src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createCustomerEditorSection.js
@@ -43,7 +43,7 @@ export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupBut
   listWrap.style.gap = "6px";
 
   const listTitle = document.createElement("h4");
-  listTitle.textContent = "Temporär gemerkte Kunden";
+  listTitle.textContent = "Gespeicherte Kunden";
   listTitle.style.margin = "0";
   listTitle.style.fontSize = "13px";
 
@@ -57,7 +57,7 @@ export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupBut
     listContent.replaceChildren();
 
     if (!Array.isArray(customers) || customers.length < 1) {
-      listContent.textContent = "Noch keine temporär gemerkten Kunden.";
+      listContent.textContent = "Noch keine gespeicherten Kunden.";
       return;
     }
 
@@ -174,7 +174,7 @@ export function createCustomerEditorSection({ applyPopupCardStyle, applyPopupBut
     await saveCustomer(model);
     await refreshRememberedCustomers();
     message.textContent =
-      "Datensatz temporaer gemerkt, noch keine dauerhafte Speicherung (nur In-Memory-Storage-Service).";
+      "Datensatz dauerhaft gespeichert.";
     message.style.background = "#f0fdf4";
     message.style.borderColor = "rgba(34, 197, 94, 0.35)";
   };

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseHistorySection.js
@@ -43,7 +43,7 @@ export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupBut
   listWrap.style.gap = "6px";
 
   const listTitle = document.createElement("h4");
-  listTitle.textContent = "Temporär gemerkte Historie";
+  listTitle.textContent = "Gespeicherte Historie";
   listTitle.style.margin = "0";
   listTitle.style.fontSize = "13px";
 
@@ -57,7 +57,7 @@ export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupBut
     listContent.replaceChildren();
 
     if (!Array.isArray(history) || history.length < 1) {
-      listContent.textContent = "Noch keine temporär gemerkte Historie.";
+      listContent.textContent = "Noch keine gespeicherte Historie.";
       return;
     }
 
@@ -175,7 +175,7 @@ export function createLicenseHistorySection({ applyPopupCardStyle, applyPopupBut
     await addHistoryEntry(model);
     await refreshRememberedHistory();
     message.textContent =
-      "Datensatz temporaer gemerkt, noch keine dauerhafte Speicherung (nur In-Memory-Storage-Service).";
+      "Datensatz dauerhaft gespeichert.";
     message.style.background = "#f0fdf4";
     message.style.borderColor = "rgba(34, 197, 94, 0.35)";
   };

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
@@ -44,7 +44,7 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
   listWrap.style.gap = "6px";
 
   const listTitle = document.createElement("h4");
-  listTitle.textContent = "Temporär gemerkte Lizenzen";
+  listTitle.textContent = "Gespeicherte Lizenzen";
   listTitle.style.margin = "0";
   listTitle.style.fontSize = "13px";
 
@@ -58,7 +58,7 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
     listContent.replaceChildren();
 
     if (!Array.isArray(licenses) || licenses.length < 1) {
-      listContent.textContent = "Noch keine temporär gemerkten Lizenzen.";
+      listContent.textContent = "Noch keine gespeicherten Lizenzen.";
       return;
     }
 
@@ -207,7 +207,7 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
     await saveLicense(model);
     await refreshRememberedLicenses();
     message.textContent =
-      "Datensatz temporaer gemerkt, noch keine dauerhafte Speicherung (nur In-Memory-Storage-Service).";
+      "Datensatz dauerhaft gespeichert.";
     message.style.background = "#f0fdf4";
     message.style.borderColor = "rgba(34, 197, 94, 0.35)";
   };


### PR DESCRIPTION
### Motivation
- Die Renderer-Fassade der Lizenzverwaltung soll statt eines In-Memory-Stubs die vorbereitete Preload-/IPC-Schnittstelle nutzen, damit Kunden, Lizenzen und Historie dauerhaft in `app.db` abgelegt werden.
- Bestehende Renderer-APIs und Masken sollen ihr Verhalten behalten (gleiche Funktionen, Promise-kompatibel), nur die Persistenzquelle ändern.

### Description
- `src/renderer/modules/lizenzverwaltung/licenseStorageService.js` wurde entfernt vom In-Memory-Stub und verwendet jetzt ausschließlich `window.bbmDb.licenseAdmin*`-Methoden (`licenseAdminListLicenseCustomers`, `licenseAdminSaveLicenseCustomer`, `licenseAdminListLicenseRecords`, `licenseAdminSaveLicenseRecord`, `licenseAdminListLicenseHistory`, `licenseAdminAddLicenseHistoryEntry`) und wirft klare Fehlermeldungen bei fehlender Preload-API oder fehlenden Methoden.
- UI-Texte in den drei Masken minimal angepasst: Erfolgsmeldungen auf "Datensatz dauerhaft gespeichert." und Listentitel/Leertexte auf "Gespeicherte …" geändert, ohne Layout- oder Funktionalitätsumbau (`src/renderer/modules/lizenzverwaltung/screens/*`).
- Tests in `scripts/tests/lizenzverwaltungModule.test.cjs` erweitert/angepasst, um die Nutzung der `window.bbmDb`-Methoden zu prüfen, das Fehlen der In-Memory-Struktur zu verifizieren und Fehlermeldungen bei fehlender Preload-API zu testen.
- Dokumentation und Status kurz nachgezogen: `docs/modules/lizenzverwaltung.md` und `STATUS.md` ergänzt, dass der Renderer-Service nun IPC/Preload nutzt und Daten in `app.db` gespeichert werden.

### Testing
- Automatisierte Tests ausgeführt: `node scripts/tests/lizenzverwaltungModule.test.cjs` (grün) und gesamtes Test-Set `npm test` (grün).
- Branch / Commit: Base-Branch `main`, Ergebnis-Branch `work`, Commit `811964f`.
- Pull-Request: Es wurde kein verifizierbarer PR-Link zurückgegeben; daher ist kein PR-Link verfügbar (PR-Erstellung in dieser Umgebung nicht bestätigt).
- Git-Status: Arbeitsverzeichnis sauber nach Commit; geänderte Dateien sind im Commit enthalten (siehe Diff): `licenseStorageService.js`, drei `screens/*`-Dateien, `scripts/tests/lizenzverwaltungModule.test.cjs`, `docs/modules/lizenzverwaltung.md`, `STATUS.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3ead96d0832291cfbee56d15dda3)