### PR TITLE
Lizenzverwaltung: Kunde als Dropdown in Lizenzen-Maske und Verknüpfung per customer_id

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -101,6 +101,9 @@ Sie ergänzt:
   - IPC-/Preload-Schnitt fuer Admin-Lizenzdaten ist vorbereitet (`license-admin:*` + `licenseAdmin*` im Preload)
   - Renderer-`licenseStorageService` nutzt jetzt die Preload-/IPC-Schnitt (`window.bbmDb.licenseAdmin*`) statt In-Memory
   - Kunden, Lizenzen und Historie werden dadurch dauerhaft in `app.db` gespeichert; UI blieb minimal angepasst
+- Lizenzverwaltung naechstes Paket ist umgesetzt:
+  - Lizenzen-Maske laedt gespeicherte Kunden per `listCustomers()` als Auswahlfeld und speichert Lizenzen mit `customer_id/customerId`-Verknuepfung.
+  - Gespeicherte Lizenzen zeigen Kundennummer/Firma lesbar an; ohne vorhandene Kunden blockiert die Maske das erfolgreiche Speichern mit Hinweis.
 
 - Lizenzverwaltung Neuversuch (In-Memory-Listenansichten) ist nachgezogen:
   - Testnachweise in `scripts/tests/lizenzverwaltungModule.test.cjs` fuer Kunden/Lizenzen/Historie um Listenfelder und Refresh nach `Merken` ergaenzt

--- a/docs/modules/lizenzverwaltung.md
+++ b/docs/modules/lizenzverwaltung.md
@@ -230,6 +230,7 @@ Kurzstand (Paket DB-Schema/Migration):
 - Die Tabellen `license_customers`, `license_records` und `license_history` sind in `src/main/db/database.js` als nicht-destruktive Tabellenanlage vorbereitet.
 - Main-Process-Service ist vorbereitet und per IPC angebunden (`src/main/licensing/licenseAdminService.js`, `src/main/ipc/licenseIpc.js`, `src/main/preload.js`).
 - IPC-/Preload-Schnitt ist vorbereitet und angebunden; Renderer-`licenseStorageService` nutzt jetzt IPC/Preload, sodass Kunden, Lizenzen und Historie dauerhaft in `app.db` gespeichert werden.
+- Lizenzen koennen jetzt einem gespeicherten Kunden zugeordnet werden (`customer_id` / `customerId`) und die Listenansicht zeigt Kundendaten lesbar an.
 
 ### Abgrenzung
 Nicht Teil dieses Schritts:

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -272,15 +272,20 @@ async function runLizenzverwaltungModuleTests(run) {
     };
     const record = await saveLicense({
       licenseId: "  LIC-200  ",
+      customerId: "  customer-200  ",
       customerNumber: "  K-200  ",
       licenseMode: "FULL",
       productScope: { zusatzfunktionen: ["mail"] },
     });
 
     assert.equal(record.licenseId, "LIC-200");
+    assert.equal(record.customerId, "customer-200");
+    assert.equal(record.customer_id, "customer-200");
     assert.equal(record.licenseMode, "full");
     assert.equal(record.id, "license-1");
     assert.equal(payload.licenseId, "LIC-200");
+    assert.equal(payload.customerId, "customer-200");
+    assert.equal(payload.customer_id, "customer-200");
     restoreWindow();
   });
 
@@ -439,11 +444,12 @@ async function runLizenzverwaltungModuleTests(run) {
 
   await run("Lizenzen-UI: bietet Neu / leeren und Pruefen", () => {
     assert.equal(licenseRecordEditorSource.includes("Lizenzen"), true);
-    assert.equal(licenseRecordEditorSource.includes("vorbereitet, noch ohne Speicherung"), true);
+    assert.equal(licenseRecordEditorSource.includes("vorbereitet, mit dauerhafter Speicherung"), true);
     assert.equal(licenseRecordEditorSource.includes("Neu / leeren"), true);
     assert.equal(licenseRecordEditorSource.includes("Pruefen"), true);
     assert.equal(licenseRecordEditorSource.includes("Merken"), true);
     assert.equal(licenseRecordEditorSource.includes("Keine Speicherung"), true);
+    assert.equal(licenseRecordEditorSource.includes("listCustomers"), true);
     assert.equal(licenseRecordEditorSource.includes("saveLicense"), true);
     assert.equal(licenseRecordEditorSource.includes("listLicenses"), true);
     assert.equal(licenseRecordEditorSource.includes("temporaer gemerkt"), false);
@@ -452,12 +458,31 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordEditorSource.includes("Gespeicherte Lizenzen"), true);
     assert.equal(licenseRecordEditorSource.includes("Noch keine gespeicherten Lizenzen."), true);
     assert.equal(licenseRecordEditorSource.includes("entry.licenseId"), true);
-    assert.equal(licenseRecordEditorSource.includes("entry.customerNumber"), true);
+    assert.equal(licenseRecordEditorSource.includes("entry.customerDisplay"), true);
+    assert.equal(licenseRecordEditorSource.includes("entry.customerId"), true);
     assert.equal(licenseRecordEditorSource.includes("entry.validUntil"), true);
     assert.equal(licenseRecordEditorSource.includes("entry.licenseMode"), true);
     assert.equal(licenseRecordEditorSource.includes("refreshRememberedLicenses"), true);
     assert.equal(licenseRecordEditorSource.includes("refreshRememberedLicenses();"), true);
     assert.equal(licenseRecordEditorSource.includes("await refreshRememberedLicenses();"), true);
+    assert.equal(licenseRecordEditorSource.includes("Bitte zuerst einen Kunden anlegen."), true);
+    assert.equal(licenseRecordEditorSource.includes("customer_id/customerId"), true);
+    assert.equal(licenseRecordEditorSource.includes('input = document.createElement("select")'), true);
+    assert.equal(licenseRecordEditorSource.includes("runValidation();"), true);
+  });
+
+  await run("Lizenzen-UI: Speichern ohne Kunden ist nicht erfolgreich", () => {
+    assert.equal(licenseRecordEditorSource.includes("if (!hasCustomers)"), true);
+    assert.equal(licenseRecordEditorSource.includes('message.textContent = "Bitte zuerst einen Kunden anlegen."'), true);
+    assert.equal(licenseRecordEditorSource.includes("if (!isValid) return;"), true);
+    assert.equal(licenseRecordEditorSource.includes("await saveLicense(model);"), true);
+  });
+
+  await run("Lizenzen-UI: Save vorbereitet mit customerId/customer_id", () => {
+    assert.equal(licenseRecordsSource.includes("customerId"), true);
+    assert.equal(licenseRecordsSource.includes("customer_id"), true);
+    assert.equal(licenseRecordsSource.includes("input.customerId"), true);
+    assert.equal(licenseRecordsSource.includes("input.customer_id"), true);
   });
 
   await run("Produktumfang-UI: nutzt PRODUCT_SCOPE und enthaelt Gruppen", () => {
@@ -564,6 +589,13 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseAdminServiceSource.includes("license_customers"), true);
     assert.equal(licenseAdminServiceSource.includes("license_records"), true);
     assert.equal(licenseAdminServiceSource.includes("license_history"), true);
+  });
+
+  await run("Lizenzverwaltung Main-Service: listLicenses liefert Kundendaten lesbar mit", () => {
+    assert.equal(licenseAdminServiceSource.includes("LEFT JOIN license_customers"), true);
+    assert.equal(licenseAdminServiceSource.includes("customerDisplay"), true);
+    assert.equal(licenseAdminServiceSource.includes("customerNumber"), true);
+    assert.equal(licenseAdminServiceSource.includes("companyName"), true);
   });
 
   await run("Lizenzverwaltung Main-Service: speichert product_scope_json als JSON-String", () => {

--- a/src/main/licensing/licenseAdminService.js
+++ b/src/main/licensing/licenseAdminService.js
@@ -150,7 +150,30 @@ function saveCustomer(customer = {}) {
 }
 
 function listLicenses() {
-  return _db().prepare(`SELECT * FROM license_records ORDER BY created_at DESC, license_id COLLATE NOCASE`).all();
+  return _db()
+    .prepare(
+      `
+      SELECT
+        lr.*,
+        lc.customer_number AS customer_number,
+        lc.company_name AS company_name,
+        lc.customer_number AS customerNumber,
+        lc.company_name AS companyName,
+        CASE
+          WHEN COALESCE(TRIM(lc.customer_number), '') <> '' AND COALESCE(TRIM(lc.company_name), '') <> ''
+            THEN lc.customer_number || ' | ' || lc.company_name
+          WHEN COALESCE(TRIM(lc.customer_number), '') <> ''
+            THEN lc.customer_number
+          WHEN COALESCE(TRIM(lc.company_name), '') <> ''
+            THEN lc.company_name
+          ELSE COALESCE(lr.customer_id, '')
+        END AS customerDisplay
+      FROM license_records lr
+      LEFT JOIN license_customers lc ON lc.id = lr.customer_id
+      ORDER BY lr.created_at DESC, lr.license_id COLLATE NOCASE
+    `
+    )
+    .all();
 }
 
 function saveLicense(license = {}) {

--- a/src/renderer/modules/lizenzverwaltung/licenseRecords.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseRecords.js
@@ -48,6 +48,8 @@ export function createDefaultCustomerRecord(overrides = {}) {
 export function createDefaultLicenseRecord(overrides = {}) {
   return {
     licenseId: "",
+    customerId: "",
+    customer_id: "",
     customerNumber: "",
     productScope: {
       standardumfang: [],
@@ -95,6 +97,8 @@ export function normalizeLicenseRecord(input = {}) {
 
   return {
     licenseId: String(input.licenseId ?? base.licenseId).trim(),
+    customerId: String(input.customerId ?? input.customer_id ?? base.customerId).trim(),
+    customer_id: String(input.customer_id ?? input.customerId ?? base.customer_id).trim(),
     customerNumber: String(input.customerNumber ?? base.customerNumber).trim(),
     productScope: {
       standardumfang: Array.isArray(input?.productScope?.standardumfang)

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
@@ -4,11 +4,12 @@ import {
   createDefaultLicenseRecord,
   normalizeLicenseRecord,
 } from "../licenseRecords.js";
-import { listLicenses, saveLicense } from "../licenseStorageService.js";
+import { listCustomers, listLicenses, saveLicense } from "../licenseStorageService.js";
 
 export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPopupButtonStyle } = {}) {
   const model = createDefaultLicenseRecord();
   const fieldInputs = new Map();
+  let knownCustomers = [];
 
   const card = document.createElement("div");
   if (typeof applyPopupCardStyle === "function") {
@@ -22,7 +23,7 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
   title.style.margin = "0";
 
   const hint = document.createElement("p");
-  hint.textContent = "vorbereitet, noch ohne Speicherung";
+  hint.textContent = "vorbereitet, mit dauerhafter Speicherung";
   hint.style.margin = "0";
   hint.style.fontSize = "12px";
   hint.style.opacity = "0.8";
@@ -53,6 +54,68 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
   listContent.style.display = "grid";
   listContent.style.gap = "4px";
 
+  const customerHint = document.createElement("div");
+  customerHint.style.fontSize = "12px";
+  customerHint.style.padding = "8px";
+  customerHint.style.borderRadius = "8px";
+  customerHint.style.background = "#f8fafc";
+  customerHint.style.border = "1px solid rgba(0,0,0,0.08)";
+
+  const getCustomerKey = (customer = {}) =>
+    String(customer.id || customer.customerId || customer.customer_id || "");
+
+  const getCustomerNumber = (customer = {}) =>
+    String(customer.customerNumber || customer.customer_number || "").trim();
+
+  const getCustomerCompany = (customer = {}) =>
+    String(customer.companyName || customer.company_name || "").trim();
+
+  const buildCustomerLabel = (customer = {}) => {
+    const customerNumber = getCustomerNumber(customer) || "-";
+    const companyName = getCustomerCompany(customer) || "-";
+    return `${customerNumber} | ${companyName}`;
+  };
+
+  const refreshCustomers = async () => {
+    const select = fieldInputs.get("customerNumber");
+    if (!select) return;
+
+    const customers = await listCustomers();
+    knownCustomers = Array.isArray(customers) ? customers : [];
+
+    select.replaceChildren();
+    if (knownCustomers.length < 1) {
+      const empty = document.createElement("option");
+      empty.value = "";
+      empty.textContent = "Bitte zuerst einen Kunden anlegen.";
+      select.appendChild(empty);
+      select.value = "";
+      model.customerId = "";
+      model.customer_id = "";
+      model.customerNumber = "";
+      customerHint.textContent = "Bitte zuerst einen Kunden anlegen.";
+      customerHint.style.background = "#fef2f2";
+      customerHint.style.borderColor = "rgba(220, 38, 38, 0.35)";
+      return;
+    }
+
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = "Kunden auswaehlen";
+    select.appendChild(placeholder);
+
+    knownCustomers.forEach((customer) => {
+      const option = document.createElement("option");
+      option.value = getCustomerKey(customer);
+      option.textContent = buildCustomerLabel(customer);
+      select.appendChild(option);
+    });
+
+    customerHint.textContent = "Kunde wird ueber customer_id/customerId mit der Lizenz verknuepft.";
+    customerHint.style.background = "#f8fafc";
+    customerHint.style.borderColor = "rgba(0,0,0,0.08)";
+  };
+
   const refreshRememberedLicenses = async () => {
     const licenses = await listLicenses();
     listContent.replaceChildren();
@@ -64,7 +127,18 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
 
     licenses.forEach((entry) => {
       const row = document.createElement("div");
-      row.textContent = `${entry.licenseId || "-"} | ${entry.customerNumber || "-"} | ${entry.validUntil || "-"} | ${entry.licenseMode || "-"}`;
+      const customerDisplay =
+        String(entry.customerDisplay || "").trim() ||
+        [
+          String(entry.customerNumber || entry.customer_number || "").trim(),
+          String(entry.companyName || entry.company_name || "").trim(),
+        ]
+          .filter(Boolean)
+          .join(" | ") ||
+        String(entry.customerId || entry.customer_id || "").trim() ||
+        "-";
+
+      row.textContent = `${entry.licenseId || entry.license_id || "-"} | ${customerDisplay} | ${entry.validUntil || entry.valid_until || "-"} | ${entry.licenseMode || entry.license_mode || "-"}`;
       listContent.appendChild(row);
     });
   };
@@ -84,6 +158,16 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
         continue;
       }
 
+      if (field.key === "customerNumber") {
+        const selectedCustomer = knownCustomers.find(
+          (entry) => getCustomerKey(entry) === String(input.value || "")
+        );
+        model.customerId = selectedCustomer ? getCustomerKey(selectedCustomer) : "";
+        model.customer_id = model.customerId;
+        model.customerNumber = selectedCustomer ? getCustomerNumber(selectedCustomer) : "";
+        continue;
+      }
+
       model[field.key] = String(input.value || "");
     }
   };
@@ -95,6 +179,8 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
 
       if (field.key === "productScope") {
         input.value = String(model.productScope?._display || "");
+      } else if (field.key === "customerNumber") {
+        input.value = String(model.customerId || model.customer_id || "");
       } else {
         input.value = model[field.key] || "";
       }
@@ -105,11 +191,15 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
   const runValidation = () => {
     updateModelFromInputs();
     const normalized = normalizeLicenseRecord(model);
+    const hasCustomers = knownCustomers.length > 0;
 
     const missingRequired = LICENSE_RECORD_FIELDS.filter((field) => {
       if (!field.required) return false;
       if (field.key === "productScope") {
         return !String(model.productScope?._display || "").trim();
+      }
+      if (field.key === "customerNumber") {
+        return !String(normalized.customerId || normalized.customer_id || "").trim();
       }
       return !String(normalized[field.key] || "").trim();
     });
@@ -119,6 +209,15 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
       if (!input) continue;
       const isMissing = missingRequired.some((entry) => entry.key === field.key);
       input.style.borderColor = isMissing ? "#dc2626" : "";
+    }
+
+    if (!hasCustomers) {
+      const customerInput = fieldInputs.get("customerNumber");
+      if (customerInput) customerInput.style.borderColor = "#dc2626";
+      message.textContent = "Bitte zuerst einen Kunden anlegen.";
+      message.style.background = "#fef2f2";
+      message.style.borderColor = "rgba(220, 38, 38, 0.35)";
+      return false;
     }
 
     if (missingRequired.length > 0) {
@@ -150,6 +249,8 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
     if (field.key === "notes") {
       input = document.createElement("textarea");
       input.rows = 4;
+    } else if (field.key === "customerNumber") {
+      input = document.createElement("select");
     } else if (field.key === "licenseMode") {
       input = document.createElement("select");
       LICENSE_MODES.forEach((mode) => {
@@ -182,6 +283,8 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
   btnReset.onclick = () => {
     Object.assign(model, createDefaultLicenseRecord());
     model.productScope._display = "";
+    model.customerId = "";
+    model.customer_id = "";
     applyModelToInputs();
     message.textContent = "Formular geleert. Noch ohne Speicherung.";
     message.style.background = "#f8fafc";
@@ -216,7 +319,8 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
 
   applyModelToInputs();
   listWrap.append(listTitle, listContent);
-  card.append(title, hint, form, buttons, message, listWrap);
+  card.append(title, hint, customerHint, form, buttons, message, listWrap);
+  refreshCustomers();
   refreshRememberedLicenses();
   return card;
 }


### PR DESCRIPTION
### Motivation
- Lizenzen sollen sauber mit bereits gespeicherten Kunden verknüpft werden, indem die vorhandenen Kunden aus `app.db` auswählbar werden und eine echte Referenz über `customer_id`/`customerId` vorbereitet wird.
- UI-Verhalten soll klar sein, wenn keine Kunden existieren (Speichern blockieren und Hinweis anzeigen) und zugleich Abwärtskompatibilität zu `customerNumber` erhalten bleiben.

### Description
- Renderer: Die Lizenzen-Maske lädt Kunden über `listCustomers()` und rendert das Feld „Kunde“ als Dropdown mit Anzeige `Kundennummer | Firma/Kundenname`, sowie einen Hinweis/Blockierer wenn keine Kunden vorhanden sind, und setzt beim Speichern `customerId`/`customer_id` im Lizenzmodell (`src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js`).
- Datenmodell/Normalisierung: `createDefaultLicenseRecord` und `normalizeLicenseRecord` wurden um `customerId`/`customer_id` ergänzt, sodass `saveLicense` kompatibel `customerId` übergibt (`src/renderer/modules/lizenzverwaltung/licenseRecords.js`).
- Main-Service: `listLicenses()` liefert nun lesbare Kundeninformationen per `LEFT JOIN` auf `license_customers` und ergänzt ein `customerDisplay`-Feld für die UI-Anzeige (`src/main/licensing/licenseAdminService.js`).
- Tests & Doku: Relevante Tests wurden erweitert/angepasst und die Doku/Status kurz ergänzt (`scripts/tests/lizenzverwaltungModule.test.cjs`, `docs/modules/lizenzverwaltung.md`, `STATUS.md`).
- Geänderte Dateien: `src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js`, `src/renderer/modules/lizenzverwaltung/licenseRecords.js`, `src/main/licensing/licenseAdminService.js`, `scripts/tests/lizenzverwaltungModule.test.cjs`, `docs/modules/lizenzverwaltung.md`, `STATUS.md`.

### Testing
- Automatisierte Tests wurden lokal ausgeführt mit `node scripts/test.cjs` und mit `npm test`, beide Läufe sind grün und alle betroffenen Tests bestehen, inklusive der angepassten Lizenzverwaltungstests.
- Spezifisch wurde die `scripts/tests/lizenzverwaltungModule.test.cjs` erweitert und erfolgreich ausgeführt, die neuen Assertions zu Dropdown/Hint, `customerId`/`customer_id` und `customerDisplay` sind bestanden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee447e33248322b7a3489af19d7e48)