### PR TITLE
Bugfix: automatische Lizenz-ID bei leerem Feld in Lizenzen‑Maske

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -104,6 +104,8 @@ Sie ergänzt:
 - Lizenzverwaltung naechstes Paket ist umgesetzt:
   - Lizenzen-Maske laedt gespeicherte Kunden per `listCustomers()` als Auswahlfeld und speichert Lizenzen mit `customer_id/customerId`-Verknuepfung.
   - Gespeicherte Lizenzen zeigen Kundennummer/Firma lesbar an; ohne vorhandene Kunden blockiert die Maske das erfolgreiche Speichern mit Hinweis.
+  - Leere Lizenz-ID wird in der Lizenzen-Maske beim Pruefen/Merken automatisch als lesbare `LIC-YYYYMMDD-HHMMSS`-ID erzeugt.
+  - Die erzeugte Lizenz-ID wird sichtbar ins Feld uebernommen; manuelle IDs bleiben weiterhin bearbeitbar.
 
 - Lizenzverwaltung Neuversuch (In-Memory-Listenansichten) ist nachgezogen:
   - Testnachweise in `scripts/tests/lizenzverwaltungModule.test.cjs` fuer Kunden/Lizenzen/Historie um Listenfelder und Refresh nach `Merken` ergaenzt

--- a/docs/modules/lizenzverwaltung.md
+++ b/docs/modules/lizenzverwaltung.md
@@ -123,6 +123,8 @@ Vorgesehene Felder:
 - Machine-ID optional
 - Notizen
 
+Hinweis: Bei neuen Lizenzen kann die Lizenz-ID automatisch erzeugt werden, wenn das Feld leer bleibt.
+
 ### Historie
 Die Historie dokumentiert erzeugte oder neu ausgegebene Lizenzdateien.
 Vorgesehene Felder:

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -469,6 +469,10 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordEditorSource.includes("customer_id/customerId"), true);
     assert.equal(licenseRecordEditorSource.includes('input = document.createElement("select")'), true);
     assert.equal(licenseRecordEditorSource.includes("runValidation();"), true);
+    assert.equal(licenseRecordEditorSource.includes("generateLicenseId"), true);
+    assert.equal(licenseRecordEditorSource.includes("LIC-"), true);
+    assert.equal(licenseRecordEditorSource.includes("model.licenseId = generateLicenseId();"), true);
+    assert.equal(licenseRecordEditorSource.includes("licenseIdInput.value = model.licenseId;"), true);
   });
 
   await run("Lizenzen-UI: Speichern ohne Kunden ist nicht erfolgreich", () => {
@@ -476,6 +480,21 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordEditorSource.includes('message.textContent = "Bitte zuerst einen Kunden anlegen."'), true);
     assert.equal(licenseRecordEditorSource.includes("if (!isValid) return;"), true);
     assert.equal(licenseRecordEditorSource.includes("await saveLicense(model);"), true);
+  });
+
+  await run("Lizenzen-UI: Leere Lizenz-ID wird automatisch erzeugt und blockiert Pruefen nicht", () => {
+    assert.equal(licenseRecordEditorSource.includes('if (!String(model.licenseId || "").trim())'), true);
+    assert.equal(licenseRecordEditorSource.includes("model.licenseId = generateLicenseId();"), true);
+    assert.equal(
+      licenseRecordEditorSource.includes("Pruefung erfolgreich: Pflichtfelder sind befuellt. Keine Speicherung erfolgt."),
+      true
+    );
+  });
+
+  await run("Lizenzen-UI: Manuelle Lizenz-ID bleibt erhalten und wird nicht ueberschrieben", () => {
+    assert.equal(licenseRecordEditorSource.includes("if (!String(model.licenseId || \"\").trim())"), true);
+    assert.equal(licenseRecordEditorSource.includes("model[field.key] = String(input.value || \"\");"), true);
+    assert.equal(licenseRecordEditorSource.includes("model.licenseId = generateLicenseId();"), true);
   });
 
   await run("Lizenzen-UI: Save vorbereitet mit customerId/customer_id", () => {

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
@@ -10,6 +10,13 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
   const model = createDefaultLicenseRecord();
   const fieldInputs = new Map();
   let knownCustomers = [];
+  const generateLicenseId = () => {
+    const now = new Date();
+    const part = (value) => String(value).padStart(2, "0");
+    const datePart = `${now.getFullYear()}${part(now.getMonth() + 1)}${part(now.getDate())}`;
+    const timePart = `${part(now.getHours())}${part(now.getMinutes())}${part(now.getSeconds())}`;
+    return `LIC-${datePart}-${timePart}`;
+  };
 
   const card = document.createElement("div");
   if (typeof applyPopupCardStyle === "function") {
@@ -190,6 +197,15 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
 
   const runValidation = () => {
     updateModelFromInputs();
+
+    if (!String(model.licenseId || "").trim()) {
+      model.licenseId = generateLicenseId();
+      const licenseIdInput = fieldInputs.get("licenseId");
+      if (licenseIdInput) {
+        licenseIdInput.value = model.licenseId;
+      }
+    }
+
     const normalized = normalizeLicenseRecord(model);
     const hasCustomers = knownCustomers.length > 0;
 


### PR DESCRIPTION
### Motivation
- Speichern/Merken in der Lizenzen-Maske scheiterte, weil die Lizenz‑ID fälschlich als manuell verpflichtendes Feld erwartet wurde, obwohl das System eine ID erzeugen können soll.

### Description
- Bei leerer Lizenz‑ID wird nun vor der Validierung eine lesbare ID im Format `LIC-YYYYMMDD-HHMMSS` erzeugt und dem Model zugewiesen sowie ins Eingabefeld übernommen, damit sie sichtbar und weiter bearbeitbar bleibt.
- Das Verhalten bei manueller Lizenz‑ID, die nicht überschrieben wird, sowie der übrige Validierungs- und Save‑Pfad (`saveLicense(model)`) wurden nicht verändert.
- Geänderte Dateien: `src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js`, `scripts/tests/lizenzverwaltungModule.test.cjs`, `docs/modules/lizenzverwaltung.md`, `STATUS.md`.

### Testing
- `npm test` ausgeführt und alle Tests sind grün (`Alle Tests bestanden`).
- Tests ergänzt/angepasst in `scripts/tests/lizenzverwaltungModule.test.cjs` zur Prüfung der automatischen ID-Erzeugung, der Feldübernahme und des Nicht-Überschreibens manueller IDs, und diese Tests liefen erfolgreich unter `npm test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4a420de08322a52bf8044dc1a109)