### PR TITLE
Lizenzverwaltung: Persistentes Speichern von Lizenzdatensätzen stabilisieren

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -106,6 +106,11 @@ Sie ergänzt:
   - Gespeicherte Lizenzen zeigen Kundennummer/Firma lesbar an; ohne vorhandene Kunden blockiert die Maske das erfolgreiche Speichern mit Hinweis.
   - Leere Lizenz-ID wird in der Lizenzen-Maske beim Pruefen/Merken automatisch als lesbare `LIC-YYYYMMDD-HHMMSS`-ID erzeugt.
   - Die erzeugte Lizenz-ID wird sichtbar ins Feld uebernommen; manuelle IDs bleiben weiterhin bearbeitbar.
+- Lizenzverwaltung Bugfix (Persistenz Lizenzen) ist umgesetzt:
+  - Lizenzen-Maske zeigt Speicherkonflikte sichtbar in der Maske (inkl. Fehlerdetails).
+  - `Merken` ruft `saveLicense(...)` nur auf, wenn `customerId/customer_id` gesetzt ist.
+  - Save-Payload fuehrt relevante camelCase/snake_case-Felder mit (`customerId/customer_id`, `productScope/product_scope_json`, `validUntil/valid_until`, `licenseMode/license_mode`).
+  - Main-Service meldet ungueltige `customer_id` nachvollziehbar (`customer_id invalid: ...`), und die gespeicherte Lizenzliste bleibt lesbar ueber `customerDisplay`/Fallbacks.
 
 - Lizenzverwaltung Neuversuch (In-Memory-Listenansichten) ist nachgezogen:
   - Testnachweise in `scripts/tests/lizenzverwaltungModule.test.cjs` fuer Kunden/Lizenzen/Historie um Listenfelder und Refresh nach `Merken` ergaenzt

--- a/STATUS.md
+++ b/STATUS.md
@@ -111,6 +111,10 @@ Sie ergänzt:
   - `Merken` ruft `saveLicense(...)` nur auf, wenn `customerId/customer_id` gesetzt ist.
   - Save-Payload fuehrt relevante camelCase/snake_case-Felder mit (`customerId/customer_id`, `productScope/product_scope_json`, `validUntil/valid_until`, `licenseMode/license_mode`).
   - Main-Service meldet ungueltige `customer_id` nachvollziehbar (`customer_id invalid: ...`), und die gespeicherte Lizenzliste bleibt lesbar ueber `customerDisplay`/Fallbacks.
+- Lizenzverwaltung Bugfix (Pflichtfelder dauerhaft sichtbar) ist umgesetzt:
+  - `normalizeLicenseRecord(...)` behaelt `productScope._display` jetzt bei und uebernimmt alternativ `product_scope_json`.
+  - Save-Payload fuehrt jetzt auch `validFrom/valid_from` konsistent mit.
+  - Die Liste `Gespeicherte Lizenzen` zeigt jetzt mindestens: Lizenz-ID | Kunde | Produktumfang | gueltig von | gueltig bis | Lizenzmodus.
 
 - Lizenzverwaltung Neuversuch (In-Memory-Listenansichten) ist nachgezogen:
   - Testnachweise in `scripts/tests/lizenzverwaltungModule.test.cjs` fuer Kunden/Lizenzen/Historie um Listenfelder und Refresh nach `Merken` ergaenzt

--- a/docs/modules/lizenzverwaltung.md
+++ b/docs/modules/lizenzverwaltung.md
@@ -240,6 +240,11 @@ Kurzstand (Bugfix Persistenz Lizenzen, April 2026):
 - `saveLicense`-Payload bleibt kompatibel fuer camelCase und snake_case (`licenseId/license_id`, `customerId/customer_id`, `productScope/product_scope_json`, `validUntil/valid_until`, `licenseMode/license_mode`).
 - `listLicenses` bleibt lesbar fuer die UI-Liste mit `customerDisplay` sowie vorhandenen Fallback-Feldern.
 
+Kurzstand (Bugfix Pflichtfelder in gespeicherter Lizenz, April 2026):
+- `normalizeLicenseRecord` behaelt bei Texteingaben den UI-Wert `productScope._display` und reduziert Produktumfang nicht mehr still auf leere Arrays.
+- Renderer-Save-Payload fuehrt `validFrom/valid_from` zusaetzlich konsistent mit.
+- Die UI-Liste zeigt gespeicherte Pflichtfelder jetzt vollstaendig mit Produktumfang sowie `gueltig von`/`gueltig bis` an.
+
 ### Abgrenzung
 Nicht Teil dieses Schritts:
 - Kunden speichern

--- a/docs/modules/lizenzverwaltung.md
+++ b/docs/modules/lizenzverwaltung.md
@@ -234,6 +234,12 @@ Kurzstand (Paket DB-Schema/Migration):
 - IPC-/Preload-Schnitt ist vorbereitet und angebunden; Renderer-`licenseStorageService` nutzt jetzt IPC/Preload, sodass Kunden, Lizenzen und Historie dauerhaft in `app.db` gespeichert werden.
 - Lizenzen koennen jetzt einem gespeicherten Kunden zugeordnet werden (`customer_id` / `customerId`) und die Listenansicht zeigt Kundendaten lesbar an.
 
+Kurzstand (Bugfix Persistenz Lizenzen, April 2026):
+- Die Lizenzen-Maske speichert nur noch, wenn `customerId/customer_id` wirklich gesetzt ist.
+- Speichern zeigt Fehler jetzt sichtbar in der Maske (inklusive nachvollziehbarer Meldung bei ungueltiger `customer_id`).
+- `saveLicense`-Payload bleibt kompatibel fuer camelCase und snake_case (`licenseId/license_id`, `customerId/customer_id`, `productScope/product_scope_json`, `validUntil/valid_until`, `licenseMode/license_mode`).
+- `listLicenses` bleibt lesbar fuer die UI-Liste mit `customerDisplay` sowie vorhandenen Fallback-Feldern.
+
 ### Abgrenzung
 Nicht Teil dieses Schritts:
 - Kunden speichern

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -7,6 +7,26 @@ function read(relPath) {
   return fs.readFileSync(path.join(process.cwd(), relPath), "utf8");
 }
 
+function loadLicenseAdminServiceWithDb(mockDbFactory) {
+  const servicePath = path.join(process.cwd(), "src/main/licensing/licenseAdminService.js");
+  const databasePath = path.join(process.cwd(), "src/main/db/database.js");
+  const previousDatabaseModule = require.cache[databasePath];
+  delete require.cache[servicePath];
+  require.cache[databasePath] = {
+    id: databasePath,
+    filename: databasePath,
+    loaded: true,
+    exports: {
+      initDatabase: mockDbFactory,
+    },
+  };
+  const service = require(servicePath);
+  if (previousDatabaseModule) require.cache[databasePath] = previousDatabaseModule;
+  else delete require.cache[databasePath];
+  delete require.cache[servicePath];
+  return service;
+}
+
 async function runLizenzverwaltungModuleTests(run) {
   const originalWindow = global.window;
   const restoreWindow = () => {
@@ -286,6 +306,33 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(payload.licenseId, "LIC-200");
     assert.equal(payload.customerId, "customer-200");
     assert.equal(payload.customer_id, "customer-200");
+    assert.equal(typeof payload.productScope, "object");
+    assert.equal(typeof payload.product_scope_json, "object");
+    assert.equal(payload.validUntil, "");
+    assert.equal(payload.valid_until, "");
+    assert.equal(payload.licenseMode, "full");
+    assert.equal(payload.license_mode, "full");
+    restoreWindow();
+  });
+
+  await run("Lizenzverwaltung: saveLicense lehnt fehlende customerId/customer_id ab", async () => {
+    global.window = {
+      bbmDb: {
+        licenseAdminSaveLicenseRecord: async () => {
+          throw new Error("darf nicht aufgerufen werden");
+        },
+      },
+    };
+    await assert.rejects(
+      () =>
+        saveLicense({
+          licenseId: "LIC-201",
+          productScope: { standardumfang: ["app", "pdf", "export"] },
+          validUntil: "2027-04-26",
+          licenseMode: "soft",
+        }),
+      /customer_id\/customerId fehlt/
+    );
     restoreWindow();
   });
 
@@ -462,6 +509,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordEditorSource.includes("entry.customerId"), true);
     assert.equal(licenseRecordEditorSource.includes("entry.validUntil"), true);
     assert.equal(licenseRecordEditorSource.includes("entry.licenseMode"), true);
+    assert.equal(licenseRecordEditorSource.includes("entry.license_id"), true);
+    assert.equal(licenseRecordEditorSource.includes("entry.customer_number"), true);
+    assert.equal(licenseRecordEditorSource.includes("entry.company_name"), true);
+    assert.equal(licenseRecordEditorSource.includes("entry.valid_until"), true);
+    assert.equal(licenseRecordEditorSource.includes("entry.license_mode"), true);
     assert.equal(licenseRecordEditorSource.includes("refreshRememberedLicenses"), true);
     assert.equal(licenseRecordEditorSource.includes("refreshRememberedLicenses();"), true);
     assert.equal(licenseRecordEditorSource.includes("await refreshRememberedLicenses();"), true);
@@ -479,7 +531,14 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordEditorSource.includes("if (!hasCustomers)"), true);
     assert.equal(licenseRecordEditorSource.includes('message.textContent = "Bitte zuerst einen Kunden anlegen."'), true);
     assert.equal(licenseRecordEditorSource.includes("if (!isValid) return;"), true);
-    assert.equal(licenseRecordEditorSource.includes("await saveLicense(model);"), true);
+    assert.equal(licenseRecordEditorSource.includes("const payload = normalizeLicenseRecord(model);"), true);
+    assert.equal(licenseRecordEditorSource.includes("if (!customerId)"), true);
+    assert.equal(
+      licenseRecordEditorSource.includes("customer_id/customerId fehlt. Bitte Kunde neu auswaehlen."),
+      true
+    );
+    assert.equal(licenseRecordEditorSource.includes("await saveLicense(payload);"), true);
+    assert.equal(licenseRecordEditorSource.includes("Speichern fehlgeschlagen:"), true);
   });
 
   await run("Lizenzen-UI: Leere Lizenz-ID wird automatisch erzeugt und blockiert Pruefen nicht", () => {
@@ -502,6 +561,9 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordsSource.includes("customer_id"), true);
     assert.equal(licenseRecordsSource.includes("input.customerId"), true);
     assert.equal(licenseRecordsSource.includes("input.customer_id"), true);
+    assert.equal(licenseRecordsSource.includes("product_scope_json"), true);
+    assert.equal(licenseRecordsSource.includes("valid_until"), true);
+    assert.equal(licenseRecordsSource.includes("license_mode"), true);
   });
 
   await run("Produktumfang-UI: nutzt PRODUCT_SCOPE und enthaelt Gruppen", () => {
@@ -617,10 +679,117 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseAdminServiceSource.includes("companyName"), true);
   });
 
+  await run("Lizenzverwaltung Main-Service: saveLicense akzeptiert customerId und customer_id", () => {
+    const calls = [];
+    const fakeDb = {
+      prepare(sql) {
+        return {
+          get(...args) {
+            calls.push({ type: "get", sql, args });
+            if (sql.includes("SELECT id FROM license_records")) return undefined;
+            if (sql.includes("SELECT * FROM license_records WHERE id = ?")) {
+              return {
+                id: args[0],
+                license_id: "LIC-300",
+                customer_id: "customer-300",
+              };
+            }
+            return undefined;
+          },
+          run(...args) {
+            calls.push({ type: "run", sql, args });
+            return { changes: 1 };
+          },
+          all() {
+            return [];
+          },
+        };
+      },
+    };
+    const service = loadLicenseAdminServiceWithDb(() => fakeDb);
+
+    service.saveLicense({
+      licenseId: "LIC-300",
+      customerId: "customer-300",
+      productScope: { standardumfang: ["app", "pdf", "export"] },
+      validUntil: "2027-04-26",
+      licenseMode: "soft",
+    });
+    service.saveLicense({
+      license_id: "LIC-301",
+      customer_id: "customer-301",
+      product_scope_json: JSON.stringify({ standardumfang: ["app", "pdf", "export"] }),
+      valid_until: "2027-05-26",
+      license_mode: "full",
+    });
+
+    const insertCalls = calls.filter((entry) => entry.type === "run" && entry.sql.includes("INSERT INTO license_records"));
+    assert.equal(insertCalls.length, 2);
+    assert.equal(insertCalls[0].args[1], "LIC-300");
+    assert.equal(insertCalls[0].args[2], "customer-300");
+    assert.equal(insertCalls[1].args[1], "LIC-301");
+    assert.equal(insertCalls[1].args[2], "customer-301");
+  });
+
+  await run("Lizenzverwaltung Main-Service: listLicenses liefert customerDisplay", () => {
+    const fakeRows = [{ license_id: "LIC-401", customerDisplay: "K-401 | Bau AG" }];
+    const fakeDb = {
+      prepare(sql) {
+        return {
+          all() {
+            if (sql.includes("FROM license_records")) return fakeRows;
+            return [];
+          },
+          get() {
+            return undefined;
+          },
+          run() {
+            return { changes: 1 };
+          },
+        };
+      },
+    };
+    const service = loadLicenseAdminServiceWithDb(() => fakeDb);
+    const rows = service.listLicenses();
+    assert.deepEqual(rows, fakeRows);
+    assert.equal(rows[0].customerDisplay, "K-401 | Bau AG");
+  });
+
   await run("Lizenzverwaltung Main-Service: speichert product_scope_json als JSON-String", () => {
     assert.equal(licenseAdminServiceSource.includes("product_scope_json"), true);
     assert.equal(licenseAdminServiceSource.includes("JSON.stringify"), true);
     assert.equal(licenseAdminServiceSource.includes("JSON.parse"), true);
+  });
+
+  await run("Lizenzverwaltung Main-Service: meldet ungueltige customer_id nachvollziehbar", () => {
+    const fakeDb = {
+      prepare(sql) {
+        return {
+          get() {
+            return undefined;
+          },
+          run() {
+            if (sql.includes("INSERT INTO license_records")) {
+              throw new Error("FOREIGN KEY constraint failed");
+            }
+            return { changes: 1 };
+          },
+          all() {
+            return [];
+          },
+        };
+      },
+    };
+    const service = loadLicenseAdminServiceWithDb(() => fakeDb);
+    assert.throws(
+      () =>
+        service.saveLicense({
+          licenseId: "LIC-999",
+          customerId: "unknown-customer",
+          productScope: {},
+        }),
+      /customer_id invalid: unknown-customer/
+    );
   });
 
   await run("Lizenzverwaltung Main-Service: bleibt im Main-Prozess ohne Renderer-Import", () => {

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -190,6 +190,17 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(normalizedLicense.licenseMode, "full");
     assert.deepEqual(normalizedLicense.productScope.zusatzfunktionen, ["mail"]);
     assert.deepEqual(normalizedLicense.productScope.standardumfang, []);
+    assert.equal(normalizedLicense.valid_from, "");
+    assert.equal(normalizedLicense.valid_until, "");
+    assert.equal(normalizedLicense.license_mode, "full");
+  });
+
+  await run("Lizenzverwaltung: normalizeLicenseRecord behaelt productScope._display", () => {
+    const normalized = normalizeLicenseRecord({
+      productScope: { _display: "app,pdf,export,mail,Protokoll" },
+    });
+    assert.equal(normalized.productScope._display, "app,pdf,export,mail,Protokoll");
+    assert.equal(normalized.product_scope_json._display, "app,pdf,export,mail,Protokoll");
   });
 
 
@@ -308,6 +319,9 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(payload.customer_id, "customer-200");
     assert.equal(typeof payload.productScope, "object");
     assert.equal(typeof payload.product_scope_json, "object");
+    assert.equal(payload.product_scope_json._display, "");
+    assert.equal(payload.validFrom, "");
+    assert.equal(payload.valid_from, "");
     assert.equal(payload.validUntil, "");
     assert.equal(payload.valid_until, "");
     assert.equal(payload.licenseMode, "full");
@@ -333,6 +347,35 @@ async function runLizenzverwaltungModuleTests(run) {
         }),
       /customer_id\/customerId fehlt/
     );
+    restoreWindow();
+  });
+
+  await run("Lizenzverwaltung: saveLicense-Payload behaelt UI-Produktumfang und Pflichtfelder", async () => {
+    let payload = null;
+    global.window = {
+      bbmDb: {
+        licenseAdminSaveLicenseRecord: async (license) => {
+          payload = license;
+          return { ...license, id: "license-2" };
+        },
+      },
+    };
+    await saveLicense({
+      licenseId: "LIC-202",
+      customerId: "customer-202",
+      productScope: { _display: "app,pdf,export,mail,Protokoll" },
+      validFrom: "2026-04-26",
+      validUntil: "2027-04-26",
+      licenseMode: "soft",
+    });
+    assert.equal(payload.productScope._display, "app,pdf,export,mail,Protokoll");
+    assert.equal(payload.product_scope_json._display, "app,pdf,export,mail,Protokoll");
+    assert.equal(payload.validFrom, "2026-04-26");
+    assert.equal(payload.valid_from, "2026-04-26");
+    assert.equal(payload.validUntil, "2027-04-26");
+    assert.equal(payload.valid_until, "2027-04-26");
+    assert.equal(payload.licenseMode, "soft");
+    assert.equal(payload.license_mode, "soft");
     restoreWindow();
   });
 
@@ -512,6 +555,10 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordEditorSource.includes("entry.license_id"), true);
     assert.equal(licenseRecordEditorSource.includes("entry.customer_number"), true);
     assert.equal(licenseRecordEditorSource.includes("entry.company_name"), true);
+    assert.equal(licenseRecordEditorSource.includes("entry.productScope ?? entry.product_scope_json"), true);
+    assert.equal(licenseRecordEditorSource.includes("JSON.parse(trimmed)"), true);
+    assert.equal(licenseRecordEditorSource.includes("productScopeDisplay"), true);
+    assert.equal(licenseRecordEditorSource.includes("entry.validFrom || entry.valid_from"), true);
     assert.equal(licenseRecordEditorSource.includes("entry.valid_until"), true);
     assert.equal(licenseRecordEditorSource.includes("entry.license_mode"), true);
     assert.equal(licenseRecordEditorSource.includes("refreshRememberedLicenses"), true);
@@ -562,6 +609,7 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseRecordsSource.includes("input.customerId"), true);
     assert.equal(licenseRecordsSource.includes("input.customer_id"), true);
     assert.equal(licenseRecordsSource.includes("product_scope_json"), true);
+    assert.equal(licenseRecordsSource.includes("valid_from"), true);
     assert.equal(licenseRecordsSource.includes("valid_until"), true);
     assert.equal(licenseRecordsSource.includes("license_mode"), true);
   });

--- a/src/main/licensing/licenseAdminService.js
+++ b/src/main/licensing/licenseAdminService.js
@@ -186,58 +186,72 @@ function saveLicense(license = {}) {
   const now = _nowIso();
 
   if (existing) {
-    db.prepare(
+    try {
+      db.prepare(
+        `
+        UPDATE license_records
+        SET license_id = ?,
+            customer_id = ?,
+            product_scope_json = ?,
+            valid_from = ?,
+            valid_until = ?,
+            license_mode = ?,
+            machine_id = ?,
+            notes = ?,
+            updated_at = ?
+        WHERE id = ?
       `
-      UPDATE license_records
-      SET license_id = ?,
-          customer_id = ?,
-          product_scope_json = ?,
-          valid_from = ?,
-          valid_until = ?,
-          license_mode = ?,
-          machine_id = ?,
-          notes = ?,
-          updated_at = ?
-      WHERE id = ?
-    `
-    ).run(
-      record.license_id,
-      record.customer_id,
-      record.product_scope_json,
-      record.valid_from,
-      record.valid_until,
-      record.license_mode,
-      record.machine_id,
-      record.notes,
-      now,
-      record.id
-    );
+      ).run(
+        record.license_id,
+        record.customer_id,
+        record.product_scope_json,
+        record.valid_from,
+        record.valid_until,
+        record.license_mode,
+        record.machine_id,
+        record.notes,
+        now,
+        record.id
+      );
+    } catch (error) {
+      if (String(error?.message || "").includes("FOREIGN KEY constraint failed")) {
+        throw new Error(`customer_id invalid: ${record.customer_id}`);
+      }
+      throw error;
+    }
   } else {
-    db.prepare(
+    try {
+      db.prepare(
+        `
+        INSERT INTO license_records (
+          id,
+          license_id,
+          customer_id,
+          product_scope_json,
+          valid_from,
+          valid_until,
+          license_mode,
+          machine_id,
+          notes
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `
-      INSERT INTO license_records (
-        id,
-        license_id,
-        customer_id,
-        product_scope_json,
-        valid_from,
-        valid_until,
-        license_mode,
-        machine_id,
-        notes
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `
-    ).run(
-      record.id,
-      record.license_id,
-      record.customer_id,
-      record.product_scope_json,
-      record.valid_from,
-      record.valid_until,
-      record.license_mode,
-      record.machine_id,
-      record.notes
-    );
+      ).run(
+        record.id,
+        record.license_id,
+        record.customer_id,
+        record.product_scope_json,
+        record.valid_from,
+        record.valid_until,
+        record.license_mode,
+        record.machine_id,
+        record.notes
+      );
+    } catch (error) {
+      if (String(error?.message || "").includes("FOREIGN KEY constraint failed")) {
+        throw new Error(`customer_id invalid: ${record.customer_id}`);
+      }
+      throw error;
+    }
   }
 
   return db.prepare(`SELECT * FROM license_records WHERE id = ?`).get(record.id);

--- a/src/renderer/modules/lizenzverwaltung/licenseRecords.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseRecords.js
@@ -94,26 +94,36 @@ export function normalizeLicenseRecord(input = {}) {
   const base = createDefaultLicenseRecord();
   const mode = String(input.licenseMode ?? base.licenseMode).trim().toLowerCase();
   const normalizedMode = LICENSE_MODES.some((entry) => entry.key === mode) ? mode : base.licenseMode;
+  const productScope = {
+    standardumfang: Array.isArray(input?.productScope?.standardumfang)
+      ? [...input.productScope.standardumfang]
+      : [...base.productScope.standardumfang],
+    zusatzfunktionen: Array.isArray(input?.productScope?.zusatzfunktionen)
+      ? [...input.productScope.zusatzfunktionen]
+      : [...base.productScope.zusatzfunktionen],
+    module: Array.isArray(input?.productScope?.module)
+      ? [...input.productScope.module]
+      : [...base.productScope.module],
+  };
+  const customerId = String(input.customerId ?? input.customer_id ?? base.customerId).trim();
+  const validUntil = String(input.validUntil ?? input.valid_until ?? base.validUntil).trim();
+  const licenseMode = String(input.licenseMode ?? input.license_mode ?? normalizedMode).trim().toLowerCase();
+  const normalizedLicenseMode = LICENSE_MODES.some((entry) => entry.key === licenseMode)
+    ? licenseMode
+    : base.licenseMode;
 
   return {
     licenseId: String(input.licenseId ?? base.licenseId).trim(),
-    customerId: String(input.customerId ?? input.customer_id ?? base.customerId).trim(),
-    customer_id: String(input.customer_id ?? input.customerId ?? base.customer_id).trim(),
+    customerId,
+    customer_id: customerId,
     customerNumber: String(input.customerNumber ?? base.customerNumber).trim(),
-    productScope: {
-      standardumfang: Array.isArray(input?.productScope?.standardumfang)
-        ? [...input.productScope.standardumfang]
-        : [...base.productScope.standardumfang],
-      zusatzfunktionen: Array.isArray(input?.productScope?.zusatzfunktionen)
-        ? [...input.productScope.zusatzfunktionen]
-        : [...base.productScope.zusatzfunktionen],
-      module: Array.isArray(input?.productScope?.module)
-        ? [...input.productScope.module]
-        : [...base.productScope.module],
-    },
+    productScope,
+    product_scope_json: productScope,
     validFrom: String(input.validFrom ?? base.validFrom).trim(),
-    validUntil: String(input.validUntil ?? base.validUntil).trim(),
-    licenseMode: normalizedMode,
+    validUntil,
+    valid_until: validUntil,
+    licenseMode: normalizedLicenseMode,
+    license_mode: normalizedLicenseMode,
     machineId: String(input.machineId ?? base.machineId).trim(),
     notes: String(input.notes ?? base.notes).trim(),
   };

--- a/src/renderer/modules/lizenzverwaltung/licenseRecords.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseRecords.js
@@ -94,18 +94,34 @@ export function normalizeLicenseRecord(input = {}) {
   const base = createDefaultLicenseRecord();
   const mode = String(input.licenseMode ?? base.licenseMode).trim().toLowerCase();
   const normalizedMode = LICENSE_MODES.some((entry) => entry.key === mode) ? mode : base.licenseMode;
+  const rawProductScope = input.productScope ?? input.product_scope_json ?? base.productScope;
+  let productScopeInput = rawProductScope;
+  if (typeof productScopeInput === "string") {
+    const trimmed = productScopeInput.trim();
+    if (trimmed) {
+      try {
+        productScopeInput = JSON.parse(trimmed);
+      } catch (_error) {
+        productScopeInput = { _display: trimmed };
+      }
+    } else {
+      productScopeInput = {};
+    }
+  }
   const productScope = {
-    standardumfang: Array.isArray(input?.productScope?.standardumfang)
-      ? [...input.productScope.standardumfang]
+    standardumfang: Array.isArray(productScopeInput?.standardumfang)
+      ? [...productScopeInput.standardumfang]
       : [...base.productScope.standardumfang],
-    zusatzfunktionen: Array.isArray(input?.productScope?.zusatzfunktionen)
-      ? [...input.productScope.zusatzfunktionen]
+    zusatzfunktionen: Array.isArray(productScopeInput?.zusatzfunktionen)
+      ? [...productScopeInput.zusatzfunktionen]
       : [...base.productScope.zusatzfunktionen],
-    module: Array.isArray(input?.productScope?.module)
-      ? [...input.productScope.module]
+    module: Array.isArray(productScopeInput?.module)
+      ? [...productScopeInput.module]
       : [...base.productScope.module],
+    _display: String(productScopeInput?._display ?? "").trim(),
   };
   const customerId = String(input.customerId ?? input.customer_id ?? base.customerId).trim();
+  const validFrom = String(input.validFrom ?? input.valid_from ?? base.validFrom).trim();
   const validUntil = String(input.validUntil ?? input.valid_until ?? base.validUntil).trim();
   const licenseMode = String(input.licenseMode ?? input.license_mode ?? normalizedMode).trim().toLowerCase();
   const normalizedLicenseMode = LICENSE_MODES.some((entry) => entry.key === licenseMode)
@@ -119,7 +135,8 @@ export function normalizeLicenseRecord(input = {}) {
     customerNumber: String(input.customerNumber ?? base.customerNumber).trim(),
     productScope,
     product_scope_json: productScope,
-    validFrom: String(input.validFrom ?? base.validFrom).trim(),
+    validFrom,
+    valid_from: validFrom,
     validUntil,
     valid_until: validUntil,
     licenseMode: normalizedLicenseMode,

--- a/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
@@ -49,7 +49,8 @@ export async function saveLicense(license) {
     ...record,
     customerId,
     customer_id: customerId,
-    product_scope_json: record.productScope,
+    product_scope_json: record.product_scope_json,
+    valid_from: record.validFrom,
     valid_until: record.validUntil,
     license_mode: record.licenseMode,
   };

--- a/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
@@ -41,8 +41,20 @@ export async function listLicenses() {
 
 export async function saveLicense(license) {
   const record = normalizeLicenseRecord(license);
+  const customerId = String(record.customerId || record.customer_id || "").trim();
+  if (!customerId) {
+    throw new Error("Lizenzverwaltung: customer_id/customerId fehlt.");
+  }
+  const payload = {
+    ...record,
+    customerId,
+    customer_id: customerId,
+    product_scope_json: record.productScope,
+    valid_until: record.validUntil,
+    license_mode: record.licenseMode,
+  };
   const save = requireApiMethod("licenseAdminSaveLicenseRecord");
-  return save(record);
+  return save(payload);
 }
 
 export async function listHistory() {

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
@@ -322,13 +322,30 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
   btnRemember.onclick = async () => {
     const isValid = runValidation();
     if (!isValid) return;
+    const payload = normalizeLicenseRecord(model);
+    const customerId = String(payload.customerId || payload.customer_id || "").trim();
+    if (!customerId) {
+      message.textContent =
+        "Speichern fehlgeschlagen: customer_id/customerId fehlt. Bitte Kunde neu auswaehlen.";
+      message.style.background = "#fef2f2";
+      message.style.borderColor = "rgba(220, 38, 38, 0.35)";
+      const customerInput = fieldInputs.get("customerNumber");
+      if (customerInput) customerInput.style.borderColor = "#dc2626";
+      return;
+    }
 
-    await saveLicense(model);
-    await refreshRememberedLicenses();
-    message.textContent =
-      "Datensatz dauerhaft gespeichert.";
-    message.style.background = "#f0fdf4";
-    message.style.borderColor = "rgba(34, 197, 94, 0.35)";
+    try {
+      await saveLicense(payload);
+      await refreshRememberedLicenses();
+      message.textContent = "Datensatz dauerhaft gespeichert.";
+      message.style.background = "#f0fdf4";
+      message.style.borderColor = "rgba(34, 197, 94, 0.35)";
+    } catch (error) {
+      const detail = String(error?.message || error || "").trim() || "Unbekannter Fehler";
+      message.textContent = `Speichern fehlgeschlagen: ${detail}`;
+      message.style.background = "#fef2f2";
+      message.style.borderColor = "rgba(220, 38, 38, 0.35)";
+    }
   };
 
   buttons.append(btnReset, btnValidate, btnRemember);

--- a/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/createLicenseRecordEditorSection.js
@@ -132,6 +132,28 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
       return;
     }
 
+    const formatProductScope = (entry = {}) => {
+      const productScopeValue = entry.productScope ?? entry.product_scope_json;
+      if (typeof productScopeValue === "string") {
+        const trimmed = productScopeValue.trim();
+        if (!trimmed) return "-";
+        try {
+          const parsed = JSON.parse(trimmed);
+          const display = String(parsed?._display || "").trim();
+          return display || trimmed;
+        } catch (_error) {
+          return trimmed;
+        }
+      }
+      if (productScopeValue && typeof productScopeValue === "object") {
+        const display = String(productScopeValue._display || "").trim();
+        if (display) return display;
+        const normalized = JSON.stringify(productScopeValue);
+        return normalized === "{}" ? "-" : normalized;
+      }
+      return "-";
+    };
+
     licenses.forEach((entry) => {
       const row = document.createElement("div");
       const customerDisplay =
@@ -144,8 +166,9 @@ export function createLicenseRecordEditorSection({ applyPopupCardStyle, applyPop
           .join(" | ") ||
         String(entry.customerId || entry.customer_id || "").trim() ||
         "-";
+      const productScopeDisplay = formatProductScope(entry);
 
-      row.textContent = `${entry.licenseId || entry.license_id || "-"} | ${customerDisplay} | ${entry.validUntil || entry.valid_until || "-"} | ${entry.licenseMode || entry.license_mode || "-"}`;
+      row.textContent = `${entry.licenseId || entry.license_id || "-"} | ${customerDisplay} | ${productScopeDisplay} | ${entry.validFrom || entry.valid_from || "-"} | ${entry.validUntil || entry.valid_until || "-"} | ${entry.licenseMode || entry.license_mode || "-"}`;
       listContent.appendChild(row);
     });
   };


### PR DESCRIPTION
### Motivation
- In der Admin-Lizenzverwaltung wurde beim Klick auf „Merken“ zwar eine Lizenz‑ID erzeugt, der Datensatz wurde aber nicht zuverlässig dauerhaft gespeichert oder in „Gespeicherte Lizenzen“ angezeigt. 
- Speziell fehlte ein robuster Guard für `customerId/customer_id`, Fehler aus dem Save-Pfad wurden nicht in der UI angezeigt und camelCase/snake_case‑Kompatibilität war nicht durchgängig gewährleistet.

### Description
- Die Lizenzen‑Maske (`createLicenseRecordEditorSection.js`) baut vor dem Speichern ein normalisiertes Payload und prüft hart auf `customerId/customer_id`, zeigt Fehler im UI an und fängt Save‑Fehler für nachvollziehbare Meldungen ab. 
- Das Renderer‑Storage (`licenseStorageService.js`) validiert nun `customerId/customer_id` und übermittelt ein Payload, das relevante Felder sowohl in camelCase als auch in snake_case enthält (z.B. `productScope` / `product_scope_json`, `validUntil` / `valid_until`, `licenseMode` / `license_mode`). 
- Die Normalisierung (`licenseRecords.js`) liefert konsistente Alias‑Felder (u.a. `customerId`/`customer_id`, `product_scope_json`, `valid_until`, `license_mode`) damit UI, Renderer und Main-Service kompatibel sind. 
- Der Main‑Service (`src/main/licensing/licenseAdminService.js`) fängt beim INSERT/UPDATE Fremdschlüssel‑Fehler ab und wirft eine fachlich verständliche Fehlermeldung (`customer_id invalid: ...`) ; `listLicenses()` liefert unverändert `customerDisplay` für die UI. 
- Tests (`scripts/tests/lizenzverwaltungModule.test.cjs`) wurden erweitert, um UI‑Fehlerpfade, Save‑Guard, automatische Lizenz‑ID → Save‑Pfad, camel/snake‑Kompatibilität und Main‑Service‑Verhalten abzudecken. 
- Doku/Status wurden angepasst (`docs/modules/lizenzverwaltung.md`, `STATUS.md`).

### Testing
- `npm test` wurde lokal ausgeführt und alle Tests liefen grün. 
- `npm start` konnte in dieser Headless/CI‑Umgebung nicht vollständig geprüft werden, da Electron systemabhängige Bibliotheken fehlen (`libatk-1.0.so.0`), daher wurde die manuelle E2E‑Prüfung (App schließen/öffnen) nicht ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee65cd29648322ac3123e33529dadf)