### PR TITLE
Fix timezone-dependent license editor test payload assertion

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -178,6 +178,20 @@ Sie ergänzt:
 ## Erledigte Meilensteine / Pakete
 
 ### Erledigt
+#### Paket: Zeitzonenstabiler Test fuer erzeugte Lizenz-ID
+- Status: erledigt
+- Beschreibung:
+  - Zeitzonenabhaengiger Testfall in `scripts/tests/licenseAdminDataflow.test.cjs` stabilisiert
+  - UTC-String-Zeitpunkt (`new Date("2026-04-26T13:14:15Z")`) durch lokale Datumskonstruktion ersetzt
+  - Erwartete Lizenz-ID `LIC-20260426-131415` bleibt unveraendert
+- Betroffene Dateien:
+  - `scripts/tests/licenseAdminDataflow.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine Aenderung an Lizenzlogik, DB, UI oder Lizenzdatei-Erzeugung
+
 #### Paket: CSS-Altpfad im Modul Protokoll abbauen
 - Status: erledigt
 - Beschreibung:

--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -363,7 +363,8 @@ async function runLicenseAdminDataflowTests(run) {
 
     assert.equal(assertCustomerContext({ id: "customer-1" }), "customer-1");
     assert.throws(() => assertCustomerContext({}), /CUSTOMER_CONTEXT_REQUIRED/);
-    assert.equal(createGeneratedLicenseId(new Date("2026-04-26T13:14:15Z")), "LIC-20260426-131415");
+    const fixedLocalDate = new Date(2026, 3, 26, 13, 14, 15);
+    assert.equal(createGeneratedLicenseId(fixedLocalDate), "LIC-20260426-131415");
 
     const payload = buildLicenseEditorPayload({
       customer: { id: "customer-55" },
@@ -376,7 +377,7 @@ async function runLicenseAdminDataflowTests(run) {
         machine_id: "MID-55",
         notes: "note",
       },
-      now: new Date("2026-04-26T13:14:15Z"),
+      now: fixedLocalDate,
     });
 
     assert.equal(payload.customer_id, "customer-55");


### PR DESCRIPTION
### Motivation
- Ein Test in `scripts/tests/licenseAdminDataflow.test.cjs` war zeitzonenabhängig, weil er `new Date("2026-04-26T13:14:15Z")` verwendete und `createGeneratedLicenseId` lokale Date-Getter nutzt, wodurch die erwartete ID lokal (z.B. Windows DE) falsch ausfiel.
- Ziel war, die Erwartung `LIC-20260426-131415` stabil über Zeitzonen hinweg zu machen, ohne Lizenzlogik, DB oder UI zu ändern.

### Description
- Der Test wurde auf eine lokale Datumskonstruktion umgestellt: `const fixedLocalDate = new Date(2026, 3, 26, 13, 14, 15)` und diese Variable für `createGeneratedLicenseId(...)` sowie als `now`-Argument an `buildLicenseEditorPayload(...)` verwendet.
- Betroffene Dateien: `scripts/tests/licenseAdminDataflow.test.cjs` (Testanpassung) und `STATUS.md` (Kurzdokumentation des Mini-Pakets).
- Es wurden keine Änderungen an der Lizenzverwaltungs-Logik, Datenbank, UI, Lizenzdatei-Erzeugung oder Architektur vorgenommen.

### Testing
- Automatisierte Tests: `npm test` ausgeführt; alle Tests wurden erfolgreich ausgeführt (grün).
- Der betroffene Test `Lizenzverwaltung UI-Lizenz-Editor: Eingabewerte werden vollstaendig ins Save-Payload uebernommen` läuft nun zeitzonenstabil und liefert die erwartete Lizenz-ID `LIC-20260426-131415`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee862123088322ba12e073329f82a0)