### PR TITLE
UI-Aufräumen: Admin-Lizenzverwaltung (kundenbezogen)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -118,6 +118,14 @@ Sie ergänzt:
   - DB-Schema-Absicherung fuer bestehende `license_records` wurde nicht-destruktiv um fehlende Spalten-Ergaenzung erweitert.
   - Renderer-/IPC-/Preload-Datenfluss ist kundenbezogen erweitert (`license-admin:list-records-by-customer`).
   - Verhaltenstests decken Kunde speichern/listen, kundenbezogenes Lizenzspeichern/listen, Pflichtfelder und Kundenkontextlogik ab.
+- Lizenzverwaltung UI-Aufraeumen (kundenbezogen) ist umgesetzt:
+  - Kundenansicht zeigt jetzt `Lizenzverwaltung` + Bereich `Kunden` mit klarer Tabelle und Buttons `Neuer Kunde` / `Zurueck zum Adminbereich`.
+  - Kundendetail ist als ausgerichtetes Formular umgesetzt, inkl. klarer Button-Fuehrung und sichtbarem Hinweisbereich.
+  - Lizenzliste je Kunde ist als Tabelle mit Spalten fuer Lizenz-ID, Produktumfang, gueltig von/bis und Lizenzmodus dargestellt.
+  - Produktumfang in der Liste zeigt kein rohes JSON mehr bei parsebaren Objekten; `{ raw: ... }` wird als Klartext, leere Arrays als `-`, gefuellte Bereiche als Kurzformat angezeigt.
+  - Lizenzformular zeigt `Neue Lizenz fuer: ...`, Produktumfang als mehrzeiliges Feld, Lizenzmodus als Auswahl (`soft`/`full`) und den neuen Button `Lizenz-ID erzeugen`.
+  - `Lizenz-ID erzeugen` schreibt nur bei leerem Feld sofort eine `LIC-YYYYMMDD-HHMMSS`-ID ins Feld; gesetzte IDs werden nicht ueberschrieben.
+  - Bestehende Speicherlogik (Auto-ID beim Speichern, Kundenkontext-Pflicht, DB-/IPC-Fluss) bleibt unveraendert.
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.
@@ -191,6 +199,23 @@ Sie ergänzt:
   - `siehe aktuellen Branch-Commit`
 - Hinweise:
   - Keine Aenderung an Lizenzlogik, DB, UI oder Lizenzdatei-Erzeugung
+
+#### Paket: UI-Aufraeumen Admin-Lizenzverwaltung (kundenbezogen)
+- Status: erledigt
+- Beschreibung:
+  - `LicenseAdminScreen` optisch/bedienbar aufgeraeumt (Kundenliste, Kundendetail, Lizenztabelle, Lizenzformular).
+  - Produktumfangsausgabe in der Kunden-Lizenzliste lesbar gemacht (`raw`-Text, Kurzformat, `-` bei leeren Arrays).
+  - Lizenzformular um Button `Lizenz-ID erzeugen` erweitert, ohne bestehende Auto-ID-Sicherheitslogik beim Speichern zu aendern.
+  - Tests in `scripts/tests/licenseAdminDataflow.test.cjs` und `scripts/tests/lizenzverwaltungModule.test.cjs` entsprechend erweitert/angepasst.
+- Betroffene Dateien:
+  - `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`
+  - `scripts/tests/licenseAdminDataflow.test.cjs`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine DB-/Schema-Aenderung, keine Lizenzdatei-/Setup-Aenderung, keine Aenderung am Projektmodul/Sidebar
 
 #### Paket: CSS-Altpfad im Modul Protokoll abbauen
 - Status: erledigt

--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -353,10 +353,23 @@ async function runLicenseAdminDataflowTests(run) {
     );
     assert.equal(formatProductScopeForList({}), "-");
   });
+
+  await run("Lizenzverwaltung UI-Liste: Produktumfang mit leeren Arrays zeigt '-'", async () => {
+    const { formatProductScopeForList } = await importEsmFromFile(
+      path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js")
+    );
+    assert.equal(
+      formatProductScopeForList({
+        product_scope_json: JSON.stringify({ standardumfang: [], zusatzfunktionen: [], module: [] }),
+      }),
+      "-"
+    );
+  });
   await run("Lizenzverwaltung UI-Lizenz-Editor: Eingabewerte werden vollstaendig ins Save-Payload uebernommen", async () => {
     const {
       assertCustomerContext,
       createGeneratedLicenseId,
+      tryGenerateLicenseId,
       buildLicenseEditorPayload,
       buildCustomerEditorPayload,
     } = await importEsmFromFile(path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js"));
@@ -365,6 +378,9 @@ async function runLicenseAdminDataflowTests(run) {
     assert.throws(() => assertCustomerContext({}), /CUSTOMER_CONTEXT_REQUIRED/);
     const fixedLocalDate = new Date(2026, 3, 26, 13, 14, 15);
     assert.equal(createGeneratedLicenseId(fixedLocalDate), "LIC-20260426-131415");
+    assert.equal(tryGenerateLicenseId("", fixedLocalDate).value, "LIC-20260426-131415");
+    assert.equal(tryGenerateLicenseId("MANUELL-1", fixedLocalDate).generated, false);
+    assert.equal(tryGenerateLicenseId("MANUELL-1", fixedLocalDate).value, "MANUELL-1");
 
     const payload = buildLicenseEditorPayload({
       customer: { id: "customer-55" },

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -747,7 +747,7 @@ async function runLizenzverwaltungModuleTests(run) {
   });
 
   await run("LicenseAdminScreen zeigt Speicherkontext und Kundenpflicht", () => {
-    assert.equal(screenSource.includes("Kunde:"), true);
+    assert.equal(screenSource.includes("Kundenkontext:"), true);
     assert.equal(screenSource.includes("CUSTOMER_CONTEXT_REQUIRED"), true);
     assert.equal(screenSource.includes("Speichern ohne geoeffneten Kunden ist unmoeglich"), true);
   });

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -7,6 +7,14 @@ export function createGeneratedLicenseId(now = new Date()) {
   )}${part(now.getSeconds())}`;
 }
 
+export function tryGenerateLicenseId(currentValue, now = new Date()) {
+  const existing = String(currentValue || "").trim();
+  if (existing) {
+    return { value: existing, generated: false, reason: "already-set" };
+  }
+  return { value: createGeneratedLicenseId(now), generated: true, reason: null };
+}
+
 export function assertCustomerContext(customer) {
   const customerId = String(customer?.id || "").trim();
   if (!customerId) {
@@ -74,6 +82,7 @@ export function formatProductScopeForList(entry = {}) {
         if (String(parsed.raw || "").trim()) return String(parsed.raw).trim();
         const label = buildProductScopeLabel(parsed);
         if (label) return label;
+        return "-";
       }
     } catch (_err) {
       return rawJson;
@@ -116,8 +125,11 @@ export default class LicenseAdminScreen {
   }
 
   async _renderCustomers(container) {
+    const title = document.createElement("h2");
+    title.textContent = "Lizenzverwaltung";
+
     const header = document.createElement("h3");
-    header.textContent = "Kundenliste";
+    header.textContent = "Kunden";
 
     const table = document.createElement("table");
     const thead = document.createElement("thead");
@@ -146,6 +158,11 @@ export default class LicenseAdminScreen {
     );
 
     const customers = await listCustomers();
+    if (!customers.length) {
+      const empty = document.createElement("caption");
+      empty.textContent = "Noch keine Kunden gespeichert.";
+      table.appendChild(empty);
+    }
     for (const customer of customers) {
       const row = document.createElement("tr");
       row.style.cursor = "pointer";
@@ -167,16 +184,18 @@ export default class LicenseAdminScreen {
       body.appendChild(row);
     }
 
-    container.append(header, actions, table);
+    container.append(title, header, actions, table);
   }
 
   async _renderCustomerDetail(container) {
     const customer = this.currentCustomer || {};
 
     const header = document.createElement("h3");
-    header.textContent = this.currentCustomer ? `Kundendetail: ${customerLabel(customer)}` : "Neuer Kunde";
+    header.textContent = `Kundendetail: ${customerLabel(customer)}`;
 
     const message = document.createElement("div");
+    message.style.minHeight = "20px";
+    message.style.fontSize = "13px";
 
     const fields = [
       ["customer_number", "Kundennummer"],
@@ -190,15 +209,21 @@ export default class LicenseAdminScreen {
     const inputs = {};
     const form = document.createElement("div");
     form.style.display = "grid";
-    form.style.gap = "8px";
+    form.style.gridTemplateColumns = "180px minmax(260px, 1fr)";
+    form.style.columnGap = "12px";
+    form.style.rowGap = "8px";
     for (const [key, label] of fields) {
-      const wrap = document.createElement("label");
-      wrap.textContent = label;
+      const title = document.createElement("label");
+      title.textContent = label;
+      title.style.alignSelf = "center";
       const input = key === "notes" ? document.createElement("textarea") : document.createElement("input");
+      if (key === "notes") input.rows = 4;
       input.value = valueOf(customer, key, key.replace("_", ""));
-      wrap.appendChild(input);
+      input.style.width = "100%";
+      title.htmlFor = `customer-${key}`;
+      input.id = `customer-${key}`;
       inputs[key] = input;
-      form.appendChild(wrap);
+      form.append(title, input);
     }
 
     const actions = document.createElement("div");
@@ -236,6 +261,7 @@ export default class LicenseAdminScreen {
         return;
       }
       this.currentView = "license-editor";
+      this.currentLicense = null;
       this._render();
     });
     newLicenseBtn.disabled = !this.currentCustomer?.id;
@@ -252,6 +278,8 @@ export default class LicenseAdminScreen {
       const title = document.createElement("h4");
       title.textContent = "Lizenzen dieses Kunden";
       licenseSection.appendChild(title);
+      licenseSection.style.borderTop = "1px solid #ddd";
+      licenseSection.style.paddingTop = "10px";
       if (!this.currentCustomer?.id) {
         const hint = document.createElement("div");
         hint.textContent = "Lizenzen sind verfuegbar, sobald der Kunde gespeichert wurde.";
@@ -264,21 +292,40 @@ export default class LicenseAdminScreen {
         empty.textContent = "Noch keine Lizenz gespeichert.";
         licenseSection.appendChild(empty);
       }
+      const table = document.createElement("table");
+      const thead = document.createElement("thead");
+      const tbody = document.createElement("tbody");
+      const tr = document.createElement("tr");
+      ["Lizenz-ID", "Produktumfang", "gueltig von", "gueltig bis", "Lizenzmodus"].forEach((label) => {
+        const th = document.createElement("th");
+        th.textContent = label;
+        tr.appendChild(th);
+      });
+      thead.appendChild(tr);
+      table.append(thead, tbody);
+
       for (const record of records) {
-        const row = document.createElement("button");
-        row.type = "button";
-        row.textContent = `${valueOf(record, "license_id", "licenseId") || "-"} | ${formatProductScopeForList(record)} | ${
-          valueOf(record, "valid_from", "validFrom") || "-"
-        } | ${valueOf(record, "valid_until", "validUntil") || "-"} | ${
-          valueOf(record, "license_mode", "licenseMode") || "-"
-        }`;
+        const row = document.createElement("tr");
+        row.style.cursor = "pointer";
         row.onclick = () => {
           this.currentView = "license-editor";
           this.currentLicense = record;
           this._render();
         };
-        licenseSection.appendChild(row);
+        [
+          valueOf(record, "license_id", "licenseId") || "-",
+          formatProductScopeForList(record),
+          valueOf(record, "valid_from", "validFrom") || "-",
+          valueOf(record, "valid_until", "validUntil") || "-",
+          valueOf(record, "license_mode", "licenseMode") || "-",
+        ].forEach((text) => {
+          const td = document.createElement("td");
+          td.textContent = text;
+          row.appendChild(td);
+        });
+        tbody.appendChild(row);
       }
+      licenseSection.appendChild(table);
     };
 
     await renderLicenses();
@@ -287,9 +334,14 @@ export default class LicenseAdminScreen {
 
   async _renderLicenseEditor(container) {
     const customer = this.currentCustomer;
+    const header = document.createElement("h3");
+    header.textContent = `Neue Lizenz fuer: ${customerLabel(customer || {})}`;
+
     const context = document.createElement("div");
-    context.textContent = `Kunde: ${customerLabel(customer || {})}`;
+    context.textContent = `Kundenkontext: ${customerLabel(customer || {})}`;
     const message = document.createElement("div");
+    message.style.minHeight = "20px";
+    message.style.fontSize = "13px";
 
     const license = this.currentLicense || {};
     const fields = [
@@ -305,15 +357,57 @@ export default class LicenseAdminScreen {
     const form = document.createElement("div");
     const inputs = {};
     form.style.display = "grid";
+    form.style.gridTemplateColumns = "180px minmax(260px, 1fr)";
+    form.style.columnGap = "12px";
+    form.style.rowGap = "8px";
     for (const [key, label] of fields) {
-      const wrap = document.createElement("label");
-      wrap.textContent = label;
-      const input = key === "notes" ? document.createElement("textarea") : document.createElement("input");
+      const title = document.createElement("label");
+      title.textContent = label;
+      title.style.alignSelf = "center";
+      let input = key === "notes" ? document.createElement("textarea") : document.createElement("input");
+      if (key === "product_scope_json") {
+        input = document.createElement("textarea");
+        input.rows = 4;
+      }
+      if (key === "license_mode") {
+        input = document.createElement("select");
+        ["", "soft", "full"].forEach((mode) => {
+          const option = document.createElement("option");
+          option.value = mode;
+          option.textContent = mode || "- auswaehlen -";
+          input.appendChild(option);
+        });
+      }
+      if (key === "notes") input.rows = 3;
       input.value = valueOf(license, key, key.replace("_", ""));
-      wrap.appendChild(input);
+      input.style.width = "100%";
+      title.htmlFor = `license-${key}`;
+      input.id = `license-${key}`;
       inputs[key] = input;
-      form.appendChild(wrap);
+      form.append(title, input);
     }
+
+    const licenseIdHint = document.createElement("div");
+    licenseIdHint.textContent =
+      "Lizenz-ID-Hinweis: Wenn leer, wird spaetestens beim Speichern automatisch eine ID erzeugt.";
+    licenseIdHint.style.fontSize = "12px";
+
+    const generateIdBtn = this._button("Lizenz-ID erzeugen", () => {
+      const result = tryGenerateLicenseId(inputs.license_id.value);
+      if (!result.generated) {
+        message.textContent = "Lizenz-ID ist bereits gesetzt.";
+        return;
+      }
+      inputs.license_id.value = result.value;
+      message.textContent = "Lizenz-ID wurde erzeugt.";
+      syncGenerateIdButton();
+    });
+
+    const syncGenerateIdButton = () => {
+      generateIdBtn.disabled = Boolean(String(inputs.license_id.value || "").trim());
+    };
+    inputs.license_id.addEventListener("input", syncGenerateIdButton);
+    syncGenerateIdButton();
 
     const actions = document.createElement("div");
     actions.style.display = "flex";
@@ -351,6 +445,7 @@ export default class LicenseAdminScreen {
       });
       this.currentLicense = null;
       message.textContent = "Formular geleert.";
+      syncGenerateIdButton();
     });
 
     const backBtn = this._button("Zurueck zum Kunden", () => {
@@ -360,7 +455,7 @@ export default class LicenseAdminScreen {
     });
 
     actions.append(saveBtn, clearBtn, backBtn);
-    container.append(context, form, actions, message);
+    container.append(header, context, form, licenseIdHint, generateIdBtn, actions, message);
   }
 
   async _render() {


### PR DESCRIPTION
### Motivation
- Die kundenbezogene Lizenzverwaltung soll optisch klarer und bedienbarer werden, ohne bestehende Speicher-/Persistenzlogik oder DB/IPC zu ändern.
- Sichtbare Probleme wie unsaubere Feldanordnung, rohes JSON im Produktumfang und fehlende, unmittelbar nutzbare Lizenz-ID-Erzeugung sollen behoben werden.

### Description
- `LicenseAdminScreen` überarbeitet: Überschrift `Lizenzverwaltung`, Kundenbereich als klare Tabelle mit Spalten `Kundennummer | Firma | Ansprechpartner | E-Mail` und Aktionen `Neuer Kunde` / `Zurueck zum Adminbereich`.
- Kundendetail als ausgerichtetes Grid-Formular mit größeren Notizen-Feldern, sichtbarem Hinweisbereich und optisch getrenntem Abschnitt `Lizenzen dieses Kunden` als Tabelle (Spalten: `Lizenz-ID`, `Produktumfang`, `gueltig von`, `gueltig bis`, `Lizenzmodus`).
- Lizenz-Editor aufgeräumt: Kontextzeile `Neue Lizenz fuer: Kundennummer | Firma`, `Produktumfang` als Textarea, `Lizenzmodus` als Select (`soft`/`full`), Hinweisbereich für Erfolg/Fehler und neuer Button `Lizenz-ID erzeugen` der bei leerem Feld sofort eine `LIC-YYYYMMDD-HHMMSS` erzeugt und eingibt, ohne bereits gesetzte IDs zu überschreiben.
- Hilfsfunktionen ergänzt/angepasst: `tryGenerateLicenseId` hinzugefügt, `formatProductScopeForList` verbessert (zeigt `raw`-Text, `-` bei leeren Arrays, Kurzformat für standardumfang/zusatzfunktionen/module statt rohem JSON).
- Tests und Doku angepasst: entsprechende Unit-/Integrationstests erweitert/aktualisiert und `STATUS.md` um den UI-Meilenstein ergänzt.
- Betroffene Dateien: `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`, `scripts/tests/licenseAdminDataflow.test.cjs`, `scripts/tests/lizenzverwaltungModule.test.cjs`, `STATUS.md`.

### Testing
- Automatisierte Tests: `npm test` ausgeführt; Ergebnis: alle Tests bestanden.
- Spezifische Test-Änderungen: `scripts/tests/licenseAdminDataflow.test.cjs` ergänzt um Fälle für leere Produktumfang-Arrays und `tryGenerateLicenseId`-Verhalten; `scripts/tests/lizenzverwaltungModule.test.cjs` angepasst, um die neue Kundenkontext-Stringprüfung (`Kundenkontext:`) abzudecken; alle relevanten Lizenzverwaltungs- und Modultests liefen grün.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4ca8bf4c8322a184b777844038c8)