### PR TITLE
Lizenzverwaltung: geführten Lizenzumfang-Editor im Admin-Lizenzformular ergänzen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -190,6 +190,7 @@ Sie ergänzt:
 - Status: erledigt
 - Beschreibung:
   - Im Lizenzformular (`Neue Lizenz / Lizenz bearbeiten`) wurde ein gefuehrter Editor fuer `Produkt`, `Standardumfang`, `Zusatzfunktionen` und `Module` eingebaut.
+  - UI-Nachforderung umgesetzt: `Produkt` steht separat oben; `Standardumfang`, `Zusatzfunktionen` und `Module` werden als drei klar getrennte Karten in einer responsiven 3-Spalten-Zeile dargestellt.
   - `product_scope_json` wird weiterhin ueber die bestehende Save-Logik gespeichert, jetzt aber strukturiert mit `product`, `standardumfang`, `zusatzfunktionen` und `module`.
   - Bestehende Altwerte bleiben kompatibel: `{ raw: ... }`, Freitext, leere Arrays und vorhandene Strukturwerte werden weiterhin gelesen/angezeigt.
   - Die Liste `Lizenzen dieses Kunden` zeigt den Produktumfang jetzt lesbar (inkl. `Dictate` statt `audio`).

--- a/STATUS.md
+++ b/STATUS.md
@@ -191,6 +191,7 @@ Sie ergänzt:
 - Beschreibung:
   - Im Lizenzformular (`Neue Lizenz / Lizenz bearbeiten`) wurde ein gefuehrter Editor fuer `Produkt`, `Standardumfang`, `Zusatzfunktionen` und `Module` eingebaut.
   - UI-Nachforderung umgesetzt: `Produkt` steht separat oben; `Standardumfang`, `Zusatzfunktionen` und `Module` werden als drei klar getrennte Karten in einer responsiven 3-Spalten-Zeile dargestellt.
+  - Fehlerkorrektur: `Neu / leeren` setzt den Scope-Zustand jetzt konsistent zurueck (Standardumfang aktiv, Zusatzfunktionen/Module leer) und erzeugt `product_scope_json` sofort neu aus dem sichtbaren Modell.
   - `product_scope_json` wird weiterhin ueber die bestehende Save-Logik gespeichert, jetzt aber strukturiert mit `product`, `standardumfang`, `zusatzfunktionen` und `module`.
   - Bestehende Altwerte bleiben kompatibel: `{ raw: ... }`, Freitext, leere Arrays und vorhandene Strukturwerte werden weiterhin gelesen/angezeigt.
   - Die Liste `Lizenzen dieses Kunden` zeigt den Produktumfang jetzt lesbar (inkl. `Dictate` statt `audio`).

--- a/STATUS.md
+++ b/STATUS.md
@@ -186,6 +186,23 @@ Sie ergänzt:
 ## Erledigte Meilensteine / Pakete
 
 ### Erledigt
+#### Paket: Gefuehrter Lizenzumfang-Editor in der Admin-Lizenzverwaltung
+- Status: erledigt
+- Beschreibung:
+  - Im Lizenzformular (`Neue Lizenz / Lizenz bearbeiten`) wurde ein gefuehrter Editor fuer `Produkt`, `Standardumfang`, `Zusatzfunktionen` und `Module` eingebaut.
+  - `product_scope_json` wird weiterhin ueber die bestehende Save-Logik gespeichert, jetzt aber strukturiert mit `product`, `standardumfang`, `zusatzfunktionen` und `module`.
+  - Bestehende Altwerte bleiben kompatibel: `{ raw: ... }`, Freitext, leere Arrays und vorhandene Strukturwerte werden weiterhin gelesen/angezeigt.
+  - Die Liste `Lizenzen dieses Kunden` zeigt den Produktumfang jetzt lesbar (inkl. `Dictate` statt `audio`).
+  - Tests fuer lesbare Ausgabe und `Dictate`-Darstellung wurden in `licenseAdminDataflow.test.cjs` erweitert.
+- Betroffene Dateien:
+  - `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`
+  - `scripts/tests/licenseAdminDataflow.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine DB-/Schema-Aenderung, keine Lizenzdatei-/Setup-Aenderung, keine IPC-Erweiterung
+
 #### Paket: Zeitzonenstabiler Test fuer erzeugte Lizenz-ID
 - Status: erledigt
 - Beschreibung:

--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -386,6 +386,9 @@ async function runLicenseAdminDataflowTests(run) {
       createGeneratedLicenseId,
       tryGenerateLicenseId,
       buildLicenseEditorPayload,
+      buildStructuredProductScopeJson,
+      createDefaultScopeSelection,
+      resetScopeSelectionToDefault,
       buildCustomerEditorPayload,
     } = await importEsmFromFile(path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js"));
 
@@ -433,6 +436,19 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(customerPayload.customer_number, "K-44");
     assert.equal(customerPayload.company_name, "Firma 44");
     assert.equal(customerPayload.contact_person, "Kontakt 44");
+
+    const scopeSelection = createDefaultScopeSelection();
+    scopeSelection.zusatzfunktionen = ["mail", "dictate"];
+    scopeSelection.module = ["protokoll"];
+    scopeSelection.raw = "legacy";
+    scopeSelection.previous = { raw: "legacy" };
+    resetScopeSelectionToDefault(scopeSelection);
+
+    const normalizedScope = buildStructuredProductScopeJson(scopeSelection, scopeSelection.previous);
+    assert.equal(normalizedScope.product, "bbm-produktiv");
+    assert.deepEqual(normalizedScope.standardumfang, ["app", "pdf", "export"]);
+    assert.deepEqual(normalizedScope.zusatzfunktionen, []);
+    assert.deepEqual(normalizedScope.module, []);
   });
 }
 

--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -333,18 +333,33 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(out, "Sonderumfang A");
   });
 
-  await run("Lizenzverwaltung UI-Liste: Produktumfang aus standardumfang/zusatzfunktionen/module wird kurz formatiert", async () => {
+  await run("Lizenzverwaltung UI-Liste: Produktumfang aus Struktur wird lesbar formatiert", async () => {
     const { formatProductScopeForList } = await importEsmFromFile(
       path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js")
     );
     const out = formatProductScopeForList({
       product_scope_json: JSON.stringify({
-        standardumfang: ["app", "pdf"],
+        product: "bbm-produktiv",
+        standardumfang: ["app", "pdf", "export"],
         zusatzfunktionen: ["mail"],
-        module: ["Protokoll"],
+        module: ["protokoll"],
       }),
     });
-    assert.equal(out, "std:app,pdf | zus:mail | mod:Protokoll");
+    assert.equal(out, "BBM-Produktiv | App, PDF, Export | Mail | Modul: Protokoll");
+  });
+
+  await run("Lizenzverwaltung UI-Liste: Dictate wird angezeigt, auch wenn audio gespeichert ist", async () => {
+    const { formatProductScopeForList } = await importEsmFromFile(
+      path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js")
+    );
+    const out = formatProductScopeForList({
+      product_scope_json: JSON.stringify({
+        product: "bbm-produktiv",
+        standardumfang: ["app", "pdf", "export"],
+        zusatzfunktionen: ["mail", "audio"],
+      }),
+    });
+    assert.equal(out, "BBM-Produktiv | App, PDF, Export | Mail, Dictate");
   });
 
   await run("Lizenzverwaltung UI-Liste: Produktumfang ohne Daten zeigt '-'", async () => {

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -1,5 +1,102 @@
 import { listCustomers, listLicensesByCustomer, saveCustomer, saveLicense } from "../licenseStorageService.js";
 
+const PRODUCT_KEY = "bbm-produktiv";
+const PRODUCT_LABEL = "BBM-Produktiv";
+const STANDARD_SCOPE_KEYS = Object.freeze(["app", "pdf", "export"]);
+const ADDITIONAL_FEATURES = Object.freeze([
+  Object.freeze({ key: "mail", label: "Mail" }),
+  Object.freeze({ key: "dictate", label: "Dictate", aliases: ["audio"] }),
+]);
+const MODULE_KEYS = Object.freeze([
+  Object.freeze({ key: "protokoll", label: "Protokoll" }),
+  Object.freeze({ key: "dummy", label: "Dummy" }),
+]);
+
+function toUniqueNormalizedArray(values = []) {
+  const seen = new Set();
+  const output = [];
+  values.forEach((value) => {
+    const normalized = String(value || "").trim().toLowerCase();
+    if (!normalized || seen.has(normalized)) return;
+    seen.add(normalized);
+    output.push(normalized);
+  });
+  return output;
+}
+
+function normalizeAdditionalFeatureKey(value) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return "";
+  if (normalized === "audio") return "dictate";
+  return normalized;
+}
+
+function parseProductScopeObject(rawValue) {
+  const trimmed = String(rawValue || "").trim();
+  const fallback = {
+    original: {},
+    product: PRODUCT_KEY,
+    standardumfang: [...STANDARD_SCOPE_KEYS],
+    zusatzfunktionen: [],
+    module: [],
+    raw: "",
+  };
+
+  if (!trimmed) {
+    return fallback;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { ...fallback, raw: trimmed };
+    }
+
+    const standardumfang = toUniqueNormalizedArray(parsed.standardumfang || []).filter((key) =>
+      STANDARD_SCOPE_KEYS.includes(key)
+    );
+
+    const extraKeys = toUniqueNormalizedArray(parsed.zusatzfunktionen || [])
+      .map((key) => normalizeAdditionalFeatureKey(key))
+      .filter((key) => ADDITIONAL_FEATURES.some((entry) => entry.key === key));
+
+    const moduleKeys = toUniqueNormalizedArray(parsed.module || []).filter((key) =>
+      MODULE_KEYS.some((entry) => entry.key === key)
+    );
+
+    return {
+      original: parsed,
+      product: String(parsed.product || "").trim().toLowerCase() || PRODUCT_KEY,
+      standardumfang: standardumfang.length ? standardumfang : [...STANDARD_SCOPE_KEYS],
+      zusatzfunktionen: extraKeys,
+      module: moduleKeys,
+      raw: String(parsed.raw || "").trim(),
+    };
+  } catch (_err) {
+    return { ...fallback, raw: trimmed };
+  }
+}
+
+function formatEntryLabel(key, entries = []) {
+  const found = entries.find((entry) => entry.key === String(key || "").trim().toLowerCase());
+  return found?.label || String(key || "").trim();
+}
+
+function buildStructuredProductScopeJson(model = {}, previous = {}) {
+  const previousObject = previous && typeof previous === "object" && !Array.isArray(previous) ? previous : {};
+  const raw = String(previousObject.raw || model.raw || "").trim();
+  return {
+    ...previousObject,
+    product: PRODUCT_KEY,
+    standardumfang: [...STANDARD_SCOPE_KEYS],
+    zusatzfunktionen: toUniqueNormalizedArray(model.zusatzfunktionen || [])
+      .map((key) => normalizeAdditionalFeatureKey(key))
+      .filter((key) => ADDITIONAL_FEATURES.some((entry) => entry.key === key)),
+    module: toUniqueNormalizedArray(model.module || []).filter((key) => MODULE_KEYS.some((entry) => entry.key === key)),
+    ...(raw ? { raw } : {}),
+  };
+}
+
 export function createGeneratedLicenseId(now = new Date()) {
   const part = (value) => String(value).padStart(2, "0");
   return `LIC-${now.getFullYear()}${part(now.getMonth() + 1)}${part(now.getDate())}-${part(now.getHours())}${part(
@@ -22,7 +119,6 @@ export function assertCustomerContext(customer) {
   }
   return customerId;
 }
-
 
 export function buildLicenseEditorPayload({ license = {}, inputs = {}, customer = null, now = new Date() } = {}) {
   const customerId = assertCustomerContext(customer);
@@ -65,8 +161,6 @@ function valueOf(item, ...keys) {
   return "";
 }
 
-
-
 export function formatProductScopeForList(entry = {}) {
   const fromObject = entry?.productScope;
   if (fromObject && typeof fromObject === "object" && !Array.isArray(fromObject)) {
@@ -75,39 +169,62 @@ export function formatProductScopeForList(entry = {}) {
   }
 
   const rawJson = String(entry?.product_scope_json || "").trim();
-  if (rawJson) {
-    try {
-      const parsed = JSON.parse(rawJson);
-      if (parsed && typeof parsed === "object") {
-        if (String(parsed.raw || "").trim()) return String(parsed.raw).trim();
-        const label = buildProductScopeLabel(parsed);
-        if (label) return label;
-        return "-";
+  if (!rawJson) return "-";
+
+  try {
+    const parsed = JSON.parse(rawJson);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      if (String(parsed.raw || "").trim() && !parsed.product && !Array.isArray(parsed.standardumfang) && !Array.isArray(parsed.zusatzfunktionen) && !Array.isArray(parsed.module)) {
+        return String(parsed.raw).trim();
       }
-    } catch (_err) {
-      return rawJson;
+      const label = buildProductScopeLabel(parsed);
+      if (label) return label;
+      if (String(parsed.raw || "").trim()) return String(parsed.raw).trim();
+      return "-";
     }
+    return rawJson;
+  } catch (_err) {
+    return rawJson;
   }
-
-  if (String(entry?.product_scope_json || "").trim()) {
-    return String(entry.product_scope_json).trim();
-  }
-
-  return "-";
 }
 
 function buildProductScopeLabel(scope = {}) {
-  const collect = [];
-  const add = (prefix, key) => {
-    if (Array.isArray(scope[key]) && scope[key].length) {
-      collect.push(`${prefix}:${scope[key].map((v) => String(v || "").trim()).filter(Boolean).join(",")}`);
-    }
-  };
-  add("std", "standardumfang");
-  add("zus", "zusatzfunktionen");
-  add("mod", "module");
-  return collect.join(" | ").trim();
+  const parts = [];
+
+  const product = String(scope.product || "").trim().toLowerCase();
+  if (product === PRODUCT_KEY) {
+    parts.push(PRODUCT_LABEL);
+  } else if (product) {
+    parts.push(product);
+  }
+
+  const standardEntries = toUniqueNormalizedArray(scope.standardumfang || [])
+    .filter((key) => STANDARD_SCOPE_KEYS.includes(key))
+    .map((key) => ({ app: "App", pdf: "PDF", export: "Export" }[key] || key));
+  if (standardEntries.length) {
+    parts.push(standardEntries.join(", "));
+  }
+
+  const extras = toUniqueNormalizedArray(scope.zusatzfunktionen || [])
+    .map((key) => normalizeAdditionalFeatureKey(key))
+    .filter((key) => ADDITIONAL_FEATURES.some((entry) => entry.key === key))
+    .map((key) => formatEntryLabel(key, ADDITIONAL_FEATURES));
+  if (extras.length) {
+    parts.push(extras.join(", "));
+  }
+
+  const modules = toUniqueNormalizedArray(scope.module || [])
+    .filter((key) => MODULE_KEYS.some((entry) => entry.key === key))
+    .map((key) => formatEntryLabel(key, MODULE_KEYS));
+  if (modules.length) {
+    const prefix = modules.length === 1 ? "Modul" : "Module";
+    parts.push(`${prefix}: ${modules.join(", ")}`);
+  }
+
+  if (!parts.length) return "";
+  return parts.join(" | ");
 }
+
 export default class LicenseAdminScreen {
   constructor({ onBackToAdminbereich } = {}) {
     this.onBackToAdminbereich = onBackToAdminbereich;
@@ -344,9 +461,10 @@ export default class LicenseAdminScreen {
     message.style.fontSize = "13px";
 
     const license = this.currentLicense || {};
+    const parsedScope = parseProductScopeObject(valueOf(license, "product_scope_json", "productScope"));
+
     const fields = [
       ["license_id", "Lizenz-ID"],
-      ["product_scope_json", "Produktumfang"],
       ["valid_from", "gueltig von"],
       ["valid_until", "gueltig bis"],
       ["license_mode", "Lizenzmodus"],
@@ -355,20 +473,22 @@ export default class LicenseAdminScreen {
     ];
 
     const form = document.createElement("div");
-    const inputs = {};
+    const inputs = { product_scope_json: document.createElement("input") };
+    inputs.product_scope_json.type = "hidden";
     form.style.display = "grid";
     form.style.gridTemplateColumns = "180px minmax(260px, 1fr)";
     form.style.columnGap = "12px";
     form.style.rowGap = "8px";
-    for (const [key, label] of fields) {
+
+    const appendFieldRow = (labelText, fieldNode) => {
       const title = document.createElement("label");
-      title.textContent = label;
+      title.textContent = labelText;
       title.style.alignSelf = "center";
+      form.append(title, fieldNode);
+    };
+
+    for (const [key, label] of fields) {
       let input = key === "notes" ? document.createElement("textarea") : document.createElement("input");
-      if (key === "product_scope_json") {
-        input = document.createElement("textarea");
-        input.rows = 4;
-      }
       if (key === "license_mode") {
         input = document.createElement("select");
         ["", "soft", "full"].forEach((mode) => {
@@ -381,11 +501,114 @@ export default class LicenseAdminScreen {
       if (key === "notes") input.rows = 3;
       input.value = valueOf(license, key, key.replace("_", ""));
       input.style.width = "100%";
-      title.htmlFor = `license-${key}`;
       input.id = `license-${key}`;
       inputs[key] = input;
-      form.append(title, input);
+      appendFieldRow(label, input);
     }
+
+    const scopeModel = {
+      raw: parsedScope.raw,
+      zusatzfunktionen: [...parsedScope.zusatzfunktionen],
+      module: [...parsedScope.module],
+      previous: parsedScope.original,
+    };
+
+    const productWrap = document.createElement("div");
+    productWrap.style.display = "grid";
+    productWrap.style.gap = "8px";
+
+    const productHint = document.createElement("div");
+    productHint.textContent = `Produkt: ${PRODUCT_LABEL}`;
+
+    const standardWrap = document.createElement("div");
+    standardWrap.style.display = "grid";
+    standardWrap.style.gap = "4px";
+    STANDARD_SCOPE_KEYS.forEach((key) => {
+      const row = document.createElement("label");
+      row.style.display = "flex";
+      row.style.gap = "8px";
+      row.style.alignItems = "center";
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.checked = true;
+      checkbox.disabled = true;
+      const text = document.createElement("span");
+      text.textContent = { app: "App", pdf: "PDF", export: "Export" }[key] || key;
+      row.append(checkbox, text);
+      standardWrap.appendChild(row);
+    });
+
+    const extrasWrap = document.createElement("div");
+    extrasWrap.style.display = "grid";
+    extrasWrap.style.gap = "4px";
+
+    ADDITIONAL_FEATURES.forEach((entry) => {
+      const row = document.createElement("label");
+      row.style.display = "flex";
+      row.style.gap = "8px";
+      row.style.alignItems = "center";
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.checked = scopeModel.zusatzfunktionen.includes(entry.key);
+      checkbox.onchange = () => {
+        if (checkbox.checked) {
+          if (!scopeModel.zusatzfunktionen.includes(entry.key)) scopeModel.zusatzfunktionen.push(entry.key);
+        } else {
+          scopeModel.zusatzfunktionen = scopeModel.zusatzfunktionen.filter((item) => item !== entry.key);
+        }
+        syncScopeJson();
+      };
+      const text = document.createElement("span");
+      text.textContent = entry.label;
+      row.append(checkbox, text);
+      extrasWrap.appendChild(row);
+    });
+
+    const moduleWrap = document.createElement("div");
+    moduleWrap.style.display = "grid";
+    moduleWrap.style.gap = "4px";
+
+    MODULE_KEYS.forEach((entry) => {
+      const row = document.createElement("label");
+      row.style.display = "flex";
+      row.style.gap = "8px";
+      row.style.alignItems = "center";
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.checked = scopeModel.module.includes(entry.key);
+      checkbox.onchange = () => {
+        if (checkbox.checked) {
+          if (!scopeModel.module.includes(entry.key)) scopeModel.module.push(entry.key);
+        } else {
+          scopeModel.module = scopeModel.module.filter((item) => item !== entry.key);
+        }
+        syncScopeJson();
+      };
+      const text = document.createElement("span");
+      text.textContent = entry.label;
+      row.append(checkbox, text);
+      moduleWrap.appendChild(row);
+    });
+
+    productWrap.append(productHint);
+
+    appendFieldRow("Produkt", productWrap);
+    appendFieldRow("Standardumfang", standardWrap);
+    appendFieldRow("Zusatzfunktionen", extrasWrap);
+    appendFieldRow("Module", moduleWrap);
+
+    if (scopeModel.raw) {
+      const legacyHint = document.createElement("div");
+      legacyHint.style.fontSize = "12px";
+      legacyHint.style.opacity = "0.8";
+      legacyHint.textContent = `Bestehender Freitext wird beibehalten: ${scopeModel.raw}`;
+      appendFieldRow("Legacy-Hinweis", legacyHint);
+    }
+
+    const syncScopeJson = () => {
+      inputs.product_scope_json.value = JSON.stringify(buildStructuredProductScopeJson(scopeModel, scopeModel.previous));
+    };
+    syncScopeJson();
 
     const licenseIdHint = document.createElement("div");
     licenseIdHint.textContent =

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -82,7 +82,7 @@ function formatEntryLabel(key, entries = []) {
   return found?.label || String(key || "").trim();
 }
 
-function buildStructuredProductScopeJson(model = {}, previous = {}) {
+export function buildStructuredProductScopeJson(model = {}, previous = {}) {
   const previousObject = previous && typeof previous === "object" && !Array.isArray(previous) ? previous : {};
   const raw = String(previousObject.raw || model.raw || "").trim();
   return {
@@ -95,6 +95,23 @@ function buildStructuredProductScopeJson(model = {}, previous = {}) {
     module: toUniqueNormalizedArray(model.module || []).filter((key) => MODULE_KEYS.some((entry) => entry.key === key)),
     ...(raw ? { raw } : {}),
   };
+}
+
+export function createDefaultScopeSelection() {
+  return {
+    raw: "",
+    zusatzfunktionen: [],
+    module: [],
+    previous: {},
+  };
+}
+
+export function resetScopeSelectionToDefault(selection = {}) {
+  selection.raw = "";
+  selection.zusatzfunktionen = [];
+  selection.module = [];
+  selection.previous = {};
+  return selection;
 }
 
 export function createGeneratedLicenseId(now = new Date()) {
@@ -506,12 +523,13 @@ export default class LicenseAdminScreen {
       appendFieldRow(label, input);
     }
 
-    const scopeModel = {
-      raw: parsedScope.raw,
-      zusatzfunktionen: [...parsedScope.zusatzfunktionen],
-      module: [...parsedScope.module],
-      previous: parsedScope.original,
-    };
+    const scopeModel = createDefaultScopeSelection();
+    scopeModel.raw = parsedScope.raw;
+    scopeModel.zusatzfunktionen = [...parsedScope.zusatzfunktionen];
+    scopeModel.module = [...parsedScope.module];
+    scopeModel.previous = parsedScope.original;
+    const zusatzfunktionChecks = new Map();
+    const moduleChecks = new Map();
 
     const standardWrap = document.createElement("div");
     standardWrap.style.display = "grid";
@@ -543,6 +561,7 @@ export default class LicenseAdminScreen {
       const checkbox = document.createElement("input");
       checkbox.type = "checkbox";
       checkbox.checked = scopeModel.zusatzfunktionen.includes(entry.key);
+      zusatzfunktionChecks.set(entry.key, checkbox);
       checkbox.onchange = () => {
         if (checkbox.checked) {
           if (!scopeModel.zusatzfunktionen.includes(entry.key)) scopeModel.zusatzfunktionen.push(entry.key);
@@ -569,6 +588,7 @@ export default class LicenseAdminScreen {
       const checkbox = document.createElement("input");
       checkbox.type = "checkbox";
       checkbox.checked = scopeModel.module.includes(entry.key);
+      moduleChecks.set(entry.key, checkbox);
       checkbox.onchange = () => {
         if (checkbox.checked) {
           if (!scopeModel.module.includes(entry.key)) scopeModel.module.push(entry.key);
@@ -697,6 +717,14 @@ export default class LicenseAdminScreen {
       Object.values(inputs).forEach((el) => {
         el.value = "";
       });
+      resetScopeSelectionToDefault(scopeModel);
+      zusatzfunktionChecks.forEach((checkbox) => {
+        checkbox.checked = false;
+      });
+      moduleChecks.forEach((checkbox) => {
+        checkbox.checked = false;
+      });
+      syncScopeJson();
       this.currentLicense = null;
       message.textContent = "Formular geleert.";
       syncGenerateIdButton();

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -513,16 +513,9 @@ export default class LicenseAdminScreen {
       previous: parsedScope.original,
     };
 
-    const productWrap = document.createElement("div");
-    productWrap.style.display = "grid";
-    productWrap.style.gap = "8px";
-
-    const productHint = document.createElement("div");
-    productHint.textContent = `Produkt: ${PRODUCT_LABEL}`;
-
     const standardWrap = document.createElement("div");
     standardWrap.style.display = "grid";
-    standardWrap.style.gap = "4px";
+    standardWrap.style.gap = "6px";
     STANDARD_SCOPE_KEYS.forEach((key) => {
       const row = document.createElement("label");
       row.style.display = "flex";
@@ -540,7 +533,7 @@ export default class LicenseAdminScreen {
 
     const extrasWrap = document.createElement("div");
     extrasWrap.style.display = "grid";
-    extrasWrap.style.gap = "4px";
+    extrasWrap.style.gap = "6px";
 
     ADDITIONAL_FEATURES.forEach((entry) => {
       const row = document.createElement("label");
@@ -566,7 +559,7 @@ export default class LicenseAdminScreen {
 
     const moduleWrap = document.createElement("div");
     moduleWrap.style.display = "grid";
-    moduleWrap.style.gap = "4px";
+    moduleWrap.style.gap = "6px";
 
     MODULE_KEYS.forEach((entry) => {
       const row = document.createElement("label");
@@ -590,12 +583,50 @@ export default class LicenseAdminScreen {
       moduleWrap.appendChild(row);
     });
 
-    productWrap.append(productHint);
+    const scopeEditorWrap = document.createElement("div");
+    scopeEditorWrap.style.display = "grid";
+    scopeEditorWrap.style.gap = "10px";
 
-    appendFieldRow("Produkt", productWrap);
-    appendFieldRow("Standardumfang", standardWrap);
-    appendFieldRow("Zusatzfunktionen", extrasWrap);
-    appendFieldRow("Module", moduleWrap);
+    const productCard = document.createElement("div");
+    productCard.style.border = "1px solid #ddd";
+    productCard.style.borderRadius = "8px";
+    productCard.style.padding = "10px";
+    productCard.style.display = "grid";
+    productCard.style.gap = "4px";
+    const productTitle = document.createElement("div");
+    productTitle.textContent = "Produkt";
+    productTitle.style.fontWeight = "600";
+    const productHint = document.createElement("div");
+    productHint.textContent = PRODUCT_LABEL;
+    productCard.append(productTitle, productHint);
+
+    const categoryGrid = document.createElement("div");
+    categoryGrid.style.display = "grid";
+    categoryGrid.style.gridTemplateColumns = "repeat(auto-fit, minmax(180px, 1fr))";
+    categoryGrid.style.gap = "10px";
+
+    const createCategoryCard = (title, body) => {
+      const card = document.createElement("div");
+      card.style.border = "1px solid #ddd";
+      card.style.borderRadius = "8px";
+      card.style.padding = "10px";
+      card.style.display = "grid";
+      card.style.gap = "8px";
+      const heading = document.createElement("div");
+      heading.textContent = title;
+      heading.style.fontWeight = "600";
+      card.append(heading, body);
+      return card;
+    };
+
+    categoryGrid.append(
+      createCategoryCard("Standardumfang", standardWrap),
+      createCategoryCard("Zusatzfunktionen", extrasWrap),
+      createCategoryCard("Module", moduleWrap)
+    );
+
+    scopeEditorWrap.append(productCard, categoryGrid);
+    appendFieldRow("Lizenzumfang", scopeEditorWrap);
 
     if (scopeModel.raw) {
       const legacyHint = document.createElement("div");


### PR DESCRIPTION
### Motivation
- Das freie `Produktumfang`-Feld im Admin-Formular ist zu ungenau für reale Lizenzvergabe und soll durch einen geführten Editor ersetzt werden.
- Die gespeicherten Daten bleiben in `product_scope_json`, benötigen aber eine klarere Struktur und lesbare Darstellung in der Lizenzliste.

### Description
- Implementiert einen geführten Lizenzumfang-Editor im Formular `Neue Lizenz / Lizenz bearbeiten` mit Bereichen `Produkt` (BBM-Produktiv), `Standardumfang` (App, PDF, Export, fest), `Zusatzfunktionen` (Mail, Dictate) und `Module` (Protokoll, Dummy).
- `product_scope_json` wird strukturiert gebildet (Felder `product`, `standardumfang`, `zusatzfunktionen`, `module`) und kompatibel zu alten `{ raw: ... }`/Freitext-Werten behandelt; bestehende Werte gehen nicht verloren.
- Listenansicht `Lizenzen dieses Kunden` zeigt den Umfang lesbar an (z. B. `BBM-Produktiv | App, PDF, Export | Mail, Dictate | Modul: Protokoll`) und normalisiert Anzeige von `audio` zu `Dictate`.
- Betroffene Dateien: `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`, `scripts/tests/licenseAdminDataflow.test.cjs`, `STATUS.md`.
- Keine Änderungen an DB-Schema, Persistenzarchitektur, Lizenzdateierzeugung, Setup oder IPC-Verträgen wurden vorgenommen.

### Testing
- Automatisierte Tests ausgeführt: `npm test -- --runInBand` und `npm test`; alle Tests liefen erfolgreich (grün).
- Ergänzte/angepasste Tests in `scripts/tests/licenseAdminDataflow.test.cjs` decken die lesbare Formatierung des `product_scope_json` und die `Dictate`-Darstellung ab, und liefen ebenfalls erfolgreich.
- Hinweis: Es wurden keine manuellen DB-/IPC-Checks ausgeführt; alle automatisierten Testläufe sind grün.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef55b073148322be49820edba1c413)