### PR TITLE
Admin-Lizenzformular an bestehende licenseGenerate-Infrastruktur anbinden

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -143,6 +143,12 @@ Sie ergänzt:
   - Kompatibilität fuer Altwerte in `license_mode` bleibt erhalten (`soft/full/none/machine` -> sinnvolle Edition/Binding-Ableitung), neue Felder `license_edition`/`license_binding` haben Vorrang.
   - DB-Schema `license_records` wurde nicht-destruktiv um optionale Spalten `license_edition` und `license_binding` ergänzt.
   - Main-Service und Renderer-Normalisierung akzeptieren/liefern snake_case + camelCase für Edition/Binding.
+- Lizenzverwaltung UI-Nachbesserung ist umgesetzt:
+  - Nach `Kunde speichern` ist `Neue Lizenz` sofort aktiv; kein Zurueck-/Neuoeffnen noetig.
+  - Im Lizenzformular wurden Buttontexte vereinheitlicht: `Lizenz speichern`, `Formular leeren`, `Zurueck`.
+  - Kundendetail ist klarer getrennt in `Kundendaten` und `Lizenzen dieses Kunden`.
+  - Die Lizenzliste je Kunde ist als saubere Tabelle mit Spalten fuer Lizenz-ID, Lizenzart, Gerätebindung, Produktumfang, gueltig von/bis und Aktion aufgebaut.
+  - Bearbeiten erfolgt ueber sichtbaren Button `Öffnen` in der Aktion-Spalte statt ueber unsichtbaren Zeilenklick.
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.
@@ -203,6 +209,22 @@ Sie ergänzt:
 ## Erledigte Meilensteine / Pakete
 
 ### Erledigt
+#### Paket: PR #39 UI-Feinschliff Kundendetail/Lizenzformular
+- Status: erledigt
+- Beschreibung:
+  - Kundendetail-Screen so angepasst, dass `Neue Lizenz` nach erfolgreichem Kundenspeichern sofort nutzbar bleibt.
+  - Lizenzformular-Buttons sprachlich auf klare Begriffe umgestellt (`Lizenz speichern`, `Formular leeren`, `Zurueck`).
+  - Lizenzliste je Kunde optisch/strukturell bereinigt (eigene Aktion-Spalte mit `Öffnen`; kein gesamter Zeilenklick).
+  - Tests auf neue Begriffe/Struktur und Direktnutzbarkeit nach Kundenspeichern erweitert.
+- Betroffene Dateien:
+  - `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine DB-/Generator-/Setup-/Sidebar-/Projektmodul-Aenderung in diesem UI-Nachschritt
+
 #### Paket: PR #39 Nachbesserung - Lizenzart/Geraetebindung getrennt und Datumsnormalisierung
 - Status: erledigt
 - Beschreibung:

--- a/STATUS.md
+++ b/STATUS.md
@@ -153,6 +153,10 @@ Sie ergänzt:
   - Im Lizenzformular gibt es jetzt den kombinierten Hauptbutton `Lizenz erstellen`.
   - Der Ablauf dahinter ist: Admin-Lizenz speichern -> vorhandenen Generator aufrufen -> Ausgabepfad anzeigen -> Ausgabeordner öffnen.
   - Es gibt keinen separaten Bedienpfad mehr mit erst `Lizenz speichern` und danach `Lizenzdatei erzeugen`.
+- Lizenzverwaltung finale UI-Vereinfachung ist umgesetzt:
+  - Im sichtbaren Lizenzformular wurden restliche Einzelbuttons entfernt (`Lizenz-ID erzeugen`, `Formular leeren`).
+  - Lizenz-ID bleibt sichtbar, wird aber beim Hauptablauf `Lizenz erstellen` automatisch erzeugt, wenn leer.
+  - Sichtbarer Hauptablauf im Formular ist jetzt auf `Lizenz erstellen` + `Zurueck` reduziert; `Ausgabeordner öffnen` erscheint nur nach erfolgreicher Erzeugung.
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.
@@ -213,6 +217,21 @@ Sie ergänzt:
 ## Erledigte Meilensteine / Pakete
 
 ### Erledigt
+#### Paket: PR #39 final - sichtbare Einzelbuttons im Lizenzformular entfernt
+- Status: erledigt
+- Beschreibung:
+  - Entfernt: `Lizenz-ID erzeugen` (Button) und `Formular leeren` (Button) aus dem sichtbaren Lizenzformular.
+  - Hinweistext bei Lizenz-ID auf automatischen Erstell-Ablauf angepasst.
+  - Tests auf reduzierte sichtbare Bedienung aktualisiert.
+- Betroffene Dateien:
+  - `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine DB-/Generator-/Setup-/Persistenz-/Sidebar-/Projektmodul-Aenderung
+
 #### Paket: PR #39 Abschluss - kombinierter Button `Lizenz erstellen`
 - Status: erledigt
 - Beschreibung:

--- a/STATUS.md
+++ b/STATUS.md
@@ -136,6 +136,13 @@ Sie ergänzt:
   - Ohne ableitbare Features wird Erzeugung blockiert (`Produktumfang enthält keine erzeugbaren Features.`).
   - Bei Erfolg wird der Ausgabepfad angezeigt und `Ausgabeordner öffnen` nutzt bestehendes `window.bbmDb.licenseOpenOutputDir(...)`.
   - Bestehende Main-IPC-Infrastruktur (`license:generate`, `license:open-output-dir`) wurde weiterverwendet, keine neue Generator-Architektur.
+- Lizenzverwaltung Nachbesserung ist umgesetzt:
+  - Lizenzformular trennt jetzt fachlich `Lizenzart` (Testlizenz/Vollversion) und `Gerätebindung` (none/machine); `Lizenzmodus` ist nicht mehr das führende Bedienfeld.
+  - Datumsfelder im Admin-Lizenzformular laufen als Date-Inputs; Generator-Payload normalisiert zusaetzlich ISO- und deutsche Eingaben (`TT.MM.JJJJ` -> `JJJJ-MM-TT`), um `VALID_FROM_REQUIRED` zu vermeiden.
+  - Bei `Gerätebindung = machine` wird `Machine-ID` vor `licenseGenerate` verpflichtend geprüft; bei `none` bleibt Machine-ID optional und wird nicht übergeben.
+  - Kompatibilität fuer Altwerte in `license_mode` bleibt erhalten (`soft/full/none/machine` -> sinnvolle Edition/Binding-Ableitung), neue Felder `license_edition`/`license_binding` haben Vorrang.
+  - DB-Schema `license_records` wurde nicht-destruktiv um optionale Spalten `license_edition` und `license_binding` ergänzt.
+  - Main-Service und Renderer-Normalisierung akzeptieren/liefern snake_case + camelCase für Edition/Binding.
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.
@@ -196,6 +203,26 @@ Sie ergänzt:
 ## Erledigte Meilensteine / Pakete
 
 ### Erledigt
+#### Paket: PR #39 Nachbesserung - Lizenzart/Geraetebindung getrennt und Datumsnormalisierung
+- Status: erledigt
+- Beschreibung:
+  - `LicenseAdminScreen` trennt nun `Lizenzart` und `Gerätebindung` im Formular, inklusive Machine-ID-Enable/Disable je Binding.
+  - Generator-Payload nutzt jetzt Edition/Binding aus neuen Feldern (mit Legacy-Fallback), normalisiert Datumswerte und validiert Machine-ID/Data vor dem IPC-Aufruf.
+  - DB-Schema und Main-Service wurden fuer optionale Felder `license_edition`/`license_binding` erweitert (nicht-destruktiv, keine neue Tabelle).
+  - Normalisierer/Tests wurden auf Kompatibilität von legacy `license_mode` + neue Felder angepasst.
+- Betroffene Dateien:
+  - `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`
+  - `src/renderer/modules/lizenzverwaltung/licenseRecords.js`
+  - `src/main/licensing/licenseAdminService.js`
+  - `src/main/db/database.js`
+  - `scripts/tests/licenseAdminDataflow.test.cjs`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine neue Generator-IPC, keine Setup-/App-Sperrlogik-Aenderung, keine Sidebar-/Projektmodul-Aenderung
+
 #### Paket: Admin-Lizenzformular an bestehende Lizenzdatei-Erzeugung angebunden
 - Status: erledigt
 - Beschreibung:

--- a/STATUS.md
+++ b/STATUS.md
@@ -149,6 +149,10 @@ Sie ergänzt:
   - Kundendetail ist klarer getrennt in `Kundendaten` und `Lizenzen dieses Kunden`.
   - Die Lizenzliste je Kunde ist als saubere Tabelle mit Spalten fuer Lizenz-ID, Lizenzart, Gerätebindung, Produktumfang, gueltig von/bis und Aktion aufgebaut.
   - Bearbeiten erfolgt ueber sichtbaren Button `Öffnen` in der Aktion-Spalte statt ueber unsichtbaren Zeilenklick.
+- Lizenzverwaltung Abschluss fuer PR #39 ist umgesetzt:
+  - Im Lizenzformular gibt es jetzt den kombinierten Hauptbutton `Lizenz erstellen`.
+  - Der Ablauf dahinter ist: Admin-Lizenz speichern -> vorhandenen Generator aufrufen -> Ausgabepfad anzeigen -> Ausgabeordner öffnen.
+  - Es gibt keinen separaten Bedienpfad mehr mit erst `Lizenz speichern` und danach `Lizenzdatei erzeugen`.
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.
@@ -209,6 +213,22 @@ Sie ergänzt:
 ## Erledigte Meilensteine / Pakete
 
 ### Erledigt
+#### Paket: PR #39 Abschluss - kombinierter Button `Lizenz erstellen`
+- Status: erledigt
+- Beschreibung:
+  - Lizenzformular auf einen klaren Hauptablauf mit einem Button `Lizenz erstellen` umgestellt.
+  - Klick speichert zuerst den Lizenzdatensatz und erzeugt danach direkt die `.bbmlic` über die bestehende Generator-Infrastruktur.
+  - Ausgabepfad bleibt sichtbar; `Ausgabeordner öffnen` bleibt verfügbar.
+  - Tests auf neue UI-Begriffe/Bedienlogik aktualisiert.
+- Betroffene Dateien:
+  - `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Kein neuer Generator-IPC, keine Setup-/Sidebar-/Projektmodul-/Persistenzarchitektur-Aenderung
+
 #### Paket: PR #39 UI-Feinschliff Kundendetail/Lizenzformular
 - Status: erledigt
 - Beschreibung:

--- a/STATUS.md
+++ b/STATUS.md
@@ -126,6 +126,16 @@ Sie ergänzt:
   - Lizenzformular zeigt `Neue Lizenz fuer: ...`, Produktumfang als mehrzeiliges Feld, Lizenzmodus als Auswahl (`soft`/`full`) und den neuen Button `Lizenz-ID erzeugen`.
   - `Lizenz-ID erzeugen` schreibt nur bei leerem Feld sofort eine `LIC-YYYYMMDD-HHMMSS`-ID ins Feld; gesetzte IDs werden nicht ueberschrieben.
   - Bestehende Speicherlogik (Auto-ID beim Speichern, Kundenkontext-Pflicht, DB-/IPC-Fluss) bleibt unveraendert.
+- Lizenzverwaltung naechstes Paket ist umgesetzt:
+  - Im Lizenzformular gibt es den Button `Lizenzdatei erzeugen`.
+  - Erzeugung ist ohne gespeicherte Lizenz blockiert (`Bitte zuerst die Lizenz speichern.`).
+  - Gespeicherte Lizenz + aktueller Kunde werden auf bestehendes `window.bbmDb.licenseGenerate(...)` gemappt.
+  - Generator-Produkt bleibt technisch `bbm-protokoll` (UI bleibt `BBM-Produktiv`).
+  - `license_mode` wird kompatibel gemappt (`soft -> none`, `full -> machine`, `none/machine` bleiben erhalten).
+  - Features werden aus `product_scope_json` fuer Generator aufgebaut (inkl. `audio`-Kompatibilitaet als `dictate`).
+  - Ohne ableitbare Features wird Erzeugung blockiert (`Produktumfang enthält keine erzeugbaren Features.`).
+  - Bei Erfolg wird der Ausgabepfad angezeigt und `Ausgabeordner öffnen` nutzt bestehendes `window.bbmDb.licenseOpenOutputDir(...)`.
+  - Bestehende Main-IPC-Infrastruktur (`license:generate`, `license:open-output-dir`) wurde weiterverwendet, keine neue Generator-Architektur.
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.
@@ -186,6 +196,25 @@ Sie ergänzt:
 ## Erledigte Meilensteine / Pakete
 
 ### Erledigt
+#### Paket: Admin-Lizenzformular an bestehende Lizenzdatei-Erzeugung angebunden
+- Status: erledigt
+- Beschreibung:
+  - Lizenzformular in `LicenseAdminScreen` um `Lizenzdatei erzeugen` erweitert; Erzeugung nur fuer gespeicherte Lizenzen.
+  - Neue Mapping-Helfer bauen Generator-Payload aus Kunde+Lizenz (customerName, licenseId, product `bbm-protokoll`, edition, binding, validFrom/validUntil, maxDevices, machineId, features).
+  - Features-Mapping aus `product_scope_json` deckt Standardumfang, Zusatzfunktionen und Module ab; `audio` bleibt kompatibel als `dictate`.
+  - UI zeigt Statusmeldungen fuer laufende Erzeugung, Erfolg/Fehler, Ausgabepfad und optional `Ausgabeordner öffnen`.
+  - Tests fuer Payload-Mapping, Binding-/Produkt-Mapping, Feature-Mapping und Feature-Leerfall wurden in `licenseAdminDataflow.test.cjs` erweitert.
+  - Strukturtests wurden um Nachweise fuer Button, Blockiermeldungen und bestehende IPC-Infrastruktur erweitert.
+- Betroffene Dateien:
+  - `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`
+  - `scripts/tests/licenseAdminDataflow.test.cjs`
+  - `scripts/tests/lizenzverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - `siehe aktuellen Branch-Commit`
+- Hinweise:
+  - Keine DB-/Schema-Aenderung, keine Setup-Aenderung, keine Sidebar-/Projektmodul-Aenderung, keine App-Sperrlogik-Aenderung
+
 #### Paket: Gefuehrter Lizenzumfang-Editor in der Admin-Lizenzverwaltung
 - Status: erledigt
 - Beschreibung:

--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -450,6 +450,78 @@ async function runLicenseAdminDataflowTests(run) {
     assert.deepEqual(normalizedScope.zusatzfunktionen, []);
     assert.deepEqual(normalizedScope.module, []);
   });
+
+  await run("Lizenzverwaltung Generator-Payload: Kunde + Lizenz werden korrekt gemappt", async () => {
+    const { buildLicenseGeneratorPayload } = await importEsmFromFile(
+      path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js")
+    );
+    const payload = buildLicenseGeneratorPayload({
+      customer: { company_name: "Musterfirma GmbH", customer_number: "K-77" },
+      license: {
+        license_id: "LIC-77",
+        valid_from: "2026-01-10",
+        valid_until: "2026-12-31",
+        license_mode: "soft",
+        machine_id: "M-ID-77",
+        product_scope_json: JSON.stringify({
+          product: "bbm-produktiv",
+          standardumfang: ["app", "pdf", "export"],
+          zusatzfunktionen: ["mail", "audio"],
+          module: ["protokoll", "dummy"],
+        }),
+      },
+    });
+
+    assert.equal(payload.customerName, "Musterfirma GmbH");
+    assert.equal(payload.licenseId, "LIC-77");
+    assert.equal(payload.validFrom, "2026-01-10");
+    assert.equal(payload.validUntil, "2026-12-31");
+    assert.equal(payload.binding, "none");
+    assert.equal(payload.product, "bbm-protokoll");
+    assert.equal(payload.edition, "standard");
+    assert.equal(payload.maxDevices, 1);
+    assert.equal(payload.machineId, "M-ID-77");
+    assert.deepEqual(payload.features, ["app", "pdf", "export", "mail", "dictate", "protokoll", "dummy"]);
+  });
+
+  await run("Lizenzverwaltung Generator-Payload: fallback customer_number und binding full->machine", async () => {
+    const { buildLicenseGeneratorPayload } = await importEsmFromFile(
+      path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js")
+    );
+    const payload = buildLicenseGeneratorPayload({
+      customer: { customer_number: "K-88" },
+      license: {
+        license_id: "LIC-88",
+        valid_from: "2026-02-01",
+        valid_until: "2026-11-30",
+        license_mode: "full",
+        product_scope_json: JSON.stringify({
+          standardumfang: ["app"],
+          zusatzfunktionen: ["mail"],
+          module: ["protokoll"],
+        }),
+      },
+    });
+    assert.equal(payload.customerName, "K-88");
+    assert.equal(payload.binding, "machine");
+  });
+
+  await run("Lizenzverwaltung Generator-Payload: keine ableitbaren Features ergibt leeres Feature-Set", async () => {
+    const { buildLicenseGeneratorPayload } = await importEsmFromFile(
+      path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js")
+    );
+    const payload = buildLicenseGeneratorPayload({
+      customer: { company_name: "Ohne Feature GmbH" },
+      license: {
+        license_id: "LIC-99",
+        valid_from: "2026-01-01",
+        valid_until: "2026-12-31",
+        license_mode: "none",
+        product_scope_json: JSON.stringify({ raw: "legacy-freitext" }),
+      },
+    });
+    assert.deepEqual(payload.features, []);
+  });
 }
 
 module.exports = { runLicenseAdminDataflowTests };

--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -15,6 +15,8 @@ function createMemoryDb() {
     const customer = getCustomerById(record.customer_id) || {};
     return {
       ...record,
+      licenseEdition: record.license_edition || null,
+      licenseBinding: record.license_binding || null,
       customer_number: customer.customer_number || null,
       company_name: customer.company_name || null,
       customerNumber: customer.customer_number || null,
@@ -69,16 +71,64 @@ function createMemoryDb() {
             return;
           }
           if (text.includes("INSERT INTO license_records")) {
-            const [id, license_id, customer_id, product_scope_json, valid_from, valid_until, license_mode, machine_id, notes] =
+            const [
+              id,
+              license_id,
+              customer_id,
+              product_scope_json,
+              valid_from,
+              valid_until,
+              license_mode,
+              license_edition,
+              license_binding,
+              machine_id,
+              notes,
+            ] =
               args;
-            licenses.push({ id, license_id, customer_id, product_scope_json, valid_from, valid_until, license_mode, machine_id, notes });
+            licenses.push({
+              id,
+              license_id,
+              customer_id,
+              product_scope_json,
+              valid_from,
+              valid_until,
+              license_mode,
+              license_edition,
+              license_binding,
+              machine_id,
+              notes,
+            });
             return;
           }
           if (text.includes("UPDATE license_records")) {
-            const [license_id, customer_id, product_scope_json, valid_from, valid_until, license_mode, machine_id, notes, _updated_at, id] =
+            const [
+              license_id,
+              customer_id,
+              product_scope_json,
+              valid_from,
+              valid_until,
+              license_mode,
+              license_edition,
+              license_binding,
+              machine_id,
+              notes,
+              _updated_at,
+              id,
+            ] =
               args;
             const row = licenses.find((entry) => entry.id === id);
-            Object.assign(row, { license_id, customer_id, product_scope_json, valid_from, valid_until, license_mode, machine_id, notes });
+            Object.assign(row, {
+              license_id,
+              customer_id,
+              product_scope_json,
+              valid_from,
+              valid_until,
+              license_mode,
+              license_edition,
+              license_binding,
+              machine_id,
+              notes,
+            });
           }
         },
       };
@@ -149,6 +199,10 @@ async function runLicenseAdminDataflowTests(run) {
       assert.equal(listedByCustomer[0].valid_from, "2026-01-01");
       assert.equal(listedByCustomer[0].valid_until, "2026-12-31");
       assert.equal(listedByCustomer[0].license_mode, "soft");
+      assert.equal(listedByCustomer[0].license_edition, "test");
+      assert.equal(listedByCustomer[0].license_binding, "none");
+      assert.equal(listedByCustomer[0].licenseEdition, "test");
+      assert.equal(listedByCustomer[0].licenseBinding, "none");
       assert.equal(typeof listedByCustomer[0].product_scope_json, "string");
     });
   });
@@ -272,6 +326,8 @@ async function runLicenseAdminDataflowTests(run) {
       validFrom: "2026-01-01",
       validUntil: "2026-12-31",
       licenseMode: "full",
+      licenseEdition: "full",
+      licenseBinding: "machine",
     });
 
     assert.equal(received.licenseId, "LIC-CAMEL-1");
@@ -283,6 +339,10 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(received.valid_until, "2026-12-31");
     assert.equal(received.licenseMode, "full");
     assert.equal(received.license_mode, "full");
+    assert.equal(received.licenseEdition, "full");
+    assert.equal(received.license_edition, "full");
+    assert.equal(received.licenseBinding, "machine");
+    assert.equal(received.license_binding, "machine");
   });
 
   await run("Lizenzverwaltung normalizeLicenseRecord: snake_case und camelCase werden vollstaendig abgebildet", async () => {
@@ -304,6 +364,8 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(snake.valid_from, "2026-01-01");
     assert.equal(snake.valid_until, "2026-12-31");
     assert.equal(snake.license_mode, "soft");
+    assert.equal(snake.license_edition, "test");
+    assert.equal(snake.license_binding, "none");
     assert.equal(snake.machine_id, "MID-1");
     assert.equal(snake.product_scope_json, JSON.stringify({ raw: "freitext" }));
 
@@ -321,6 +383,8 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(camel.valid_from, "2026-03-01");
     assert.equal(camel.valid_until, "2026-10-31");
     assert.equal(camel.license_mode, "full");
+    assert.equal(camel.license_edition, "full");
+    assert.equal(camel.license_binding, "machine");
     assert.equal(camel.machine_id, "MID-2");
   });
 
@@ -459,8 +523,10 @@ async function runLicenseAdminDataflowTests(run) {
       customer: { company_name: "Musterfirma GmbH", customer_number: "K-77" },
       license: {
         license_id: "LIC-77",
-        valid_from: "2026-01-10",
-        valid_until: "2026-12-31",
+        valid_from: "01.05.2026",
+        valid_until: "01.05.2027",
+        license_edition: "test",
+        license_binding: "none",
         license_mode: "soft",
         machine_id: "M-ID-77",
         product_scope_json: JSON.stringify({
@@ -474,17 +540,17 @@ async function runLicenseAdminDataflowTests(run) {
 
     assert.equal(payload.customerName, "Musterfirma GmbH");
     assert.equal(payload.licenseId, "LIC-77");
-    assert.equal(payload.validFrom, "2026-01-10");
-    assert.equal(payload.validUntil, "2026-12-31");
+    assert.equal(payload.validFrom, "2026-05-01");
+    assert.equal(payload.validUntil, "2027-05-01");
     assert.equal(payload.binding, "none");
     assert.equal(payload.product, "bbm-protokoll");
-    assert.equal(payload.edition, "standard");
+    assert.equal(payload.edition, "test");
     assert.equal(payload.maxDevices, 1);
-    assert.equal(payload.machineId, "M-ID-77");
+    assert.equal(payload.machineId, undefined);
     assert.deepEqual(payload.features, ["app", "pdf", "export", "mail", "dictate", "protokoll", "dummy"]);
   });
 
-  await run("Lizenzverwaltung Generator-Payload: fallback customer_number und binding full->machine", async () => {
+  await run("Lizenzverwaltung Generator-Payload: fallback customer_number und edition/binding full+machine", async () => {
     const { buildLicenseGeneratorPayload } = await importEsmFromFile(
       path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js")
     );
@@ -492,9 +558,10 @@ async function runLicenseAdminDataflowTests(run) {
       customer: { customer_number: "K-88" },
       license: {
         license_id: "LIC-88",
-        valid_from: "2026-02-01",
-        valid_until: "2026-11-30",
-        license_mode: "full",
+        valid_from: "31.12.2026",
+        valid_until: "2027-12-31",
+        license_edition: "full",
+        license_binding: "machine",
         product_scope_json: JSON.stringify({
           standardumfang: ["app"],
           zusatzfunktionen: ["mail"],
@@ -503,6 +570,7 @@ async function runLicenseAdminDataflowTests(run) {
       },
     });
     assert.equal(payload.customerName, "K-88");
+    assert.equal(payload.edition, "full");
     assert.equal(payload.binding, "machine");
   });
 
@@ -521,6 +589,46 @@ async function runLicenseAdminDataflowTests(run) {
       },
     });
     assert.deepEqual(payload.features, []);
+  });
+
+  await run("Lizenzverwaltung Datum: normalizeDateForGenerator unterstuetzt ISO und Deutsch", async () => {
+    const { normalizeDateForGenerator } = await importEsmFromFile(
+      path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js")
+    );
+    assert.equal(normalizeDateForGenerator("2026-05-01"), "2026-05-01");
+    assert.equal(normalizeDateForGenerator("01.05.2026"), "2026-05-01");
+    assert.equal(normalizeDateForGenerator("31.12.2026"), "2026-12-31");
+    assert.equal(normalizeDateForGenerator("31.13.2026"), "");
+  });
+
+  await run("Lizenzverwaltung Kompatibilitaet license_mode: soft/full/none/machine", async () => {
+    const { getLicenseEditionAndBinding } = await importEsmFromFile(
+      path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js")
+    );
+    assert.deepEqual(getLicenseEditionAndBinding({ license_mode: "soft" }), { edition: "test", binding: "none" });
+    assert.deepEqual(getLicenseEditionAndBinding({ license_mode: "full" }), { edition: "full", binding: "machine" });
+    assert.deepEqual(getLicenseEditionAndBinding({ license_mode: "none" }), { edition: "test", binding: "none" });
+    assert.deepEqual(getLicenseEditionAndBinding({ license_mode: "machine" }), { edition: "full", binding: "machine" });
+  });
+
+  await run("Lizenzverwaltung Generator-Payload: binding machine erzwingt machineId im Payload", async () => {
+    const { buildLicenseGeneratorPayload } = await importEsmFromFile(
+      path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js")
+    );
+    const payload = buildLicenseGeneratorPayload({
+      customer: { company_name: "Vollversion GmbH" },
+      license: {
+        license_id: "LIC-MACHINE-1",
+        valid_from: "2026-06-01",
+        valid_until: "2026-07-01",
+        license_edition: "full",
+        license_binding: "machine",
+        machine_id: "MID-M-1",
+        product_scope_json: JSON.stringify({ standardumfang: ["app"] }),
+      },
+    });
+    assert.equal(payload.binding, "machine");
+    assert.equal(payload.machineId, "MID-M-1");
   });
 }
 

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -669,6 +669,8 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseIpcSource.includes('ipcMain.handle("license:get-installed"'), true);
     assert.equal(licenseIpcSource.includes('ipcMain.handle("license:import"'), true);
     assert.equal(licenseIpcSource.includes('ipcMain.handle("license:delete"'), true);
+    assert.equal(licenseIpcSource.includes('ipcMain.handle("license:generate"'), true);
+    assert.equal(licenseIpcSource.includes('ipcMain.handle("license:open-output-dir"'), true);
   });
 
   await run(
@@ -738,6 +740,14 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Neue Lizenz"), true);
     assert.equal(screenSource.includes("Zurueck zur Kundenliste"), true);
     assert.equal(screenSource.includes("Zurueck zum Kunden"), true);
+    assert.equal(screenSource.includes("Lizenzdatei erzeugen"), true);
+    assert.equal(screenSource.includes("Ausgabeordner öffnen"), true);
+    assert.equal(screenSource.includes("Bitte zuerst die Lizenz speichern."), true);
+    assert.equal(screenSource.includes("Lizenzdatei wird erzeugt ..."), true);
+    assert.equal(screenSource.includes("Lizenzdatei wurde erzeugt."), true);
+    assert.equal(screenSource.includes("Produktumfang enthält keine erzeugbaren Features."), true);
+    assert.equal(screenSource.includes("licenseGenerate"), true);
+    assert.equal(screenSource.includes("licenseOpenOutputDir"), true);
   });
 
 

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -752,7 +752,8 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Zurueck zur Kundenliste"), true);
     assert.equal(screenSource.includes("Lizenz erstellen"), true);
     assert.equal(screenSource.includes("Lizenz speichern"), false);
-    assert.equal(screenSource.includes("Formular leeren"), true);
+    assert.equal(screenSource.includes("Formular leeren"), false);
+    assert.equal(screenSource.includes("Lizenz-ID erzeugen"), false);
     assert.equal(screenSource.includes("Zurueck"), true);
     assert.equal(screenSource.includes("Merken"), false);
     assert.equal(screenSource.includes("Neu / leeren"), false);

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -125,7 +125,8 @@ async function runLizenzverwaltungModuleTests(run) {
       "productScope",
       "validFrom",
       "validUntil",
-      "licenseMode",
+      "licenseEdition",
+      "licenseBinding",
       "machineId",
       "notes",
     ]);
@@ -137,7 +138,8 @@ async function runLizenzverwaltungModuleTests(run) {
       "Produktumfang",
       "gueltig von",
       "gueltig bis",
-      "Lizenzmodus",
+      "Lizenzart",
+      "Gerätebindung",
       "Machine-ID",
       "Notizen",
     ]);
@@ -167,6 +169,8 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(normalizedLicense.licenseId, "LIC-1");
     assert.equal(normalizedLicense.customerNumber, "K-100");
     assert.equal(normalizedLicense.licenseMode, "full");
+    assert.equal(normalizedLicense.licenseEdition, "full");
+    assert.equal(normalizedLicense.licenseBinding, "machine");
     assert.deepEqual(normalizedLicense.productScope.zusatzfunktionen, ["mail"]);
     assert.deepEqual(normalizedLicense.productScope.standardumfang, []);
   });
@@ -429,7 +433,8 @@ async function runLizenzverwaltungModuleTests(run) {
       "Produktumfang",
       "gueltig von",
       "gueltig bis",
-      "Lizenzmodus",
+      "Lizenzart",
+      "Gerätebindung",
       "Machine-ID",
       "Notizen",
     ]);
@@ -568,6 +573,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(databaseSource.includes("license_records"), true);
     assert.equal(databaseSource.includes("product_scope_json TEXT NOT NULL"), true);
     assert.equal(databaseSource.includes("license_history"), true);
+  });
+
+  await run("Lizenzverwaltung DB-Schema: optionale Spalten license_edition/license_binding sind vorhanden", () => {
+    assert.equal(databaseSource.includes("license_edition TEXT"), true);
+    assert.equal(databaseSource.includes("license_binding TEXT"), true);
   });
 
   await run("Lizenzverwaltung DB-Schema: Referenzen customer_id und license_record_id sind vorbereitet", () => {
@@ -746,6 +756,10 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Lizenzdatei wird erzeugt ..."), true);
     assert.equal(screenSource.includes("Lizenzdatei wurde erzeugt."), true);
     assert.equal(screenSource.includes("Produktumfang enthält keine erzeugbaren Features."), true);
+    assert.equal(screenSource.includes("Machine-ID ist erforderlich, wenn die Lizenz an ein Gerät gebunden wird."), true);
+    assert.equal(screenSource.includes("Bitte gültige Datumswerte eintragen."), true);
+    assert.equal(screenSource.includes("\"Lizenzart\""), true);
+    assert.equal(screenSource.includes("\"Gerätebindung\""), true);
     assert.equal(screenSource.includes("licenseGenerate"), true);
     assert.equal(screenSource.includes("licenseOpenOutputDir"), true);
   });

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -747,9 +747,17 @@ async function runLizenzverwaltungModuleTests(run) {
 
   await run("LicenseAdminScreen enthaelt kundenbezogene Lizenzfunktionen", () => {
     assert.equal(screenSource.includes("Lizenzen dieses Kunden"), true);
+    assert.equal(screenSource.includes("Kundendaten"), true);
     assert.equal(screenSource.includes("Neue Lizenz"), true);
     assert.equal(screenSource.includes("Zurueck zur Kundenliste"), true);
-    assert.equal(screenSource.includes("Zurueck zum Kunden"), true);
+    assert.equal(screenSource.includes("Lizenz speichern"), true);
+    assert.equal(screenSource.includes("Formular leeren"), true);
+    assert.equal(screenSource.includes("Zurueck"), true);
+    assert.equal(screenSource.includes("Merken"), false);
+    assert.equal(screenSource.includes("Neu / leeren"), false);
+    assert.equal(screenSource.includes("Zurueck zum Kunden"), false);
+    assert.equal(screenSource.includes("Aktion"), true);
+    assert.equal(screenSource.includes("Öffnen"), true);
     assert.equal(screenSource.includes("Lizenzdatei erzeugen"), true);
     assert.equal(screenSource.includes("Ausgabeordner öffnen"), true);
     assert.equal(screenSource.includes("Bitte zuerst die Lizenz speichern."), true);
@@ -762,6 +770,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("\"Gerätebindung\""), true);
     assert.equal(screenSource.includes("licenseGenerate"), true);
     assert.equal(screenSource.includes("licenseOpenOutputDir"), true);
+  });
+
+  await run("Kundendetail: nach Kunde speichern ist Neue Lizenz direkt nutzbar", () => {
+    assert.equal(screenSource.includes("this.currentCustomer = saved;"), true);
+    assert.equal(screenSource.includes("newLicenseBtn.disabled = false;"), true);
   });
 
 

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -750,7 +750,8 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Kundendaten"), true);
     assert.equal(screenSource.includes("Neue Lizenz"), true);
     assert.equal(screenSource.includes("Zurueck zur Kundenliste"), true);
-    assert.equal(screenSource.includes("Lizenz speichern"), true);
+    assert.equal(screenSource.includes("Lizenz erstellen"), true);
+    assert.equal(screenSource.includes("Lizenz speichern"), false);
     assert.equal(screenSource.includes("Formular leeren"), true);
     assert.equal(screenSource.includes("Zurueck"), true);
     assert.equal(screenSource.includes("Merken"), false);
@@ -758,9 +759,8 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Zurueck zum Kunden"), false);
     assert.equal(screenSource.includes("Aktion"), true);
     assert.equal(screenSource.includes("Öffnen"), true);
-    assert.equal(screenSource.includes("Lizenzdatei erzeugen"), true);
+    assert.equal(screenSource.includes("Lizenzdatei erzeugen"), false);
     assert.equal(screenSource.includes("Ausgabeordner öffnen"), true);
-    assert.equal(screenSource.includes("Bitte zuerst die Lizenz speichern."), true);
     assert.equal(screenSource.includes("Lizenzdatei wird erzeugt ..."), true);
     assert.equal(screenSource.includes("Lizenzdatei wurde erzeugt."), true);
     assert.equal(screenSource.includes("Produktumfang enthält keine erzeugbaren Features."), true);

--- a/src/main/db/database.js
+++ b/src/main/db/database.js
@@ -1116,6 +1116,8 @@ function ensureLicenseAdminSchema(dbConn) {
         valid_from TEXT,
         valid_until TEXT,
         license_mode TEXT,
+        license_edition TEXT,
+        license_binding TEXT,
         machine_id TEXT,
         notes TEXT,
         created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
@@ -1142,6 +1144,12 @@ function ensureLicenseAdminSchema(dbConn) {
   }
   if (!columnExists(dbConn, "license_records", "license_mode")) {
     dbConn.exec(`ALTER TABLE license_records ADD COLUMN license_mode TEXT;`);
+  }
+  if (!columnExists(dbConn, "license_records", "license_edition")) {
+    dbConn.exec(`ALTER TABLE license_records ADD COLUMN license_edition TEXT;`);
+  }
+  if (!columnExists(dbConn, "license_records", "license_binding")) {
+    dbConn.exec(`ALTER TABLE license_records ADD COLUMN license_binding TEXT;`);
   }
   if (!columnExists(dbConn, "license_records", "machine_id")) {
     dbConn.exec(`ALTER TABLE license_records ADD COLUMN machine_id TEXT;`);

--- a/src/main/licensing/licenseAdminService.js
+++ b/src/main/licensing/licenseAdminService.js
@@ -65,6 +65,21 @@ function _normalizeCustomerRecord(customer = {}) {
 
 function _normalizeLicenseRecord(license = {}) {
   const id = _trimText(license.id) || randomUUID();
+  const modeRaw = _trimText(license.license_mode || license.licenseMode).toLowerCase();
+  const editionRaw = _trimText(license.license_edition || license.licenseEdition).toLowerCase();
+  const bindingRaw = _trimText(license.license_binding || license.licenseBinding).toLowerCase();
+  const legacyDefaults =
+    modeRaw === "full" || modeRaw === "machine"
+      ? { license_edition: "full", license_binding: "machine", license_mode: "full" }
+      : { license_edition: "test", license_binding: "none", license_mode: "soft" };
+  const license_edition = editionRaw === "full" || editionRaw === "test" ? editionRaw : legacyDefaults.license_edition;
+  const license_binding = bindingRaw === "machine" || bindingRaw === "none" ? bindingRaw : legacyDefaults.license_binding;
+  const license_mode =
+    modeRaw === "full" || modeRaw === "soft" || modeRaw === "machine" || modeRaw === "none"
+      ? modeRaw
+      : license_binding === "machine"
+        ? "full"
+        : "soft";
 
   return {
     id,
@@ -75,7 +90,9 @@ function _normalizeLicenseRecord(license = {}) {
     ),
     valid_from: _optionalText(license.valid_from || license.validFrom),
     valid_until: _optionalText(license.valid_until || license.validUntil),
-    license_mode: _optionalText(license.license_mode || license.licenseMode),
+    license_mode: _optionalText(license_mode),
+    license_edition: _optionalText(license_edition),
+    license_binding: _optionalText(license_binding),
     machine_id: _optionalText(license.machine_id || license.machineId),
     notes: _optionalText(license.notes),
   };
@@ -101,6 +118,8 @@ function _baseListLicensesQuery() {
   return `
     SELECT
       lr.*,
+      lr.license_edition AS licenseEdition,
+      lr.license_binding AS licenseBinding,
       lc.customer_number AS customer_number,
       lc.company_name AS company_name,
       lc.customer_number AS customerNumber,
@@ -209,6 +228,8 @@ function saveLicense(license = {}) {
   if (!record.valid_from) throw new Error("valid_from required");
   if (!record.valid_until) throw new Error("valid_until required");
   if (!record.license_mode) throw new Error("license_mode required");
+  if (!record.license_edition) throw new Error("license_edition required");
+  if (!record.license_binding) throw new Error("license_binding required");
 
   const existing = db.prepare(`SELECT id FROM license_records WHERE id = ?`).get(record.id);
   const now = _nowIso();
@@ -223,6 +244,8 @@ function saveLicense(license = {}) {
           valid_from = ?,
           valid_until = ?,
           license_mode = ?,
+          license_edition = ?,
+          license_binding = ?,
           machine_id = ?,
           notes = ?,
           updated_at = ?
@@ -235,6 +258,8 @@ function saveLicense(license = {}) {
       record.valid_from,
       record.valid_until,
       record.license_mode,
+      record.license_edition,
+      record.license_binding,
       record.machine_id,
       record.notes,
       now,
@@ -251,9 +276,11 @@ function saveLicense(license = {}) {
         valid_from,
         valid_until,
         license_mode,
+        license_edition,
+        license_binding,
         machine_id,
         notes
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `
     ).run(
       record.id,
@@ -263,6 +290,8 @@ function saveLicense(license = {}) {
       record.valid_from,
       record.valid_until,
       record.license_mode,
+      record.license_edition,
+      record.license_binding,
       record.machine_id,
       record.notes
     );

--- a/src/renderer/modules/lizenzverwaltung/licenseRecords.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseRecords.js
@@ -13,7 +13,8 @@ export const LICENSE_RECORD_FIELDS = Object.freeze([
   Object.freeze({ key: "productScope", label: "Produktumfang", required: true }),
   Object.freeze({ key: "validFrom", label: "gueltig von", required: true }),
   Object.freeze({ key: "validUntil", label: "gueltig bis", required: true }),
-  Object.freeze({ key: "licenseMode", label: "Lizenzmodus", required: true }),
+  Object.freeze({ key: "licenseEdition", label: "Lizenzart", required: true }),
+  Object.freeze({ key: "licenseBinding", label: "Gerätebindung", required: true }),
   Object.freeze({ key: "machineId", label: "Machine-ID", required: false }),
   Object.freeze({ key: "notes", label: "Notizen", required: false }),
 ]);
@@ -67,6 +68,10 @@ export function createDefaultLicenseRecord(overrides = {}) {
     valid_until: "",
     licenseMode: "soft",
     license_mode: "soft",
+    licenseEdition: "test",
+    license_edition: "test",
+    licenseBinding: "none",
+    license_binding: "none",
     machineId: "",
     machine_id: "",
     notes: "",
@@ -159,7 +164,16 @@ export function normalizeLicenseRecord(input = {}) {
   const validUntil = String(input.validUntil ?? input.valid_until ?? base.validUntil).trim();
   const machineId = String(input.machineId ?? input.machine_id ?? base.machineId).trim();
   const modeRaw = String(input.licenseMode ?? input.license_mode ?? base.licenseMode).trim().toLowerCase();
+  const editionRaw = String(input.licenseEdition ?? input.license_edition ?? "").trim().toLowerCase();
+  const bindingRaw = String(input.licenseBinding ?? input.license_binding ?? "").trim().toLowerCase();
   const normalizedMode = LICENSE_MODES.some((entry) => entry.key === modeRaw) ? modeRaw : base.licenseMode;
+  const legacyDefaults =
+    modeRaw === "full" || modeRaw === "machine"
+      ? { licenseEdition: "full", licenseBinding: "machine" }
+      : { licenseEdition: "test", licenseBinding: "none" };
+  const normalizedEdition = editionRaw === "test" || editionRaw === "full" ? editionRaw : legacyDefaults.licenseEdition;
+  const normalizedBinding = bindingRaw === "none" || bindingRaw === "machine" ? bindingRaw : legacyDefaults.licenseBinding;
+  const compatMode = normalizedBinding === "machine" ? "full" : "soft";
   const productScope = normalizeProductScope(input.productScope, input.product_scope_json, base.productScope);
 
   return {
@@ -174,8 +188,12 @@ export function normalizeLicenseRecord(input = {}) {
     valid_from: validFrom,
     validUntil,
     valid_until: validUntil,
-    licenseMode: normalizedMode,
-    license_mode: normalizedMode,
+    licenseMode: normalizedMode || compatMode,
+    license_mode: compatMode,
+    licenseEdition: normalizedEdition,
+    license_edition: normalizedEdition,
+    licenseBinding: normalizedBinding,
+    license_binding: normalizedBinding,
     machineId,
     machine_id: machineId,
     notes: String(input.notes ?? base.notes).trim(),

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -863,67 +863,6 @@ export default class LicenseAdminScreen {
     const actions = document.createElement("div");
     actions.style.display = "flex";
     actions.style.gap = "8px";
-    const generationActions = document.createElement("div");
-    generationActions.style.display = "flex";
-    generationActions.style.gap = "8px";
-    const generateLicenseFileBtn = this._button("Lizenzdatei erzeugen", async () => {
-      if (!this.currentLicense?.id) {
-        message.textContent = "Bitte zuerst die Lizenz speichern.";
-        generationOutput.textContent = "";
-        return;
-      }
-      const api = window?.bbmDb || {};
-      if (typeof api.licenseGenerate !== "function") {
-        message.textContent = "Fehler: Lizenz-Generator-IPC ist nicht verfuegbar.";
-        generationOutput.textContent = "";
-        return;
-      }
-      const payload = buildLicenseGeneratorPayload({
-        customer: this.currentCustomer || {},
-        license: this.currentLicense || {},
-      });
-      if (!payload.validFrom || !payload.validUntil) {
-        message.textContent = "Bitte gültige Datumswerte eintragen.";
-        generationOutput.textContent = "";
-        return;
-      }
-      if (!payload.features.length) {
-        message.textContent = "Produktumfang enthält keine erzeugbaren Features.";
-        generationOutput.textContent = "";
-        return;
-      }
-      if (payload.binding === "machine" && !String(payload.machineId || "").trim()) {
-        message.textContent = "Machine-ID ist erforderlich, wenn die Lizenz an ein Gerät gebunden wird.";
-        generationOutput.textContent = "";
-        return;
-      }
-
-      const previousText = generateLicenseFileBtn.textContent;
-      generateLicenseFileBtn.disabled = true;
-      openOutputDirBtn.disabled = true;
-      message.textContent = "Lizenzdatei wird erzeugt ...";
-      generationOutput.textContent = "";
-      try {
-        const res = await api.licenseGenerate(payload);
-        if (!res?.ok) {
-          message.textContent = `Fehler: ${res?.error || "Lizenz konnte nicht erzeugt werden."}`;
-          return;
-        }
-        message.textContent = "Lizenzdatei wurde erzeugt.";
-        const outputPath = String(res?.outputPath || "").trim();
-        if (outputPath) {
-          generationOutput.textContent = `Ausgabepfad: ${outputPath}`;
-          openOutputDirBtn.dataset.outputPath = outputPath;
-          openOutputDirBtn.style.display = "";
-          openOutputDirBtn.disabled = false;
-        }
-      } catch (err) {
-        message.textContent = `Fehler: ${err?.message || err || "Lizenz konnte nicht erzeugt werden."}`;
-      } finally {
-        generateLicenseFileBtn.textContent = previousText;
-        generateLicenseFileBtn.disabled = false;
-      }
-    });
     const openOutputDirBtn = this._button("Ausgabeordner öffnen", async () => {
       const api = window?.bbmDb || {};
       const outputPath = String(openOutputDirBtn.dataset.outputPath || "").trim();
@@ -940,10 +879,14 @@ export default class LicenseAdminScreen {
     });
     openOutputDirBtn.style.display = "none";
 
-    const saveBtn = this._button("Lizenz speichern", async () => {
+    const createBtn = this._button("Lizenz erstellen", async () => {
+      const previousText = createBtn.textContent;
+      createBtn.disabled = true;
+      openOutputDirBtn.disabled = true;
       try {
+        const activeLicense = this.currentLicense || license || {};
         const payload = buildLicenseEditorPayload({
-          license,
+          license: activeLicense,
           customer,
           inputs: {
             license_id: inputs.license_id.value,
@@ -959,16 +902,56 @@ export default class LicenseAdminScreen {
         });
         const saved = await saveLicense(payload);
         this.currentLicense = saved;
-        message.textContent = "Lizenz gespeichert.";
         openOutputDirBtn.style.display = "none";
         openOutputDirBtn.dataset.outputPath = "";
         generationOutput.textContent = "";
+
+        const api = window?.bbmDb || {};
+        if (typeof api.licenseGenerate !== "function") {
+          message.textContent = "Fehler: Lizenz-Generator-IPC ist nicht verfuegbar.";
+          return;
+        }
+
+        const generatorPayload = buildLicenseGeneratorPayload({
+          customer: this.currentCustomer || {},
+          license: saved || {},
+        });
+        if (!generatorPayload.validFrom || !generatorPayload.validUntil) {
+          message.textContent = "Bitte gültige Datumswerte eintragen.";
+          return;
+        }
+        if (!generatorPayload.features.length) {
+          message.textContent = "Produktumfang enthält keine erzeugbaren Features.";
+          return;
+        }
+        if (generatorPayload.binding === "machine" && !String(generatorPayload.machineId || "").trim()) {
+          message.textContent = "Machine-ID ist erforderlich, wenn die Lizenz an ein Gerät gebunden wird.";
+          return;
+        }
+
+        message.textContent = "Lizenzdatei wird erzeugt ...";
+        const res = await api.licenseGenerate(generatorPayload);
+        if (!res?.ok) {
+          message.textContent = `Fehler: ${res?.error || "Lizenz konnte nicht erzeugt werden."}`;
+          return;
+        }
+        message.textContent = "Lizenzdatei wurde erzeugt.";
+        const outputPath = String(res?.outputPath || "").trim();
+        if (outputPath) {
+          generationOutput.textContent = `Ausgabepfad: ${outputPath}`;
+          openOutputDirBtn.dataset.outputPath = outputPath;
+          openOutputDirBtn.style.display = "";
+          openOutputDirBtn.disabled = false;
+        }
       } catch (err) {
         if (String(err?.message || "") === "CUSTOMER_CONTEXT_REQUIRED") {
           message.textContent = "Fehler: Speichern ohne geoeffneten Kunden ist unmoeglich.";
         } else {
           message.textContent = `Fehler: ${err?.message || err}`;
         }
+      } finally {
+        createBtn.textContent = previousText;
+        createBtn.disabled = false;
       }
     });
 
@@ -995,9 +978,8 @@ export default class LicenseAdminScreen {
       this._render();
     });
 
-    actions.append(saveBtn, clearBtn, backBtn);
-    generationActions.append(generateLicenseFileBtn, openOutputDirBtn);
-    container.append(header, context, form, licenseIdHint, generateIdBtn, actions, generationActions, message, generationOutput);
+    actions.append(createBtn, clearBtn, backBtn, openOutputDirBtn);
+    container.append(header, context, form, licenseIdHint, generateIdBtn, actions, message, generationOutput);
   }
 
   async _render() {

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -2,6 +2,7 @@ import { listCustomers, listLicensesByCustomer, saveCustomer, saveLicense } from
 
 const PRODUCT_KEY = "bbm-produktiv";
 const PRODUCT_LABEL = "BBM-Produktiv";
+const GENERATOR_PRODUCT_KEY = "bbm-protokoll";
 const STANDARD_SCOPE_KEYS = Object.freeze(["app", "pdf", "export"]);
 const ADDITIONAL_FEATURES = Object.freeze([
   Object.freeze({ key: "mail", label: "Mail" }),
@@ -29,6 +30,10 @@ function normalizeAdditionalFeatureKey(value) {
   if (!normalized) return "";
   if (normalized === "audio") return "dictate";
   return normalized;
+}
+
+function normalizeModuleKey(value) {
+  return String(value || "").trim().toLowerCase();
 }
 
 function parseProductScopeObject(rawValue) {
@@ -161,6 +166,69 @@ export function buildCustomerEditorPayload({ customer = {}, inputs = {} } = {}) 
     email: String(inputs.email || "").trim(),
     phone: String(inputs.phone || "").trim(),
     notes: String(inputs.notes || "").trim(),
+  };
+}
+
+export function mapLicenseModeToGeneratorBinding(licenseMode) {
+  const normalized = String(licenseMode || "").trim().toLowerCase();
+  if (normalized === "full") return "machine";
+  if (normalized === "machine") return "machine";
+  if (normalized === "soft") return "none";
+  if (normalized === "none") return "none";
+  return "";
+}
+
+export function parseGeneratorFeaturesFromProductScope(rawValue) {
+  const trimmed = String(rawValue || "").trim();
+  if (!trimmed) return [];
+
+  let parsed = null;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (_err) {
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+
+  const features = new Set();
+
+  toUniqueNormalizedArray(parsed.standardumfang || [])
+    .filter((key) => STANDARD_SCOPE_KEYS.includes(key))
+    .forEach((key) => features.add(key));
+
+  toUniqueNormalizedArray(parsed.zusatzfunktionen || [])
+    .map((key) => normalizeAdditionalFeatureKey(key))
+    .filter((key) => ADDITIONAL_FEATURES.some((entry) => entry.key === key))
+    .forEach((key) => features.add(key));
+
+  toUniqueNormalizedArray(parsed.module || [])
+    .map((key) => normalizeModuleKey(key))
+    .filter((key) => MODULE_KEYS.some((entry) => entry.key === key))
+    .forEach((key) => features.add(key));
+
+  return [...features];
+}
+
+export function buildLicenseGeneratorPayload({ customer = {}, license = {} } = {}) {
+  const customerName =
+    valueOf(customer, "company_name", "companyName") || valueOf(customer, "customer_number", "customerNumber");
+  const licenseId = valueOf(license, "license_id", "licenseId");
+  const validFrom = valueOf(license, "valid_from", "validFrom");
+  const validUntil = valueOf(license, "valid_until", "validUntil");
+  const binding = mapLicenseModeToGeneratorBinding(valueOf(license, "license_mode", "licenseMode"));
+  const features = parseGeneratorFeaturesFromProductScope(valueOf(license, "product_scope_json", "productScope"));
+  const machineId = valueOf(license, "machine_id", "machineId");
+  return {
+    customerName,
+    licenseId,
+    product: GENERATOR_PRODUCT_KEY,
+    edition: "standard",
+    binding,
+    validFrom,
+    validUntil,
+    maxDevices: 1,
+    ...(machineId ? { machineId } : {}),
+    features,
   };
 }
 
@@ -476,6 +544,9 @@ export default class LicenseAdminScreen {
     const message = document.createElement("div");
     message.style.minHeight = "20px";
     message.style.fontSize = "13px";
+    const generationOutput = document.createElement("div");
+    generationOutput.style.fontSize = "12px";
+    generationOutput.style.opacity = "0.9";
 
     const license = this.currentLicense || {};
     const parsedScope = parseProductScopeObject(valueOf(license, "product_scope_json", "productScope"));
@@ -686,6 +757,73 @@ export default class LicenseAdminScreen {
     const actions = document.createElement("div");
     actions.style.display = "flex";
     actions.style.gap = "8px";
+    const generationActions = document.createElement("div");
+    generationActions.style.display = "flex";
+    generationActions.style.gap = "8px";
+    const generateLicenseFileBtn = this._button("Lizenzdatei erzeugen", async () => {
+      if (!this.currentLicense?.id) {
+        message.textContent = "Bitte zuerst die Lizenz speichern.";
+        generationOutput.textContent = "";
+        return;
+      }
+      const api = window?.bbmDb || {};
+      if (typeof api.licenseGenerate !== "function") {
+        message.textContent = "Fehler: Lizenz-Generator-IPC ist nicht verfuegbar.";
+        generationOutput.textContent = "";
+        return;
+      }
+      const payload = buildLicenseGeneratorPayload({
+        customer: this.currentCustomer || {},
+        license: this.currentLicense || {},
+      });
+      if (!payload.features.length) {
+        message.textContent = "Produktumfang enthält keine erzeugbaren Features.";
+        generationOutput.textContent = "";
+        return;
+      }
+
+      const previousText = generateLicenseFileBtn.textContent;
+      generateLicenseFileBtn.disabled = true;
+      openOutputDirBtn.disabled = true;
+      message.textContent = "Lizenzdatei wird erzeugt ...";
+      generationOutput.textContent = "";
+      try {
+        const res = await api.licenseGenerate(payload);
+        if (!res?.ok) {
+          message.textContent = `Fehler: ${res?.error || "Lizenz konnte nicht erzeugt werden."}`;
+          return;
+        }
+        message.textContent = "Lizenzdatei wurde erzeugt.";
+        const outputPath = String(res?.outputPath || "").trim();
+        if (outputPath) {
+          generationOutput.textContent = `Ausgabepfad: ${outputPath}`;
+          openOutputDirBtn.dataset.outputPath = outputPath;
+          openOutputDirBtn.style.display = "";
+          openOutputDirBtn.disabled = false;
+        }
+      } catch (err) {
+        message.textContent = `Fehler: ${err?.message || err || "Lizenz konnte nicht erzeugt werden."}`;
+      } finally {
+        generateLicenseFileBtn.textContent = previousText;
+        generateLicenseFileBtn.disabled = false;
+      }
+    });
+    const openOutputDirBtn = this._button("Ausgabeordner öffnen", async () => {
+      const api = window?.bbmDb || {};
+      const outputPath = String(openOutputDirBtn.dataset.outputPath || "").trim();
+      if (!outputPath || typeof api.licenseOpenOutputDir !== "function") return;
+      try {
+        const res = await api.licenseOpenOutputDir({ outputPath });
+        if (!res?.ok) {
+          message.textContent = `Fehler: ${res?.error || "Ausgabeordner konnte nicht geoeffnet werden."}`;
+          return;
+        }
+      } catch (err) {
+        message.textContent = `Fehler: ${err?.message || err || "Ausgabeordner konnte nicht geoeffnet werden."}`;
+      }
+    });
+    openOutputDirBtn.style.display = "none";
+
     const saveBtn = this._button("Merken", async () => {
       try {
         const payload = buildLicenseEditorPayload({
@@ -704,6 +842,9 @@ export default class LicenseAdminScreen {
         const saved = await saveLicense(payload);
         this.currentLicense = saved;
         message.textContent = "Lizenz gespeichert.";
+        openOutputDirBtn.style.display = "none";
+        openOutputDirBtn.dataset.outputPath = "";
+        generationOutput.textContent = "";
       } catch (err) {
         if (String(err?.message || "") === "CUSTOMER_CONTEXT_REQUIRED") {
           message.textContent = "Fehler: Speichern ohne geoeffneten Kunden ist unmoeglich.";
@@ -737,7 +878,8 @@ export default class LicenseAdminScreen {
     });
 
     actions.append(saveBtn, clearBtn, backBtn);
-    container.append(header, context, form, licenseIdHint, generateIdBtn, actions, message);
+    generationActions.append(generateLicenseFileBtn, openOutputDirBtn);
+    container.append(header, context, form, licenseIdHint, generateIdBtn, actions, generationActions, message, generationOutput);
   }
 
   async _render() {

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -840,25 +840,8 @@ export default class LicenseAdminScreen {
 
     const licenseIdHint = document.createElement("div");
     licenseIdHint.textContent =
-      "Lizenz-ID-Hinweis: Wenn leer, wird spaetestens beim Speichern automatisch eine ID erzeugt.";
+      "Wenn die Lizenz-ID leer ist, wird beim Erstellen automatisch eine ID erzeugt.";
     licenseIdHint.style.fontSize = "12px";
-
-    const generateIdBtn = this._button("Lizenz-ID erzeugen", () => {
-      const result = tryGenerateLicenseId(inputs.license_id.value);
-      if (!result.generated) {
-        message.textContent = "Lizenz-ID ist bereits gesetzt.";
-        return;
-      }
-      inputs.license_id.value = result.value;
-      message.textContent = "Lizenz-ID wurde erzeugt.";
-      syncGenerateIdButton();
-    });
-
-    const syncGenerateIdButton = () => {
-      generateIdBtn.disabled = Boolean(String(inputs.license_id.value || "").trim());
-    };
-    inputs.license_id.addEventListener("input", syncGenerateIdButton);
-    syncGenerateIdButton();
 
     const actions = document.createElement("div");
     actions.style.display = "flex";
@@ -955,31 +938,14 @@ export default class LicenseAdminScreen {
       }
     });
 
-    const clearBtn = this._button("Formular leeren", () => {
-      Object.values(inputs).forEach((el) => {
-        el.value = "";
-      });
-      resetScopeSelectionToDefault(scopeModel);
-      zusatzfunktionChecks.forEach((checkbox) => {
-        checkbox.checked = false;
-      });
-      moduleChecks.forEach((checkbox) => {
-        checkbox.checked = false;
-      });
-      syncScopeJson();
-      this.currentLicense = null;
-      message.textContent = "Formular geleert.";
-      syncGenerateIdButton();
-    });
-
     const backBtn = this._button("Zurueck", () => {
       this.currentLicense = null;
       this.currentView = "customer-detail";
       this._render();
     });
 
-    actions.append(createBtn, clearBtn, backBtn, openOutputDirBtn);
-    container.append(header, context, form, licenseIdHint, generateIdBtn, actions, message, generationOutput);
+    actions.append(createBtn, backBtn, openOutputDirBtn);
+    container.append(header, context, form, licenseIdHint, actions, message, generationOutput);
   }
 
   async _render() {

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -178,6 +178,55 @@ export function mapLicenseModeToGeneratorBinding(licenseMode) {
   return "";
 }
 
+export function mapLegacyLicenseModeToEditionAndBinding(licenseMode) {
+  const normalized = String(licenseMode || "").trim().toLowerCase();
+  if (normalized === "full") return { edition: "full", binding: "machine" };
+  if (normalized === "machine") return { edition: "full", binding: "machine" };
+  if (normalized === "none") return { edition: "test", binding: "none" };
+  if (normalized === "soft") return { edition: "test", binding: "none" };
+  return { edition: "test", binding: "none" };
+}
+
+export function normalizeDateForGenerator(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+  const isoMatch = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (isoMatch) {
+    const date = new Date(`${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}T00:00:00Z`);
+    if (Number.isNaN(date.getTime())) return "";
+    if (
+      date.getUTCFullYear() !== Number(isoMatch[1]) ||
+      date.getUTCMonth() + 1 !== Number(isoMatch[2]) ||
+      date.getUTCDate() !== Number(isoMatch[3])
+    ) {
+      return "";
+    }
+    return `${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}`;
+  }
+
+  const deMatch = raw.match(/^(\d{2})\.(\d{2})\.(\d{4})$/);
+  if (!deMatch) return "";
+  const day = Number(deMatch[1]);
+  const month = Number(deMatch[2]);
+  const year = Number(deMatch[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (Number.isNaN(date.getTime())) return "";
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() + 1 !== month || date.getUTCDate() !== day) return "";
+  return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+export function getLicenseEditionAndBinding(license = {}) {
+  const editionRaw = String(valueOf(license, "license_edition", "licenseEdition")).trim().toLowerCase();
+  const bindingRaw = String(valueOf(license, "license_binding", "licenseBinding")).trim().toLowerCase();
+  const hasEdition = editionRaw === "test" || editionRaw === "full";
+  const hasBinding = bindingRaw === "none" || bindingRaw === "machine";
+  const legacy = mapLegacyLicenseModeToEditionAndBinding(valueOf(license, "license_mode", "licenseMode"));
+  return {
+    edition: hasEdition ? editionRaw : legacy.edition,
+    binding: hasBinding ? bindingRaw : legacy.binding,
+  };
+}
+
 export function parseGeneratorFeaturesFromProductScope(rawValue) {
   const trimmed = String(rawValue || "").trim();
   if (!trimmed) return [];
@@ -213,21 +262,23 @@ export function buildLicenseGeneratorPayload({ customer = {}, license = {} } = {
   const customerName =
     valueOf(customer, "company_name", "companyName") || valueOf(customer, "customer_number", "customerNumber");
   const licenseId = valueOf(license, "license_id", "licenseId");
-  const validFrom = valueOf(license, "valid_from", "validFrom");
-  const validUntil = valueOf(license, "valid_until", "validUntil");
-  const binding = mapLicenseModeToGeneratorBinding(valueOf(license, "license_mode", "licenseMode"));
+  const validFrom = normalizeDateForGenerator(valueOf(license, "valid_from", "validFrom"));
+  const validUntil = normalizeDateForGenerator(valueOf(license, "valid_until", "validUntil"));
+  const model = getLicenseEditionAndBinding(license);
+  const binding = model.binding;
+  const edition = model.edition;
   const features = parseGeneratorFeaturesFromProductScope(valueOf(license, "product_scope_json", "productScope"));
   const machineId = valueOf(license, "machine_id", "machineId");
   return {
     customerName,
     licenseId,
     product: GENERATOR_PRODUCT_KEY,
-    edition: "standard",
+    edition,
     binding,
     validFrom,
     validUntil,
     maxDevices: 1,
-    ...(machineId ? { machineId } : {}),
+    ...(binding === "machine" && machineId ? { machineId } : {}),
     features,
   };
 }
@@ -498,7 +549,7 @@ export default class LicenseAdminScreen {
       const thead = document.createElement("thead");
       const tbody = document.createElement("tbody");
       const tr = document.createElement("tr");
-      ["Lizenz-ID", "Produktumfang", "gueltig von", "gueltig bis", "Lizenzmodus"].forEach((label) => {
+      ["Lizenz-ID", "Produktumfang", "gueltig von", "gueltig bis", "Lizenzart", "Gerätebindung"].forEach((label) => {
         const th = document.createElement("th");
         th.textContent = label;
         tr.appendChild(th);
@@ -514,12 +565,14 @@ export default class LicenseAdminScreen {
           this.currentLicense = record;
           this._render();
         };
+        const mode = getLicenseEditionAndBinding(record);
         [
           valueOf(record, "license_id", "licenseId") || "-",
           formatProductScopeForList(record),
           valueOf(record, "valid_from", "validFrom") || "-",
           valueOf(record, "valid_until", "validUntil") || "-",
-          valueOf(record, "license_mode", "licenseMode") || "-",
+          mode.edition === "full" ? "Vollversion" : "Testlizenz",
+          mode.binding === "machine" ? "An Machine-ID binden" : "Ohne Gerätebindung",
         ].forEach((text) => {
           const td = document.createElement("td");
           td.textContent = text;
@@ -555,7 +608,8 @@ export default class LicenseAdminScreen {
       ["license_id", "Lizenz-ID"],
       ["valid_from", "gueltig von"],
       ["valid_until", "gueltig bis"],
-      ["license_mode", "Lizenzmodus"],
+      ["license_edition", "Lizenzart"],
+      ["license_binding", "Gerätebindung"],
       ["machine_id", "Machine-ID"],
       ["notes", "Notizen"],
     ];
@@ -577,17 +631,39 @@ export default class LicenseAdminScreen {
 
     for (const [key, label] of fields) {
       let input = key === "notes" ? document.createElement("textarea") : document.createElement("input");
-      if (key === "license_mode") {
+      if (key === "license_edition") {
         input = document.createElement("select");
-        ["", "soft", "full"].forEach((mode) => {
+        [
+          { value: "test", label: "Testlizenz" },
+          { value: "full", label: "Vollversion" },
+        ].forEach((entry) => {
           const option = document.createElement("option");
-          option.value = mode;
-          option.textContent = mode || "- auswaehlen -";
+          option.value = entry.value;
+          option.textContent = entry.label;
+          input.appendChild(option);
+        });
+      }
+      if (key === "license_binding") {
+        input = document.createElement("select");
+        [
+          { value: "none", label: "Ohne Gerätebindung" },
+          { value: "machine", label: "An Machine-ID binden" },
+        ].forEach((entry) => {
+          const option = document.createElement("option");
+          option.value = entry.value;
+          option.textContent = entry.label;
           input.appendChild(option);
         });
       }
       if (key === "notes") input.rows = 3;
-      input.value = valueOf(license, key, key.replace("_", ""));
+      const currentMode = getLicenseEditionAndBinding(license);
+      if (key === "license_edition") input.value = currentMode.edition;
+      else if (key === "license_binding") input.value = currentMode.binding;
+      else input.value = valueOf(license, key, key.replace("_", ""));
+      if (key === "valid_from" || key === "valid_until") {
+        input.type = "date";
+        input.value = normalizeDateForGenerator(input.value);
+      }
       input.style.width = "100%";
       input.id = `license-${key}`;
       inputs[key] = input;
@@ -731,6 +807,16 @@ export default class LicenseAdminScreen {
       inputs.product_scope_json.value = JSON.stringify(buildStructuredProductScopeJson(scopeModel, scopeModel.previous));
     };
     syncScopeJson();
+    const syncMachineIdState = () => {
+      const binding = String(inputs.license_binding?.value || "none").trim().toLowerCase();
+      const isMachine = binding === "machine";
+      inputs.machine_id.disabled = !isMachine;
+      if (!isMachine) {
+        inputs.machine_id.value = "";
+      }
+    };
+    inputs.license_binding?.addEventListener("change", syncMachineIdState);
+    syncMachineIdState();
 
     const licenseIdHint = document.createElement("div");
     licenseIdHint.textContent =
@@ -776,8 +862,18 @@ export default class LicenseAdminScreen {
         customer: this.currentCustomer || {},
         license: this.currentLicense || {},
       });
+      if (!payload.validFrom || !payload.validUntil) {
+        message.textContent = "Bitte gültige Datumswerte eintragen.";
+        generationOutput.textContent = "";
+        return;
+      }
       if (!payload.features.length) {
         message.textContent = "Produktumfang enthält keine erzeugbaren Features.";
+        generationOutput.textContent = "";
+        return;
+      }
+      if (payload.binding === "machine" && !String(payload.machineId || "").trim()) {
+        message.textContent = "Machine-ID ist erforderlich, wenn die Lizenz an ein Gerät gebunden wird.";
         generationOutput.textContent = "";
         return;
       }
@@ -834,7 +930,9 @@ export default class LicenseAdminScreen {
             product_scope_json: inputs.product_scope_json.value,
             valid_from: inputs.valid_from.value,
             valid_until: inputs.valid_until.value,
-            license_mode: inputs.license_mode.value,
+            license_mode: inputs.license_binding.value === "machine" ? "full" : "soft",
+            license_edition: inputs.license_edition.value,
+            license_binding: inputs.license_binding.value,
             machine_id: inputs.machine_id.value,
             notes: inputs.notes.value,
           },

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -479,11 +479,25 @@ export default class LicenseAdminScreen {
       form.append(title, input);
     }
 
+    const customerActions = document.createElement("div");
+    customerActions.style.display = "flex";
+    customerActions.style.gap = "8px";
+
     const actions = document.createElement("div");
     actions.style.display = "flex";
     actions.style.gap = "8px";
+    actions.style.justifyContent = "space-between";
+    actions.style.alignItems = "center";
 
     const licenseSection = document.createElement("div");
+    const customerSection = document.createElement("div");
+    customerSection.style.display = "grid";
+    customerSection.style.gap = "8px";
+    customerSection.style.border = "1px solid #ddd";
+    customerSection.style.borderRadius = "8px";
+    customerSection.style.padding = "12px";
+    const customerTitle = document.createElement("h4");
+    customerTitle.textContent = "Kundendaten";
 
     const saveBtn = this._button("Kunde speichern", async () => {
       try {
@@ -501,6 +515,7 @@ export default class LicenseAdminScreen {
           })
         );
         this.currentCustomer = saved;
+        newLicenseBtn.disabled = false;
         message.textContent = "Kunde gespeichert.";
         await renderLicenses();
       } catch (err) {
@@ -524,15 +539,16 @@ export default class LicenseAdminScreen {
       this._render();
     });
 
-    actions.append(saveBtn, newLicenseBtn, backBtn);
+    customerActions.append(saveBtn, backBtn);
 
     const renderLicenses = async () => {
       licenseSection.replaceChildren();
       const title = document.createElement("h4");
       title.textContent = "Lizenzen dieses Kunden";
       licenseSection.appendChild(title);
-      licenseSection.style.borderTop = "1px solid #ddd";
-      licenseSection.style.paddingTop = "10px";
+      licenseSection.style.border = "1px solid #ddd";
+      licenseSection.style.borderRadius = "8px";
+      licenseSection.style.padding = "12px";
       if (!this.currentCustomer?.id) {
         const hint = document.createElement("div");
         hint.textContent = "Lizenzen sind verfuegbar, sobald der Kunde gespeichert wurde.";
@@ -549,7 +565,7 @@ export default class LicenseAdminScreen {
       const thead = document.createElement("thead");
       const tbody = document.createElement("tbody");
       const tr = document.createElement("tr");
-      ["Lizenz-ID", "Produktumfang", "gueltig von", "gueltig bis", "Lizenzart", "Gerätebindung"].forEach((label) => {
+      ["Lizenz-ID", "Lizenzart", "Gerätebindung", "Produktumfang", "gueltig von", "gueltig bis", "Aktion"].forEach((label) => {
         const th = document.createElement("th");
         th.textContent = label;
         tr.appendChild(th);
@@ -559,32 +575,36 @@ export default class LicenseAdminScreen {
 
       for (const record of records) {
         const row = document.createElement("tr");
-        row.style.cursor = "pointer";
-        row.onclick = () => {
-          this.currentView = "license-editor";
-          this.currentLicense = record;
-          this._render();
-        };
         const mode = getLicenseEditionAndBinding(record);
         [
           valueOf(record, "license_id", "licenseId") || "-",
+          mode.edition === "full" ? "Vollversion" : "Testlizenz",
+          mode.binding === "machine" ? "An Machine-ID binden" : "Ohne Gerätebindung",
           formatProductScopeForList(record),
           valueOf(record, "valid_from", "validFrom") || "-",
           valueOf(record, "valid_until", "validUntil") || "-",
-          mode.edition === "full" ? "Vollversion" : "Testlizenz",
-          mode.binding === "machine" ? "An Machine-ID binden" : "Ohne Gerätebindung",
         ].forEach((text) => {
           const td = document.createElement("td");
           td.textContent = text;
           row.appendChild(td);
         });
+        const actionCell = document.createElement("td");
+        const openBtn = this._button("Öffnen", () => {
+          this.currentView = "license-editor";
+          this.currentLicense = record;
+          this._render();
+        });
+        actionCell.appendChild(openBtn);
+        row.appendChild(actionCell);
         tbody.appendChild(row);
       }
       licenseSection.appendChild(table);
     };
 
     await renderLicenses();
-    container.append(header, form, actions, message, licenseSection);
+    actions.append(newLicenseBtn);
+    customerSection.append(customerTitle, form, customerActions);
+    container.append(header, customerSection, licenseSection, actions, message);
   }
 
   async _renderLicenseEditor(container) {
@@ -920,7 +940,7 @@ export default class LicenseAdminScreen {
     });
     openOutputDirBtn.style.display = "none";
 
-    const saveBtn = this._button("Merken", async () => {
+    const saveBtn = this._button("Lizenz speichern", async () => {
       try {
         const payload = buildLicenseEditorPayload({
           license,
@@ -952,7 +972,7 @@ export default class LicenseAdminScreen {
       }
     });
 
-    const clearBtn = this._button("Neu / leeren", () => {
+    const clearBtn = this._button("Formular leeren", () => {
       Object.values(inputs).forEach((el) => {
         el.value = "";
       });
@@ -969,7 +989,7 @@ export default class LicenseAdminScreen {
       syncGenerateIdButton();
     });
 
-    const backBtn = this._button("Zurueck zum Kunden", () => {
+    const backBtn = this._button("Zurueck", () => {
       this.currentLicense = null;
       this.currentView = "customer-detail";
       this._render();


### PR DESCRIPTION
### Motivation
- Bestehende Lizenzdatei-Erzeugung (`license:generate` / `window.bbmDb.licenseGenerate`) aus der Admin-Lizenzverwaltung aufrufbar machen, damit aus einer gespeicherten Lizenz direkt eine .bbmlic erzeugt werden kann.
- Keine neue Generator-Architektur, keine DB-/Schema-Änderungen und keine Änderungen an Main-IPC außer Nutzung vorhandener IPCs.

### Description
- UI: Im Lizenzformular wurde der Button `Lizenzdatei erzeugen` ergänzt sowie ein optionaler Button `Ausgabeordner öffnen` und Status-/Fehleranzeige während der Erzeugung implementiert; Erzeugung ist ohne gespeicherte Lizenz blockiert (`Bitte zuerst die Lizenz speichern.`).
- Mapping-Helpers: Neue Helfer `mapLicenseModeToGeneratorBinding`, `parseGeneratorFeaturesFromProductScope` und `buildLicenseGeneratorPayload` bauen aus `currentCustomer` + `currentLicense` das Payload für den bestehenden Generator; das technische `product` ist weiterhin `bbm-protokoll` und `edition` ist `standard`.
- Features: `product_scope_json` wird in Generator-`features` übersetzt (Standardumfang, Zusatzfunktionen, Module), inklusive Kompatibilität `audio -> dictate`; nicht-eindeutige Freitextwerte werden nicht als Features verwendet; Erzeugung wird blockiert bei leerem Feature-Set.
- Integration: Nutzung der vorhandenen Preload/API-Methoden `window.bbmDb.licenseGenerate(...)` und `window.bbmDb.licenseOpenOutputDir(...)` ohne neue IPCs.
- Dateien geändert: `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`, Tests: `scripts/tests/licenseAdminDataflow.test.cjs`, `scripts/tests/lizenzverwaltungModule.test.cjs`, Doku: `STATUS.md`.

### Testing
- Automatisierte Tests: `npm test` ausgeführt und alle Tests sind grün.
- Neue/erweiterte Tests: Unit-Tests in `scripts/tests/licenseAdminDataflow.test.cjs` prüfen das Payload-Mapping (Kundenname aus `company_name` / Fallback `customer_number`, `license_id`, `valid_from`/`valid_until`, `soft -> none` und `full -> machine`, `product` = `bbm-protokoll`, `features`-Ableitung inkl. `audio -> dictate` und leerer-Feature-Fall) und sind erfolgreich.
- Strukturtests in `scripts/tests/lizenzverwaltungModule.test.cjs` wurden erweitert, um Vorhandensein des Buttons/Textes und die Nutzung der vorhandenen IPC-Namen (`license:generate`, `license:open-output-dir`) zu verifizieren; diese Tests sind ebenfalls erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef60745e9c8322b0a9be272fac7692)