### PR TITLE
Kunden-Setup in Lizenzverwaltung mit eingebetteter .bbmlic

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -169,6 +169,10 @@ Sie ergänzt:
   - Erfolgsmeldung fuer `Kunden-Setup wurde erstellt.` wird nur noch gesetzt, wenn ein echtes Setup-Artefakt im Kunden-Ausgabeordner gefunden wurde.
   - Fehlt Kunden-Ausgabeordner oder Setup-`.exe`, liefert der Main-Flow `CUSTOMER_SETUP_ARTIFACT_NOT_FOUND` statt false-positive Erfolg.
   - Build-Diagnose wird mitgegeben (`repoRoot`, `outputDir`, `customerSlug`, `licenseFilePath`, `exitCode`, `stdout`, `stderr`) und im UI bei Fehlern sichtbar gemacht.
+- Lizenzverwaltung Kunden-Setup-Stabilisierung ist umgesetzt:
+  - Build startet nicht mehr blind mit `process.execPath`, sondern ueber aufgeloeste Node-Laufzeit (`npm_node_execpath` -> `NODE_EXE` -> `node`).
+  - Kunden-Setup-Build hat Timeout-Schutz; bei Hänger wird mit `CUSTOMER_SETUP_BUILD_TIMEOUT` sauber beendet.
+  - Spawn-Fehler liefern `CUSTOMER_SETUP_BUILD_FAILED`; der IPC antwortet damit immer mit einem Abschlussstatus statt offenem Hänger.
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.

--- a/STATUS.md
+++ b/STATUS.md
@@ -157,6 +157,14 @@ Sie ergänzt:
   - Im sichtbaren Lizenzformular wurden restliche Einzelbuttons entfernt (`Lizenz-ID erzeugen`, `Formular leeren`).
   - Lizenz-ID bleibt sichtbar, wird aber beim Hauptablauf `Lizenz erstellen` automatisch erzeugt, wenn leer.
   - Sichtbarer Hauptablauf im Formular ist jetzt auf `Lizenz erstellen` + `Zurueck` reduziert; `Ausgabeordner öffnen` erscheint nur nach erfolgreicher Erzeugung.
+- Lizenzverwaltung naechster Schritt (Kunden-Setup) ist umgesetzt:
+  - Nach erfolgreicher Lizenzerzeugung wird der Lizenzpfad im Lizenzdatensatz gespeichert (`license_file_path`, `license_file_created_at`).
+  - Im Lizenzformular ist `Kunden-Setup erstellen` verfuegbar; ohne bekannte erzeugte Lizenzdatei erscheint `Bitte zuerst die Lizenz erstellen.`.
+  - Kunden-Setup-Build nutzt bestehende `scripts/dist.cjs`/electron-builder-Infrastruktur im optionalen Kundenmodus (kein neuer Installer-Generator).
+  - Kundenmodus uebergibt `.bbmlic` als `extraResource` nach `license/customer.bbmlic`, baut nach `dist/customers/<slug>/` und setzt kundenbezogenen Setup-Dateinamen.
+  - Main-/Preload-IPC fuer Build-Aufruf ist angebunden (`license-admin:create-customer-setup` / `licenseAdminCreateCustomerSetup`).
+  - Lizenz-Bootstrap liest bei fehlender `userData/license.json` eine gebuendelte `resources/license/customer.bbmlic` und uebernimmt sie als installierte Lizenz; bestehende `userData/license.json` bleibt vorrangig.
+  - `licenseVerifier.js` Produktpruefung bleibt unveraendert.
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.

--- a/STATUS.md
+++ b/STATUS.md
@@ -174,6 +174,7 @@ Sie ergänzt:
   - Kunden-Setup-Build hat Timeout-Schutz; bei Hänger wird mit `CUSTOMER_SETUP_BUILD_TIMEOUT` sauber beendet.
   - Spawn-Fehler liefern `CUSTOMER_SETUP_BUILD_FAILED`; der IPC antwortet damit immer mit einem Abschlussstatus statt offenem Hänger.
   - Pro Buildlauf wird eine Logdatei unter `dist/customers/<slug>/customer-setup-build.log` geschrieben (inkl. Node-Befehl, Env, stdout/stderr, Exitcode, Artefakte).
+  - Kundenmodus-Builderkonfiguration deaktiviert native Rebuilds (`npmRebuild: false`, `buildDependenciesFromSource: false`), um `better-sqlite3`-Locking in der laufenden App zu vermeiden.
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.

--- a/STATUS.md
+++ b/STATUS.md
@@ -165,6 +165,10 @@ Sie ergänzt:
   - Main-/Preload-IPC fuer Build-Aufruf ist angebunden (`license-admin:create-customer-setup` / `licenseAdminCreateCustomerSetup`).
   - Lizenz-Bootstrap liest bei fehlender `userData/license.json` eine gebuendelte `resources/license/customer.bbmlic` und uebernimmt sie als installierte Lizenz; bestehende `userData/license.json` bleibt vorrangig.
   - `licenseVerifier.js` Produktpruefung bleibt unveraendert.
+- Lizenzverwaltung Kunden-Setup-Nachbesserung ist umgesetzt:
+  - Erfolgsmeldung fuer `Kunden-Setup wurde erstellt.` wird nur noch gesetzt, wenn ein echtes Setup-Artefakt im Kunden-Ausgabeordner gefunden wurde.
+  - Fehlt Kunden-Ausgabeordner oder Setup-`.exe`, liefert der Main-Flow `CUSTOMER_SETUP_ARTIFACT_NOT_FOUND` statt false-positive Erfolg.
+  - Build-Diagnose wird mitgegeben (`repoRoot`, `outputDir`, `customerSlug`, `licenseFilePath`, `exitCode`, `stdout`, `stderr`) und im UI bei Fehlern sichtbar gemacht.
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.

--- a/STATUS.md
+++ b/STATUS.md
@@ -173,6 +173,7 @@ Sie ergänzt:
   - Build startet nicht mehr blind mit `process.execPath`, sondern ueber aufgeloeste Node-Laufzeit (`npm_node_execpath` -> `NODE_EXE` -> `node`).
   - Kunden-Setup-Build hat Timeout-Schutz; bei Hänger wird mit `CUSTOMER_SETUP_BUILD_TIMEOUT` sauber beendet.
   - Spawn-Fehler liefern `CUSTOMER_SETUP_BUILD_FAILED`; der IPC antwortet damit immer mit einem Abschlussstatus statt offenem Hänger.
+  - Pro Buildlauf wird eine Logdatei unter `dist/customers/<slug>/customer-setup-build.log` geschrieben (inkl. Node-Befehl, Env, stdout/stderr, Exitcode, Artefakte).
 - Protokoll-Modul ist eingefroren.
 - `npm test` war gruen.
 - GitHub Action `.github/workflows/npm-test.yml` ist eingerichtet und fuehrt `npm test` auf `main` sowie `modularisierung/projektverwaltung` bei Push/Pull-Request aus.

--- a/scripts/dist.cjs
+++ b/scripts/dist.cjs
@@ -47,18 +47,69 @@ function findRepoRoot(start) {
   return null;
 }
 
-function main() {
-  const repoRoot = findRepoRoot(process.cwd());
+function sanitizeCustomerSlug(value) {
+  const cleaned = String(value || "")
+    .trim()
+    .replace(/[<>:"/\\|?*\x00-\x1f]/g, " ")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return cleaned || "customer";
+}
+
+function buildCustomerDistConfig({
+  baseBuild = {},
+  baseVersion = "0.0.0",
+  customerLicenseFile = "",
+  customerSlug = "",
+} = {}) {
+  if (!customerLicenseFile) {
+    return {
+      build: { ...baseBuild },
+      outputDir: String(baseBuild?.directories?.output || "").trim() || "dist",
+      artifactName: null,
+    };
+  }
+
+  const safeSlug = sanitizeCustomerSlug(customerSlug);
+  const outputDir = path.join("dist", "customers", safeSlug);
+  const artifactName = `BBM-${baseVersion}-${safeSlug}-Setup.\${ext}`;
+  const extraResources = Array.isArray(baseBuild.extraResources) ? [...baseBuild.extraResources] : [];
+  extraResources.push({
+    from: customerLicenseFile,
+    to: "license/customer.bbmlic",
+  });
+
+  return {
+    build: {
+      ...baseBuild,
+      directories: {
+        ...(baseBuild.directories || {}),
+        output: outputDir,
+      },
+      extraResources,
+      nsis: {
+        ...(baseBuild.nsis || {}),
+        artifactName,
+      },
+    },
+    outputDir,
+    artifactName,
+  };
+}
+
+function runDist({ cwd = process.cwd(), env = process.env } = {}) {
+  const repoRoot = findRepoRoot(cwd);
   if (!repoRoot) {
     console.error("[dist] Fehler: package.json nicht gefunden (Repo-Root).");
-    process.exit(1);
+    return Promise.resolve(1);
   }
 
   const pkgPath = path.join(repoRoot, "package.json");
   const pkg = readJsonSafe(pkgPath);
   if (!pkg) {
     console.error("[dist] Fehler: package.json konnte nicht gelesen werden.");
-    process.exit(1);
+    return Promise.resolve(1);
   }
 
   const baseBuild = pkg.build || {};
@@ -83,10 +134,18 @@ function main() {
 
   const prefix = isDev ? "BBM-DEV" : "BBM";
   const nsisName = `${prefix}-${baseVersion}-Setup.\${ext}`;
+  const customerLicenseFile = String(env.BBM_CUSTOMER_LICENSE_FILE || "").trim();
+  const customerSlug = sanitizeCustomerSlug(env.BBM_CUSTOMER_SLUG || env.BBM_CUSTOMER_NAME || "");
+  const customerConfig = buildCustomerDistConfig({
+    baseBuild,
+    baseVersion,
+    customerLicenseFile,
+    customerSlug,
+  });
 
   // Override-Config für electron-builder (als separate Config-Datei)
   const override = {
-    ...baseBuild,
+    ...customerConfig.build,
     appId,
     productName,
     extraMetadata: {
@@ -95,10 +154,12 @@ function main() {
       buildChannel: channel,
     },
     // ✅ pro Target eigene artifactName (kein ${target})
-    nsis: {
-      ...(baseBuild.nsis || {}),
-      artifactName: nsisName,
-    },
+    nsis: customerLicenseFile
+      ? { ...(customerConfig.build.nsis || {}) }
+      : {
+          ...(baseBuild.nsis || {}),
+          artifactName: nsisName,
+        },
   };
 
   const tmpConfigPath = path.join(repoRoot, "dist", `builder-config-${Date.now()}.json`);
@@ -110,31 +171,51 @@ function main() {
   console.log(" Version: ", baseVersion);
   console.log(" appId:   ", appId);
   console.log(" Name:    ", productName);
-  console.log(" NSIS:    ", nsisName);
+  console.log(" NSIS:    ", customerConfig.artifactName || nsisName);
+  if (customerLicenseFile) {
+    console.log(" Kundenmodus: aktiv");
+    console.log(" Lizenzdatei: ", customerLicenseFile);
+    console.log(" Ausgabe:     ", customerConfig.outputDir);
+  }
   console.log("======================================");
 
   const cliJs = path.join(repoRoot, "node_modules", "electron-builder", "out", "cli", "cli.js");
   if (!fs.existsSync(cliJs)) {
     console.error("[dist] Fehler: electron-builder CLI nicht gefunden:", cliJs);
-    process.exit(1);
+    return Promise.resolve(1);
   }
 
   console.log("[dist] Starte electron-builder...");
   console.log("[dist] node", cliJs);
 
-  const child = spawn(process.execPath, [cliJs, "--config", tmpConfigPath], {
-    cwd: repoRoot,
-    stdio: "inherit",
-    windowsHide: false,
-  });
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [cliJs, "--config", tmpConfigPath], {
+      cwd: repoRoot,
+      stdio: "inherit",
+      windowsHide: false,
+    });
 
-  child.on("close", (code) => {
-    console.log("[dist] Exitcode:", code);
-    try {
-      fs.unlinkSync(tmpConfigPath);
-    } catch (_e) {}
-    process.exit(code || 0);
+    child.on("close", (code) => {
+      console.log("[dist] Exitcode:", code);
+      try {
+        fs.unlinkSync(tmpConfigPath);
+      } catch (_e) {}
+      resolve(code || 0);
+    });
   });
 }
 
-main();
+async function main() {
+  const code = await runDist();
+  process.exit(code || 0);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  sanitizeCustomerSlug,
+  buildCustomerDistConfig,
+  runDist,
+};

--- a/scripts/dist.cjs
+++ b/scripts/dist.cjs
@@ -73,7 +73,7 @@ function buildCustomerDistConfig({
 
   const safeSlug = sanitizeCustomerSlug(customerSlug);
   const outputDir = path.join("dist", "customers", safeSlug);
-  const artifactName = `BBM-${baseVersion}-${safeSlug}-Setup.\${ext}`;
+  const artifactName = `BBM-${baseVersion}-${safeSlug}-Setup.exe`;
   const extraResources = Array.isArray(baseBuild.extraResources) ? [...baseBuild.extraResources] : [];
   extraResources.push({
     from: customerLicenseFile,
@@ -181,7 +181,11 @@ function runDist({ cwd = process.cwd(), env = process.env } = {}) {
 
   const cliJs = path.join(repoRoot, "node_modules", "electron-builder", "out", "cli", "cli.js");
   if (!fs.existsSync(cliJs)) {
+    console.error("ELECTRON_BUILDER_NOT_FOUND");
     console.error("[dist] Fehler: electron-builder CLI nicht gefunden:", cliJs);
+    try {
+      fs.unlinkSync(tmpConfigPath);
+    } catch (_e) {}
     return Promise.resolve(1);
   }
 
@@ -193,6 +197,15 @@ function runDist({ cwd = process.cwd(), env = process.env } = {}) {
       cwd: repoRoot,
       stdio: "inherit",
       windowsHide: false,
+    });
+
+    child.on("error", (err) => {
+      console.error("CUSTOMER_SETUP_BUILD_FAILED");
+      console.error("[dist] Spawn-Fehler:", err?.message || err);
+      try {
+        fs.unlinkSync(tmpConfigPath);
+      } catch (_e) {}
+      resolve(1);
     });
 
     child.on("close", (code) => {

--- a/scripts/dist.cjs
+++ b/scripts/dist.cjs
@@ -83,6 +83,8 @@ function buildCustomerDistConfig({
   return {
     build: {
       ...baseBuild,
+      npmRebuild: false,
+      buildDependenciesFromSource: false,
       directories: {
         ...(baseBuild.directories || {}),
         output: outputDir,

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -18,6 +18,9 @@ const { runAusgabeModuleTests } = require("./tests/ausgabeModule.test.cjs");
 const { runAudioModuleTests } = require("./tests/audioModule.test.cjs");
 const { runLizenzverwaltungModuleTests } = require("./tests/lizenzverwaltungModule.test.cjs");
 const { runLicenseAdminDataflowTests } = require("./tests/licenseAdminDataflow.test.cjs");
+const { runDistCustomerBuildTests } = require("./tests/distCustomerBuild.test.cjs");
+const { runLicenseStorageBootstrapTests } = require("./tests/licenseStorageBootstrap.test.cjs");
+const { runLicenseIpcCustomerSetupTests } = require("./tests/licenseIpcCustomerSetup.test.cjs");
 
 let failed = false;
 
@@ -82,6 +85,9 @@ async function main() {
   await runAudioModuleTests(run);
   await runLizenzverwaltungModuleTests(run);
   await runLicenseAdminDataflowTests(run);
+  await runDistCustomerBuildTests(run);
+  await runLicenseIpcCustomerSetupTests(run);
+  await runLicenseStorageBootstrapTests(run);
 
   if (failed) {
     process.exitCode = 1;

--- a/scripts/tests/distCustomerBuild.test.cjs
+++ b/scripts/tests/distCustomerBuild.test.cjs
@@ -1,0 +1,45 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const { buildCustomerDistConfig } = require('../../scripts/dist.cjs');
+
+async function runDistCustomerBuildTests(run) {
+  await run('dist.cjs: ohne BBM_CUSTOMER_LICENSE_FILE bleibt Build unveraendert', () => {
+    const baseBuild = {
+      directories: { output: 'dist' },
+      extraResources: [{ from: 'a', to: 'b' }],
+      nsis: { artifactName: 'Default-${version}.exe' },
+    };
+    const out = buildCustomerDistConfig({ baseBuild, baseVersion: '1.2.3', customerLicenseFile: '' });
+    assert.equal(out.outputDir, 'dist');
+    assert.equal(out.artifactName, null);
+    assert.deepEqual(out.build.directories, { output: 'dist' });
+    assert.equal(out.build.extraResources.length, 1);
+    assert.equal(out.build.nsis.artifactName, 'Default-${version}.exe');
+  });
+
+  await run('dist.cjs: mit BBM_CUSTOMER_LICENSE_FILE wird extraResource und Kundenziel gesetzt', () => {
+    const out = buildCustomerDistConfig({
+      baseBuild: {
+        directories: { output: 'dist' },
+        extraResources: [{ from: 'dev/models', to: 'audio/models' }],
+        nsis: {},
+      },
+      baseVersion: '2.0.0',
+      customerLicenseFile: path.join('C:', 'tmp', 'customer.bbmlic'),
+      customerSlug: 'K-100-Musterfirma-GmbH',
+    });
+
+    assert.equal(out.outputDir, path.join('dist', 'customers', 'K-100-Musterfirma-GmbH'));
+    assert.equal(out.artifactName, 'BBM-2.0.0-K-100-Musterfirma-GmbH-Setup.${ext}');
+    const embedded = out.build.extraResources.find((entry) => entry.to === 'license/customer.bbmlic');
+    assert.equal(Boolean(embedded), true);
+    assert.equal(embedded.from.endsWith('customer.bbmlic'), true);
+    assert.equal(out.build.directories.output, path.join('dist', 'customers', 'K-100-Musterfirma-GmbH'));
+    assert.equal(out.build.nsis.artifactName, 'BBM-2.0.0-K-100-Musterfirma-GmbH-Setup.${ext}');
+  });
+}
+
+module.exports = {
+  runDistCustomerBuildTests,
+};

--- a/scripts/tests/distCustomerBuild.test.cjs
+++ b/scripts/tests/distCustomerBuild.test.cjs
@@ -31,12 +31,12 @@ async function runDistCustomerBuildTests(run) {
     });
 
     assert.equal(out.outputDir, path.join('dist', 'customers', 'K-100-Musterfirma-GmbH'));
-    assert.equal(out.artifactName, 'BBM-2.0.0-K-100-Musterfirma-GmbH-Setup.${ext}');
+    assert.equal(out.artifactName, 'BBM-2.0.0-K-100-Musterfirma-GmbH-Setup.exe');
     const embedded = out.build.extraResources.find((entry) => entry.to === 'license/customer.bbmlic');
     assert.equal(Boolean(embedded), true);
     assert.equal(embedded.from.endsWith('customer.bbmlic'), true);
     assert.equal(out.build.directories.output, path.join('dist', 'customers', 'K-100-Musterfirma-GmbH'));
-    assert.equal(out.build.nsis.artifactName, 'BBM-2.0.0-K-100-Musterfirma-GmbH-Setup.${ext}');
+    assert.equal(out.build.nsis.artifactName, 'BBM-2.0.0-K-100-Musterfirma-GmbH-Setup.exe');
   });
 }
 

--- a/scripts/tests/distCustomerBuild.test.cjs
+++ b/scripts/tests/distCustomerBuild.test.cjs
@@ -9,6 +9,8 @@ async function runDistCustomerBuildTests(run) {
       directories: { output: 'dist' },
       extraResources: [{ from: 'a', to: 'b' }],
       nsis: { artifactName: 'Default-${version}.exe' },
+      npmRebuild: true,
+      buildDependenciesFromSource: true,
     };
     const out = buildCustomerDistConfig({ baseBuild, baseVersion: '1.2.3', customerLicenseFile: '' });
     assert.equal(out.outputDir, 'dist');
@@ -16,6 +18,8 @@ async function runDistCustomerBuildTests(run) {
     assert.deepEqual(out.build.directories, { output: 'dist' });
     assert.equal(out.build.extraResources.length, 1);
     assert.equal(out.build.nsis.artifactName, 'Default-${version}.exe');
+    assert.equal(out.build.npmRebuild, true);
+    assert.equal(out.build.buildDependenciesFromSource, true);
   });
 
   await run('dist.cjs: mit BBM_CUSTOMER_LICENSE_FILE wird extraResource und Kundenziel gesetzt', () => {
@@ -37,6 +41,8 @@ async function runDistCustomerBuildTests(run) {
     assert.equal(embedded.from.endsWith('customer.bbmlic'), true);
     assert.equal(out.build.directories.output, path.join('dist', 'customers', 'K-100-Musterfirma-GmbH'));
     assert.equal(out.build.nsis.artifactName, 'BBM-2.0.0-K-100-Musterfirma-GmbH-Setup.exe');
+    assert.equal(out.build.npmRebuild, false);
+    assert.equal(out.build.buildDependenciesFromSource, false);
   });
 }
 

--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -17,6 +17,8 @@ function createMemoryDb() {
       ...record,
       licenseEdition: record.license_edition || null,
       licenseBinding: record.license_binding || null,
+      licenseFilePath: record.license_file_path || null,
+      licenseFileCreatedAt: record.license_file_created_at || null,
       customer_number: customer.customer_number || null,
       company_name: customer.company_name || null,
       customerNumber: customer.customer_number || null,
@@ -82,6 +84,8 @@ function createMemoryDb() {
               license_edition,
               license_binding,
               machine_id,
+              license_file_path,
+              license_file_created_at,
               notes,
             ] =
               args;
@@ -96,6 +100,8 @@ function createMemoryDb() {
               license_edition,
               license_binding,
               machine_id,
+              license_file_path,
+              license_file_created_at,
               notes,
             });
             return;
@@ -111,6 +117,8 @@ function createMemoryDb() {
               license_edition,
               license_binding,
               machine_id,
+              license_file_path,
+              license_file_created_at,
               notes,
               _updated_at,
               id,
@@ -127,6 +135,8 @@ function createMemoryDb() {
               license_edition,
               license_binding,
               machine_id,
+              license_file_path,
+              license_file_created_at,
               notes,
             });
           }
@@ -187,6 +197,8 @@ async function runLicenseAdminDataflowTests(run) {
         valid_from: "2026-01-01",
         valid_until: "2026-12-31",
         license_mode: "soft",
+        license_file_path: "C:\\license-tool\\output\\k101.bbmlic",
+        license_file_created_at: "2026-04-27T10:00:00.000Z",
       });
 
       assert.equal(savedLicense.customer_id, customer.id);
@@ -203,6 +215,10 @@ async function runLicenseAdminDataflowTests(run) {
       assert.equal(listedByCustomer[0].license_binding, "none");
       assert.equal(listedByCustomer[0].licenseEdition, "test");
       assert.equal(listedByCustomer[0].licenseBinding, "none");
+      assert.equal(listedByCustomer[0].license_file_path, "C:\\license-tool\\output\\k101.bbmlic");
+      assert.equal(listedByCustomer[0].licenseFilePath, "C:\\license-tool\\output\\k101.bbmlic");
+      assert.equal(listedByCustomer[0].license_file_created_at, "2026-04-27T10:00:00.000Z");
+      assert.equal(listedByCustomer[0].licenseFileCreatedAt, "2026-04-27T10:00:00.000Z");
       assert.equal(typeof listedByCustomer[0].product_scope_json, "string");
     });
   });
@@ -328,6 +344,8 @@ async function runLicenseAdminDataflowTests(run) {
       licenseMode: "full",
       licenseEdition: "full",
       licenseBinding: "machine",
+      licenseFilePath: "C:\\tmp\\camel-1.bbmlic",
+      licenseFileCreatedAt: "2026-04-27T12:30:00.000Z",
     });
 
     assert.equal(received.licenseId, "LIC-CAMEL-1");
@@ -343,6 +361,10 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(received.license_edition, "full");
     assert.equal(received.licenseBinding, "machine");
     assert.equal(received.license_binding, "machine");
+    assert.equal(received.licenseFilePath, "C:\\tmp\\camel-1.bbmlic");
+    assert.equal(received.license_file_path, "C:\\tmp\\camel-1.bbmlic");
+    assert.equal(received.licenseFileCreatedAt, "2026-04-27T12:30:00.000Z");
+    assert.equal(received.license_file_created_at, "2026-04-27T12:30:00.000Z");
   });
 
   await run("Lizenzverwaltung normalizeLicenseRecord: snake_case und camelCase werden vollstaendig abgebildet", async () => {
@@ -358,6 +380,8 @@ async function runLicenseAdminDataflowTests(run) {
       valid_until: "2026-12-31",
       license_mode: "soft",
       machine_id: "MID-1",
+      license_file_path: "C:\\tmp\\snake.bbmlic",
+      license_file_created_at: "2026-04-27T11:00:00.000Z",
     });
     assert.equal(snake.license_id, "LIC-1");
     assert.equal(snake.customer_id, "c-1");
@@ -367,6 +391,10 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(snake.license_edition, "test");
     assert.equal(snake.license_binding, "none");
     assert.equal(snake.machine_id, "MID-1");
+    assert.equal(snake.license_file_path, "C:\\tmp\\snake.bbmlic");
+    assert.equal(snake.licenseFilePath, "C:\\tmp\\snake.bbmlic");
+    assert.equal(snake.license_file_created_at, "2026-04-27T11:00:00.000Z");
+    assert.equal(snake.licenseFileCreatedAt, "2026-04-27T11:00:00.000Z");
     assert.equal(snake.product_scope_json, JSON.stringify({ raw: "freitext" }));
 
     const camel = normalizeLicenseRecord({
@@ -377,6 +405,8 @@ async function runLicenseAdminDataflowTests(run) {
       validUntil: "2026-10-31",
       licenseMode: "full",
       machineId: "MID-2",
+      licenseFilePath: "C:\\tmp\\camel.bbmlic",
+      licenseFileCreatedAt: "2026-04-27T12:00:00.000Z",
     });
     assert.equal(camel.license_id, "LIC-2");
     assert.equal(camel.customer_id, "c-2");
@@ -386,6 +416,10 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(camel.license_edition, "full");
     assert.equal(camel.license_binding, "machine");
     assert.equal(camel.machine_id, "MID-2");
+    assert.equal(camel.license_file_path, "C:\\tmp\\camel.bbmlic");
+    assert.equal(camel.licenseFilePath, "C:\\tmp\\camel.bbmlic");
+    assert.equal(camel.license_file_created_at, "2026-04-27T12:00:00.000Z");
+    assert.equal(camel.licenseFileCreatedAt, "2026-04-27T12:00:00.000Z");
   });
 
 

--- a/scripts/tests/licenseIpcCustomerSetup.test.cjs
+++ b/scripts/tests/licenseIpcCustomerSetup.test.cjs
@@ -6,7 +6,7 @@ const EventEmitter = require('node:events');
 const Module = require('node:module');
 const REAL_REPO_ROOT = process.cwd();
 
-function createFakeChild({ exitCode = 0, stdout = '', stderr = '', error = null } = {}) {
+function createFakeChild({ exitCode = 0, stdout = '', stderr = '', error = null, stayAlive = false } = {}) {
   const child = new EventEmitter();
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
@@ -17,6 +17,7 @@ function createFakeChild({ exitCode = 0, stdout = '', stderr = '', error = null 
       child.emit('error', error);
       return;
     }
+    if (stayAlive) return;
     child.emit('close', exitCode);
   });
   return child;
@@ -106,6 +107,30 @@ async function runLicenseIpcCustomerSetupTests(run) {
     });
   });
 
+  await run('licenseIpc: resolveNodeExecutableForBuild bevorzugt npm_node_execpath', () => {
+    withLicenseIpcModule({}, (mod) => {
+      const nodePath = mod.resolveNodeExecutableForBuild({
+        env: { npm_node_execpath: '/tmp/node-a', NODE_EXE: '/tmp/node-b' },
+        existsSync: (candidate) => candidate === '/tmp/node-a' || candidate === '/tmp/node-b',
+        execPath: '/tmp/electron.exe',
+        isElectronRuntime: true,
+      });
+      assert.equal(nodePath, '/tmp/node-a');
+    });
+  });
+
+  await run('licenseIpc: resolveNodeExecutableForBuild nutzt bei Electron nicht blind process.execPath', () => {
+    withLicenseIpcModule({}, (mod) => {
+      const nodePath = mod.resolveNodeExecutableForBuild({
+        env: {},
+        existsSync: () => true,
+        execPath: '/tmp/electron.exe',
+        isElectronRuntime: true,
+      });
+      assert.equal(nodePath, 'node');
+    });
+  });
+
   await run('licenseIpc: exitCode 0 aber outputDir fehlt -> CUSTOMER_SETUP_ARTIFACT_NOT_FOUND', async () => {
     await withTempRepo(
       () => {},
@@ -173,6 +198,49 @@ async function runLicenseIpcCustomerSetupTests(run) {
             assert.equal(res.artifactPath.includes('K-12-Gamma-GmbH'), true);
             assert.equal(res.setupPath.includes('.exe'), true);
             assert.equal(res.stdout.includes('builder-start'), true);
+          }
+        );
+      }
+    );
+  });
+
+  await run('licenseIpc: Timeout liefert CUSTOMER_SETUP_BUILD_TIMEOUT', async () => {
+    await withTempRepo(
+      () => {},
+      async ({ repoRoot, licenseFilePath }) => {
+        await withLicenseIpcModule(
+          { cwd: repoRoot, spawnImpl: () => createFakeChild({ stayAlive: true }) },
+          async (mod) => {
+            const res = await mod._runCustomerSetupBuild(
+              {
+                customer: { customer_number: 'K-13', company_name: 'Delta GmbH' },
+                license: { license_binding: 'none' },
+                licenseFilePath,
+              },
+              { timeoutMs: 5 }
+            );
+            assert.equal(res.ok, false);
+            assert.equal(res.error, 'CUSTOMER_SETUP_BUILD_TIMEOUT');
+          }
+        );
+      }
+    );
+  });
+
+  await run('licenseIpc: Spawn-Error liefert CUSTOMER_SETUP_BUILD_FAILED', async () => {
+    await withTempRepo(
+      () => {},
+      async ({ repoRoot, licenseFilePath }) => {
+        await withLicenseIpcModule(
+          { cwd: repoRoot, spawnImpl: () => createFakeChild({ error: new Error('spawn kaputt') }) },
+          async (mod) => {
+            const res = await mod._runCustomerSetupBuild({
+              customer: { customer_number: 'K-14', company_name: 'Epsilon GmbH' },
+              license: { license_binding: 'none' },
+              licenseFilePath,
+            });
+            assert.equal(res.ok, false);
+            assert.equal(res.error, 'CUSTOMER_SETUP_BUILD_FAILED');
           }
         );
       }

--- a/scripts/tests/licenseIpcCustomerSetup.test.cjs
+++ b/scripts/tests/licenseIpcCustomerSetup.test.cjs
@@ -1,0 +1,69 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+function withLicenseIpcModule(fn) {
+  const originalLoad = Module._load;
+  Module._load = function patched(request, parent, isMain) {
+    if (request === 'electron' && String(parent?.filename || '').endsWith('licenseIpc.js')) {
+      return {
+        app: { isPackaged: false, getVersion: () => '1.0.0' },
+        BrowserWindow: { fromWebContents: () => null },
+        dialog: {},
+        ipcMain: { handle: () => {} },
+        shell: { openPath: async () => '' },
+      };
+    }
+    if (request.endsWith('/licenseStorage') || request === '../licensing/licenseStorage') {
+      return { saveLicense: () => ({}), loadLicense: () => null, deleteLicense: () => true };
+    }
+    if (request.endsWith('/deviceIdentity') || request === '../licensing/deviceIdentity') {
+      return { getMachineId: () => 'MID-1' };
+    }
+    if (request.endsWith('/licenseVerifier') || request === '../licensing/licenseVerifier') {
+      return { verifyLicense: () => ({ valid: false, reason: 'NO_LICENSE' }) };
+    }
+    if (request.endsWith('/licenseService') || request === '../licensing/licenseService') {
+      return { refreshStatus: () => ({ valid: false, reason: 'NO_LICENSE' }) };
+    }
+    if (request.endsWith('/licenseAdminService') || request === '../licensing/licenseAdminService') {
+      return {
+        listCustomers: () => [],
+        saveCustomer: (c) => c,
+        listLicenses: () => [],
+        listLicensesByCustomer: () => [],
+        saveLicense: (l) => l,
+        listHistory: () => [],
+        addHistoryEntry: (e) => e,
+      };
+    }
+    return originalLoad.apply(this, arguments);
+  };
+  try {
+    const modPath = path.join(process.cwd(), 'src/main/ipc/licenseIpc.js');
+    delete require.cache[require.resolve(modPath)];
+    const mod = require(modPath);
+    return fn(mod);
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+async function runLicenseIpcCustomerSetupTests(run) {
+  await run('licenseIpc: Kunden-Slug aus Kundennummer + Firmenname wird sicher gebaut', () => {
+    withLicenseIpcModule((mod) => {
+      const slug = mod._buildCustomerSetupSlug({ customer_number: 'K-100', company_name: 'Musterfirma GmbH' });
+      assert.equal(slug, 'K-100-Musterfirma-GmbH');
+    });
+  });
+
+  await run('licenseIpc: fehlender licenseFilePath blockiert Kunden-Setup-Payload', () => {
+    withLicenseIpcModule((mod) => {
+      assert.throws(() => mod._validateCustomerSetupPayload({ customer: {}, license: {} }), /LICENSE_FILE_PATH_REQUIRED/);
+    });
+  });
+}
+
+module.exports = {
+  runLicenseIpcCustomerSetupTests,
+};

--- a/scripts/tests/licenseIpcCustomerSetup.test.cjs
+++ b/scripts/tests/licenseIpcCustomerSetup.test.cjs
@@ -1,9 +1,32 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
+const EventEmitter = require('node:events');
 const Module = require('node:module');
+const REAL_REPO_ROOT = process.cwd();
 
-function withLicenseIpcModule(fn) {
+function createFakeChild({ exitCode = 0, stdout = '', stderr = '', error = null } = {}) {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  process.nextTick(() => {
+    if (stdout) child.stdout.emit('data', stdout);
+    if (stderr) child.stderr.emit('data', stderr);
+    if (error) {
+      child.emit('error', error);
+      return;
+    }
+    child.emit('close', exitCode);
+  });
+  return child;
+}
+
+function withLicenseIpcModule({ spawnImpl, cwd } = {}, fn) {
   const originalLoad = Module._load;
+  const originalCwd = process.cwd();
+  if (cwd) process.chdir(cwd);
+
   Module._load = function patched(request, parent, isMain) {
     if (request === 'electron' && String(parent?.filename || '').endsWith('licenseIpc.js')) {
       return {
@@ -13,6 +36,9 @@ function withLicenseIpcModule(fn) {
         ipcMain: { handle: () => {} },
         shell: { openPath: async () => '' },
       };
+    }
+    if (request === 'child_process' && String(parent?.filename || '').endsWith('licenseIpc.js')) {
+      return { spawn: spawnImpl || (() => createFakeChild()) };
     }
     if (request.endsWith('/licenseStorage') || request === '../licensing/licenseStorage') {
       return { saveLicense: () => ({}), loadLicense: () => null, deleteLicense: () => true };
@@ -40,27 +66,117 @@ function withLicenseIpcModule(fn) {
     return originalLoad.apply(this, arguments);
   };
   try {
-    const modPath = path.join(process.cwd(), 'src/main/ipc/licenseIpc.js');
+    const modPath = path.join(REAL_REPO_ROOT, 'src/main/ipc/licenseIpc.js');
     delete require.cache[require.resolve(modPath)];
     const mod = require(modPath);
     return fn(mod);
   } finally {
     Module._load = originalLoad;
+    if (cwd) process.chdir(originalCwd);
+  }
+}
+
+async function withTempRepo(setupFn, fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bbm-license-ipc-'));
+  const repoRoot = path.join(tmp, 'repo');
+  fs.mkdirSync(path.join(repoRoot, 'scripts'), { recursive: true });
+  fs.writeFileSync(path.join(repoRoot, 'package.json'), '{"name":"x"}', 'utf8');
+  fs.writeFileSync(path.join(repoRoot, 'scripts', 'dist.cjs'), 'console.log("fake");', 'utf8');
+  const licenseFilePath = path.join(repoRoot, 'tmp-license.bbmlic');
+  fs.writeFileSync(licenseFilePath, '{}', 'utf8');
+  setupFn({ repoRoot, licenseFilePath });
+  try {
+    return await fn({ repoRoot, licenseFilePath });
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
   }
 }
 
 async function runLicenseIpcCustomerSetupTests(run) {
   await run('licenseIpc: Kunden-Slug aus Kundennummer + Firmenname wird sicher gebaut', () => {
-    withLicenseIpcModule((mod) => {
+    withLicenseIpcModule({}, (mod) => {
       const slug = mod._buildCustomerSetupSlug({ customer_number: 'K-100', company_name: 'Musterfirma GmbH' });
       assert.equal(slug, 'K-100-Musterfirma-GmbH');
     });
   });
 
   await run('licenseIpc: fehlender licenseFilePath blockiert Kunden-Setup-Payload', () => {
-    withLicenseIpcModule((mod) => {
+    withLicenseIpcModule({}, (mod) => {
       assert.throws(() => mod._validateCustomerSetupPayload({ customer: {}, license: {} }), /LICENSE_FILE_PATH_REQUIRED/);
     });
+  });
+
+  await run('licenseIpc: exitCode 0 aber outputDir fehlt -> CUSTOMER_SETUP_ARTIFACT_NOT_FOUND', async () => {
+    await withTempRepo(
+      () => {},
+      async ({ repoRoot, licenseFilePath }) => {
+        await withLicenseIpcModule(
+          { cwd: repoRoot, spawnImpl: () => createFakeChild({ exitCode: 0, stdout: 'ok-log', stderr: 'warn-log' }) },
+          async (mod) => {
+            const res = await mod._runCustomerSetupBuild({
+              customer: { customer_number: 'K-10', company_name: 'Alpha GmbH' },
+              license: { license_binding: 'none' },
+              licenseFilePath,
+            });
+            assert.equal(res.ok, false);
+            assert.equal(res.error, 'CUSTOMER_SETUP_ARTIFACT_NOT_FOUND');
+            assert.equal(res.customerSlug, 'K-10-Alpha-GmbH');
+            assert.equal(res.exitCode, 0);
+            assert.equal(res.stdout.includes('ok-log'), true);
+            assert.equal(res.stderr.includes('warn-log'), true);
+          }
+        );
+      }
+    );
+  });
+
+  await run('licenseIpc: outputDir ohne .exe -> CUSTOMER_SETUP_ARTIFACT_NOT_FOUND', async () => {
+    await withTempRepo(
+      ({ repoRoot }) => {
+        fs.mkdirSync(path.join(repoRoot, 'dist', 'customers', 'K-11-Beta-GmbH'), { recursive: true });
+        fs.writeFileSync(path.join(repoRoot, 'dist', 'customers', 'K-11-Beta-GmbH', 'readme.txt'), 'x', 'utf8');
+      },
+      async ({ repoRoot, licenseFilePath }) => {
+        await withLicenseIpcModule(
+          { cwd: repoRoot, spawnImpl: () => createFakeChild({ exitCode: 0 }) },
+          async (mod) => {
+            const res = await mod._runCustomerSetupBuild({
+              customer: { customer_number: 'K-11', company_name: 'Beta GmbH' },
+              license: { license_binding: 'none' },
+              licenseFilePath,
+            });
+            assert.equal(res.ok, false);
+            assert.equal(res.error, 'CUSTOMER_SETUP_ARTIFACT_NOT_FOUND');
+          }
+        );
+      }
+    );
+  });
+
+  await run('licenseIpc: outputDir mit slug-.exe -> ok true + artifactPath', async () => {
+    await withTempRepo(
+      ({ repoRoot }) => {
+        const outDir = path.join(repoRoot, 'dist', 'customers', 'K-12-Gamma-GmbH');
+        fs.mkdirSync(outDir, { recursive: true });
+        fs.writeFileSync(path.join(outDir, 'BBM-1.5.0-K-12-Gamma-GmbH-Setup.exe'), 'bin', 'utf8');
+      },
+      async ({ repoRoot, licenseFilePath }) => {
+        await withLicenseIpcModule(
+          { cwd: repoRoot, spawnImpl: () => createFakeChild({ exitCode: 0, stdout: 'builder-start' }) },
+          async (mod) => {
+            const res = await mod._runCustomerSetupBuild({
+              customer: { customer_number: 'K-12', company_name: 'Gamma GmbH' },
+              license: { license_binding: 'none' },
+              licenseFilePath,
+            });
+            assert.equal(res.ok, true);
+            assert.equal(res.artifactPath.includes('K-12-Gamma-GmbH'), true);
+            assert.equal(res.setupPath.includes('.exe'), true);
+            assert.equal(res.stdout.includes('builder-start'), true);
+          }
+        );
+      }
+    );
   });
 }
 

--- a/scripts/tests/licenseIpcCustomerSetup.test.cjs
+++ b/scripts/tests/licenseIpcCustomerSetup.test.cjs
@@ -109,25 +109,29 @@ async function runLicenseIpcCustomerSetupTests(run) {
 
   await run('licenseIpc: resolveNodeExecutableForBuild bevorzugt npm_node_execpath', () => {
     withLicenseIpcModule({}, (mod) => {
-      const nodePath = mod.resolveNodeExecutableForBuild({
+      const resolved = mod.resolveNodeExecutableForBuild({
         env: { npm_node_execpath: '/tmp/node-a', NODE_EXE: '/tmp/node-b' },
         existsSync: (candidate) => candidate === '/tmp/node-a' || candidate === '/tmp/node-b',
         execPath: '/tmp/electron.exe',
         isElectronRuntime: true,
+        spawnSyncImpl: () => ({ status: 0 }),
       });
-      assert.equal(nodePath, '/tmp/node-a');
+      assert.equal(resolved.ok, true);
+      assert.equal(resolved.nodeExecutable, '/tmp/node-a');
     });
   });
 
   await run('licenseIpc: resolveNodeExecutableForBuild nutzt bei Electron nicht blind process.execPath', () => {
     withLicenseIpcModule({}, (mod) => {
-      const nodePath = mod.resolveNodeExecutableForBuild({
+      const resolved = mod.resolveNodeExecutableForBuild({
         env: {},
-        existsSync: () => true,
+        existsSync: () => false,
         execPath: '/tmp/electron.exe',
         isElectronRuntime: true,
+        spawnSyncImpl: () => ({ status: 1 }),
       });
-      assert.equal(nodePath, 'node');
+      assert.equal(resolved.ok, false);
+      assert.equal(resolved.error, 'NODE_EXECUTABLE_NOT_FOUND');
     });
   });
 
@@ -142,6 +146,8 @@ async function runLicenseIpcCustomerSetupTests(run) {
               customer: { customer_number: 'K-10', company_name: 'Alpha GmbH' },
               license: { license_binding: 'none' },
               licenseFilePath,
+            }, {
+              nodeResolver: () => ({ ok: true, nodeExecutable: 'node', trace: ['test'] }),
             });
             assert.equal(res.ok, false);
             assert.equal(res.error, 'CUSTOMER_SETUP_ARTIFACT_NOT_FOUND');
@@ -149,6 +155,8 @@ async function runLicenseIpcCustomerSetupTests(run) {
             assert.equal(res.exitCode, 0);
             assert.equal(res.stdout.includes('ok-log'), true);
             assert.equal(res.stderr.includes('warn-log'), true);
+            assert.equal(typeof res.logPath, 'string');
+            assert.equal(fs.existsSync(res.logPath), true);
           }
         );
       }
@@ -169,9 +177,12 @@ async function runLicenseIpcCustomerSetupTests(run) {
               customer: { customer_number: 'K-11', company_name: 'Beta GmbH' },
               license: { license_binding: 'none' },
               licenseFilePath,
+            }, {
+              nodeResolver: () => ({ ok: true, nodeExecutable: 'node', trace: ['test'] }),
             });
             assert.equal(res.ok, false);
             assert.equal(res.error, 'CUSTOMER_SETUP_ARTIFACT_NOT_FOUND');
+            assert.equal(fs.existsSync(res.logPath), true);
           }
         );
       }
@@ -193,11 +204,18 @@ async function runLicenseIpcCustomerSetupTests(run) {
               customer: { customer_number: 'K-12', company_name: 'Gamma GmbH' },
               license: { license_binding: 'none' },
               licenseFilePath,
+            }, {
+              nodeResolver: () => ({ ok: true, nodeExecutable: 'node', trace: ['test'] }),
             });
             assert.equal(res.ok, true);
             assert.equal(res.artifactPath.includes('K-12-Gamma-GmbH'), true);
             assert.equal(res.setupPath.includes('.exe'), true);
             assert.equal(res.stdout.includes('builder-start'), true);
+            assert.equal(fs.existsSync(res.logPath), true);
+            assert.equal(res.cwd, repoRoot);
+            assert.equal(res.env.BBM_CUSTOMER_LICENSE_FILE, licenseFilePath);
+            assert.equal(res.env.BBM_CUSTOMER_SLUG, 'K-12-Gamma-GmbH');
+            assert.equal(res.env.BBM_CUSTOMER_NAME, 'Gamma GmbH');
           }
         );
       }
@@ -217,10 +235,40 @@ async function runLicenseIpcCustomerSetupTests(run) {
                 license: { license_binding: 'none' },
                 licenseFilePath,
               },
-              { timeoutMs: 5 }
+              {
+                timeoutMs: 5,
+                nodeResolver: () => ({ ok: true, nodeExecutable: 'node', trace: ['test'] }),
+              }
             );
             assert.equal(res.ok, false);
             assert.equal(res.error, 'CUSTOMER_SETUP_BUILD_TIMEOUT');
+            assert.equal(fs.existsSync(res.logPath), true);
+          }
+        );
+      }
+    );
+  });
+
+  await run('licenseIpc: fehlender Node liefert NODE_EXECUTABLE_NOT_FOUND', async () => {
+    await withTempRepo(
+      () => {},
+      async ({ repoRoot, licenseFilePath }) => {
+        await withLicenseIpcModule(
+          { cwd: repoRoot, spawnImpl: () => createFakeChild({ stayAlive: true }) },
+          async (mod) => {
+            const res = await mod._runCustomerSetupBuild(
+              {
+                customer: { customer_number: 'K-15', company_name: 'Zeta GmbH' },
+                license: { license_binding: 'none' },
+                licenseFilePath,
+              },
+              {
+                nodeResolver: () => ({ ok: false, error: 'NODE_EXECUTABLE_NOT_FOUND', nodeExecutable: '', trace: [] }),
+              }
+            );
+            assert.equal(res.ok, false);
+            assert.equal(res.error, 'NODE_EXECUTABLE_NOT_FOUND');
+            assert.equal(fs.existsSync(res.logPath), true);
           }
         );
       }
@@ -238,9 +286,12 @@ async function runLicenseIpcCustomerSetupTests(run) {
               customer: { customer_number: 'K-14', company_name: 'Epsilon GmbH' },
               license: { license_binding: 'none' },
               licenseFilePath,
+            }, {
+              nodeResolver: () => ({ ok: true, nodeExecutable: 'node', trace: ['test'] }),
             });
             assert.equal(res.ok, false);
             assert.equal(res.error, 'CUSTOMER_SETUP_BUILD_FAILED');
+            assert.equal(fs.existsSync(res.logPath), true);
           }
         );
       }

--- a/scripts/tests/licenseStorageBootstrap.test.cjs
+++ b/scripts/tests/licenseStorageBootstrap.test.cjs
@@ -1,0 +1,112 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const Module = require('node:module');
+
+function withMockedLicenseStorage({ userDataSetup, resourcesSetup }, fn) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bbm-license-storage-'));
+  const userDataPath = path.join(tmpRoot, 'userData');
+  const appPath = path.join(tmpRoot, 'app');
+  const resourcesPath = path.join(appPath, 'resources');
+  fs.mkdirSync(userDataPath, { recursive: true });
+  fs.mkdirSync(path.join(resourcesPath, 'license'), { recursive: true });
+  fs.mkdirSync(appPath, { recursive: true });
+
+  if (typeof userDataSetup === 'function') userDataSetup({ userDataPath, resourcesPath, appPath });
+  if (typeof resourcesSetup === 'function') resourcesSetup({ userDataPath, resourcesPath, appPath });
+
+  const originalLoad = Module._load;
+  Module._load = function patched(request, parent, isMain) {
+    if (request === 'electron' && String(parent?.filename || '').endsWith('licenseStorage.js')) {
+      return {
+        app: {
+          isPackaged: true,
+          getPath: (name) => (name === 'userData' ? userDataPath : ''),
+          getAppPath: () => appPath,
+        },
+      };
+    }
+    if (request === './deviceIdentity' && String(parent?.filename || '').endsWith('licenseStorage.js')) {
+      return { getMachineId: () => 'MACHINE-TEST-1' };
+    }
+    return originalLoad.apply(this, arguments);
+  };
+
+  try {
+    const modPath = path.join(process.cwd(), 'src/main/licensing/licenseStorage.js');
+    delete require.cache[require.resolve(modPath)];
+    const mod = require(modPath);
+    return fn({ mod, userDataPath, resourcesPath });
+  } finally {
+    Module._load = originalLoad;
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+async function runLicenseStorageBootstrapTests(run) {
+  await run('Lizenz-Bootstrap: bundled license/customer.bbmlic wird genutzt, wenn userData/license.json fehlt', () => {
+    withMockedLicenseStorage(
+      {
+        resourcesSetup: ({ resourcesPath }) => {
+          const bundledPath = path.join(resourcesPath, 'license', 'customer.bbmlic');
+          fs.writeFileSync(
+            bundledPath,
+            JSON.stringify({ license: { product: 'bbm-protokoll' }, signature: 'abc' }),
+            'utf8'
+          );
+        },
+      },
+      ({ mod, userDataPath }) => {
+        const loaded = mod.loadLicense();
+        assert.equal(Boolean(loaded), true);
+        assert.equal(loaded.license.product, 'bbm-protokoll');
+        assert.equal(fs.existsSync(path.join(userDataPath, 'license.json')), true);
+      }
+    );
+  });
+
+  await run('Lizenz-Bootstrap: userData/license.json hat Vorrang vor gebuendelter Lizenz', () => {
+    withMockedLicenseStorage(
+      {
+        userDataSetup: ({ userDataPath }) => {
+          fs.writeFileSync(
+            path.join(userDataPath, 'license.json'),
+            JSON.stringify({ license: { product: 'bbm-protokoll', source: 'userData' }, signature: 'u' }),
+            'utf8'
+          );
+        },
+        resourcesSetup: ({ resourcesPath }) => {
+          fs.writeFileSync(
+            path.join(resourcesPath, 'license', 'customer.bbmlic'),
+            JSON.stringify({ license: { product: 'bbm-protokoll', source: 'bundled' }, signature: 'b' }),
+            'utf8'
+          );
+        },
+      },
+      ({ mod }) => {
+        const loaded = mod.loadLicense();
+        assert.equal(loaded.license.source, 'userData');
+      }
+    );
+  });
+
+  await run('Lizenz-Bootstrap: ungueltige bundled license fuehrt zu null (NO_LICENSE/INVALID_FORMAT via Verifier)', () => {
+    withMockedLicenseStorage(
+      {
+        resourcesSetup: ({ resourcesPath }) => {
+          fs.writeFileSync(path.join(resourcesPath, 'license', 'customer.bbmlic'), 'not-json', 'utf8');
+        },
+      },
+      ({ mod, userDataPath }) => {
+        const loaded = mod.loadLicense();
+        assert.equal(loaded, null);
+        assert.equal(fs.existsSync(path.join(userDataPath, 'license.json')), false);
+      }
+    );
+  });
+}
+
+module.exports = {
+  runLicenseStorageBootstrapTests,
+};

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -368,6 +368,9 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Bitte zuerst die Lizenz erstellen."), true);
     assert.equal(screenSource.includes("Kunden-Setup wird erstellt ..."), true);
     assert.equal(screenSource.includes("Kunden-Setup wurde erstellt."), true);
+    assert.equal(screenSource.includes("if (!res?.ok)"), true);
+    assert.equal(screenSource.includes("stdout:"), true);
+    assert.equal(screenSource.includes("stderr:"), true);
     assert.equal(screenSource.includes("Lizenz erstellen"), true);
     assert.equal(screenSource.includes("Lizenz-ID erzeugen"), false);
     assert.equal(screenSource.includes("Formular leeren"), false);

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -371,6 +371,8 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("if (!res?.ok)"), true);
     assert.equal(screenSource.includes("stdout:"), true);
     assert.equal(screenSource.includes("stderr:"), true);
+    assert.equal(screenSource.includes("customerSlug:"), true);
+    assert.equal(screenSource.includes("exitCode:"), true);
     assert.equal(screenSource.includes("Lizenz erstellen"), true);
     assert.equal(screenSource.includes("Lizenz-ID erzeugen"), false);
     assert.equal(screenSource.includes("Formular leeren"), false);

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -369,10 +369,11 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Kunden-Setup wird erstellt ..."), true);
     assert.equal(screenSource.includes("Kunden-Setup wurde erstellt."), true);
     assert.equal(screenSource.includes("if (!res?.ok)"), true);
-    assert.equal(screenSource.includes("stdout:"), true);
-    assert.equal(screenSource.includes("stderr:"), true);
+    assert.equal(screenSource.includes("stdout(last):"), true);
+    assert.equal(screenSource.includes("stderr(last):"), true);
     assert.equal(screenSource.includes("customerSlug:"), true);
     assert.equal(screenSource.includes("exitCode:"), true);
+    assert.equal(screenSource.includes("logPath:"), true);
     assert.equal(screenSource.includes("Lizenz erstellen"), true);
     assert.equal(screenSource.includes("Lizenz-ID erzeugen"), false);
     assert.equal(screenSource.includes("Formular leeren"), false);

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -35,6 +35,8 @@ async function runLizenzverwaltungModuleTests(run) {
       saveLicense,
       listHistory,
       addHistoryEntry,
+      createCustomerSetup,
+      buildCustomerSetupPayload,
     },
     {
       getProjektverwaltungModuleEntry,
@@ -190,6 +192,7 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(typeof saveLicense, "function");
     assert.equal(typeof listHistory, "function");
     assert.equal(typeof addHistoryEntry, "function");
+    assert.equal(typeof createCustomerSetup, "function");
 
     assert.equal(listCustomers.constructor.name, "AsyncFunction");
     assert.equal(saveCustomer.constructor.name, "AsyncFunction");
@@ -197,6 +200,7 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(saveLicense.constructor.name, "AsyncFunction");
     assert.equal(listHistory.constructor.name, "AsyncFunction");
     assert.equal(addHistoryEntry.constructor.name, "AsyncFunction");
+    assert.equal(createCustomerSetup.constructor.name, "AsyncFunction");
 
     assert.equal(typeof listCustomers().then, "function");
     assert.equal(typeof listLicenses().then, "function");
@@ -347,6 +351,34 @@ async function runLizenzverwaltungModuleTests(run) {
       /Preload-API-Methode fehlt \(licenseAdminSaveLicenseCustomer\)\./
     );
     restoreWindow();
+  });
+
+  await run("Lizenzverwaltung: Build-Mapping fuer Kunden-Setup Payload", () => {
+    const payload = buildCustomerSetupPayload({
+      customer: { customer_number: "K-100", company_name: "Musterfirma GmbH" },
+      license: { license_file_path: "C:\\tmp\\customer.bbmlic" },
+    });
+    assert.equal(payload.customer.customer_number, "K-100");
+    assert.equal(payload.license.license_file_path, "C:\\tmp\\customer.bbmlic");
+    assert.equal(payload.licenseFilePath, "C:\\tmp\\customer.bbmlic");
+  });
+
+  await run("Lizenzverwaltung UI: Kunden-Setup-Texte und Hinweise vorhanden", () => {
+    assert.equal(screenSource.includes("Kunden-Setup erstellen"), true);
+    assert.equal(screenSource.includes("Bitte zuerst die Lizenz erstellen."), true);
+    assert.equal(screenSource.includes("Kunden-Setup wird erstellt ..."), true);
+    assert.equal(screenSource.includes("Kunden-Setup wurde erstellt."), true);
+    assert.equal(screenSource.includes("Lizenz erstellen"), true);
+    assert.equal(screenSource.includes("Lizenz-ID erzeugen"), false);
+    assert.equal(screenSource.includes("Formular leeren"), false);
+    assert.equal(screenSource.includes("Lizenzdatei erzeugen"), false);
+  });
+
+  await run("Lizenzverwaltung Main/Preload/Schema: Kunden-Setup-IPC und Lizenzpfad-Spalten vorhanden", () => {
+    assert.equal(databaseSource.includes("license_file_path"), true);
+    assert.equal(databaseSource.includes("license_file_created_at"), true);
+    assert.equal(preloadSource.includes("licenseAdminCreateCustomerSetup"), true);
+    assert.equal(licenseIpcSource.includes("license-admin:create-customer-setup"), true);
   });
 
   await run("Lizenzverwaltung: Historien-Datensatz zentral vorbereitet", () => {

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -374,6 +374,12 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("customerSlug:"), true);
     assert.equal(screenSource.includes("exitCode:"), true);
     assert.equal(screenSource.includes("logPath:"), true);
+    assert.equal(
+      screenSource.includes(
+        "Kunden-Setup konnte nicht erstellt werden, weil eine Build-Datei gesperrt ist. Bitte App schließen und Kunden-Setup manuell über den Build-Befehl erstellen."
+      ),
+      true
+    );
     assert.equal(screenSource.includes("Lizenz erstellen"), true);
     assert.equal(screenSource.includes("Lizenz-ID erzeugen"), false);
     assert.equal(screenSource.includes("Formular leeren"), false);

--- a/src/main/db/database.js
+++ b/src/main/db/database.js
@@ -1157,6 +1157,12 @@ function ensureLicenseAdminSchema(dbConn) {
   if (!columnExists(dbConn, "license_records", "notes")) {
     dbConn.exec(`ALTER TABLE license_records ADD COLUMN notes TEXT;`);
   }
+  if (!columnExists(dbConn, "license_records", "license_file_path")) {
+    dbConn.exec(`ALTER TABLE license_records ADD COLUMN license_file_path TEXT;`);
+  }
+  if (!columnExists(dbConn, "license_records", "license_file_created_at")) {
+    dbConn.exec(`ALTER TABLE license_records ADD COLUMN license_file_created_at TEXT;`);
+  }
   if (!columnExists(dbConn, "license_records", "created_at")) {
     dbConn.exec(
       `ALTER TABLE license_records ADD COLUMN created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'));`

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -305,6 +305,113 @@ function _extractGeneratedPath(runResult, inputData) {
   return fs.existsSync(fallbackPath) ? fallbackPath : "";
 }
 
+function _findRepoRoot(startDir) {
+  let current = path.resolve(startDir || process.cwd());
+  const root = path.parse(current).root;
+  while (true) {
+    if (fs.existsSync(path.join(current, "package.json")) && fs.existsSync(path.join(current, "scripts", "dist.cjs"))) {
+      return current;
+    }
+    if (current === root) break;
+    current = path.dirname(current);
+  }
+  return "";
+}
+
+function _sanitizeCustomerSlug(value, fallback = "customer") {
+  const cleaned = String(value || "")
+    .trim()
+    .replace(/[<>:"/\\|?*\x00-\x1f]/g, " ")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return cleaned || fallback;
+}
+
+function _buildCustomerSetupSlug(customer = {}) {
+  const customerNumber = String(customer.customer_number || customer.customerNumber || "").trim();
+  const companyName = String(customer.company_name || customer.companyName || "").trim();
+  const combined = [customerNumber, companyName].filter(Boolean).join(" ");
+  return _sanitizeCustomerSlug(combined);
+}
+
+function _resolveCustomerSetupArtifactPath(outputDir, customerSlug) {
+  const normalizedOutputDir = String(outputDir || "").trim();
+  if (!normalizedOutputDir || !fs.existsSync(normalizedOutputDir)) return "";
+  const safeSlug = _sanitizeCustomerSlug(customerSlug || "");
+  const files = fs.readdirSync(normalizedOutputDir);
+  const setupFile = files.find((name) => name.toLowerCase().endsWith(".exe") && name.includes(safeSlug));
+  if (setupFile) return path.join(normalizedOutputDir, setupFile);
+  const anyExe = files.find((name) => name.toLowerCase().endsWith(".exe"));
+  return anyExe ? path.join(normalizedOutputDir, anyExe) : "";
+}
+
+function _validateCustomerSetupPayload(raw = {}) {
+  const customer = raw?.customer && typeof raw.customer === "object" ? raw.customer : {};
+  const license = raw?.license && typeof raw.license === "object" ? raw.license : {};
+  const licenseFilePath = String(raw?.licenseFilePath || raw?.license_file_path || "").trim();
+  if (!licenseFilePath) throw new Error("LICENSE_FILE_PATH_REQUIRED");
+  if (!fs.existsSync(licenseFilePath)) throw new Error("LICENSE_FILE_NOT_FOUND");
+
+  const binding = String(license.license_binding || license.licenseBinding || "").trim().toLowerCase();
+  const machineId = String(license.machine_id || license.machineId || "").trim();
+  if (binding === "machine" && !machineId) {
+    throw new Error("MACHINE_ID_REQUIRED_FOR_BINDING");
+  }
+
+  return {
+    customer,
+    license,
+    licenseFilePath,
+    customerSlug: _buildCustomerSetupSlug(customer),
+    customerName: String(customer.company_name || customer.companyName || "").trim(),
+  };
+}
+
+async function _runCustomerSetupBuild(payload = {}) {
+  if (app.isPackaged) return { ok: false, error: "CUSTOMER_SETUP_BUILD_NOT_ALLOWED" };
+  const repoRoot = _findRepoRoot(process.cwd());
+  if (!repoRoot) return { ok: false, error: "REPO_ROOT_NOT_FOUND" };
+  const distScriptPath = path.join(repoRoot, "scripts", "dist.cjs");
+  if (!fs.existsSync(distScriptPath)) return { ok: false, error: "DIST_SCRIPT_NOT_FOUND" };
+
+  const validated = _validateCustomerSetupPayload(payload);
+  const outputDir = path.join(repoRoot, "dist", "customers", validated.customerSlug);
+
+  return await new Promise((resolve) => {
+    const child = spawn(process.execPath, [distScriptPath], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        BBM_CUSTOMER_LICENSE_FILE: validated.licenseFilePath,
+        BBM_CUSTOMER_SLUG: validated.customerSlug,
+        BBM_CUSTOMER_NAME: validated.customerName,
+      },
+      windowsHide: true,
+    });
+
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk || "");
+    });
+
+    child.on("close", (code) => {
+      if (code !== 0) {
+        resolve({ ok: false, error: (stderr || "").trim() || "CUSTOMER_SETUP_BUILD_FAILED" });
+        return;
+      }
+      const artifactPath = _resolveCustomerSetupArtifactPath(outputDir, validated.customerSlug);
+      resolve({
+        ok: true,
+        outputDir,
+        setupPath: artifactPath,
+        artifactPath,
+        customerSlug: validated.customerSlug,
+      });
+    });
+  });
+}
+
 // Zentrale Laufzeit-/Diagnose-Einstiege des App-Kerns.
 function registerLicenseStatusIpc() {
   ipcMain.handle("license:get-status", async () => {
@@ -625,6 +732,17 @@ function registerLicenseAdminDataIpc() {
   ipcMain.handle("license-admin:add-history-entry", async (_event, entry) => {
     return licenseAdminService.addHistoryEntry(entry || {});
   });
+
+  ipcMain.handle("license-admin:create-customer-setup", async (_event, payload) => {
+    try {
+      return await _runCustomerSetupBuild(payload || {});
+    } catch (err) {
+      return {
+        ok: false,
+        error: String(err?.message || err || "CUSTOMER_SETUP_BUILD_FAILED").trim() || "CUSTOMER_SETUP_BUILD_FAILED",
+      };
+    }
+  });
 }
 
 function registerLicenseIpc() {
@@ -636,4 +754,6 @@ function registerLicenseIpc() {
 
 module.exports = {
   registerLicenseIpc,
+  _buildCustomerSetupSlug,
+  _validateCustomerSetupPayload,
 };

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -341,9 +341,7 @@ function _resolveCustomerSetupArtifactPath(outputDir, customerSlug) {
   const safeSlug = _sanitizeCustomerSlug(customerSlug || "");
   const files = fs.readdirSync(normalizedOutputDir);
   const setupFile = files.find((name) => name.toLowerCase().endsWith(".exe") && name.includes(safeSlug));
-  if (setupFile) return path.join(normalizedOutputDir, setupFile);
-  const anyExe = files.find((name) => name.toLowerCase().endsWith(".exe"));
-  return anyExe ? path.join(normalizedOutputDir, anyExe) : "";
+  return setupFile ? path.join(normalizedOutputDir, setupFile) : "";
 }
 
 function _validateCustomerSetupPayload(raw = {}) {
@@ -390,23 +388,74 @@ async function _runCustomerSetupBuild(payload = {}) {
       windowsHide: true,
     });
 
+    let stdout = "";
     let stderr = "";
+    let finished = false;
+    const finish = (result) => {
+      if (finished) return;
+      finished = true;
+      resolve(result);
+    };
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk || "");
+    });
     child.stderr.on("data", (chunk) => {
       stderr += String(chunk || "");
     });
+    child.on("error", (err) => {
+      finish({
+        ok: false,
+        error: "CUSTOMER_SETUP_BUILD_FAILED",
+        repoRoot,
+        outputDir,
+        customerSlug: validated.customerSlug,
+        licenseFilePath: validated.licenseFilePath,
+        exitCode: null,
+        stdout,
+        stderr: `${stderr}\n${String(err?.message || err || "")}`.trim(),
+      });
+    });
 
     child.on("close", (code) => {
+      const artifactPath = _resolveCustomerSetupArtifactPath(outputDir, validated.customerSlug);
+      const diagnostics = {
+        repoRoot,
+        outputDir,
+        customerSlug: validated.customerSlug,
+        licenseFilePath: validated.licenseFilePath,
+        exitCode: code,
+        stdout,
+        stderr,
+      };
       if (code !== 0) {
-        resolve({ ok: false, error: (stderr || "").trim() || "CUSTOMER_SETUP_BUILD_FAILED" });
+        const text = `${stdout}\n${stderr}`.toUpperCase();
+        const mappedError = text.includes("ELECTRON_BUILDER_NOT_FOUND")
+          ? "ELECTRON_BUILDER_NOT_FOUND"
+          : "CUSTOMER_SETUP_BUILD_FAILED";
+        finish({ ok: false, error: mappedError, ...diagnostics });
         return;
       }
-      const artifactPath = _resolveCustomerSetupArtifactPath(outputDir, validated.customerSlug);
-      resolve({
+      const hasOutputDir = fs.existsSync(outputDir);
+      const hasArtifact = !!artifactPath && fs.existsSync(artifactPath);
+      const pathHasSlug = hasArtifact && artifactPath.includes(validated.customerSlug);
+      if (!hasOutputDir || !hasArtifact || !pathHasSlug) {
+        finish({
+          ok: false,
+          error: "CUSTOMER_SETUP_ARTIFACT_NOT_FOUND",
+          setupPath: artifactPath,
+          artifactPath,
+          ...diagnostics,
+        });
+        return;
+      }
+      finish({
         ok: true,
         outputDir,
         setupPath: artifactPath,
         artifactPath,
         customerSlug: validated.customerSlug,
+        ...diagnostics,
       });
     });
   });
@@ -756,4 +805,5 @@ module.exports = {
   registerLicenseIpc,
   _buildCustomerSetupSlug,
   _validateCustomerSetupPayload,
+  _runCustomerSetupBuild,
 };

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -335,6 +335,32 @@ function _buildCustomerSetupSlug(customer = {}) {
   return _sanitizeCustomerSlug(combined);
 }
 
+function resolveNodeExecutableForBuild({
+  env = process.env,
+  existsSync = fs.existsSync,
+  execPath = process.execPath,
+  isElectronRuntime = !!process.versions?.electron,
+} = {}) {
+  const npmNodeExecPath = String(env?.npm_node_execpath || "").trim();
+  if (npmNodeExecPath && existsSync(npmNodeExecPath)) {
+    return npmNodeExecPath;
+  }
+
+  const nodeExe = String(env?.NODE_EXE || "").trim();
+  if (nodeExe && existsSync(nodeExe)) {
+    return nodeExe;
+  }
+
+  if (!isElectronRuntime) {
+    const currentExec = String(execPath || "").trim();
+    if (currentExec && existsSync(currentExec)) {
+      return currentExec;
+    }
+  }
+
+  return "node";
+}
+
 function _resolveCustomerSetupArtifactPath(outputDir, customerSlug) {
   const normalizedOutputDir = String(outputDir || "").trim();
   if (!normalizedOutputDir || !fs.existsSync(normalizedOutputDir)) return "";
@@ -366,7 +392,7 @@ function _validateCustomerSetupPayload(raw = {}) {
   };
 }
 
-async function _runCustomerSetupBuild(payload = {}) {
+async function _runCustomerSetupBuild(payload = {}, options = {}) {
   if (app.isPackaged) return { ok: false, error: "CUSTOMER_SETUP_BUILD_NOT_ALLOWED" };
   const repoRoot = _findRepoRoot(process.cwd());
   if (!repoRoot) return { ok: false, error: "REPO_ROOT_NOT_FOUND" };
@@ -375,9 +401,14 @@ async function _runCustomerSetupBuild(payload = {}) {
 
   const validated = _validateCustomerSetupPayload(payload);
   const outputDir = path.join(repoRoot, "dist", "customers", validated.customerSlug);
+  const nodeExe = resolveNodeExecutableForBuild();
+  const timeoutMs =
+    Number.isFinite(Number(options?.timeoutMs)) && Number(options.timeoutMs) > 0
+      ? Math.floor(Number(options.timeoutMs))
+      : 15 * 60 * 1000;
 
   return await new Promise((resolve) => {
-    const child = spawn(process.execPath, [distScriptPath], {
+    const child = spawn(nodeExe, [distScriptPath], {
       cwd: repoRoot,
       env: {
         ...process.env,
@@ -391,9 +422,11 @@ async function _runCustomerSetupBuild(payload = {}) {
     let stdout = "";
     let stderr = "";
     let finished = false;
+    let timeoutHandle = null;
     const finish = (result) => {
       if (finished) return;
       finished = true;
+      if (timeoutHandle) clearTimeout(timeoutHandle);
       resolve(result);
     };
 
@@ -412,10 +445,31 @@ async function _runCustomerSetupBuild(payload = {}) {
         customerSlug: validated.customerSlug,
         licenseFilePath: validated.licenseFilePath,
         exitCode: null,
+        nodeExecutable: nodeExe,
         stdout,
         stderr: `${stderr}\n${String(err?.message || err || "")}`.trim(),
       });
     });
+
+    timeoutHandle = setTimeout(() => {
+      try {
+        child.kill();
+      } catch (_err) {
+        // ignore
+      }
+      finish({
+        ok: false,
+        error: "CUSTOMER_SETUP_BUILD_TIMEOUT",
+        repoRoot,
+        outputDir,
+        customerSlug: validated.customerSlug,
+        licenseFilePath: validated.licenseFilePath,
+        exitCode: null,
+        nodeExecutable: nodeExe,
+        stdout,
+        stderr,
+      });
+    }, timeoutMs);
 
     child.on("close", (code) => {
       const artifactPath = _resolveCustomerSetupArtifactPath(outputDir, validated.customerSlug);
@@ -425,6 +479,7 @@ async function _runCustomerSetupBuild(payload = {}) {
         customerSlug: validated.customerSlug,
         licenseFilePath: validated.licenseFilePath,
         exitCode: code,
+        nodeExecutable: nodeExe,
         stdout,
         stderr,
       };
@@ -804,6 +859,7 @@ function registerLicenseIpc() {
 module.exports = {
   registerLicenseIpc,
   _buildCustomerSetupSlug,
+  resolveNodeExecutableForBuild,
   _validateCustomerSetupPayload,
   _runCustomerSetupBuild,
 };

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -4,7 +4,7 @@ const { app, BrowserWindow, dialog, ipcMain, shell } = require("electron");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const { spawn } = require("child_process");
+const { spawn, spawnSync } = require("child_process");
 
 const { saveLicense, loadLicense, deleteLicense } = require("../licensing/licenseStorage");
 const { getMachineId } = require("../licensing/deviceIdentity");
@@ -335,30 +335,145 @@ function _buildCustomerSetupSlug(customer = {}) {
   return _sanitizeCustomerSlug(combined);
 }
 
+function _isNodeRunnable(command, { spawnSyncImpl = spawnSync } = {}) {
+  const candidate = String(command || "").trim();
+  if (!candidate) return false;
+  try {
+    const probe = spawnSyncImpl(candidate, ["-v"], {
+      windowsHide: true,
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+    return probe && probe.status === 0;
+  } catch (_err) {
+    return false;
+  }
+}
+
 function resolveNodeExecutableForBuild({
   env = process.env,
   existsSync = fs.existsSync,
   execPath = process.execPath,
   isElectronRuntime = !!process.versions?.electron,
+  platform = process.platform,
+  spawnSyncImpl = spawnSync,
 } = {}) {
-  const npmNodeExecPath = String(env?.npm_node_execpath || "").trim();
-  if (npmNodeExecPath && existsSync(npmNodeExecPath)) {
-    return npmNodeExecPath;
-  }
+  const trace = [];
+  const checkExistingExecutable = (label, candidate) => {
+    const value = String(candidate || "").trim();
+    if (!value) return "";
+    if (!existsSync(value)) {
+      trace.push(`${label}:missing`);
+      return "";
+    }
+    if (!_isNodeRunnable(value, { spawnSyncImpl })) {
+      trace.push(`${label}:not-runnable`);
+      return "";
+    }
+    trace.push(`${label}:ok`);
+    return value;
+  };
 
-  const nodeExe = String(env?.NODE_EXE || "").trim();
-  if (nodeExe && existsSync(nodeExe)) {
-    return nodeExe;
-  }
+  const npmNodeExecPath = checkExistingExecutable("npm_node_execpath", env?.npm_node_execpath);
+  if (npmNodeExecPath) return { ok: true, nodeExecutable: npmNodeExecPath, trace };
+
+  const nodeExe = checkExistingExecutable("NODE_EXE", env?.NODE_EXE);
+  if (nodeExe) return { ok: true, nodeExecutable: nodeExe, trace };
 
   if (!isElectronRuntime) {
-    const currentExec = String(execPath || "").trim();
-    if (currentExec && existsSync(currentExec)) {
-      return currentExec;
+    const currentExec = checkExistingExecutable("process.execPath", execPath);
+    if (currentExec) return { ok: true, nodeExecutable: currentExec, trace };
+  } else {
+    trace.push("process.execPath:skip-electron-runtime");
+  }
+
+  if (_isNodeRunnable("node", { spawnSyncImpl })) {
+    trace.push("node-path:ok");
+    return { ok: true, nodeExecutable: "node", trace };
+  }
+  trace.push("node-path:not-runnable");
+
+  if (platform === "win32") {
+    try {
+      const whereResult = spawnSyncImpl("where.exe", ["node"], {
+        windowsHide: true,
+        stdio: "pipe",
+        encoding: "utf8",
+      });
+      if (whereResult?.status === 0) {
+        const candidates = String(whereResult.stdout || "")
+          .split(/\r?\n/)
+          .map((entry) => entry.trim())
+          .filter(Boolean);
+        for (const candidate of candidates) {
+          if (_isNodeRunnable(candidate, { spawnSyncImpl })) {
+            trace.push(`where.exe:ok:${candidate}`);
+            return { ok: true, nodeExecutable: candidate, trace };
+          }
+        }
+      }
+      trace.push("where.exe:not-runnable");
+    } catch (_err) {
+      trace.push("where.exe:error");
     }
   }
 
-  return "node";
+  return { ok: false, error: "NODE_EXECUTABLE_NOT_FOUND", nodeExecutable: "", trace };
+}
+
+function _collectSetupArtifacts(outputDir) {
+  const normalizedOutputDir = String(outputDir || "").trim();
+  if (!normalizedOutputDir || !fs.existsSync(normalizedOutputDir)) return [];
+  return fs
+    .readdirSync(normalizedOutputDir)
+    .filter((name) => name.toLowerCase().endsWith(".exe"))
+    .map((name) => path.join(normalizedOutputDir, name));
+}
+
+function _writeCustomerSetupBuildLog({
+  logPath,
+  nodeExecutable,
+  distScriptPath,
+  repoRoot,
+  cwd,
+  outputDir,
+  customerSlug,
+  customerName,
+  licenseFilePath,
+  envSnapshot = {},
+  stdout = "",
+  stderr = "",
+  exitCode = null,
+  artifacts = [],
+}) {
+  try {
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    const lines = [
+      `timestamp: ${new Date().toISOString()}`,
+      `nodeExecutable: ${nodeExecutable || "-"}`,
+      `distScriptPath: ${distScriptPath || "-"}`,
+      `repoRoot: ${repoRoot || "-"}`,
+      `cwd: ${cwd || "-"}`,
+      `outputDir: ${outputDir || "-"}`,
+      `customerSlug: ${customerSlug || "-"}`,
+      `customerName: ${customerName || "-"}`,
+      `licenseFilePath: ${licenseFilePath || "-"}`,
+      `exitCode: ${exitCode === null || exitCode === undefined ? "-" : exitCode}`,
+      `env.BBM_CUSTOMER_LICENSE_FILE: ${envSnapshot.BBM_CUSTOMER_LICENSE_FILE || "-"}`,
+      `env.BBM_CUSTOMER_SLUG: ${envSnapshot.BBM_CUSTOMER_SLUG || "-"}`,
+      `env.BBM_CUSTOMER_NAME: ${envSnapshot.BBM_CUSTOMER_NAME || "-"}`,
+      `artifacts: ${artifacts.length ? artifacts.join(" | ") : "-"}`,
+      "",
+      "stdout:",
+      String(stdout || ""),
+      "",
+      "stderr:",
+      String(stderr || ""),
+    ];
+    fs.writeFileSync(logPath, `${lines.join("\n")}\n`, "utf8");
+  } catch (_err) {
+    // ignore log-write failures
+  }
 }
 
 function _resolveCustomerSetupArtifactPath(outputDir, customerSlug) {
@@ -401,21 +516,66 @@ async function _runCustomerSetupBuild(payload = {}, options = {}) {
 
   const validated = _validateCustomerSetupPayload(payload);
   const outputDir = path.join(repoRoot, "dist", "customers", validated.customerSlug);
-  const nodeExe = resolveNodeExecutableForBuild();
+  const nodeResolver = typeof options?.nodeResolver === "function" ? options.nodeResolver : resolveNodeExecutableForBuild;
+  const resolvedNode = nodeResolver();
+  const nodeExe = String(resolvedNode?.nodeExecutable || "").trim();
+  const envForBuild = {
+    ...process.env,
+    BBM_CUSTOMER_LICENSE_FILE: validated.licenseFilePath,
+    BBM_CUSTOMER_SLUG: validated.customerSlug,
+    BBM_CUSTOMER_NAME: validated.customerName,
+  };
+  fs.mkdirSync(outputDir, { recursive: true });
+  const logPath = path.join(outputDir, "customer-setup-build.log");
   const timeoutMs =
     Number.isFinite(Number(options?.timeoutMs)) && Number(options.timeoutMs) > 0
       ? Math.floor(Number(options.timeoutMs))
       : 15 * 60 * 1000;
+  if (!resolvedNode?.ok || !nodeExe) {
+    _writeCustomerSetupBuildLog({
+      logPath,
+      nodeExecutable: nodeExe,
+      distScriptPath,
+      repoRoot,
+      cwd: repoRoot,
+      outputDir,
+      customerSlug: validated.customerSlug,
+      customerName: validated.customerName,
+      licenseFilePath: validated.licenseFilePath,
+      envSnapshot: envForBuild,
+      stdout: "",
+      stderr: String(resolvedNode?.error || "NODE_EXECUTABLE_NOT_FOUND"),
+      exitCode: null,
+      artifacts: _collectSetupArtifacts(outputDir),
+    });
+    return {
+      ok: false,
+      error: "NODE_EXECUTABLE_NOT_FOUND",
+      nodeExecutable: nodeExe,
+      nodeResolutionTrace: Array.isArray(resolvedNode?.trace) ? resolvedNode.trace : [],
+      distScriptPath,
+      repoRoot,
+      cwd: repoRoot,
+      outputDir,
+      customerSlug: validated.customerSlug,
+      customerName: validated.customerName,
+      licenseFilePath: validated.licenseFilePath,
+      exitCode: null,
+      stdout: "",
+      stderr: "NODE_EXECUTABLE_NOT_FOUND",
+      logPath,
+      env: {
+        BBM_CUSTOMER_LICENSE_FILE: envForBuild.BBM_CUSTOMER_LICENSE_FILE,
+        BBM_CUSTOMER_SLUG: envForBuild.BBM_CUSTOMER_SLUG,
+        BBM_CUSTOMER_NAME: envForBuild.BBM_CUSTOMER_NAME,
+      },
+    };
+  }
 
   return await new Promise((resolve) => {
     const child = spawn(nodeExe, [distScriptPath], {
       cwd: repoRoot,
-      env: {
-        ...process.env,
-        BBM_CUSTOMER_LICENSE_FILE: validated.licenseFilePath,
-        BBM_CUSTOMER_SLUG: validated.customerSlug,
-        BBM_CUSTOMER_NAME: validated.customerName,
-      },
+      env: envForBuild,
       windowsHide: true,
     });
 
@@ -437,17 +597,45 @@ async function _runCustomerSetupBuild(payload = {}, options = {}) {
       stderr += String(chunk || "");
     });
     child.on("error", (err) => {
+      const localStderr = `${stderr}\n${String(err?.message || err || "")}`.trim();
+      const artifacts = _collectSetupArtifacts(outputDir);
+      _writeCustomerSetupBuildLog({
+        logPath,
+        nodeExecutable: nodeExe,
+        distScriptPath,
+        repoRoot,
+        cwd: repoRoot,
+        outputDir,
+        customerSlug: validated.customerSlug,
+        customerName: validated.customerName,
+        licenseFilePath: validated.licenseFilePath,
+        envSnapshot: envForBuild,
+        stdout,
+        stderr: localStderr,
+        exitCode: null,
+        artifacts,
+      });
       finish({
         ok: false,
         error: "CUSTOMER_SETUP_BUILD_FAILED",
         repoRoot,
         outputDir,
         customerSlug: validated.customerSlug,
+        customerName: validated.customerName,
         licenseFilePath: validated.licenseFilePath,
         exitCode: null,
         nodeExecutable: nodeExe,
+        nodeResolutionTrace: Array.isArray(resolvedNode?.trace) ? resolvedNode.trace : [],
+        distScriptPath,
+        cwd: repoRoot,
         stdout,
-        stderr: `${stderr}\n${String(err?.message || err || "")}`.trim(),
+        stderr: localStderr,
+        logPath,
+        env: {
+          BBM_CUSTOMER_LICENSE_FILE: envForBuild.BBM_CUSTOMER_LICENSE_FILE,
+          BBM_CUSTOMER_SLUG: envForBuild.BBM_CUSTOMER_SLUG,
+          BBM_CUSTOMER_NAME: envForBuild.BBM_CUSTOMER_NAME,
+        },
       });
     });
 
@@ -457,32 +645,88 @@ async function _runCustomerSetupBuild(payload = {}, options = {}) {
       } catch (_err) {
         // ignore
       }
+      const artifacts = _collectSetupArtifacts(outputDir);
+      _writeCustomerSetupBuildLog({
+        logPath,
+        nodeExecutable: nodeExe,
+        distScriptPath,
+        repoRoot,
+        cwd: repoRoot,
+        outputDir,
+        customerSlug: validated.customerSlug,
+        customerName: validated.customerName,
+        licenseFilePath: validated.licenseFilePath,
+        envSnapshot: envForBuild,
+        stdout,
+        stderr,
+        exitCode: null,
+        artifacts,
+      });
       finish({
         ok: false,
         error: "CUSTOMER_SETUP_BUILD_TIMEOUT",
         repoRoot,
         outputDir,
         customerSlug: validated.customerSlug,
+        customerName: validated.customerName,
         licenseFilePath: validated.licenseFilePath,
         exitCode: null,
         nodeExecutable: nodeExe,
+        nodeResolutionTrace: Array.isArray(resolvedNode?.trace) ? resolvedNode.trace : [],
+        distScriptPath,
+        cwd: repoRoot,
         stdout,
         stderr,
+        logPath,
+        env: {
+          BBM_CUSTOMER_LICENSE_FILE: envForBuild.BBM_CUSTOMER_LICENSE_FILE,
+          BBM_CUSTOMER_SLUG: envForBuild.BBM_CUSTOMER_SLUG,
+          BBM_CUSTOMER_NAME: envForBuild.BBM_CUSTOMER_NAME,
+        },
+        artifacts,
       });
     }, timeoutMs);
 
     child.on("close", (code) => {
       const artifactPath = _resolveCustomerSetupArtifactPath(outputDir, validated.customerSlug);
+      const artifacts = _collectSetupArtifacts(outputDir);
       const diagnostics = {
         repoRoot,
+        distScriptPath,
+        cwd: repoRoot,
         outputDir,
         customerSlug: validated.customerSlug,
+        customerName: validated.customerName,
         licenseFilePath: validated.licenseFilePath,
         exitCode: code,
         nodeExecutable: nodeExe,
+        nodeResolutionTrace: Array.isArray(resolvedNode?.trace) ? resolvedNode.trace : [],
         stdout,
         stderr,
+        logPath,
+        env: {
+          BBM_CUSTOMER_LICENSE_FILE: envForBuild.BBM_CUSTOMER_LICENSE_FILE,
+          BBM_CUSTOMER_SLUG: envForBuild.BBM_CUSTOMER_SLUG,
+          BBM_CUSTOMER_NAME: envForBuild.BBM_CUSTOMER_NAME,
+        },
+        artifacts,
       };
+      _writeCustomerSetupBuildLog({
+        logPath,
+        nodeExecutable: nodeExe,
+        distScriptPath,
+        repoRoot,
+        cwd: repoRoot,
+        outputDir,
+        customerSlug: validated.customerSlug,
+        customerName: validated.customerName,
+        licenseFilePath: validated.licenseFilePath,
+        envSnapshot: envForBuild,
+        stdout,
+        stderr,
+        exitCode: code,
+        artifacts,
+      });
       if (code !== 0) {
         const text = `${stdout}\n${stderr}`.toUpperCase();
         const mappedError = text.includes("ELECTRON_BUILDER_NOT_FOUND")

--- a/src/main/licensing/licenseAdminService.js
+++ b/src/main/licensing/licenseAdminService.js
@@ -94,6 +94,8 @@ function _normalizeLicenseRecord(license = {}) {
     license_edition: _optionalText(license_edition),
     license_binding: _optionalText(license_binding),
     machine_id: _optionalText(license.machine_id || license.machineId),
+    license_file_path: _optionalText(license.license_file_path || license.licenseFilePath),
+    license_file_created_at: _optionalText(license.license_file_created_at || license.licenseFileCreatedAt),
     notes: _optionalText(license.notes),
   };
 }
@@ -120,6 +122,8 @@ function _baseListLicensesQuery() {
       lr.*,
       lr.license_edition AS licenseEdition,
       lr.license_binding AS licenseBinding,
+      lr.license_file_path AS licenseFilePath,
+      lr.license_file_created_at AS licenseFileCreatedAt,
       lc.customer_number AS customer_number,
       lc.company_name AS company_name,
       lc.customer_number AS customerNumber,
@@ -247,6 +251,8 @@ function saveLicense(license = {}) {
           license_edition = ?,
           license_binding = ?,
           machine_id = ?,
+          license_file_path = ?,
+          license_file_created_at = ?,
           notes = ?,
           updated_at = ?
       WHERE id = ?
@@ -261,6 +267,8 @@ function saveLicense(license = {}) {
       record.license_edition,
       record.license_binding,
       record.machine_id,
+      record.license_file_path,
+      record.license_file_created_at,
       record.notes,
       now,
       record.id
@@ -279,8 +287,10 @@ function saveLicense(license = {}) {
         license_edition,
         license_binding,
         machine_id,
+        license_file_path,
+        license_file_created_at,
         notes
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `
     ).run(
       record.id,
@@ -293,6 +303,8 @@ function saveLicense(license = {}) {
       record.license_edition,
       record.license_binding,
       record.machine_id,
+      record.license_file_path,
+      record.license_file_created_at,
       record.notes
     );
   }

--- a/src/main/licensing/licenseStorage.js
+++ b/src/main/licensing/licenseStorage.js
@@ -10,16 +10,45 @@ function getLicenseFilePath() {
   return path.join(userData, "license.json");
 }
 
+function getBundledCustomerLicensePath() {
+  const packagedResources = process.resourcesPath || path.join(app.getAppPath(), "resources");
+  const resourcesPath = app?.isPackaged ? packagedResources : path.join(app.getAppPath(), "resources");
+  return path.join(resourcesPath, "license", "customer.bbmlic");
+}
+
+function _readJsonSafe(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    return JSON.parse(raw);
+  } catch (_err) {
+    return null;
+  }
+}
+
 function loadLicense() {
   try {
     const filePath = getLicenseFilePath();
 
-    if (!fs.existsSync(filePath)) {
+    if (fs.existsSync(filePath)) {
+      return _readJsonSafe(filePath);
+    }
+
+    const bundledPath = getBundledCustomerLicensePath();
+    if (!fs.existsSync(bundledPath)) {
       return null;
     }
 
-    const raw = fs.readFileSync(filePath, "utf8");
-    return JSON.parse(raw);
+    const bundledLicense = _readJsonSafe(bundledPath);
+    if (!bundledLicense) {
+      return null;
+    }
+
+    try {
+      saveLicense(bundledLicense);
+    } catch (_err) {
+      // fallback only: still return bundled content
+    }
+    return bundledLicense;
   } catch (err) {
     console.error("[licenseStorage] load failed:", err?.message || err);
     return null;
@@ -68,4 +97,5 @@ module.exports = {
   saveLicense,
   deleteLicense,
   getLicenseFilePath,
+  getBundledCustomerLicensePath,
 };

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -211,6 +211,7 @@ contextBridge.exposeInMainWorld("bbmDb", {
   licenseAdminSaveLicenseRecord: (license) => ipcRenderer.invoke("license-admin:save-record", license),
   licenseAdminListLicenseHistory: () => ipcRenderer.invoke("license-admin:list-history"),
   licenseAdminAddLicenseHistoryEntry: (entry) => ipcRenderer.invoke("license-admin:add-history-entry", entry),
+  licenseAdminCreateCustomerSetup: (payload) => ipcRenderer.invoke("license-admin:create-customer-setup", payload),
 
   // DEV: Audio Override Status
   devAudioUnlockStatus: () => ipcRenderer.invoke("dev:audioUnlockStatus"),

--- a/src/renderer/modules/lizenzverwaltung/licenseRecords.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseRecords.js
@@ -74,6 +74,10 @@ export function createDefaultLicenseRecord(overrides = {}) {
     license_binding: "none",
     machineId: "",
     machine_id: "",
+    licenseFilePath: "",
+    license_file_path: "",
+    licenseFileCreatedAt: "",
+    license_file_created_at: "",
     notes: "",
     ...overrides,
   };
@@ -163,6 +167,10 @@ export function normalizeLicenseRecord(input = {}) {
   const validFrom = String(input.validFrom ?? input.valid_from ?? base.validFrom).trim();
   const validUntil = String(input.validUntil ?? input.valid_until ?? base.validUntil).trim();
   const machineId = String(input.machineId ?? input.machine_id ?? base.machineId).trim();
+  const licenseFilePath = String(input.licenseFilePath ?? input.license_file_path ?? base.licenseFilePath).trim();
+  const licenseFileCreatedAt = String(
+    input.licenseFileCreatedAt ?? input.license_file_created_at ?? base.licenseFileCreatedAt
+  ).trim();
   const modeRaw = String(input.licenseMode ?? input.license_mode ?? base.licenseMode).trim().toLowerCase();
   const editionRaw = String(input.licenseEdition ?? input.license_edition ?? "").trim().toLowerCase();
   const bindingRaw = String(input.licenseBinding ?? input.license_binding ?? "").trim().toLowerCase();
@@ -196,6 +204,10 @@ export function normalizeLicenseRecord(input = {}) {
     license_binding: normalizedBinding,
     machineId,
     machine_id: machineId,
+    licenseFilePath,
+    license_file_path: licenseFilePath,
+    licenseFileCreatedAt,
+    license_file_created_at: licenseFileCreatedAt,
     notes: String(input.notes ?? base.notes).trim(),
   };
 }

--- a/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
@@ -60,3 +60,8 @@ export async function addHistoryEntry(entry) {
   const add = requireApiMethod("licenseAdminAddLicenseHistoryEntry");
   return add(record);
 }
+
+export async function createCustomerSetup(payload) {
+  const create = requireApiMethod("licenseAdminCreateCustomerSetup");
+  return create(payload || {});
+}

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -305,6 +305,13 @@ function valueOf(item, ...keys) {
   return "";
 }
 
+function truncateText(value, maxLen = 280) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+  if (raw.length <= maxLen) return raw;
+  return `${raw.slice(0, maxLen)} ...`;
+}
+
 export function buildCustomerSetupPayload({ customer = {}, license = {} } = {}) {
   const licenseFilePath = valueOf(license, "license_file_path", "licenseFilePath");
   return {
@@ -900,9 +907,18 @@ export default class LicenseAdminScreen {
       createCustomerSetupBtn.disabled = true;
       try {
         message.textContent = "Kunden-Setup wird erstellt ...";
+        setupOutput.textContent = "";
         const res = await createCustomerSetup(payload);
         if (!res?.ok) {
           message.textContent = `Fehler: ${res?.error || "Kunden-Setup konnte nicht erstellt werden."}`;
+          const diagnostics = [];
+          if (res?.outputDir) diagnostics.push(`outputDir: ${res.outputDir}`);
+          if (res?.setupPath || res?.artifactPath) diagnostics.push(`setupPath: ${res.setupPath || res?.artifactPath}`);
+          const stdout = truncateText(res?.stdout);
+          const stderr = truncateText(res?.stderr);
+          if (stdout) diagnostics.push(`stdout: ${stdout}`);
+          if (stderr) diagnostics.push(`stderr: ${stderr}`);
+          setupOutput.textContent = diagnostics.join("\n");
           return;
         }
         message.textContent = "Kunden-Setup wurde erstellt.";

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -919,7 +919,14 @@ export default class LicenseAdminScreen {
         setupOutput.textContent = "";
         const res = await createCustomerSetup(payload);
         if (!res?.ok) {
-          message.textContent = `Fehler: ${res?.error || "Kunden-Setup konnte nicht erstellt werden."}`;
+          const combinedErrorText = `${String(res?.stderr || "")}\n${String(res?.stdout || "")}`.toUpperCase();
+          const isFileLockError = combinedErrorText.includes("EBUSY") || combinedErrorText.includes("RESOURCE BUSY OR LOCKED");
+          if (isFileLockError) {
+            message.textContent =
+              "Kunden-Setup konnte nicht erstellt werden, weil eine Build-Datei gesperrt ist. Bitte App schließen und Kunden-Setup manuell über den Build-Befehl erstellen.";
+          } else {
+            message.textContent = `Fehler: ${res?.error || "Kunden-Setup konnte nicht erstellt werden."}`;
+          }
           const diagnostics = [];
           if (res?.outputDir) diagnostics.push(`outputDir: ${res.outputDir}`);
           if (res?.customerSlug) diagnostics.push(`customerSlug: ${res.customerSlug}`);

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -913,6 +913,8 @@ export default class LicenseAdminScreen {
           message.textContent = `Fehler: ${res?.error || "Kunden-Setup konnte nicht erstellt werden."}`;
           const diagnostics = [];
           if (res?.outputDir) diagnostics.push(`outputDir: ${res.outputDir}`);
+          if (res?.customerSlug) diagnostics.push(`customerSlug: ${res.customerSlug}`);
+          if (res?.exitCode !== undefined && res?.exitCode !== null) diagnostics.push(`exitCode: ${res.exitCode}`);
           if (res?.setupPath || res?.artifactPath) diagnostics.push(`setupPath: ${res.setupPath || res?.artifactPath}`);
           const stdout = truncateText(res?.stdout);
           const stderr = truncateText(res?.stderr);

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -1,4 +1,10 @@
-import { listCustomers, listLicensesByCustomer, saveCustomer, saveLicense } from "../licenseStorageService.js";
+import {
+  createCustomerSetup,
+  listCustomers,
+  listLicensesByCustomer,
+  saveCustomer,
+  saveLicense,
+} from "../licenseStorageService.js";
 
 const PRODUCT_KEY = "bbm-produktiv";
 const PRODUCT_LABEL = "BBM-Produktiv";
@@ -153,6 +159,8 @@ export function buildLicenseEditorPayload({ license = {}, inputs = {}, customer 
     valid_until: String(inputs.valid_until || "").trim(),
     license_mode: String(inputs.license_mode || "").trim(),
     machine_id: String(inputs.machine_id || "").trim(),
+    license_file_path: valueOf(license, "license_file_path", "licenseFilePath"),
+    license_file_created_at: valueOf(license, "license_file_created_at", "licenseFileCreatedAt"),
     notes: String(inputs.notes || "").trim(),
   };
 }
@@ -295,6 +303,15 @@ function valueOf(item, ...keys) {
     if (value !== null && value !== undefined && String(value).trim()) return String(value).trim();
   }
   return "";
+}
+
+export function buildCustomerSetupPayload({ customer = {}, license = {} } = {}) {
+  const licenseFilePath = valueOf(license, "license_file_path", "licenseFilePath");
+  return {
+    customer,
+    license,
+    licenseFilePath,
+  };
 }
 
 export function formatProductScopeForList(entry = {}) {
@@ -620,6 +637,9 @@ export default class LicenseAdminScreen {
     const generationOutput = document.createElement("div");
     generationOutput.style.fontSize = "12px";
     generationOutput.style.opacity = "0.9";
+    const setupOutput = document.createElement("div");
+    setupOutput.style.fontSize = "12px";
+    setupOutput.style.opacity = "0.9";
 
     const license = this.currentLicense || {};
     const parsedScope = parseProductScopeObject(valueOf(license, "product_scope_json", "productScope"));
@@ -861,6 +881,47 @@ export default class LicenseAdminScreen {
       }
     });
     openOutputDirBtn.style.display = "none";
+    const createCustomerSetupBtn = this._button("Kunden-Setup erstellen", async () => {
+      const activeLicense = this.currentLicense || license || {};
+      const payload = buildCustomerSetupPayload({
+        customer: this.currentCustomer || {},
+        license: activeLicense,
+      });
+      if (!String(payload.licenseFilePath || "").trim()) {
+        message.textContent = "Bitte zuerst die Lizenz erstellen.";
+        return;
+      }
+      const binding = String(activeLicense.license_binding || activeLicense.licenseBinding || "").trim().toLowerCase();
+      const machineId = String(activeLicense.machine_id || activeLicense.machineId || "").trim();
+      if (binding === "machine" && !machineId) {
+        message.textContent = "Machine-ID ist erforderlich, wenn die Lizenz an ein Gerät gebunden wird.";
+        return;
+      }
+      createCustomerSetupBtn.disabled = true;
+      try {
+        message.textContent = "Kunden-Setup wird erstellt ...";
+        const res = await createCustomerSetup(payload);
+        if (!res?.ok) {
+          message.textContent = `Fehler: ${res?.error || "Kunden-Setup konnte nicht erstellt werden."}`;
+          return;
+        }
+        message.textContent = "Kunden-Setup wurde erstellt.";
+        const outPath = String(res?.setupPath || res?.artifactPath || "").trim();
+        const outDir = String(res?.outputDir || "").trim();
+        setupOutput.textContent = outPath ? `Ausgabepfad: ${outPath}` : outDir ? `Ausgabepfad: ${outDir}` : "";
+        const dirToOpen = outPath || outDir;
+        if (dirToOpen) {
+          openOutputDirBtn.dataset.outputPath = dirToOpen;
+          openOutputDirBtn.style.display = "";
+          openOutputDirBtn.disabled = false;
+        }
+      } catch (err) {
+        message.textContent = `Fehler: ${err?.message || err}`;
+      } finally {
+        createCustomerSetupBtn.disabled = false;
+      }
+    });
+    createCustomerSetupBtn.disabled = !valueOf(license, "license_file_path", "licenseFilePath");
 
     const createBtn = this._button("Lizenz erstellen", async () => {
       const previousText = createBtn.textContent;
@@ -885,9 +946,11 @@ export default class LicenseAdminScreen {
         });
         const saved = await saveLicense(payload);
         this.currentLicense = saved;
+        createCustomerSetupBtn.disabled = true;
         openOutputDirBtn.style.display = "none";
         openOutputDirBtn.dataset.outputPath = "";
         generationOutput.textContent = "";
+        setupOutput.textContent = "";
 
         const api = window?.bbmDb || {};
         if (typeof api.licenseGenerate !== "function") {
@@ -922,6 +985,13 @@ export default class LicenseAdminScreen {
         const outputPath = String(res?.outputPath || "").trim();
         if (outputPath) {
           generationOutput.textContent = `Ausgabepfad: ${outputPath}`;
+          const updated = await saveLicense({
+            ...(saved || {}),
+            license_file_path: outputPath,
+            license_file_created_at: new Date().toISOString(),
+          });
+          this.currentLicense = updated;
+          createCustomerSetupBtn.disabled = false;
           openOutputDirBtn.dataset.outputPath = outputPath;
           openOutputDirBtn.style.display = "";
           openOutputDirBtn.disabled = false;
@@ -944,8 +1014,8 @@ export default class LicenseAdminScreen {
       this._render();
     });
 
-    actions.append(createBtn, backBtn, openOutputDirBtn);
-    container.append(header, context, form, licenseIdHint, actions, message, generationOutput);
+    actions.append(createBtn, createCustomerSetupBtn, backBtn, openOutputDirBtn);
+    container.append(header, context, form, licenseIdHint, actions, message, generationOutput, setupOutput);
   }
 
   async _render() {

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -312,6 +312,15 @@ function truncateText(value, maxLen = 280) {
   return `${raw.slice(0, maxLen)} ...`;
 }
 
+function tailLines(value, maxLines = 6) {
+  const lines = String(value || "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (!lines.length) return "";
+  return lines.slice(-Math.max(1, maxLines)).join(" | ");
+}
+
 export function buildCustomerSetupPayload({ customer = {}, license = {} } = {}) {
   const licenseFilePath = valueOf(license, "license_file_path", "licenseFilePath");
   return {
@@ -915,11 +924,12 @@ export default class LicenseAdminScreen {
           if (res?.outputDir) diagnostics.push(`outputDir: ${res.outputDir}`);
           if (res?.customerSlug) diagnostics.push(`customerSlug: ${res.customerSlug}`);
           if (res?.exitCode !== undefined && res?.exitCode !== null) diagnostics.push(`exitCode: ${res.exitCode}`);
+          if (res?.logPath) diagnostics.push(`logPath: ${res.logPath}`);
           if (res?.setupPath || res?.artifactPath) diagnostics.push(`setupPath: ${res.setupPath || res?.artifactPath}`);
-          const stdout = truncateText(res?.stdout);
-          const stderr = truncateText(res?.stderr);
-          if (stdout) diagnostics.push(`stdout: ${stdout}`);
-          if (stderr) diagnostics.push(`stderr: ${stderr}`);
+          const stdout = truncateText(tailLines(res?.stdout));
+          const stderr = truncateText(tailLines(res?.stderr));
+          if (stdout) diagnostics.push(`stdout(last): ${stdout}`);
+          if (stderr) diagnostics.push(`stderr(last): ${stderr}`);
           setupOutput.textContent = diagnostics.join("\n");
           return;
         }

--- a/src/renderer/modules/lizenzverwaltung/screens/index.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/index.js
@@ -1,3 +1,4 @@
 export { default as LicenseAdminScreen } from "./LicenseAdminScreen.js";
+export { buildCustomerSetupPayload } from "./LicenseAdminScreen.js";
 
 export const LIZENZVERWALTUNG_WORK_SCREEN_ID = "licenseAdmin";


### PR DESCRIPTION
### Motivation
- Nächster Meilenstein der Lizenzverwaltung: aus erzeugter/.gespeicherter `.bbmlic` ein kundenbezogenes Setup bauen, damit Admins nicht manuell mit Dateien und Ordnern hantieren müssen.  
- Bestehende Dist-/`electron-builder`-Infrastruktur weiterverwenden und nur einen optionalen Kundenmodus ergänzen, ohne permanente Repo-Änderungen an `package.json` oder neue Abhängigkeiten.  
- Stabilität wahren: keine Änderung an Lizenzprüfungslogik (`licenseVerifier.js` EXPECTED_PRODUCT), keine neue Persistenzarchitektur und keine App-Sperrlogik anpassen.  

### Description
- UI: Button `Kunden-Setup erstellen` im Lizenzformular ergänzt, mit Statusmeldungen (`Bitte zuerst die Lizenz erstellen.`, `Kunden-Setup wird erstellt ...`, `Kunden-Setup wurde erstellt.`) und nach Erfolg Anzeige/Aufruf des Ausgabeordners; Lizenzpfad wird nach erfolgreicher `.bbmlic`-Erzeugung im Lizenzdatensatz gespeichert (`license_file_path`, `license_file_created_at`).  
- Main/Preload/IPC: Neuer IPC-Handler `license-admin:create-customer-setup` und Preload-Brücke `window.bbmDb.licenseAdminCreateCustomerSetup(...)` implementiert; Main prüft Payload (inkl. Machine-ID-Regel), bildet sicheren Kunden-Slug und startet `scripts/dist.cjs` im Kundenmodus.  
- Dist/Builder: `scripts/dist.cjs` erweitert um optionalen Kundenmodus via Umgebungsvariablen `BBM_CUSTOMER_LICENSE_FILE`, `BBM_CUSTOMER_SLUG`, `BBM_CUSTOMER_NAME`, der die `.bbmlic` als `extraResource` nach `license/customer.bbmlic` einbettet und Ausgabe nach `dist/customers/<slug>/` sowie kundenbezogenen Artefaktnamen erzeugt.  
- Persistenz/DB: nicht-destruktive Schemaerweiterung für `license_records` um optionale Spalten `license_file_path` und `license_file_created_at`; Renderer/Main Normalisierung akzeptieren snake_case und camelCase für diese Felder; Bootstrap-Logik ergänzt, sodass bei fehlender `userData/license.json` eine gebündelte `resources/license/customer.bbmlic` als installierte Lizenz verwendet wird (userData hat Vorrang).  

### Testing
- Automatisierte Tests: `npm test` ausgeführt und komplett grün ("Alle Tests bestanden.").  
- Neue/erweiterte Tests: hinzugefügt/angepasst wurden `scripts/tests/distCustomerBuild.test.cjs`, `scripts/tests/licenseIpcCustomerSetup.test.cjs`, `scripts/tests/licenseStorageBootstrap.test.cjs`, sowie Anpassungen in `scripts/tests/licenseAdminDataflow.test.cjs` und `scripts/tests/lizenzverwaltungModule.test.cjs` zur Abdeckung von DB-Feldern, Payload-Mapping, Dist-Kundenmodus und Bootstrap-Verhalten.  
- Integration: Laufende Lizenz-Generierung bleibt unverändert und die erzeugten Output-Pfade werden im Lizenzdatensatz gespeichert und per UI sichtbar gemacht.  
- Ergebnis: Alle Tests (bestehende + neue) erfolgreich durchgelaufen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef89c4cdac83228afd4d1986d98d77)