### PR TITLE
Testzeitraum in Lizenzverwaltung integrieren und alte Trial-UI entfernen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -16,6 +16,16 @@ Sie ergänzt:
 ---
 
 ## Aktueller Gesamtstand
+- Lizenzverwaltung Testzeitraum ist integriert:
+  - Im Admin-Lizenzformular (`Neue Lizenz`) zeigt `Lizenzart = Testlizenz` jetzt den Bereich `Testzeitraum` mit `gueltig von`, `Testdauer` (14/30/60/90/Individuell) und automatischer Berechnung von `gueltig bis`.
+  - Neue Testlizenzen starten mit `Testlizenz`, `Ohne Gerätebindung`, `gueltig von = heute`, `Testdauer = 30 Tage`, `gueltig bis = gueltig von + 30`.
+  - Bei bestehenden Testlizenzen wird die Dauer aus `valid_from`/`valid_until` abgeleitet (14/30/60/90 oder `Individuell`).
+  - Generator-Payload bleibt unverändert maßgeblich über `validFrom`/`validUntil`, `edition=test`, `binding=none`, ohne `machineId` bei `none`.
+- Alte Entwicklungs-Testversionseinstellung ist aus der UI entfernt:
+  - sichtbare Entwicklungstexte `Nutzungstage-Limit aktiv` und `Nutzungstage (0 = aus)` werden nicht mehr angezeigt.
+  - parallele Renderer-Startprüfung über `trial.daysLimit` wurde entfernt; maßgeblich bleibt die signierte Lizenzprüfung.
+- Nächster offener Schritt:
+  - fachliche Sichtprüfung im Adminbereich (Testlizenz 30 Tage, Individuell, Vollversion) und PR-Review gegen `main`.
 - Die Projektverwaltung ist als Renderer-Modul abgeschlossen.
 - Ausgabe / Drucken / E-Mail ist als Renderer-Modul aufgestellt.
   - Keine Sidebar-Anbindung.

--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -635,6 +635,18 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(normalizeDateForGenerator("31.13.2026"), "");
   });
 
+  await run("Lizenzverwaltung Testzeitraum: addDaysToIsoDate und getTestDurationDays arbeiten konsistent", async () => {
+    const { addDaysToIsoDate, getTestDurationDays } = await importEsmFromFile(
+      path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js")
+    );
+
+    assert.equal(addDaysToIsoDate("2026-01-10", 30), "2026-02-09");
+    assert.equal(addDaysToIsoDate("2026-01-10", 14), "2026-01-24");
+    assert.equal(getTestDurationDays("2026-01-10", "2026-01-24"), 14);
+    assert.equal(getTestDurationDays("2026-01-10", "2026-02-09"), 30);
+    assert.equal(getTestDurationDays("2026-01-10", "2025-12-31"), null);
+  });
+
   await run("Lizenzverwaltung Kompatibilitaet license_mode: soft/full/none/machine", async () => {
     const { getLicenseEditionAndBinding } = await importEsmFromFile(
       path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js")

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -67,6 +67,7 @@ async function runLizenzverwaltungModuleTests(run) {
   const moduleCatalogSource = read("src/renderer/app/modules/moduleCatalog.js");
   const projectWorkspaceSource = read("src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js");
   const settingsViewSource = read("src/renderer/views/SettingsView.js");
+  const rendererMainSource = read("src/renderer/main.js");
   const databaseSource = read("src/main/db/database.js");
   const licenseAdminServiceSource = read("src/main/licensing/licenseAdminService.js");
   const preloadSource = read("src/main/preload.js");
@@ -89,6 +90,29 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal("createLicenseEditorSection" in { getLizenzverwaltungModuleEntry }, false);
     assert.equal(read("src/renderer/modules/lizenzverwaltung/index.js").includes("createLicenseEditorSection"), false);
     assert.equal(read("src/renderer/modules/lizenzverwaltung/screens/index.js").includes("createLicenseEditorSection"), false);
+  });
+
+  await run("Lizenzverwaltung: Testzeitraum-Texte sind im Lizenzeditor vorhanden", () => {
+    assert.equal(screenSource.includes("Testzeitraum"), true);
+    assert.equal(screenSource.includes("Testdauer"), true);
+    assert.equal(screenSource.includes("14 Tage"), true);
+    assert.equal(screenSource.includes("30 Tage"), true);
+    assert.equal(screenSource.includes("60 Tage"), true);
+    assert.equal(screenSource.includes("90 Tage"), true);
+    assert.equal(screenSource.includes("Individuell"), true);
+    assert.equal(screenSource.includes("Tage"), true);
+  });
+
+  await run("Entwicklungseinstellungen: alte Nutzungstage-Texte werden nicht mehr angezeigt", () => {
+    assert.equal(settingsViewSource.includes("Nutzungstage-Limit aktiv"), false);
+    assert.equal(settingsViewSource.includes("Nutzungstage (0 = aus)"), false);
+  });
+
+  await run("Renderer-Start: keine parallele trial.daysLimit-Laufzeitpruefung mehr", () => {
+    assert.equal(rendererMainSource.includes("trial.daysLimit"), false);
+    assert.equal(rendererMainSource.includes("trial.enabled"), false);
+    assert.equal(rendererMainSource.includes("trial.firstStartAt"), false);
+    assert.equal(rendererMainSource.includes("enforceTrialLimit"), false);
   });
 
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -15,9 +15,6 @@ import { applyPopupButtonStyle, applyPopupCardStyle } from "./ui/popupButtonStyl
 const APP_VERSION = "1.0";
 const FEATURE_FLAG_KEY = "bbm.useNewCompanyWorkflow";
 const UI_MODE_KEY = "bbm.uiMode";
-const TRIAL_DAYS_KEY = "trial.daysLimit";
-const TRIAL_ENABLED_KEY = "trial.enabled";
-const TRIAL_FIRST_START_KEY = "trial.firstStartAt";
 const PRINT_V2_PAD_LEFT_KEY = "print.v2.pagePadLeftMm";
 const PRINT_V2_PAD_RIGHT_KEY = "print.v2.pagePadRightMm";
 const PRINT_V2_PAD_TOP_KEY = "print.v2.pagePadTopMm";
@@ -157,68 +154,6 @@ const showStartupOverlay = ({ durationMs = 3000 } = {}) => {
       if (overlay.parentElement) overlay.parentElement.removeChild(overlay);
     }, 280);
   }, Math.max(500, Number(durationMs) || 3000));
-};
-
-const enforceTrialLimit = async () => {
-  const api = window.bbmDb || {};
-  if (typeof api.appSettingsGetMany !== "function") return true;
-
-  let data = {};
-  try {
-    const res = await api.appSettingsGetMany([TRIAL_ENABLED_KEY, TRIAL_DAYS_KEY, TRIAL_FIRST_START_KEY]);
-    if (!res?.ok) return true;
-    data = res.data || {};
-  } catch (_e) {
-    return true;
-  }
-
-  const enabledRaw = String(data[TRIAL_ENABLED_KEY] || "").trim().toLowerCase();
-  const enabled = enabledRaw === "1" || enabledRaw === "true" || enabledRaw === "yes" || enabledRaw === "on";
-  const limit = Math.max(0, Math.floor(Number(data[TRIAL_DAYS_KEY] || 0) || 0));
-  if (!enabled || limit <= 0) return true;
-
-  let firstStart = Math.floor(Number(data[TRIAL_FIRST_START_KEY] || 0) || 0);
-  if (!Number.isFinite(firstStart) || firstStart <= 0) {
-    firstStart = Date.now();
-    if (typeof api.appSettingsSetMany === "function") {
-      try {
-        await api.appSettingsSetMany({ [TRIAL_FIRST_START_KEY]: String(firstStart) });
-      } catch (_e) {
-        // ignore
-      }
-    }
-  }
-
-  const dayMs = 24 * 60 * 60 * 1000;
-  const usedDays = Math.floor((Date.now() - firstStart) / dayMs) + 1;
-  const remainingDays = limit - usedDays;
-
-  // Hinweis in den letzten 5 Tagen vor Ablauf
-  if (remainingDays >= 0 && remainingDays <= 4) {
-    const msg =
-      remainingDays === 0
-        ? "Hinweis: Die Testversion läuft heute ab."
-        : `Hinweis: Die Testversion läuft in ${remainingDays + 1} Tagen ab.`;
-    alert(msg);
-  }
-
-  if (usedDays <= limit) return true;
-
-  alert(`Testversion abgelaufen (${limit} Nutzungstage).`);
-  if (typeof api.appQuit === "function") {
-    try {
-      await api.appQuit();
-      return false;
-    } catch (_e) {
-      // ignore
-    }
-  }
-  try {
-    window.close();
-  } catch (_e) {
-    // ignore
-  }
-  return false;
 };
 
 const ensureInitialPrintLayoutDefaults = async () => {
@@ -1018,8 +953,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     bottomSection.replaceChildren(btnQuit);
   };
 
-  const canContinue = await enforceTrialLimit();
-  if (!canContinue) return;
   await ensureInitialPrintLayoutDefaults();
 
   const uiMode = readUiMode();

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -223,6 +223,30 @@ export function normalizeDateForGenerator(value) {
   return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 }
 
+export function addDaysToIsoDate(isoDate, daysToAdd = 0) {
+  const normalized = normalizeDateForGenerator(isoDate);
+  if (!normalized) return "";
+  const base = new Date(`${normalized}T00:00:00Z`);
+  if (Number.isNaN(base.getTime())) return "";
+  const normalizedDays = Math.max(0, Math.floor(Number(daysToAdd) || 0));
+  base.setUTCDate(base.getUTCDate() + normalizedDays);
+  return `${String(base.getUTCFullYear()).padStart(4, "0")}-${String(base.getUTCMonth() + 1).padStart(2, "0")}-${String(
+    base.getUTCDate()
+  ).padStart(2, "0")}`;
+}
+
+export function getTestDurationDays(validFrom, validUntil) {
+  const fromIso = normalizeDateForGenerator(validFrom);
+  const untilIso = normalizeDateForGenerator(validUntil);
+  if (!fromIso || !untilIso) return null;
+  const fromDate = new Date(`${fromIso}T00:00:00Z`);
+  const untilDate = new Date(`${untilIso}T00:00:00Z`);
+  if (Number.isNaN(fromDate.getTime()) || Number.isNaN(untilDate.getTime())) return null;
+  const diffMs = untilDate.getTime() - fromDate.getTime();
+  if (diffMs < 0) return null;
+  return Math.floor(diffMs / (24 * 60 * 60 * 1000));
+}
+
 export function getLicenseEditionAndBinding(license = {}) {
   const editionRaw = String(valueOf(license, "license_edition", "licenseEdition")).trim().toLowerCase();
   const bindingRaw = String(valueOf(license, "license_binding", "licenseBinding")).trim().toLowerCase();
@@ -726,6 +750,15 @@ export default class LicenseAdminScreen {
       appendFieldRow(label, input);
     }
 
+    const todayIso = new Date().toISOString().slice(0, 10);
+    const isExistingLicense = !!String(valueOf(license, "id")).trim();
+    if (!isExistingLicense) {
+      inputs.license_edition.value = "test";
+      inputs.license_binding.value = "none";
+      inputs.valid_from.value = todayIso;
+      inputs.valid_until.value = addDaysToIsoDate(todayIso, 30);
+    }
+
     const scopeModel = createDefaultScopeSelection();
     scopeModel.raw = parsedScope.raw;
     scopeModel.zusatzfunktionen = [...parsedScope.zusatzfunktionen];
@@ -873,6 +906,98 @@ export default class LicenseAdminScreen {
     };
     inputs.license_binding?.addEventListener("change", syncMachineIdState);
     syncMachineIdState();
+
+    const testDurationWrap = document.createElement("div");
+    testDurationWrap.style.display = "grid";
+    testDurationWrap.style.gap = "8px";
+    const testDurationSelect = document.createElement("select");
+    [
+      { value: "14", label: "14 Tage" },
+      { value: "30", label: "30 Tage" },
+      { value: "60", label: "60 Tage" },
+      { value: "90", label: "90 Tage" },
+      { value: "custom", label: "Individuell" },
+    ].forEach((entry) => {
+      const option = document.createElement("option");
+      option.value = entry.value;
+      option.textContent = entry.label;
+      testDurationSelect.appendChild(option);
+    });
+    testDurationSelect.id = "license-test-duration";
+    testDurationSelect.style.width = "100%";
+
+    const customDaysInput = document.createElement("input");
+    customDaysInput.type = "number";
+    customDaysInput.min = "1";
+    customDaysInput.max = "365";
+    customDaysInput.step = "1";
+    customDaysInput.id = "license-test-days";
+    customDaysInput.value = "30";
+    customDaysInput.style.width = "100%";
+
+    const customDaysWrap = document.createElement("div");
+    customDaysWrap.style.display = "grid";
+    customDaysWrap.style.gap = "6px";
+    const customDaysLabel = document.createElement("label");
+    customDaysLabel.textContent = "Tage";
+    customDaysWrap.append(customDaysLabel, customDaysInput);
+    testDurationWrap.append(mkSingleFieldWrap("Testdauer", testDurationSelect), customDaysWrap);
+    appendFieldRow("Testzeitraum", testDurationWrap);
+
+    const normalizeCustomDays = () => {
+      const raw = Math.floor(Number(customDaysInput.value) || 30);
+      const normalized = Math.max(1, Math.min(365, raw));
+      customDaysInput.value = String(normalized);
+      return normalized;
+    };
+
+    const resolveDurationForSelection = () => {
+      const selected = String(testDurationSelect.value || "30").trim();
+      if (selected === "custom") return normalizeCustomDays();
+      const numeric = Math.max(1, Math.floor(Number(selected) || 30));
+      return numeric;
+    };
+
+    const applyComputedValidUntil = () => {
+      const validFrom = normalizeDateForGenerator(inputs.valid_from.value);
+      if (!validFrom) return;
+      const durationDays = resolveDurationForSelection();
+      inputs.valid_from.value = validFrom;
+      inputs.valid_until.value = addDaysToIsoDate(validFrom, durationDays);
+    };
+
+    const syncTestPeriodState = () => {
+      const isTest = String(inputs.license_edition?.value || "test").trim().toLowerCase() === "test";
+      const useCustom = String(testDurationSelect.value || "") === "custom";
+      testDurationWrap.style.display = isTest ? "grid" : "none";
+      customDaysWrap.style.display = isTest && useCustom ? "grid" : "none";
+      inputs.valid_until.disabled = isTest;
+      if (isTest) {
+        inputs.license_binding.value = "none";
+        applyComputedValidUntil();
+      }
+      syncMachineIdState();
+    };
+
+    const initialDuration = getTestDurationDays(inputs.valid_from.value, inputs.valid_until.value);
+    if (initialDuration !== null && ["14", "30", "60", "90"].includes(String(initialDuration))) {
+      testDurationSelect.value = String(initialDuration);
+    } else if (initialDuration !== null && initialDuration > 0) {
+      testDurationSelect.value = "custom";
+      customDaysInput.value = String(Math.max(1, Math.min(365, initialDuration)));
+    } else {
+      testDurationSelect.value = "30";
+      customDaysInput.value = "30";
+    }
+
+    testDurationSelect.addEventListener("change", syncTestPeriodState);
+    customDaysInput.addEventListener("change", () => {
+      normalizeCustomDays();
+      syncTestPeriodState();
+    });
+    inputs.valid_from.addEventListener("change", syncTestPeriodState);
+    inputs.license_edition.addEventListener("change", syncTestPeriodState);
+    syncTestPeriodState();
 
     const licenseIdHint = document.createElement("div");
     licenseIdHint.textContent =
@@ -1074,4 +1199,14 @@ export default class LicenseAdminScreen {
     this._render();
     return this.root;
   }
+}
+
+function mkSingleFieldWrap(labelText, fieldNode) {
+  const wrap = document.createElement("div");
+  wrap.style.display = "grid";
+  wrap.style.gap = "6px";
+  const label = document.createElement("label");
+  label.textContent = labelText;
+  wrap.append(label, fieldNode);
+  return wrap;
 }

--- a/src/renderer/ui/MainHeader.js
+++ b/src/renderer/ui/MainHeader.js
@@ -95,8 +95,6 @@ export default class MainHeader {
     this._setupStatusRefreshPending = false;
 
     // Trial / Build channel
-    this._trialInfoLoading = null;
-    this._trialInfoText = "";
     this._buildChannelLoading = null;
     this._buildChannel = "";
     this._baseWindowTitle = String(document?.title || "BBM").trim() || "BBM";
@@ -1585,64 +1583,6 @@ export default class MainHeader {
     this._applyPrintMenuState(fallbackState);
   }
 
-  // ============================================================
-  // Trial: Fenster-Titel AN, Header-Anzeige AUS
-  // ============================================================
-  async _refreshTrialInfo() {
-    const api = window.bbmDb || {};
-
-    // Header-Anzeige immer aus
-    if (this.elTrialInfo) {
-      this.elTrialInfo.textContent = "";
-      this.elTrialInfo.style.display = "none";
-    }
-
-    if (typeof api.appSettingsGetMany !== "function") {
-      this._trialInfoText = "";
-      document.title = this._baseWindowTitle;
-      return;
-    }
-    if (this._trialInfoLoading) return;
-
-    this._trialInfoLoading = (async () => {
-      try {
-        const res = await api.appSettingsGetMany(["trial.enabled", "trial.daysLimit", "trial.firstStartAt"]);
-        if (!res?.ok) {
-          this._trialInfoText = "";
-          return;
-        }
-        const data = res.data || {};
-        const enabledRaw = String(data["trial.enabled"] || "").trim().toLowerCase();
-        const enabled = enabledRaw === "1" || enabledRaw === "true" || enabledRaw === "yes" || enabledRaw === "on";
-        const limit = Math.max(0, Math.floor(Number(data["trial.daysLimit"] || 0) || 0));
-        const firstStart = Math.floor(Number(data["trial.firstStartAt"] || 0) || 0);
-
-        if (!enabled || limit <= 0 || firstStart <= 0) {
-          this._trialInfoText = "";
-          return;
-        }
-
-        const dayMs = 24 * 60 * 60 * 1000;
-        const usedDays = Math.floor((Date.now() - firstStart) / dayMs) + 1;
-        const remaining = Math.max(0, limit - usedDays + 1);
-        this._trialInfoText = `Testversion: noch ${remaining} Tage`;
-      } catch (_e) {
-        this._trialInfoText = "";
-      } finally {
-        // ✅ nur Fenster-Titel setzen (Electron/Windows-Zeile)
-        document.title = this._trialInfoText ? `${this._baseWindowTitle} - ${this._trialInfoText}` : this._baseWindowTitle;
-
-        // ✅ Header bleibt aus
-        if (this.elTrialInfo) {
-          this.elTrialInfo.textContent = "";
-          this.elTrialInfo.style.display = "none";
-        }
-
-        this._trialInfoLoading = null;
-      }
-    })();
-  }
-
   async _refreshBuildChannelBadge() {
     if (!this.elDevBadge) return;
     this.elDevBadge.style.display = "none";
@@ -1692,7 +1632,6 @@ export default class MainHeader {
     }
 
     // ✅ Fenster-Titel Trial AN (Header AUS)
-    this._refreshTrialInfo();
 
     // ✅ DEV Badge
     this._refreshBuildChannelBadge();

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -1039,8 +1039,6 @@ export default class SettingsView {
 
     const TOPS_TITLE_KEY = "tops.titleMax";
     const TOPS_LONG_KEY = "tops.longMax";
-    const TRIAL_DAYS_KEY = "trial.daysLimit";
-    const TRIAL_ENABLED_KEY = "trial.enabled";
     const TOPS_FONT_LIST_KEY = "tops.fontscale.list";
     const TOPS_FONT_EDIT_KEY = "tops.fontscale.editbox";
     const PRINT_V2_PAD_LEFT_KEY = "print.v2.pagePadLeftMm";
@@ -1097,17 +1095,6 @@ export default class SettingsView {
     const isValidInt = (val) => {
       const n = Math.floor(Number(val));
       return Number.isFinite(n) && n > 0;
-    };
-
-    const clampNonNegativeInt = (val, min, max, fallback) => {
-      const n = Math.floor(Number(val));
-      if (!Number.isFinite(n) || n < 0) return fallback;
-      return Math.max(min, Math.min(max, n));
-    };
-
-    const isValidNonNegativeInt = (val) => {
-      const n = Math.floor(Number(val));
-      return Number.isFinite(n) && n >= 0;
     };
 
     const loadTopLimitSettings = async () => {
@@ -1171,107 +1158,6 @@ export default class SettingsView {
     const topsRowLong = mkRow("Langtext max", inpTopsLongMax);
     topsRowLong.style.marginBottom = "4px";
     topsLimitBox.append(topsLimitTitle, topsRowShort, topsRowLong, topsLimitMsg);
-
-    const trialBox = document.createElement("div");
-    applyPopupCardStyle(trialBox);
-    trialBox.style.padding = "8px 10px";
-    trialBox.style.maxWidth = "720px";
-    trialBox.style.marginTop = "0";
-    trialBox.style.boxSizing = "border-box";
-
-    const trialTitle = document.createElement("div");
-    trialTitle.textContent = "Testversion";
-    trialTitle.style.fontWeight = "bold";
-    trialTitle.style.marginBottom = "6px";
-
-    const trialEnabled = document.createElement("input");
-    trialEnabled.type = "checkbox";
-    trialEnabled.checked = false;
-
-    const trialEnabledWrap = document.createElement("div");
-    trialEnabledWrap.style.display = "flex";
-    trialEnabledWrap.style.alignItems = "center";
-    trialEnabledWrap.style.gap = "8px";
-
-    const trialEnabledLabel = document.createElement("div");
-    trialEnabledLabel.textContent = "Nutzungstage-Limit aktiv";
-    trialEnabledWrap.append(trialEnabled, trialEnabledLabel);
-
-    const inpTrialDays = document.createElement("input");
-    inpTrialDays.type = "number";
-    inpTrialDays.min = "0";
-    inpTrialDays.step = "1";
-    inpTrialDays.style.width = "100%";
-
-    const trialStatus = document.createElement("div");
-    trialStatus.style.fontSize = "12px";
-    trialStatus.style.opacity = "0.75";
-    trialStatus.style.marginTop = "4px";
-
-    const loadTrialSettings = async () => {
-      const api = window.bbmDb || {};
-      if (typeof api.appSettingsGetMany !== "function") {
-        trialEnabled.checked = false;
-        inpTrialDays.value = "0";
-        inpTrialDays.disabled = true;
-        inpTrialDays.style.opacity = "0.55";
-        return;
-      }
-      const res = await api.appSettingsGetMany([TRIAL_ENABLED_KEY, TRIAL_DAYS_KEY]);
-      if (!res?.ok) {
-        trialEnabled.checked = false;
-        inpTrialDays.value = "0";
-        inpTrialDays.disabled = true;
-        inpTrialDays.style.opacity = "0.55";
-        return;
-      }
-      const data = res.data || {};
-      const enabledRaw = String(data[TRIAL_ENABLED_KEY] || "").trim().toLowerCase();
-      const enabled = enabledRaw === "1" || enabledRaw === "true" || enabledRaw === "yes" || enabledRaw === "on";
-      const trialDays = clampNonNegativeInt(data[TRIAL_DAYS_KEY], 0, 3650, 0);
-      trialEnabled.checked = enabled;
-      inpTrialDays.value = String(trialDays);
-      inpTrialDays.disabled = !enabled;
-      inpTrialDays.style.opacity = enabled ? "1" : "0.55";
-      trialStatus.textContent = "";
-    };
-
-    const saveTrialSettings = async () => {
-      const api = window.bbmDb || {};
-      if (typeof api.appSettingsSetMany !== "function") {
-        trialStatus.textContent = "Settings-API fehlt (IPC noch nicht aktiv).";
-        return false;
-      }
-      const valid = isValidNonNegativeInt(inpTrialDays.value);
-      const trialDays = clampNonNegativeInt(inpTrialDays.value, 0, 3650, 0);
-      inpTrialDays.value = String(trialDays);
-      const res = await api.appSettingsSetMany({
-        [TRIAL_ENABLED_KEY]: trialEnabled.checked ? "1" : "0",
-        [TRIAL_DAYS_KEY]: String(trialDays),
-      });
-      if (!res?.ok) {
-        trialStatus.textContent = res?.error || "Speichern fehlgeschlagen";
-        return false;
-      }
-      trialStatus.textContent = valid ? "Gespeichert" : "Ung?ltiger Wert ? Standard wurde verwendet.";
-      return true;
-    };
-
-    trialEnabled.addEventListener("change", async () => {
-      inpTrialDays.disabled = !trialEnabled.checked;
-      inpTrialDays.style.opacity = trialEnabled.checked ? "1" : "0.55";
-      await saveTrialSettings();
-    });
-    inpTrialDays.addEventListener("change", async () => {
-      if (!trialEnabled.checked) return;
-      await saveTrialSettings();
-    });
-
-    const trialRowDays = mkRow("Nutzungstage (0 = aus)", inpTrialDays);
-    trialRowDays.style.marginBottom = "4px";
-
-    trialBox.append(trialTitle, trialEnabledWrap, trialRowDays, trialStatus);
-
 
     const printV2LayoutBox = document.createElement("div");
     applyPopupCardStyle(printV2LayoutBox);
@@ -2438,7 +2324,7 @@ export default class SettingsView {
 
     licenseBox.append(licenseTitle, licenseHint, btnLicenseOpen);
 
-    devRightCol.append(devDefaultsBox, licenseBox, topsLimitBox, trialBox);
+    devRightCol.append(devDefaultsBox, licenseBox, topsLimitBox);
     devTopCardsRow.append(versionBox, devRightCol);
 
     const themeBox = document.createElement("div");
@@ -4070,7 +3956,6 @@ export default class SettingsView {
         this._devPopupOpen = true;
         await loadDbDiagnostics();
         await loadTopLimitSettings();
-        await loadTrialSettings();
         await loadVersioningData();
 
         if (versionBox) {
@@ -4097,7 +3982,7 @@ export default class SettingsView {
         const tabVersion = document.createElement("div");
         tabVersion.style.display = "grid";
         tabVersion.style.gap = "10px";
-        tabVersion.append(versionBox, buildChannelBox, devDefaultsBox, trialBox);
+        tabVersion.append(versionBox, buildChannelBox, devDefaultsBox);
 
         const tabDb = document.createElement("div");
         tabDb.style.display = "grid";
@@ -4173,8 +4058,7 @@ export default class SettingsView {
           closeOnly: false,
           saveFn: async () => {
             const okTops = (await saveTopLimitSettings()) !== false;
-            const okTrial = (await saveTrialSettings()) !== false;
-            return okTops && okTrial;
+            return okTops;
           },
         });
       },


### PR DESCRIPTION
### Motivation
- Testzeiträume sollen fachlich in der Admin-Lizenzverwaltung gepflegt werden und nicht mehr als separate Laufzeitlogik in den Entwicklungseinstellungen geführt werden.
- Die Änderung vermeidet parallele Laufzeitprüfungen und macht `valid_from`/`valid_until` zur einzigen Laufzeit-Wahrheit für Testlizenzen.

### Description
- Lizenz-Editor (`src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`) erhält Hilfsfunktionen `addDaysToIsoDate` und `getTestDurationDays` sowie einen sichtbaren Bereich „Testzeitraum“ mit Auswahl `14/30/60/90/Individuell`, Tage-Feld (1–365), automatischer Berechnung von `gültig bis` und Default-Verhalten für neue Testlizenzen (edition=test, binding=none, gültig von = heute, Dauer = 30 Tage).
- Lizenz-Editor initialisiert bei neuen Lizenzen Default-Werte und leitet bei bestehenden Testlizenzen die Testdauer aus `valid_from`/`valid_until` ab; bei Testlizenz ist `valid_until` nicht frei editierbar und Machine-ID wird bei `binding=none` nicht benötigt.
- Alte Entwicklungseinstellungen und UI-Elemente für Trial (`Nutzungstage-Limit aktiv`, `Nutzungstage (0 = aus)`) wurden aus `SettingsView` entfernt und der Dev-Save-Flow entsprechend bereinigt.
- Parallele Renderer-Startprüfung/Anzeige (`enforceTrialLimit`, Trial-Header-Refresh und `trial.*` keys) wurde aus `src/renderer/main.js` und `src/renderer/ui/MainHeader.js` entfernt; Tests und `STATUS.md` wurden angepasst/ergänzt.

### Testing
- Alle automatisierten Tests wurden lokal ausgeführt mit `npm test` und sind grün ("Alle Tests bestanden.").
- Tests ergänzt/angepasst: `scripts/tests/lizenzverwaltungModule.test.cjs` (UI-Texte / alte Entwicklungstexte / Renderer-Start-Prüfung) und `scripts/tests/licenseAdminDataflow.test.cjs` (Datums-/Dauer-Funktionen `addDaysToIsoDate` / `getTestDurationDays`).
- Vorhandene Lizenz- und Generator-Tests bleiben intakt und bestätigen, dass Generator-Payload (`edition`, `binding`, `validFrom`, `validUntil`, `machineId` nur bei `machine`) unverändert korrekt produziert wird.
- Es wurden keine Schema-, Verifier- oder Machine-ID-Logikänderungen vorgenommen, und es wurden keine neuen Abhängigkeiten hinzugefügt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efaf57276c8322bd51749d54452886)