### PR TITLE
Update PR #41: Testlizenz startet erst bei erster Installation

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -20,6 +20,7 @@ Sie ergänzt:
   - Testlizenzen tragen jetzt `trialDurationDays` signiert im Generator-Payload; der Testzeitraum startet erst bei erster erfolgreicher Lizenzinstallation/-nutzung.
   - Laufzeitpruefung fuer Testlizenzen nutzt `trialStartedAt + trialDurationDays` statt `valid_from + Dauer`; Vollversion bleibt bei `validUntil`.
   - Admin-UI zeigt fuer Testlizenz den Bereich `Testzeitraum` (14/30/60/90/Individuell, 1..365) inkl. Hinweis auf Start bei erster Installation/erstem Start; `gueltig von/bis` wird fuer Test nicht mehr als fachlicher Start/Ende dargestellt.
+  - Formularlayout im Lizenzeditor wurde auf klare Feld-zu-Beschriftung-Blocks umgebaut; bei Testlizenz ist `Machine-ID` ausgeblendet.
   - Alte Entwicklungs-Parallel-Logik fuer Nutzungstage (`trial.enabled`, `trial.daysLimit`, `trial.firstStartAt`, `enforceTrialLimit`) ist aus UI/Runtime entfernt.
   - Lizenz-Admin-Datenmodell wurde minimal um `trial_duration_days` erweitert; Kunden-Setup-Fluss blieb unveraendert.
   - Testabdeckung erweitert (Generator-/Verifier-/Storage-/UI/IPC-Faelle); `npm test` ist gruen.

--- a/STATUS.md
+++ b/STATUS.md
@@ -16,6 +16,13 @@ Sie ergänzt:
 ---
 
 ## Aktueller Gesamtstand
+- Lizenzverwaltung PR #41 Nachbesserung (Testlizenz-Startzeitpunkt) ist umgesetzt:
+  - Testlizenzen tragen jetzt `trialDurationDays` signiert im Generator-Payload; der Testzeitraum startet erst bei erster erfolgreicher Lizenzinstallation/-nutzung.
+  - Laufzeitpruefung fuer Testlizenzen nutzt `trialStartedAt + trialDurationDays` statt `valid_from + Dauer`; Vollversion bleibt bei `validUntil`.
+  - Admin-UI zeigt fuer Testlizenz den Bereich `Testzeitraum` (14/30/60/90/Individuell, 1..365) inkl. Hinweis auf Start bei erster Installation/erstem Start; `gueltig von/bis` wird fuer Test nicht mehr als fachlicher Start/Ende dargestellt.
+  - Alte Entwicklungs-Parallel-Logik fuer Nutzungstage (`trial.enabled`, `trial.daysLimit`, `trial.firstStartAt`, `enforceTrialLimit`) ist aus UI/Runtime entfernt.
+  - Lizenz-Admin-Datenmodell wurde minimal um `trial_duration_days` erweitert; Kunden-Setup-Fluss blieb unveraendert.
+  - Testabdeckung erweitert (Generator-/Verifier-/Storage-/UI/IPC-Faelle); `npm test` ist gruen.
 - Die Projektverwaltung ist als Renderer-Modul abgeschlossen.
 - Ausgabe / Drucken / E-Mail ist als Renderer-Modul aufgestellt.
   - Keine Sidebar-Anbindung.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -21,6 +21,7 @@ const { runLicenseAdminDataflowTests } = require("./tests/licenseAdminDataflow.t
 const { runDistCustomerBuildTests } = require("./tests/distCustomerBuild.test.cjs");
 const { runLicenseStorageBootstrapTests } = require("./tests/licenseStorageBootstrap.test.cjs");
 const { runLicenseIpcCustomerSetupTests } = require("./tests/licenseIpcCustomerSetup.test.cjs");
+const { runLicenseTrialRuntimeTests } = require("./tests/licenseTrialRuntime.test.cjs");
 
 let failed = false;
 
@@ -87,6 +88,7 @@ async function main() {
   await runLicenseAdminDataflowTests(run);
   await runDistCustomerBuildTests(run);
   await runLicenseIpcCustomerSetupTests(run);
+  await runLicenseTrialRuntimeTests(run);
   await runLicenseStorageBootstrapTests(run);
 
   if (failed) {

--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -80,6 +80,7 @@ function createMemoryDb() {
               product_scope_json,
               valid_from,
               valid_until,
+              trial_duration_days,
               license_mode,
               license_edition,
               license_binding,
@@ -96,6 +97,7 @@ function createMemoryDb() {
               product_scope_json,
               valid_from,
               valid_until,
+              trial_duration_days,
               license_mode,
               license_edition,
               license_binding,
@@ -113,6 +115,7 @@ function createMemoryDb() {
               product_scope_json,
               valid_from,
               valid_until,
+              trial_duration_days,
               license_mode,
               license_edition,
               license_binding,
@@ -131,6 +134,7 @@ function createMemoryDb() {
               product_scope_json,
               valid_from,
               valid_until,
+              trial_duration_days,
               license_mode,
               license_edition,
               license_binding,
@@ -196,6 +200,7 @@ async function runLicenseAdminDataflowTests(run) {
         product_scope_json: { standardumfang: ["app", "pdf", "export"] },
         valid_from: "2026-01-01",
         valid_until: "2026-12-31",
+        trial_duration_days: 30,
         license_mode: "soft",
         license_file_path: "C:\\license-tool\\output\\k101.bbmlic",
         license_file_created_at: "2026-04-27T10:00:00.000Z",
@@ -211,6 +216,7 @@ async function runLicenseAdminDataflowTests(run) {
       assert.equal(listedByCustomer[0].valid_from, "2026-01-01");
       assert.equal(listedByCustomer[0].valid_until, "2026-12-31");
       assert.equal(listedByCustomer[0].license_mode, "soft");
+      assert.equal(listedByCustomer[0].trial_duration_days, 30);
       assert.equal(listedByCustomer[0].license_edition, "test");
       assert.equal(listedByCustomer[0].license_binding, "none");
       assert.equal(listedByCustomer[0].licenseEdition, "test");
@@ -519,6 +525,22 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(payload.valid_until, "2026-12-31");
     assert.equal(payload.license_mode, "full");
 
+    const trialPayload = buildLicenseEditorPayload({
+      customer: { id: "customer-55" },
+      inputs: {
+        license_id: "LIC-TRIAL",
+        product_scope_json: "scope-text",
+        valid_from: "2026-05-01",
+        valid_until: "2026-12-31",
+        license_edition: "test",
+        license_binding: "none",
+        trial_duration_days: "60",
+      },
+      now: fixedLocalDate,
+    });
+    assert.equal(trialPayload.valid_until, "");
+    assert.equal(trialPayload.trial_duration_days, "60");
+
     const customerPayload = buildCustomerEditorPayload({
       customer: { id: "c-44" },
       inputs: {
@@ -575,7 +597,8 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(payload.customerName, "Musterfirma GmbH");
     assert.equal(payload.licenseId, "LIC-77");
     assert.equal(payload.validFrom, "2026-05-01");
-    assert.equal(payload.validUntil, "2027-05-01");
+    assert.equal(payload.validUntil, "");
+    assert.equal(payload.trialDurationDays, 30);
     assert.equal(payload.binding, "none");
     assert.equal(payload.product, "bbm-protokoll");
     assert.equal(payload.edition, "test");
@@ -663,6 +686,27 @@ async function runLicenseAdminDataflowTests(run) {
     });
     assert.equal(payload.binding, "machine");
     assert.equal(payload.machineId, "MID-M-1");
+  });
+
+  await run("Lizenzverwaltung Generator-Payload: Testlizenz uebernimmt trialDurationDays", async () => {
+    const { buildLicenseGeneratorPayload } = await importEsmFromFile(
+      path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js")
+    );
+    const payload = buildLicenseGeneratorPayload({
+      customer: { company_name: "Testdauer GmbH" },
+      license: {
+        license_id: "LIC-TRIAL-1",
+        valid_from: "2026-06-01",
+        trial_duration_days: "60",
+        license_edition: "test",
+        license_binding: "none",
+        product_scope_json: JSON.stringify({ standardumfang: ["app"] }),
+      },
+    });
+    assert.equal(payload.edition, "test");
+    assert.equal(payload.binding, "none");
+    assert.equal(payload.trialDurationDays, 60);
+    assert.equal(payload.validUntil, "");
   });
 }
 

--- a/scripts/tests/licenseIpcCustomerSetup.test.cjs
+++ b/scripts/tests/licenseIpcCustomerSetup.test.cjs
@@ -135,6 +135,40 @@ async function runLicenseIpcCustomerSetupTests(run) {
     });
   });
 
+  await run('licenseIpc: Testlizenz-Payload verlangt trialDurationDays statt validUntil', () => {
+    withLicenseIpcModule({}, (mod) => {
+      const parsed = mod._validateGenerationPayload({
+        customerName: 'Testkunde',
+        licenseId: 'LIC-T-1',
+        edition: 'test',
+        binding: 'none',
+        validFrom: '2026-06-01',
+        trialDurationDays: 30,
+        maxDevices: 1,
+        features: ['app'],
+      });
+      assert.equal(parsed.validUntil, '');
+      assert.equal(parsed.trialDurationDays, 30);
+    });
+  });
+
+  await run('licenseIpc: Testlizenz ohne trialDurationDays wird abgewiesen', () => {
+    withLicenseIpcModule({}, (mod) => {
+      assert.throws(
+        () => mod._validateGenerationPayload({
+          customerName: 'Testkunde',
+          licenseId: 'LIC-T-2',
+          edition: 'test',
+          binding: 'none',
+          validFrom: '2026-06-01',
+          maxDevices: 1,
+          features: ['app'],
+        }),
+        /TRIAL_DURATION_DAYS_REQUIRED/
+      );
+    });
+  });
+
   await run('licenseIpc: exitCode 0 aber outputDir fehlt -> CUSTOMER_SETUP_ARTIFACT_NOT_FOUND', async () => {
     await withTempRepo(
       () => {},

--- a/scripts/tests/licenseTrialRuntime.test.cjs
+++ b/scripts/tests/licenseTrialRuntime.test.cjs
@@ -1,0 +1,154 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const Module = require('node:module');
+
+function withPatchedLoad(patchFn, fn) {
+  const originalLoad = Module._load;
+  Module._load = function patched(request, parent, isMain) {
+    const replacement = patchFn(request, parent, isMain);
+    if (replacement !== undefined) return replacement;
+    return originalLoad.apply(this, arguments);
+  };
+  try {
+    return fn();
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+function loadLicenseVerifierWithStubs({ machineId = 'MID-TEST' } = {}) {
+  const modPath = path.join(process.cwd(), 'src/main/licensing/licenseVerifier.js');
+  delete require.cache[require.resolve(modPath)];
+  return withPatchedLoad((request, parent) => {
+    const fromVerifier = String(parent?.filename || '').endsWith(path.join('licensing', 'licenseVerifier.js'));
+    if (!fromVerifier) return undefined;
+    if (request === 'fs') {
+      return {
+        existsSync: () => true,
+        readFileSync: () => '-----BEGIN PUBLIC KEY-----\nFAKE\n-----END PUBLIC KEY-----',
+      };
+    }
+    if (request === 'crypto') {
+      return { verify: () => true };
+    }
+    if (request === './deviceIdentity') {
+      return { getMachineId: () => machineId };
+    }
+    return undefined;
+  }, () => require(modPath));
+}
+
+function createValidLicense({ edition = 'test', binding = 'none', validUntil = '2030-01-01T00:00:00.000Z', trialDurationDays = 30 } = {}) {
+  const license = {
+    schemaVersion: 1,
+    product: 'bbm-protokoll',
+    licenseId: 'LIC-TRIAL-1',
+    customerName: 'Muster GmbH',
+    edition,
+    issuedAt: '2026-01-01T00:00:00.000Z',
+    validUntil,
+    maxDevices: 1,
+    features: ['app'],
+    binding,
+  };
+  if (edition === 'test' && binding === 'none') {
+    license.trialDurationDays = trialDurationDays;
+  }
+  return {
+    license,
+    signature: 'ZmFrZQ==',
+  };
+}
+
+function withTempUserData(fn) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bbm-trial-storage-'));
+  try {
+    return fn(tempRoot);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function loadLicenseStorageWithStubs({ userDataPath, machineId = 'MID-TEST' }) {
+  const modPath = path.join(process.cwd(), 'src/main/licensing/licenseStorage.js');
+  delete require.cache[require.resolve(modPath)];
+  return withPatchedLoad((request, parent) => {
+    const fromStorage = String(parent?.filename || '').endsWith(path.join('licensing', 'licenseStorage.js'));
+    if (!fromStorage) return undefined;
+    if (request === 'electron') {
+      return {
+        app: {
+          getPath: () => userDataPath,
+          getAppPath: () => process.cwd(),
+          isPackaged: false,
+        },
+      };
+    }
+    if (request === './deviceIdentity') {
+      return { getMachineId: () => machineId };
+    }
+    return undefined;
+  }, () => require(modPath));
+}
+
+async function runLicenseTrialRuntimeTests(run) {
+  await run('Lizenzpruefung: Testlizenz akzeptiert binding none ohne Machine-ID', () => {
+    const { verifyLicense } = loadLicenseVerifierWithStubs({ machineId: '' });
+    const result = verifyLicense(createValidLicense({ edition: 'test', binding: 'none', trialDurationDays: 30 }));
+    assert.equal(result.valid, true);
+    assert.equal(result.reason, null);
+  });
+
+  await run('Lizenzpruefung: Testablauf wird aus trialStartedAt + trialDurationDays berechnet', () => {
+    const { verifyLicense } = loadLicenseVerifierWithStubs();
+    const now = Date.now();
+    const startedAtExpired = new Date(now - 31 * 24 * 60 * 60 * 1000).toISOString();
+    const expired = verifyLicense({
+      ...createValidLicense({ edition: 'test', binding: 'none', trialDurationDays: 30 }),
+      trialStartedAt: startedAtExpired,
+    });
+    assert.equal(expired.valid, false);
+    assert.equal(expired.reason, 'LICENSE_EXPIRED');
+
+    const startedAtFresh = new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const active = verifyLicense({
+      ...createValidLicense({ edition: 'test', binding: 'none', trialDurationDays: 30 }),
+      trialStartedAt: startedAtFresh,
+    });
+    assert.equal(active.valid, true);
+    assert.equal(typeof active.daysRemaining, 'number');
+    assert.equal(active.daysRemaining > 0, true);
+  });
+
+  await run('Lizenzpruefung: Vollversion bleibt bei validUntil-basierter Pruefung', () => {
+    const { verifyLicense } = loadLicenseVerifierWithStubs({ machineId: 'MID-1' });
+    const full = verifyLicense({
+      ...createValidLicense({ edition: 'full', binding: 'machine', validUntil: '2099-01-01T00:00:00.000Z' }),
+      machineId: 'MID-1',
+    });
+    assert.equal(full.valid, true);
+    assert.equal(full.reason, null);
+  });
+
+  await run('licenseStorage: setzt trialStartedAt beim ersten Speichern einer Testlizenz', () => {
+    withTempUserData((userDataPath) => {
+      const storage = loadLicenseStorageWithStubs({ userDataPath, machineId: 'MID-A' });
+      const saved = storage.saveLicense(createValidLicense({ edition: 'test', binding: 'none', trialDurationDays: 30 }));
+      assert.equal(typeof saved.trialStartedAt, 'string');
+      assert.equal(saved.trialStartedAt.length > 10, true);
+    });
+  });
+
+  await run('licenseStorage: ueberschreibt vorhandenes trialStartedAt nicht', () => {
+    withTempUserData((userDataPath) => {
+      const storage = loadLicenseStorageWithStubs({ userDataPath, machineId: 'MID-A' });
+      const first = storage.saveLicense(createValidLicense({ edition: 'test', binding: 'none', trialDurationDays: 30 }));
+      const second = storage.saveLicense(createValidLicense({ edition: 'test', binding: 'none', trialDurationDays: 30 }));
+      assert.equal(second.trialStartedAt, first.trialStartedAt);
+    });
+  });
+}
+
+module.exports = { runLicenseTrialRuntimeTests };

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -127,6 +127,7 @@ async function runLizenzverwaltungModuleTests(run) {
       "productScope",
       "validFrom",
       "validUntil",
+      "trialDurationDays",
       "licenseEdition",
       "licenseBinding",
       "machineId",
@@ -140,6 +141,7 @@ async function runLizenzverwaltungModuleTests(run) {
       "Produktumfang",
       "gueltig von",
       "gueltig bis",
+      "Testdauer (Tage)",
       "Lizenzart",
       "Gerätebindung",
       "Machine-ID",
@@ -477,6 +479,7 @@ async function runLizenzverwaltungModuleTests(run) {
       "Produktumfang",
       "gueltig von",
       "gueltig bis",
+      "Testdauer (Tage)",
       "Lizenzart",
       "Gerätebindung",
       "Machine-ID",
@@ -622,6 +625,7 @@ async function runLizenzverwaltungModuleTests(run) {
   await run("Lizenzverwaltung DB-Schema: optionale Spalten license_edition/license_binding sind vorhanden", () => {
     assert.equal(databaseSource.includes("license_edition TEXT"), true);
     assert.equal(databaseSource.includes("license_binding TEXT"), true);
+    assert.equal(databaseSource.includes("trial_duration_days INTEGER"), true);
   });
 
   await run("Lizenzverwaltung DB-Schema: Referenzen customer_id und license_record_id sind vorbereitet", () => {
@@ -811,6 +815,8 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Produktumfang enthält keine erzeugbaren Features."), true);
     assert.equal(screenSource.includes("Machine-ID ist erforderlich, wenn die Lizenz an ein Gerät gebunden wird."), true);
     assert.equal(screenSource.includes("Bitte gültige Datumswerte eintragen."), true);
+    assert.equal(screenSource.includes("Der Testzeitraum beginnt bei erster Installation / erstem Start."), true);
+    assert.equal(screenSource.includes("Testzeitraum"), true);
     assert.equal(screenSource.includes("\"Lizenzart\""), true);
     assert.equal(screenSource.includes("\"Gerätebindung\""), true);
     assert.equal(screenSource.includes("licenseGenerate"), true);
@@ -832,6 +838,14 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Kundenkontext:"), true);
     assert.equal(screenSource.includes("CUSTOMER_CONTEXT_REQUIRED"), true);
     assert.equal(screenSource.includes("Speichern ohne geoeffneten Kunden ist unmoeglich"), true);
+  });
+
+  await run("Entwicklungs-Trial-Einstellungen bleiben entfernt", () => {
+    assert.equal(settingsViewSource.includes("Nutzungstage-Limit aktiv"), false);
+    assert.equal(settingsViewSource.includes("Nutzungstage (0 = aus)"), false);
+    assert.equal(settingsViewSource.includes("trial.enabled"), false);
+    assert.equal(settingsViewSource.includes("trial.daysLimit"), false);
+    assert.equal(settingsViewSource.includes("trial.firstStartAt"), false);
   });
 
   await run("Lizenz / bearbeiten: enthaelt Produktumfang statt flacher Feature-Zeile", () => {

--- a/src/main/db/database.js
+++ b/src/main/db/database.js
@@ -1115,6 +1115,7 @@ function ensureLicenseAdminSchema(dbConn) {
         product_scope_json TEXT NOT NULL,
         valid_from TEXT,
         valid_until TEXT,
+        trial_duration_days INTEGER,
         license_mode TEXT,
         license_edition TEXT,
         license_binding TEXT,
@@ -1141,6 +1142,9 @@ function ensureLicenseAdminSchema(dbConn) {
   }
   if (!columnExists(dbConn, "license_records", "valid_until")) {
     dbConn.exec(`ALTER TABLE license_records ADD COLUMN valid_until TEXT;`);
+  }
+  if (!columnExists(dbConn, "license_records", "trial_duration_days")) {
+    dbConn.exec(`ALTER TABLE license_records ADD COLUMN trial_duration_days INTEGER;`);
   }
   if (!columnExists(dbConn, "license_records", "license_mode")) {
     dbConn.exec(`ALTER TABLE license_records ADD COLUMN license_mode TEXT;`);

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -150,6 +150,7 @@ function _toEditableLicensePayload(parsed = {}, filePath = "") {
     issuedAt,
     validFrom,
     validUntil: String(license.validUntil || "").trim(),
+    trialDurationDays: _normalizeTrialDurationDays(license.trialDurationDays),
     maxDevices:
       typeof license.maxDevices === "number"
         ? license.maxDevices
@@ -196,6 +197,14 @@ function _computeValidUntil(validFrom, durationDays) {
   return dt.toISOString().slice(0, 10);
 }
 
+function _normalizeTrialDurationDays(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  const days = Math.floor(num);
+  if (days < 1 || days > 365) return null;
+  return days;
+}
+
 function _validateGenerationPayload(raw = {}) {
   const product = String(raw?.product || "bbm-protokoll").trim() || "bbm-protokoll";
   const customerName = String(raw?.customerName || "").trim();
@@ -209,6 +218,7 @@ function _validateGenerationPayload(raw = {}) {
       : Number(raw.durationDays);
   const explicitValidUntil = _normalizeIsoDate(raw?.validUntil);
   const validUntil = explicitValidUntil || _computeValidUntil(validFrom, durationDays);
+  const trialDurationDays = _normalizeTrialDurationDays(raw?.trialDurationDays);
   const maxDevices = Number(raw?.maxDevices);
   const features = Array.isArray(raw?.features)
     ? raw.features.map((v) => String(v || "").trim()).filter(Boolean)
@@ -219,8 +229,13 @@ function _validateGenerationPayload(raw = {}) {
   if (!licenseId) throw new Error("LICENSE_ID_REQUIRED");
   if (!["none", "machine"].includes(binding)) throw new Error("BINDING_INVALID");
   if (!validFrom) throw new Error("VALID_FROM_REQUIRED");
-  if (!validUntil) throw new Error("VALID_UNTIL_REQUIRED");
-  if (new Date(`${validUntil}T00:00:00Z`).getTime() < new Date(`${validFrom}T00:00:00Z`).getTime()) {
+  const isTestLicense = edition === "test" && binding === "none";
+  if (!isTestLicense && !validUntil) throw new Error("VALID_UNTIL_REQUIRED");
+  if (isTestLicense && !trialDurationDays) throw new Error("TRIAL_DURATION_DAYS_REQUIRED");
+  if (
+    !isTestLicense &&
+    new Date(`${validUntil}T00:00:00Z`).getTime() < new Date(`${validFrom}T00:00:00Z`).getTime()
+  ) {
     throw new Error("VALID_UNTIL_BEFORE_VALID_FROM");
   }
   if (!Number.isFinite(maxDevices) || maxDevices < 1) throw new Error("MAX_DEVICES_INVALID");
@@ -237,7 +252,8 @@ function _validateGenerationPayload(raw = {}) {
     edition,
     binding,
     validFrom,
-    validUntil,
+    validUntil: isTestLicense ? "" : validUntil,
+    trialDurationDays: isTestLicense ? trialDurationDays : null,
     durationDays: Number.isFinite(durationDays) && durationDays > 0 ? Math.floor(durationDays) : null,
     maxDevices: Math.floor(maxDevices),
     features,
@@ -993,6 +1009,7 @@ function registerLicenseDevGeneratorIpc() {
             binding: inputData.binding,
             validFrom: inputData.validFrom,
             validUntil: inputData.validUntil,
+            ...(inputData.trialDurationDays ? { trialDurationDays: inputData.trialDurationDays } : {}),
             maxDevices: inputData.maxDevices,
             features: inputData.features,
             notes: inputData.notes,
@@ -1026,6 +1043,7 @@ function registerLicenseDevGeneratorIpc() {
         machineId: inputData.binding === "machine" ? inputData.machineId : "",
         validFrom: inputData.validFrom,
         validUntil: inputData.validUntil,
+        trialDurationDays: inputData.trialDurationDays,
         features: inputData.features,
       };
     } catch (err) {
@@ -1103,6 +1121,7 @@ function registerLicenseIpc() {
 module.exports = {
   registerLicenseIpc,
   _buildCustomerSetupSlug,
+  _validateGenerationPayload,
   resolveNodeExecutableForBuild,
   _validateCustomerSetupPayload,
   _runCustomerSetupBuild,

--- a/src/main/ipc/settingsIpc.js
+++ b/src/main/ipc/settingsIpc.js
@@ -280,9 +280,6 @@ const GLOBAL_APP_SETTING_KEYS = new Set([
   "tops.fontscale.list",
   "tops.fontscale.editbox",
   "audio.whisper.quality",
-  "trial.enabled",
-  "trial.daysLimit",
-  "trial.firstStartAt",
 ]);
 const GLOBAL_APP_SETTING_ALLOWED_PREFIXES = ["defaults.", "meta.touched.", "bbm_whatsnew_seen_"];
 

--- a/src/main/licensing/licenseAdminService.js
+++ b/src/main/licensing/licenseAdminService.js
@@ -15,6 +15,14 @@ function _optionalText(value) {
   return trimmed || null;
 }
 
+function _optionalInt(value) {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  const int = Math.floor(parsed);
+  return int > 0 ? int : null;
+}
+
 function _nowIso() {
   return new Date().toISOString();
 }
@@ -90,6 +98,7 @@ function _normalizeLicenseRecord(license = {}) {
     ),
     valid_from: _optionalText(license.valid_from || license.validFrom),
     valid_until: _optionalText(license.valid_until || license.validUntil),
+    trial_duration_days: _optionalInt(license.trial_duration_days || license.trialDurationDays),
     license_mode: _optionalText(license_mode),
     license_edition: _optionalText(license_edition),
     license_binding: _optionalText(license_binding),
@@ -230,7 +239,9 @@ function saveLicense(license = {}) {
   if (!record.customer_id) throw new Error("customer_id required");
   if (!record.product_scope_json) throw new Error("product_scope_json required");
   if (!record.valid_from) throw new Error("valid_from required");
-  if (!record.valid_until) throw new Error("valid_until required");
+  const isTestLicense = record.license_edition === "test" && record.license_binding === "none";
+  if (!isTestLicense && !record.valid_until) throw new Error("valid_until required");
+  if (isTestLicense && !record.trial_duration_days) throw new Error("trial_duration_days required");
   if (!record.license_mode) throw new Error("license_mode required");
   if (!record.license_edition) throw new Error("license_edition required");
   if (!record.license_binding) throw new Error("license_binding required");
@@ -247,6 +258,7 @@ function saveLicense(license = {}) {
           product_scope_json = ?,
           valid_from = ?,
           valid_until = ?,
+          trial_duration_days = ?,
           license_mode = ?,
           license_edition = ?,
           license_binding = ?,
@@ -263,6 +275,7 @@ function saveLicense(license = {}) {
       record.product_scope_json,
       record.valid_from,
       record.valid_until,
+      record.trial_duration_days,
       record.license_mode,
       record.license_edition,
       record.license_binding,
@@ -283,6 +296,7 @@ function saveLicense(license = {}) {
         product_scope_json,
         valid_from,
         valid_until,
+        trial_duration_days,
         license_mode,
         license_edition,
         license_binding,
@@ -290,7 +304,7 @@ function saveLicense(license = {}) {
         license_file_path,
         license_file_created_at,
         notes
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `
     ).run(
       record.id,
@@ -299,6 +313,7 @@ function saveLicense(license = {}) {
       record.product_scope_json,
       record.valid_from,
       record.valid_until,
+      record.trial_duration_days,
       record.license_mode,
       record.license_edition,
       record.license_binding,

--- a/src/main/licensing/licenseStorage.js
+++ b/src/main/licensing/licenseStorage.js
@@ -59,11 +59,23 @@ function saveLicense(licensePayload) {
   const filePath = getLicenseFilePath();
   const machineId = getMachineId();
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const existing = fs.existsSync(filePath) ? _readJsonSafe(filePath) || {} : {};
+  const previousTrialStartedAt = String(existing?.trialStartedAt || "").trim();
+  const previousInstalledAt = String(existing?.installedAt || "").trim();
+  const binding = String(licensePayload?.license?.binding || "").trim().toLowerCase() || "none";
+  const edition = String(licensePayload?.license?.edition || "").trim().toLowerCase();
+  const trialStartIso =
+    previousTrialStartedAt ||
+    String(licensePayload?.trialStartedAt || "").trim() ||
+    String(licensePayload?.installedAt || "").trim() ||
+    previousInstalledAt ||
+    new Date().toISOString();
 
   const stored = {
     ...licensePayload,
     machineId,
-    installedAt: new Date().toISOString(),
+    installedAt: previousInstalledAt || String(licensePayload?.installedAt || "").trim() || new Date().toISOString(),
+    ...(edition === "test" && binding === "none" ? { trialStartedAt: trialStartIso } : {}),
   };
 
   fs.writeFileSync(

--- a/src/main/licensing/licenseVerifier.js
+++ b/src/main/licensing/licenseVerifier.js
@@ -73,6 +73,14 @@ function isIsoDateString(value) {
   return !Number.isNaN(parsed.getTime());
 }
 
+function parsePositiveInt(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  const int = Math.floor(num);
+  if (int < 1) return null;
+  return int;
+}
+
 function verifyLicense(licenseData) {
   if (!licenseData) {
     return { valid: false, reason: "NO_LICENSE" };
@@ -91,7 +99,6 @@ function verifyLicense(licenseData) {
     "customerName",
     "edition",
     "issuedAt",
-    "validUntil",
     "maxDevices",
     "features",
   ];
@@ -117,12 +124,20 @@ function verifyLicense(licenseData) {
     return { valid: false, reason: "INVALID_FORMAT" };
   }
 
+  const edition = String(license.edition || "").trim().toLowerCase();
+  if (!["test", "full"].includes(edition)) {
+    return { valid: false, reason: "INVALID_FORMAT" };
+  }
+
   const binding = String(license.binding || "").trim().toLowerCase() || "none";
   if (!["none", "machine"].includes(binding)) {
     return { valid: false, reason: "INVALID_FORMAT" };
   }
 
-  if (!isIsoDateString(license.issuedAt) || !isIsoDateString(license.validUntil)) {
+  if (!isIsoDateString(license.issuedAt)) {
+    return { valid: false, reason: "INVALID_FORMAT" };
+  }
+  if (edition === "full" && !isIsoDateString(license.validUntil)) {
     return { valid: false, reason: "INVALID_FORMAT" };
   }
 
@@ -147,12 +162,29 @@ function verifyLicense(licenseData) {
   }
 
   const now = Date.now();
-  const expiresAt = new Date(license.validUntil).getTime();
-  if (Number.isNaN(expiresAt)) {
+  let expiresAt = null;
+  if (edition === "test" && binding === "none") {
+    const trialDurationDays = parsePositiveInt(license.trialDurationDays);
+    if (!trialDurationDays) {
+      return { valid: false, reason: "INVALID_FORMAT", license };
+    }
+    const startedAtRaw = String(licenseData.trialStartedAt || licenseData.installedAt || "").trim();
+    if (startedAtRaw) {
+      const startedAt = new Date(startedAtRaw).getTime();
+      if (Number.isNaN(startedAt)) {
+        return { valid: false, reason: "INVALID_FORMAT", license };
+      }
+      expiresAt = startedAt + trialDurationDays * 24 * 60 * 60 * 1000;
+    }
+  } else {
+    expiresAt = new Date(license.validUntil).getTime();
+  }
+
+  if (expiresAt !== null && Number.isNaN(expiresAt)) {
     return { valid: false, reason: "INVALID_FORMAT", license };
   }
 
-  if (now > expiresAt) {
+  if (expiresAt !== null && now > expiresAt) {
     return {
       valid: false,
       reason: "LICENSE_EXPIRED",
@@ -162,9 +194,9 @@ function verifyLicense(licenseData) {
     };
   }
 
-  const msRemaining = expiresAt - now;
-  const daysRemaining = Math.ceil(msRemaining / (1000 * 60 * 60 * 24));
-  const expiresSoon = daysRemaining <= 14;
+  const msRemaining = expiresAt === null ? null : expiresAt - now;
+  const daysRemaining = msRemaining === null ? null : Math.ceil(msRemaining / (1000 * 60 * 60 * 24));
+  const expiresSoon = typeof daysRemaining === "number" ? daysRemaining <= 14 : false;
 
   return {
     valid: true,

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -15,9 +15,6 @@ import { applyPopupButtonStyle, applyPopupCardStyle } from "./ui/popupButtonStyl
 const APP_VERSION = "1.0";
 const FEATURE_FLAG_KEY = "bbm.useNewCompanyWorkflow";
 const UI_MODE_KEY = "bbm.uiMode";
-const TRIAL_DAYS_KEY = "trial.daysLimit";
-const TRIAL_ENABLED_KEY = "trial.enabled";
-const TRIAL_FIRST_START_KEY = "trial.firstStartAt";
 const PRINT_V2_PAD_LEFT_KEY = "print.v2.pagePadLeftMm";
 const PRINT_V2_PAD_RIGHT_KEY = "print.v2.pagePadRightMm";
 const PRINT_V2_PAD_TOP_KEY = "print.v2.pagePadTopMm";
@@ -159,67 +156,6 @@ const showStartupOverlay = ({ durationMs = 3000 } = {}) => {
   }, Math.max(500, Number(durationMs) || 3000));
 };
 
-const enforceTrialLimit = async () => {
-  const api = window.bbmDb || {};
-  if (typeof api.appSettingsGetMany !== "function") return true;
-
-  let data = {};
-  try {
-    const res = await api.appSettingsGetMany([TRIAL_ENABLED_KEY, TRIAL_DAYS_KEY, TRIAL_FIRST_START_KEY]);
-    if (!res?.ok) return true;
-    data = res.data || {};
-  } catch (_e) {
-    return true;
-  }
-
-  const enabledRaw = String(data[TRIAL_ENABLED_KEY] || "").trim().toLowerCase();
-  const enabled = enabledRaw === "1" || enabledRaw === "true" || enabledRaw === "yes" || enabledRaw === "on";
-  const limit = Math.max(0, Math.floor(Number(data[TRIAL_DAYS_KEY] || 0) || 0));
-  if (!enabled || limit <= 0) return true;
-
-  let firstStart = Math.floor(Number(data[TRIAL_FIRST_START_KEY] || 0) || 0);
-  if (!Number.isFinite(firstStart) || firstStart <= 0) {
-    firstStart = Date.now();
-    if (typeof api.appSettingsSetMany === "function") {
-      try {
-        await api.appSettingsSetMany({ [TRIAL_FIRST_START_KEY]: String(firstStart) });
-      } catch (_e) {
-        // ignore
-      }
-    }
-  }
-
-  const dayMs = 24 * 60 * 60 * 1000;
-  const usedDays = Math.floor((Date.now() - firstStart) / dayMs) + 1;
-  const remainingDays = limit - usedDays;
-
-  // Hinweis in den letzten 5 Tagen vor Ablauf
-  if (remainingDays >= 0 && remainingDays <= 4) {
-    const msg =
-      remainingDays === 0
-        ? "Hinweis: Die Testversion läuft heute ab."
-        : `Hinweis: Die Testversion läuft in ${remainingDays + 1} Tagen ab.`;
-    alert(msg);
-  }
-
-  if (usedDays <= limit) return true;
-
-  alert(`Testversion abgelaufen (${limit} Nutzungstage).`);
-  if (typeof api.appQuit === "function") {
-    try {
-      await api.appQuit();
-      return false;
-    } catch (_e) {
-      // ignore
-    }
-  }
-  try {
-    window.close();
-  } catch (_e) {
-    // ignore
-  }
-  return false;
-};
 
 const ensureInitialPrintLayoutDefaults = async () => {
   const api = window.bbmDb || {};
@@ -1018,8 +954,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     bottomSection.replaceChildren(btnQuit);
   };
 
-  const canContinue = await enforceTrialLimit();
-  if (!canContinue) return;
   await ensureInitialPrintLayoutDefaults();
 
   const uiMode = readUiMode();

--- a/src/renderer/modules/lizenzverwaltung/licenseRecords.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseRecords.js
@@ -12,7 +12,8 @@ export const LICENSE_RECORD_FIELDS = Object.freeze([
   Object.freeze({ key: "customerNumber", label: "Kunde", required: true }),
   Object.freeze({ key: "productScope", label: "Produktumfang", required: true }),
   Object.freeze({ key: "validFrom", label: "gueltig von", required: true }),
-  Object.freeze({ key: "validUntil", label: "gueltig bis", required: true }),
+  Object.freeze({ key: "validUntil", label: "gueltig bis", required: false }),
+  Object.freeze({ key: "trialDurationDays", label: "Testdauer (Tage)", required: false }),
   Object.freeze({ key: "licenseEdition", label: "Lizenzart", required: true }),
   Object.freeze({ key: "licenseBinding", label: "Gerätebindung", required: true }),
   Object.freeze({ key: "machineId", label: "Machine-ID", required: false }),
@@ -66,6 +67,8 @@ export function createDefaultLicenseRecord(overrides = {}) {
     valid_from: "",
     validUntil: "",
     valid_until: "",
+    trialDurationDays: 30,
+    trial_duration_days: 30,
     licenseMode: "soft",
     license_mode: "soft",
     licenseEdition: "test",
@@ -166,6 +169,14 @@ export function normalizeLicenseRecord(input = {}) {
   const customerId = String(input.customerId ?? input.customer_id ?? base.customerId).trim();
   const validFrom = String(input.validFrom ?? input.valid_from ?? base.validFrom).trim();
   const validUntil = String(input.validUntil ?? input.valid_until ?? base.validUntil).trim();
+  const trialDurationDaysRaw = String(
+    input.trialDurationDays ?? input.trial_duration_days ?? base.trialDurationDays
+  ).trim();
+  const trialDurationDaysParsed = Math.floor(Number(trialDurationDaysRaw));
+  const trialDurationDays =
+    Number.isFinite(trialDurationDaysParsed) && trialDurationDaysParsed >= 1 && trialDurationDaysParsed <= 365
+      ? trialDurationDaysParsed
+      : 30;
   const machineId = String(input.machineId ?? input.machine_id ?? base.machineId).trim();
   const licenseFilePath = String(input.licenseFilePath ?? input.license_file_path ?? base.licenseFilePath).trim();
   const licenseFileCreatedAt = String(
@@ -196,6 +207,8 @@ export function normalizeLicenseRecord(input = {}) {
     valid_from: validFrom,
     validUntil,
     valid_until: validUntil,
+    trialDurationDays,
+    trial_duration_days: trialDurationDays,
     licenseMode: normalizedMode || compatMode,
     license_mode: compatMode,
     licenseEdition: normalizedEdition,

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -150,13 +150,16 @@ export function assertCustomerContext(customer) {
 
 export function buildLicenseEditorPayload({ license = {}, inputs = {}, customer = null, now = new Date() } = {}) {
   const customerId = assertCustomerContext(customer);
+  const normalizedTrialDurationDays = normalizeTrialDurationDays(inputs.trial_duration_days, 30);
+  const isTestLicense = String(inputs.license_edition || "").trim().toLowerCase() === "test";
   return {
     id: license.id,
     customer_id: customerId,
     license_id: String(inputs.license_id || "").trim() || createGeneratedLicenseId(now),
     product_scope_json: String(inputs.product_scope_json || "").trim(),
     valid_from: String(inputs.valid_from || "").trim(),
-    valid_until: String(inputs.valid_until || "").trim(),
+    valid_until: isTestLicense ? "" : String(inputs.valid_until || "").trim(),
+    trial_duration_days: isTestLicense ? String(normalizedTrialDurationDays) : "",
     license_mode: String(inputs.license_mode || "").trim(),
     machine_id: String(inputs.machine_id || "").trim(),
     license_file_path: valueOf(license, "license_file_path", "licenseFilePath"),
@@ -223,6 +226,15 @@ export function normalizeDateForGenerator(value) {
   return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
 }
 
+export function normalizeTrialDurationDays(value, fallback = 30) {
+  const raw = String(value ?? "").trim();
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+  const days = Math.floor(parsed);
+  if (days < 1 || days > 365) return fallback;
+  return days;
+}
+
 export function getLicenseEditionAndBinding(license = {}) {
   const editionRaw = String(valueOf(license, "license_edition", "licenseEdition")).trim().toLowerCase();
   const bindingRaw = String(valueOf(license, "license_binding", "licenseBinding")).trim().toLowerCase();
@@ -275,6 +287,7 @@ export function buildLicenseGeneratorPayload({ customer = {}, license = {} } = {
   const model = getLicenseEditionAndBinding(license);
   const binding = model.binding;
   const edition = model.edition;
+  const trialDurationDays = normalizeTrialDurationDays(valueOf(license, "trial_duration_days", "trialDurationDays"), 30);
   const features = parseGeneratorFeaturesFromProductScope(valueOf(license, "product_scope_json", "productScope"));
   const machineId = valueOf(license, "machine_id", "machineId");
   return {
@@ -284,7 +297,8 @@ export function buildLicenseGeneratorPayload({ customer = {}, license = {} } = {
     edition,
     binding,
     validFrom,
-    validUntil,
+    validUntil: edition === "test" && binding === "none" ? "" : validUntil,
+    ...(edition === "test" && binding === "none" ? { trialDurationDays } : {}),
     maxDevices: 1,
     ...(binding === "machine" && machineId ? { machineId } : {}),
     features,
@@ -666,6 +680,7 @@ export default class LicenseAdminScreen {
       ["valid_until", "gueltig bis"],
       ["license_edition", "Lizenzart"],
       ["license_binding", "Gerätebindung"],
+      ["trial_duration_days", "Testzeitraum"],
       ["machine_id", "Machine-ID"],
       ["notes", "Notizen"],
     ];
@@ -683,7 +698,10 @@ export default class LicenseAdminScreen {
       title.textContent = labelText;
       title.style.alignSelf = "center";
       form.append(title, fieldNode);
+      return { title, fieldNode };
     };
+
+    const fieldRows = {};
 
     for (const [key, label] of fields) {
       let input = key === "notes" ? document.createElement("textarea") : document.createElement("input");
@@ -711,10 +729,65 @@ export default class LicenseAdminScreen {
           input.appendChild(option);
         });
       }
+      if (key === "trial_duration_days") {
+        input = document.createElement("div");
+        input.style.display = "grid";
+        input.style.gap = "8px";
+        const durationSelect = document.createElement("select");
+        [
+          { value: "14", label: "14 Tage" },
+          { value: "30", label: "30 Tage" },
+          { value: "60", label: "60 Tage" },
+          { value: "90", label: "90 Tage" },
+          { value: "custom", label: "Individuell" },
+        ].forEach((entry) => {
+          const option = document.createElement("option");
+          option.value = entry.value;
+          option.textContent = entry.label;
+          durationSelect.appendChild(option);
+        });
+        const customRow = document.createElement("div");
+        customRow.style.display = "none";
+        customRow.style.gridTemplateColumns = "80px minmax(120px, 1fr)";
+        customRow.style.gap = "8px";
+        const customLabel = document.createElement("div");
+        customLabel.textContent = "Tage";
+        customLabel.style.alignSelf = "center";
+        const customInput = document.createElement("input");
+        customInput.type = "number";
+        customInput.min = "1";
+        customInput.max = "365";
+        customInput.step = "1";
+        customInput.style.width = "100%";
+        customRow.append(customLabel, customInput);
+        const trialHint = document.createElement("div");
+        trialHint.style.fontSize = "12px";
+        trialHint.style.opacity = "0.85";
+        trialHint.textContent = "Der Testzeitraum beginnt bei erster Installation / erstem Start.";
+        input.append(durationSelect, customRow, trialHint);
+        input._durationSelect = durationSelect;
+        input._customInput = customInput;
+        input._customRow = customRow;
+      }
       if (key === "notes") input.rows = 3;
       const currentMode = getLicenseEditionAndBinding(license);
       if (key === "license_edition") input.value = currentMode.edition;
       else if (key === "license_binding") input.value = currentMode.binding;
+      else if (key === "trial_duration_days") {
+        const initialTrialDays = normalizeTrialDurationDays(
+          valueOf(license, "trial_duration_days", "trialDurationDays"),
+          30
+        );
+        if ([14, 30, 60, 90].includes(initialTrialDays)) {
+          input._durationSelect.value = String(initialTrialDays);
+          input._customInput.value = String(initialTrialDays);
+          input._customRow.style.display = "none";
+        } else {
+          input._durationSelect.value = "custom";
+          input._customInput.value = String(initialTrialDays);
+          input._customRow.style.display = "grid";
+        }
+      }
       else input.value = valueOf(license, key, key.replace("_", ""));
       if (key === "valid_from" || key === "valid_until") {
         input.type = "date";
@@ -723,7 +796,7 @@ export default class LicenseAdminScreen {
       input.style.width = "100%";
       input.id = `license-${key}`;
       inputs[key] = input;
-      appendFieldRow(label, input);
+      fieldRows[key] = appendFieldRow(label, input);
     }
 
     const scopeModel = createDefaultScopeSelection();
@@ -871,7 +944,49 @@ export default class LicenseAdminScreen {
         inputs.machine_id.value = "";
       }
     };
+    const syncTrialDurationState = () => {
+      const selector = inputs.trial_duration_days?._durationSelect;
+      const customInput = inputs.trial_duration_days?._customInput;
+      const customRow = inputs.trial_duration_days?._customRow;
+      if (!selector || !customInput || !customRow) return;
+      const isCustom = selector.value === "custom";
+      customRow.style.display = isCustom ? "grid" : "none";
+      if (!isCustom) {
+        customInput.value = selector.value;
+      }
+    };
+    const syncEditionUiState = () => {
+      const edition = String(inputs.license_edition?.value || "test").trim().toLowerCase();
+      const isTestLicense = edition === "test";
+      if (isTestLicense) {
+        inputs.license_binding.value = "none";
+      }
+      inputs.license_binding.disabled = isTestLicense;
+      syncMachineIdState();
+      if (fieldRows.valid_from) {
+        fieldRows.valid_from.title.textContent = isTestLicense ? "Ausgestellt am (technisch)" : "gueltig von";
+        fieldRows.valid_from.title.style.opacity = isTestLicense ? "0.65" : "1";
+        fieldRows.valid_from.fieldNode.style.display = isTestLicense ? "none" : "";
+      }
+      if (fieldRows.valid_until) {
+        fieldRows.valid_until.fieldNode.style.display = isTestLicense ? "none" : "";
+        fieldRows.valid_until.title.style.display = isTestLicense ? "none" : "";
+      }
+      if (fieldRows.trial_duration_days) {
+        fieldRows.trial_duration_days.fieldNode.style.display = isTestLicense ? "" : "none";
+        fieldRows.trial_duration_days.title.style.display = isTestLicense ? "" : "none";
+      }
+    };
     inputs.license_binding?.addEventListener("change", syncMachineIdState);
+    inputs.trial_duration_days?._durationSelect?.addEventListener("change", syncTrialDurationState);
+    inputs.license_edition?.addEventListener("change", syncEditionUiState);
+    inputs.trial_duration_days?._customInput?.addEventListener("change", () => {
+      inputs.trial_duration_days._customInput.value = String(
+        normalizeTrialDurationDays(inputs.trial_duration_days._customInput.value, 30)
+      );
+    });
+    syncTrialDurationState();
+    syncEditionUiState();
     syncMachineIdState();
 
     const licenseIdHint = document.createElement("div");
@@ -975,6 +1090,17 @@ export default class LicenseAdminScreen {
             license_mode: inputs.license_binding.value === "machine" ? "full" : "soft",
             license_edition: inputs.license_edition.value,
             license_binding: inputs.license_binding.value,
+            trial_duration_days:
+              String(inputs.license_edition.value || "").trim().toLowerCase() === "test"
+                ? String(
+                    normalizeTrialDurationDays(
+                      inputs.trial_duration_days?._durationSelect?.value === "custom"
+                        ? inputs.trial_duration_days?._customInput?.value
+                        : inputs.trial_duration_days?._durationSelect?.value,
+                      30
+                    )
+                  )
+                : "",
             machine_id: inputs.machine_id.value,
             notes: inputs.notes.value,
           },
@@ -998,7 +1124,15 @@ export default class LicenseAdminScreen {
           license: saved || {},
         });
         if (!generatorPayload.validFrom || !generatorPayload.validUntil) {
-          message.textContent = "Bitte gültige Datumswerte eintragen.";
+          if (generatorPayload.edition === "test" && generatorPayload.binding === "none") {
+            // Testlizenz nutzt trialDurationDays statt manuellem validUntil.
+          } else {
+            message.textContent = "Bitte gültige Datumswerte eintragen.";
+            return;
+          }
+        }
+        if (generatorPayload.edition === "test" && generatorPayload.binding === "none" && !generatorPayload.trialDurationDays) {
+          message.textContent = "Bitte Testdauer waehlen (1 bis 365 Tage).";
           return;
         }
         if (!generatorPayload.features.length) {

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -689,16 +689,19 @@ export default class LicenseAdminScreen {
     const inputs = { product_scope_json: document.createElement("input") };
     inputs.product_scope_json.type = "hidden";
     form.style.display = "grid";
-    form.style.gridTemplateColumns = "180px minmax(260px, 1fr)";
-    form.style.columnGap = "12px";
-    form.style.rowGap = "8px";
+    form.style.gridTemplateColumns = "minmax(320px, 1fr)";
+    form.style.rowGap = "10px";
 
     const appendFieldRow = (labelText, fieldNode) => {
+      const row = document.createElement("div");
+      row.style.display = "grid";
+      row.style.gap = "6px";
       const title = document.createElement("label");
       title.textContent = labelText;
-      title.style.alignSelf = "center";
-      form.append(title, fieldNode);
-      return { title, fieldNode };
+      title.style.fontWeight = "600";
+      row.append(title, fieldNode);
+      form.append(row);
+      return { title, fieldNode, row };
     };
 
     const fieldRows = {};
@@ -733,6 +736,9 @@ export default class LicenseAdminScreen {
         input = document.createElement("div");
         input.style.display = "grid";
         input.style.gap = "8px";
+        const trialTitle = document.createElement("div");
+        trialTitle.textContent = "Testdauer";
+        trialTitle.style.fontWeight = "500";
         const durationSelect = document.createElement("select");
         [
           { value: "14", label: "14 Tage" },
@@ -764,7 +770,7 @@ export default class LicenseAdminScreen {
         trialHint.style.fontSize = "12px";
         trialHint.style.opacity = "0.85";
         trialHint.textContent = "Der Testzeitraum beginnt bei erster Installation / erstem Start.";
-        input.append(durationSelect, customRow, trialHint);
+        input.append(trialTitle, durationSelect, customRow, trialHint);
         input._durationSelect = durationSelect;
         input._customInput = customInput;
         input._customRow = customRow;
@@ -966,15 +972,16 @@ export default class LicenseAdminScreen {
       if (fieldRows.valid_from) {
         fieldRows.valid_from.title.textContent = isTestLicense ? "Ausgestellt am (technisch)" : "gueltig von";
         fieldRows.valid_from.title.style.opacity = isTestLicense ? "0.65" : "1";
-        fieldRows.valid_from.fieldNode.style.display = isTestLicense ? "none" : "";
+        fieldRows.valid_from.row.style.display = isTestLicense ? "none" : "";
       }
       if (fieldRows.valid_until) {
-        fieldRows.valid_until.fieldNode.style.display = isTestLicense ? "none" : "";
-        fieldRows.valid_until.title.style.display = isTestLicense ? "none" : "";
+        fieldRows.valid_until.row.style.display = isTestLicense ? "none" : "";
       }
       if (fieldRows.trial_duration_days) {
-        fieldRows.trial_duration_days.fieldNode.style.display = isTestLicense ? "" : "none";
-        fieldRows.trial_duration_days.title.style.display = isTestLicense ? "" : "none";
+        fieldRows.trial_duration_days.row.style.display = isTestLicense ? "" : "none";
+      }
+      if (fieldRows.machine_id) {
+        fieldRows.machine_id.row.style.display = isTestLicense ? "none" : "";
       }
     };
     inputs.license_binding?.addEventListener("change", syncMachineIdState);

--- a/src/renderer/ui/MainHeader.js
+++ b/src/renderer/ui/MainHeader.js
@@ -1589,58 +1589,12 @@ export default class MainHeader {
   // Trial: Fenster-Titel AN, Header-Anzeige AUS
   // ============================================================
   async _refreshTrialInfo() {
-    const api = window.bbmDb || {};
-
-    // Header-Anzeige immer aus
     if (this.elTrialInfo) {
       this.elTrialInfo.textContent = "";
       this.elTrialInfo.style.display = "none";
     }
-
-    if (typeof api.appSettingsGetMany !== "function") {
-      this._trialInfoText = "";
-      document.title = this._baseWindowTitle;
-      return;
-    }
-    if (this._trialInfoLoading) return;
-
-    this._trialInfoLoading = (async () => {
-      try {
-        const res = await api.appSettingsGetMany(["trial.enabled", "trial.daysLimit", "trial.firstStartAt"]);
-        if (!res?.ok) {
-          this._trialInfoText = "";
-          return;
-        }
-        const data = res.data || {};
-        const enabledRaw = String(data["trial.enabled"] || "").trim().toLowerCase();
-        const enabled = enabledRaw === "1" || enabledRaw === "true" || enabledRaw === "yes" || enabledRaw === "on";
-        const limit = Math.max(0, Math.floor(Number(data["trial.daysLimit"] || 0) || 0));
-        const firstStart = Math.floor(Number(data["trial.firstStartAt"] || 0) || 0);
-
-        if (!enabled || limit <= 0 || firstStart <= 0) {
-          this._trialInfoText = "";
-          return;
-        }
-
-        const dayMs = 24 * 60 * 60 * 1000;
-        const usedDays = Math.floor((Date.now() - firstStart) / dayMs) + 1;
-        const remaining = Math.max(0, limit - usedDays + 1);
-        this._trialInfoText = `Testversion: noch ${remaining} Tage`;
-      } catch (_e) {
-        this._trialInfoText = "";
-      } finally {
-        // ✅ nur Fenster-Titel setzen (Electron/Windows-Zeile)
-        document.title = this._trialInfoText ? `${this._baseWindowTitle} - ${this._trialInfoText}` : this._baseWindowTitle;
-
-        // ✅ Header bleibt aus
-        if (this.elTrialInfo) {
-          this.elTrialInfo.textContent = "";
-          this.elTrialInfo.style.display = "none";
-        }
-
-        this._trialInfoLoading = null;
-      }
-    })();
+    this._trialInfoText = "";
+    document.title = this._baseWindowTitle;
   }
 
   async _refreshBuildChannelBadge() {

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -332,7 +332,8 @@ export default class SettingsView {
     if (code === "CUSTOMER_NAME_REQUIRED") return "Bitte Kunde / Firma angeben.";
     if (code === "LICENSE_ID_REQUIRED") return "Bitte eine Lizenznummer angeben.";
     if (code === "VALID_FROM_REQUIRED") return "Bitte ein gueltiges Startdatum setzen.";
-    if (code === "VALID_UNTIL_REQUIRED") return "Bitte ein gueltiges Enddatum oder Nutzungstage setzen.";
+    if (code === "VALID_UNTIL_REQUIRED") return "Bitte ein gueltiges Enddatum setzen.";
+    if (code === "TRIAL_DURATION_DAYS_REQUIRED") return "Bitte eine gueltige Testdauer (1-365 Tage) setzen.";
     if (code === "VALID_UNTIL_BEFORE_VALID_FROM") return "Das Enddatum darf nicht vor dem Startdatum liegen.";
     if (code === "BINDING_INVALID") return "Bitte einen gueltigen Lizenzmodus auswaehlen.";
     if (code === "MACHINE_ID_REQUIRED_FOR_BINDING") return "Fuer Vollversion ist eine gueltige Machine-ID erforderlich.";
@@ -1039,8 +1040,6 @@ export default class SettingsView {
 
     const TOPS_TITLE_KEY = "tops.titleMax";
     const TOPS_LONG_KEY = "tops.longMax";
-    const TRIAL_DAYS_KEY = "trial.daysLimit";
-    const TRIAL_ENABLED_KEY = "trial.enabled";
     const TOPS_FONT_LIST_KEY = "tops.fontscale.list";
     const TOPS_FONT_EDIT_KEY = "tops.fontscale.editbox";
     const PRINT_V2_PAD_LEFT_KEY = "print.v2.pagePadLeftMm";
@@ -1099,16 +1098,7 @@ export default class SettingsView {
       return Number.isFinite(n) && n > 0;
     };
 
-    const clampNonNegativeInt = (val, min, max, fallback) => {
-      const n = Math.floor(Number(val));
-      if (!Number.isFinite(n) || n < 0) return fallback;
-      return Math.max(min, Math.min(max, n));
-    };
-
-    const isValidNonNegativeInt = (val) => {
-      const n = Math.floor(Number(val));
-      return Number.isFinite(n) && n >= 0;
-    };
+    const loadTrialSettings = async () => {};
 
     const loadTopLimitSettings = async () => {
       const api = window.bbmDb || {};
@@ -1171,106 +1161,6 @@ export default class SettingsView {
     const topsRowLong = mkRow("Langtext max", inpTopsLongMax);
     topsRowLong.style.marginBottom = "4px";
     topsLimitBox.append(topsLimitTitle, topsRowShort, topsRowLong, topsLimitMsg);
-
-    const trialBox = document.createElement("div");
-    applyPopupCardStyle(trialBox);
-    trialBox.style.padding = "8px 10px";
-    trialBox.style.maxWidth = "720px";
-    trialBox.style.marginTop = "0";
-    trialBox.style.boxSizing = "border-box";
-
-    const trialTitle = document.createElement("div");
-    trialTitle.textContent = "Testversion";
-    trialTitle.style.fontWeight = "bold";
-    trialTitle.style.marginBottom = "6px";
-
-    const trialEnabled = document.createElement("input");
-    trialEnabled.type = "checkbox";
-    trialEnabled.checked = false;
-
-    const trialEnabledWrap = document.createElement("div");
-    trialEnabledWrap.style.display = "flex";
-    trialEnabledWrap.style.alignItems = "center";
-    trialEnabledWrap.style.gap = "8px";
-
-    const trialEnabledLabel = document.createElement("div");
-    trialEnabledLabel.textContent = "Nutzungstage-Limit aktiv";
-    trialEnabledWrap.append(trialEnabled, trialEnabledLabel);
-
-    const inpTrialDays = document.createElement("input");
-    inpTrialDays.type = "number";
-    inpTrialDays.min = "0";
-    inpTrialDays.step = "1";
-    inpTrialDays.style.width = "100%";
-
-    const trialStatus = document.createElement("div");
-    trialStatus.style.fontSize = "12px";
-    trialStatus.style.opacity = "0.75";
-    trialStatus.style.marginTop = "4px";
-
-    const loadTrialSettings = async () => {
-      const api = window.bbmDb || {};
-      if (typeof api.appSettingsGetMany !== "function") {
-        trialEnabled.checked = false;
-        inpTrialDays.value = "0";
-        inpTrialDays.disabled = true;
-        inpTrialDays.style.opacity = "0.55";
-        return;
-      }
-      const res = await api.appSettingsGetMany([TRIAL_ENABLED_KEY, TRIAL_DAYS_KEY]);
-      if (!res?.ok) {
-        trialEnabled.checked = false;
-        inpTrialDays.value = "0";
-        inpTrialDays.disabled = true;
-        inpTrialDays.style.opacity = "0.55";
-        return;
-      }
-      const data = res.data || {};
-      const enabledRaw = String(data[TRIAL_ENABLED_KEY] || "").trim().toLowerCase();
-      const enabled = enabledRaw === "1" || enabledRaw === "true" || enabledRaw === "yes" || enabledRaw === "on";
-      const trialDays = clampNonNegativeInt(data[TRIAL_DAYS_KEY], 0, 3650, 0);
-      trialEnabled.checked = enabled;
-      inpTrialDays.value = String(trialDays);
-      inpTrialDays.disabled = !enabled;
-      inpTrialDays.style.opacity = enabled ? "1" : "0.55";
-      trialStatus.textContent = "";
-    };
-
-    const saveTrialSettings = async () => {
-      const api = window.bbmDb || {};
-      if (typeof api.appSettingsSetMany !== "function") {
-        trialStatus.textContent = "Settings-API fehlt (IPC noch nicht aktiv).";
-        return false;
-      }
-      const valid = isValidNonNegativeInt(inpTrialDays.value);
-      const trialDays = clampNonNegativeInt(inpTrialDays.value, 0, 3650, 0);
-      inpTrialDays.value = String(trialDays);
-      const res = await api.appSettingsSetMany({
-        [TRIAL_ENABLED_KEY]: trialEnabled.checked ? "1" : "0",
-        [TRIAL_DAYS_KEY]: String(trialDays),
-      });
-      if (!res?.ok) {
-        trialStatus.textContent = res?.error || "Speichern fehlgeschlagen";
-        return false;
-      }
-      trialStatus.textContent = valid ? "Gespeichert" : "Ung?ltiger Wert ? Standard wurde verwendet.";
-      return true;
-    };
-
-    trialEnabled.addEventListener("change", async () => {
-      inpTrialDays.disabled = !trialEnabled.checked;
-      inpTrialDays.style.opacity = trialEnabled.checked ? "1" : "0.55";
-      await saveTrialSettings();
-    });
-    inpTrialDays.addEventListener("change", async () => {
-      if (!trialEnabled.checked) return;
-      await saveTrialSettings();
-    });
-
-    const trialRowDays = mkRow("Nutzungstage (0 = aus)", inpTrialDays);
-    trialRowDays.style.marginBottom = "4px";
-
-    trialBox.append(trialTitle, trialEnabledWrap, trialRowDays, trialStatus);
 
 
     const printV2LayoutBox = document.createElement("div");
@@ -2438,7 +2328,7 @@ export default class SettingsView {
 
     licenseBox.append(licenseTitle, licenseHint, btnLicenseOpen);
 
-    devRightCol.append(devDefaultsBox, licenseBox, topsLimitBox, trialBox);
+    devRightCol.append(devDefaultsBox, licenseBox, topsLimitBox);
     devTopCardsRow.append(versionBox, devRightCol);
 
     const themeBox = document.createElement("div");
@@ -4097,7 +3987,7 @@ export default class SettingsView {
         const tabVersion = document.createElement("div");
         tabVersion.style.display = "grid";
         tabVersion.style.gap = "10px";
-        tabVersion.append(versionBox, buildChannelBox, devDefaultsBox, trialBox);
+        tabVersion.append(versionBox, buildChannelBox, devDefaultsBox);
 
         const tabDb = document.createElement("div");
         tabDb.style.display = "grid";


### PR DESCRIPTION
### Motivation
- Testlaufzeit-Logik war fehlerhaft: Testlizenzen nutzten `valid_from + Dauer`, wodurch Testtage vor Installation verloren gehen konnten.
- Fachliche Vorgabe: Testlizenzen sollen beim ersten erfolgreichen Laden/Installieren starten und die Laufzeit aus signierter Testdauer berechnet werden.

### Description
- Verifier: Bei `edition === 'test' && binding === 'none'` wird nun die Laufzeit aus `trialStartedAt + trialDurationDays` berechnet; Vollversionen bleiben bei `validUntil` und `EXPECTED_PRODUCT` unverändert (`src/main/licensing/licenseVerifier.js`).
- Storage: `saveLicense` setzt beim ersten erfolgreichen Speichern einer Testlizenz `trialStartedAt` (überschreibt vorhandenes Feld nicht) und bewahrt `installedAt` (src/main/licensing/licenseStorage.js).
- Generator/IPC: `trialDurationDays` validiert (1..365), für Testlizenzen verpflichtend statt `validUntil`, wird in Generator-Input/Output transportiert und in `_validateGenerationPayload` berücksichtigt (src/main/ipc/licenseIpc.js).
- Admin-Service / DB: Datenmodell erweitert um `trial_duration_days` mit Normalisierung/Validierung in Service/DB-Migration und Save/Update-Statements (src/main/db/database.js, src/main/licensing/licenseAdminService.js).
- Renderer UI: Lizenz-Editor zeigt neuen Bereich „Testzeitraum“ (Auswahl 14/30/60/90/Individuell mit 1..365) und Hinweistext; für Testlizenz werden `gültig von/bis` nicht als fachlicher Teststart/-ende dargestellt; Payloads übertragen `trial_duration_days` (src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js, src/renderer/modules/lizenzverwaltung/licenseRecords.js).
- Bereinigung: Alte Entwicklungs-/Nutzungstage-Logik (`trial.enabled`, `trial.daysLimit`, `trial.firstStartAt`, `enforceTrialLimit`) wurde aus UI/Startup/Settings entfernt oder versteckt (src/renderer/main.js, src/renderer/views/SettingsView.js, src/main/ipc/settingsIpc.js, src/renderer/ui/MainHeader.js).
- Tests: Neue und angepasste Tests für Generator-, Verifier-, Storage-, IPC- und UI-Flows hinzugefügt/aktualisiert; Test-Runner erweitert (scripts/tests/licenseTrialRuntime.test.cjs, Anpassungen in diversen Tests).
- Dokumentation: `STATUS.md` ergänzt mit Kurzbeschreibung der Änderung.

### Testing
- Automatisierte Tests: `npm test` ausgeführt; alle Tests bestanden (inkl. neuen Trial-Tests). 
- Getestete Bereiche: Lizenz-Generator-Payload-Mapping, IPC-Validierung für Testlizenz, Verifier-Laufzeitberechnung (trialStartedAt + trialDurationDays), Storage setzt `trialStartedAt` nur beim ersten Speichern, Admin-Service DB-Save/List mit `trial_duration_days`, UI-Anpassungen im Lizenz-Editor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb62763688322a711374e88508b92)