### PR TITLE
Machine-Binding Schritt 2: Lizenzanforderung im Admin importieren

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -16,6 +16,15 @@ Sie ergänzt:
 ---
 
 ## Aktueller Gesamtstand
+- Machine-Binding Schritt 2 (Admin-Import) ist umgesetzt:
+  - Admin-Lizenzformular hat den Button `Lizenzanforderung importieren` (nur im Lizenzformular, keine Kundenliste/Projektbereich).
+  - Neuer Main-IPC `license-admin:import-license-request` oeffnet Datei-Dialog, liest JSON, validiert (`schemaVersion`, `requestType`, `product`, `machineId`, `createdAt`, `appVersion`) und liefert strukturierte Request-Daten.
+  - Preload stellt `window.bbmDb.licenseAdminImportLicenseRequest()` bereit.
+  - Nach erfolgreichem Import werden im Formular `Machine-ID`, `Gerätebindung=machine` und `Lizenzart=full` gesetzt; es erfolgt **kein** automatisches Speichern.
+  - UI zeigt klare Erfolg-/Fehlerhinweise inkl. Produktfehler, fehlender Machine-ID sowie optional `customerName`/`licenseId`.
+  - Bestehender Generatorfluss bleibt bestehen und nutzt danach weiterhin den bestehenden Ablauf `Lizenz erstellen`.
+  - Keine Aenderung an `licenseVerifier.js EXPECTED_PRODUCT`, keine Setup-/Mail-/Online-Aktivierungs-Erweiterung.
+  - Testabdeckung fuer Import-IPC, Preload und UI-Texte wurde erweitert; `npm test` bleibt Pflichtpruefung.
 - Neuer Machine-Binding-Baustein ist umgesetzt:
   - Kunden-App kann jetzt eine Lizenzanforderungsdatei `bbm-license-request.json` speichern (nur Anfrage, keine Lizenz-/Signatur-Erzeugung).
   - Main-IPC `license:create-request` baut ein strukturiertes Request-JSON mit `schemaVersion`, `requestType`, `product`, `appVersion`, `createdAt`, `machineId` sowie optional `customerName`/`licenseId`/`notes`.

--- a/scripts/tests/licenseRequest.test.cjs
+++ b/scripts/tests/licenseRequest.test.cjs
@@ -32,14 +32,20 @@ function read(relPath) {
   return fs.readFileSync(path.join(REPO_ROOT, relPath), "utf8");
 }
 
-function createDefaultStubs({ saveResult, machineId = "MID-REQ-1", appVersion = "9.9.9", loadLicenseResult = null }) {
+function createDefaultStubs({
+  saveResult,
+  openResult,
+  machineId = "MID-REQ-1",
+  appVersion = "9.9.9",
+  loadLicenseResult = null,
+}) {
   const handlers = new Map();
   const electron = {
     app: { isPackaged: false, getVersion: () => appVersion },
     BrowserWindow: { fromWebContents: () => null },
     dialog: {
       showSaveDialog: async () => saveResult || { canceled: true },
-      showOpenDialog: async () => ({ canceled: true, filePaths: [] }),
+      showOpenDialog: async () => openResult || { canceled: true, filePaths: [] },
     },
     ipcMain: {
       handle: (channel, handler) => handlers.set(channel, handler),
@@ -166,11 +172,188 @@ async function runLicenseRequestTests(run) {
     assert.equal(preloadSource.includes('ipcRenderer.invoke("license:create-request"'), true);
   });
 
+  await run("Preload: window.bbmDb.licenseAdminImportLicenseRequest ist vorhanden", () => {
+    const preloadSource = read("src/main/preload.js");
+    assert.equal(preloadSource.includes("licenseAdminImportLicenseRequest"), true);
+    assert.equal(preloadSource.includes('ipcRenderer.invoke("license-admin:import-license-request"'), true);
+  });
+
   await run("Renderer/UI: Texte fuer Lizenzanforderung sind vorhanden", () => {
     const settingsSource = read("src/renderer/views/SettingsView.js");
+    const licenseAdminSource = read("src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js");
     assert.equal(settingsSource.includes("Lizenzanforderung speichern"), true);
     assert.equal(settingsSource.includes("Lizenzanforderung wurde gespeichert."), true);
     assert.equal(settingsSource.includes("Lizenzanforderung konnte nicht gespeichert werden."), true);
+    assert.equal(licenseAdminSource.includes("Lizenzanforderung importieren"), true);
+    assert.equal(
+      licenseAdminSource.includes("Lizenzanforderung importiert. Machine-ID wurde übernommen."),
+      true
+    );
+    assert.equal(
+      licenseAdminSource.includes("Lizenzanforderung konnte nicht importiert werden."),
+      true
+    );
+    assert.equal(
+      licenseAdminSource.includes("Lizenzanforderung gehört nicht zu diesem Produkt."),
+      true
+    );
+    assert.equal(
+      licenseAdminSource.includes("Lizenzanforderung enthält keine Machine-ID."),
+      true
+    );
+  });
+
+  await run("Main/IPC: license-admin:import-license-request wird registriert", () => {
+    const { handlers, stubs } = createDefaultStubs({});
+    return withPatchedLicenseIpc(stubs, (mod) => {
+      mod.registerLicenseIpc();
+      assert.equal(handlers.has("license-admin:import-license-request"), true);
+    });
+  });
+
+  await run("Main/IPC: gueltige Lizenzanforderung wird importiert", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-import-request-ok-"));
+    try {
+      const requestPath = path.join(tmp, "bbm-license-request.json");
+      fs.writeFileSync(
+        requestPath,
+        JSON.stringify({
+          schemaVersion: 1,
+          requestType: "machine-license-request",
+          product: "bbm-protokoll",
+          appName: "BBM",
+          appVersion: "1.5.0",
+          createdAt: "2026-04-28T10:00:00.000Z",
+          machineId: "MID-IMPORT-1",
+          customerName: "Muster GmbH",
+          licenseId: "LIC-42",
+        }),
+        "utf8"
+      );
+      const { handlers, stubs } = createDefaultStubs({
+        openResult: { canceled: false, filePaths: [requestPath] },
+      });
+      await withPatchedLicenseIpc(stubs, async (mod) => {
+        mod.registerLicenseIpc();
+        const res = await handlers.get("license-admin:import-license-request")({ sender: {} });
+        assert.equal(res.ok, true);
+        assert.equal(res.request.machineId, "MID-IMPORT-1");
+        assert.equal(res.request.customerName, "Muster GmbH");
+        assert.equal(res.request.licenseId, "LIC-42");
+      });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  await run("Main/IPC: falsches requestType wird abgewiesen", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-import-request-type-"));
+    try {
+      const requestPath = path.join(tmp, "bbm-license-request.json");
+      fs.writeFileSync(
+        requestPath,
+        JSON.stringify({
+          schemaVersion: 1,
+          requestType: "other-request",
+          product: "bbm-protokoll",
+          appVersion: "1.5.0",
+          createdAt: "2026-04-28T10:00:00.000Z",
+          machineId: "MID-IMPORT-2",
+        }),
+        "utf8"
+      );
+      const { handlers, stubs } = createDefaultStubs({ openResult: { canceled: false, filePaths: [requestPath] } });
+      await withPatchedLicenseIpc(stubs, async (mod) => {
+        mod.registerLicenseIpc();
+        const res = await handlers.get("license-admin:import-license-request")({ sender: {} });
+        assert.equal(res.ok, false);
+        assert.equal(res.error, "INVALID_REQUEST_TYPE");
+      });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  await run("Main/IPC: falsches product wird abgewiesen", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-import-request-product-"));
+    try {
+      const requestPath = path.join(tmp, "bbm-license-request.json");
+      fs.writeFileSync(
+        requestPath,
+        JSON.stringify({
+          schemaVersion: 1,
+          requestType: "machine-license-request",
+          product: "other-product",
+          appVersion: "1.5.0",
+          createdAt: "2026-04-28T10:00:00.000Z",
+          machineId: "MID-IMPORT-3",
+        }),
+        "utf8"
+      );
+      const { handlers, stubs } = createDefaultStubs({ openResult: { canceled: false, filePaths: [requestPath] } });
+      await withPatchedLicenseIpc(stubs, async (mod) => {
+        mod.registerLicenseIpc();
+        const res = await handlers.get("license-admin:import-license-request")({ sender: {} });
+        assert.equal(res.ok, false);
+        assert.equal(res.error, "INVALID_PRODUCT");
+      });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  await run("Main/IPC: fehlende machineId wird abgewiesen", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-import-request-machine-"));
+    try {
+      const requestPath = path.join(tmp, "bbm-license-request.json");
+      fs.writeFileSync(
+        requestPath,
+        JSON.stringify({
+          schemaVersion: 1,
+          requestType: "machine-license-request",
+          product: "bbm-protokoll",
+          appVersion: "1.5.0",
+          createdAt: "2026-04-28T10:00:00.000Z",
+        }),
+        "utf8"
+      );
+      const { handlers, stubs } = createDefaultStubs({ openResult: { canceled: false, filePaths: [requestPath] } });
+      await withPatchedLicenseIpc(stubs, async (mod) => {
+        mod.registerLicenseIpc();
+        const res = await handlers.get("license-admin:import-license-request")({ sender: {} });
+        assert.equal(res.ok, false);
+        assert.equal(res.error, "MISSING_MACHINE_ID");
+      });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  await run("Main/IPC: ungueltiges JSON wird abgewiesen", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-import-request-json-"));
+    try {
+      const requestPath = path.join(tmp, "bbm-license-request.json");
+      fs.writeFileSync(requestPath, "{ invalid", "utf8");
+      const { handlers, stubs } = createDefaultStubs({ openResult: { canceled: false, filePaths: [requestPath] } });
+      await withPatchedLicenseIpc(stubs, async (mod) => {
+        mod.registerLicenseIpc();
+        const res = await handlers.get("license-admin:import-license-request")({ sender: {} });
+        assert.equal(res.ok, false);
+        assert.equal(typeof res.error, "string");
+      });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  await run("Main/IPC: Abbruch im Open-Dialog liefert canceled true", async () => {
+    const { handlers, stubs } = createDefaultStubs({ openResult: { canceled: true, filePaths: [] } });
+    await withPatchedLicenseIpc(stubs, async (mod) => {
+      mod.registerLicenseIpc();
+      const res = await handlers.get("license-admin:import-license-request")({ sender: {} });
+      assert.equal(res.ok, false);
+      assert.equal(res.canceled, true);
+    });
   });
 
   await run("Grenzen: EXPECTED_PRODUCT bleibt unveraendert", () => {

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -84,6 +84,14 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(entry.screens?.licenseAdmin, LicenseAdminScreen);
   });
 
+  await run("Lizenzverwaltung UI: Lizenzanforderung-Import im Lizenzformular vorhanden", () => {
+    assert.equal(screenSource.includes("Lizenzanforderung importieren"), true);
+    assert.equal(screenSource.includes("licenseAdminImportLicenseRequest"), true);
+    assert.equal(screenSource.includes("inputs.license_binding.value = \"machine\""), true);
+    assert.equal(screenSource.includes("inputs.license_edition.value = \"full\""), true);
+    assert.equal(screenSource.includes("inputs.machine_id.value = String(request.machineId || \"\").trim()"), true);
+  });
+
 
   await run("Lizenzverwaltung Modulindex: kein Pflicht-Export createLicenseEditorSection fuer Admin", () => {
     assert.equal("createLicenseEditorSection" in { getLizenzverwaltungModuleEntry }, false);

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -111,25 +111,59 @@ function _readLicenseFile(filePath) {
 function _readLicenseRequestFile(filePath) {
   const raw = fs.readFileSync(filePath, "utf8");
   const parsed = JSON.parse(raw);
+  return _validateLicenseRequestPayload(parsed, filePath);
+}
+
+function _validateLicenseRequestPayload(payload, filePath = "") {
+  const parsed = payload;
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     const err = new Error("INVALID_FORMAT");
     err.code = "INVALID_FORMAT";
     throw err;
   }
-  const product = String(parsed.product || "").trim();
+  const schemaVersion = Number(parsed.schemaVersion);
+  const requestType = String(parsed.requestType || "").trim();
+  const product = String(parsed.product || "").trim().toLowerCase();
   const machineId = String(parsed.machineId || "").trim();
-  if (!product || !machineId) {
+  const createdAt = String(parsed.createdAt || "").trim();
+  const appVersion = String(parsed.appVersion || "").trim();
+  if (schemaVersion !== 1 || requestType !== "machine-license-request") {
+    const err = new Error("INVALID_REQUEST_TYPE");
+    err.code = "INVALID_REQUEST_TYPE";
+    throw err;
+  }
+  if (product !== "bbm-protokoll") {
+    const err = new Error("INVALID_PRODUCT");
+    err.code = "INVALID_PRODUCT";
+    throw err;
+  }
+  if (!machineId) {
+    const err = new Error("MISSING_MACHINE_ID");
+    err.code = "MISSING_MACHINE_ID";
+    throw err;
+  }
+  if (!createdAt || !appVersion) {
     const err = new Error("INVALID_FORMAT");
     err.code = "INVALID_FORMAT";
     throw err;
   }
+  const appName = String(parsed.appName || "").trim();
+  const customerName = String(parsed.customerName || "").trim();
+  const licenseId = String(parsed.licenseId || "").trim();
+  const notes = String(parsed.notes || "").trim();
   return {
     filePath: String(filePath || "").trim(),
+    schemaVersion: 1,
+    requestType: "machine-license-request",
     product,
     machineId,
-    appVersion: String(parsed.appVersion || "").trim(),
-    createdAt: String(parsed.createdAt || "").trim(),
-    customerHint: String(parsed.customerHint || parsed.customerName || "").trim(),
+    appName,
+    appVersion,
+    createdAt,
+    customerName,
+    licenseId,
+    notes,
+    customerHint: String(parsed.customerHint || customerName).trim(),
   };
 }
 
@@ -1127,6 +1161,26 @@ function registerLicenseAdminDataIpc() {
       return {
         ok: false,
         error: String(err?.message || err || "CUSTOMER_SETUP_BUILD_FAILED").trim() || "CUSTOMER_SETUP_BUILD_FAILED",
+      };
+    }
+  });
+
+  ipcMain.handle("license-admin:import-license-request", async (event) => {
+    try {
+      const result = await dialog.showOpenDialog(_pickWindow(event), {
+        title: "Lizenzanforderung importieren",
+        properties: ["openFile"],
+        filters: [{ name: "Lizenzanforderung", extensions: ["json"] }],
+      });
+      if (result.canceled || !Array.isArray(result.filePaths) || !result.filePaths[0]) {
+        return { ok: false, canceled: true };
+      }
+      const request = _readLicenseRequestFile(String(result.filePaths[0] || "").trim());
+      return { ok: true, request };
+    } catch (err) {
+      return {
+        ok: false,
+        error: String(err?.code || err?.message || "INVALID_FORMAT").trim() || "INVALID_FORMAT",
       };
     }
   });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -212,6 +212,7 @@ contextBridge.exposeInMainWorld("bbmDb", {
   licenseAdminListLicenseHistory: () => ipcRenderer.invoke("license-admin:list-history"),
   licenseAdminAddLicenseHistoryEntry: (entry) => ipcRenderer.invoke("license-admin:add-history-entry", entry),
   licenseAdminCreateCustomerSetup: (payload) => ipcRenderer.invoke("license-admin:create-customer-setup", payload),
+  licenseAdminImportLicenseRequest: () => ipcRenderer.invoke("license-admin:import-license-request"),
 
   // DEV: Audio Override Status
   devAudioUnlockStatus: () => ipcRenderer.invoke("dev:audioUnlockStatus"),

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -1004,6 +1004,50 @@ export default class LicenseAdminScreen {
     const actions = document.createElement("div");
     actions.style.display = "flex";
     actions.style.gap = "8px";
+    const importRequestBtn = this._button("Lizenzanforderung importieren", async () => {
+      const api = window?.bbmDb || {};
+      if (typeof api.licenseAdminImportLicenseRequest !== "function") {
+        message.textContent = "Lizenzanforderung konnte nicht importiert werden.";
+        return;
+      }
+      const previousMachineId = String(inputs.machine_id?.value || "").trim();
+      try {
+        const res = await api.licenseAdminImportLicenseRequest();
+        if (!res?.ok) {
+          if (res?.canceled) return;
+          const errorCode = String(res?.error || "").trim().toUpperCase();
+          if (errorCode === "INVALID_PRODUCT") {
+            message.textContent = "Lizenzanforderung gehört nicht zu diesem Produkt.";
+            return;
+          }
+          if (errorCode === "MISSING_MACHINE_ID") {
+            message.textContent = "Lizenzanforderung enthält keine Machine-ID.";
+            return;
+          }
+          message.textContent = "Lizenzanforderung konnte nicht importiert werden.";
+          return;
+        }
+        const request = res?.request || {};
+        inputs.machine_id.value = String(request.machineId || "").trim();
+        inputs.license_binding.value = "machine";
+        inputs.license_edition.value = "full";
+        syncEditionUiState();
+        syncMachineIdState();
+        const infoLines = ["Lizenzanforderung importiert. Machine-ID wurde übernommen."];
+        if (previousMachineId && previousMachineId !== inputs.machine_id.value) {
+          infoLines.push("Vorhandene Machine-ID wurde durch die importierte Machine-ID ersetzt.");
+        }
+        if (String(request.customerName || "").trim()) {
+          infoLines.push(`Anfrage von: ${request.customerName}`);
+        }
+        if (String(request.licenseId || "").trim()) {
+          infoLines.push(`Anfrage zu Lizenz-ID: ${request.licenseId}`);
+        }
+        message.textContent = infoLines.join("\n");
+      } catch (_err) {
+        message.textContent = "Lizenzanforderung konnte nicht importiert werden.";
+      }
+    });
     const openOutputDirBtn = this._button("Ausgabeordner öffnen", async () => {
       const api = window?.bbmDb || {};
       const outputPath = String(openOutputDirBtn.dataset.outputPath || "").trim();
@@ -1190,7 +1234,7 @@ export default class LicenseAdminScreen {
       this._render();
     });
 
-    actions.append(createBtn, createCustomerSetupBtn, backBtn, openOutputDirBtn);
+    actions.append(importRequestBtn, createBtn, createCustomerSetupBtn, backBtn, openOutputDirBtn);
     container.append(header, context, form, licenseIdHint, actions, message, generationOutput, setupOutput);
   }
 


### PR DESCRIPTION
### Motivation
- Ermöglichen, dass ein Administrator eine vom Kunden erzeugte `bbm-license-request.json` importieren und die `machineId` in das Lizenzformular übernehmen kann, damit anschliessend eine gerätegebundene Vollversionslizenz erzeugt werden kann.
- Kleine, sichere Ergänzung nur in der Lizenz-Admin-Fluss; bestehendes Verhalten und Generator-Flow bleiben unverändert.
- Tests und Preload-/IPC-Schnittstelle müssen die neue Import-Funktionalität abdecken.

### Description
- Main: Neuer IPC-Handler `license-admin:import-license-request` in `src/main/ipc/licenseIpc.js` implementiert, der einen Open-Dialog öffnet, die JSON-Datei liest, parst und mit `_validateLicenseRequestPayload` auf Pflichtfelder (`schemaVersion=1`, `requestType=machine-license-request`, `product=bbm-protokoll`, `machineId`, `createdAt`, `appVersion`) validiert und strukturierte Request-Daten zurückgibt oder Fehler/`canceled` meldet.
- Preload: `window.bbmDb` um `licenseAdminImportLicenseRequest()` ergänzt in `src/main/preload.js` und damit der Renderer an den neuen IPC-Kanal angebunden.
- Renderer/UI: In `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js` wurde der Button `Lizenzanforderung importieren` ergänzt und so verdrahtet, dass bei erfolgreichem Import `machine_id` gesetzt, `license_binding` auf `machine` und `license_edition` auf `full` gesetzt werden; die UI zeigt klare Erfolg- und Fehlertexte (Produkt-Mismatch, fehlende Machine-ID usw.) und überschreibt vorhandene Machine-ID nur mit ausdrücklicher Meldung; es erfolgt kein automatisches Speichern.
- Tests und Doku: Tests für Import-Flow ergänzt (`scripts/tests/licenseRequest.test.cjs`, `scripts/tests/lizenzverwaltungModule.test.cjs`) und `STATUS.md` aktualisiert; keine Änderungen an `licenseVerifier.js EXPECTED_PRODUCT` und keine Änderungen an Mail/Setup/Online-Aktivierung/Generator-Logik.

### Testing
- Automatisierte Tests: `npm test` ausgeführt; alle Tests erfolgreich ("Alle Tests bestanden.").
- Ergänzte Tests: Main/IPC-Import-Fälle (gültig, falscher `requestType`, falsches `product`, fehlende `machineId`, ungültiges JSON, Dialog-Abbruch) sowie Preload-API-Existenz und Renderer-UI-Texte/Hook wurden hinzugefügt und liefen grün.
- Ergebnis: Test-Suite grün, `git status` sauber nach Commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f063e0d2408322bb55f864b477059c)