### PR TITLE
Machine-Binding Schritt 3: Antwortlizenz-Ablauf in UI sichtbar führen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -16,6 +16,12 @@ Sie ergänzt:
 ---
 
 ## Aktueller Gesamtstand
+- Machine-Binding Schritt 3 (Antwortlizenz-UI-Fuehrung) ist umgesetzt:
+  - Admin-Lizenzformular zeigt bei `Gerätebindung = An Machine-ID binden` den Hinweis `Gerätegebundene Vollversion` mit klarer Schrittfuehrung (Import Lizenzanforderung -> `Lizenz erstellen` -> Antwortlizenz).
+  - Nach erfolgreichem `Lizenz erstellen` wird bei Vollversion + Machine-Binding + vorhandener Machine-ID zusaetzlich angezeigt: `Antwortlizenz wurde erstellt.` sowie `Diese .bbmlic-Datei an den Kunden zurückgeben.`.
+  - Ausgabepfadanzeige und Button `Ausgabeordner öffnen` bleiben unveraendert im bestehenden Generator-Hauptablauf.
+  - Kunden-Lizenzstatusbereich ergaenzt den Hinweis `Antwortlizenz erhalten?` mit Verweis auf den bestehenden Lizenzimport; kein neuer Import-Mechanismus, keine neue Navigation.
+  - Tests wurden auf die neuen UI-Texte erweitert; bestehende Flows (`licenseGenerate`, Lizenzimport) bleiben unveraendert und `npm test` bleibt Pflichtpruefung.
 - Machine-Binding Schritt 2 (Admin-Import) ist umgesetzt:
   - Admin-Lizenzformular hat den Button `Lizenzanforderung importieren` (nur im Lizenzformular, keine Kundenliste/Projektbereich).
   - Neuer Main-IPC `license-admin:import-license-request` oeffnet Datei-Dialog, liest JSON, validiert (`schemaVersion`, `requestType`, `product`, `machineId`, `createdAt`, `appVersion`) und liefert strukturierte Request-Daten.

--- a/STATUS.md
+++ b/STATUS.md
@@ -27,6 +27,10 @@ Sie ergänzt:
 - PR #46 Bugfix (Generator-Input fuer Testversion ohne validUntil-Feld) ist umgesetzt:
   - Main-IPC `license:generate` schreibt fuer Testversion `validUntil` nicht mehr in die Input-JSON an den Generator.
   - Die alte Hilfslogik zur Ableitung `validUntil` aus `validFrom + Dauer` wurde entfernt; kein Rueckfall auf das Altmodell.
+- PR #46 Hinweis externer Generator ist dokumentiert:
+  - Der produktive Generator liegt extern unter `C:\\license-tool\\generate-license.cjs` und hat keine gepflegte Repo-Quelle in diesem Projekt.
+  - Falls der externe Generator weiter `validUntil` fuer Testversion erzwingt, liefert die App jetzt klar den Hinweis: `Externer Lizenzgenerator ist nicht kompatibel mit Testversion ohne validUntil.`
+  - In diesem Fall muss `C:\\license-tool\\generate-license.cjs` manuell kompatibel angepasst werden (Testversion ohne `validUntil`, mit Pflicht `trialDurationDays`).
 - Lizenzverwaltung Nachsteuerung fuer PR #46 ist umgesetzt:
   - Lizenzformular fuehrt jetzt zwei fachlich getrennte Wege ueber `Lizenztyp`: `Testversion` und `Vollversion`.
   - `Testversion` bleibt ohne Machine-ID, zeigt Testdauer, nutzt weiter `Lizenz erstellen` + `Kunden-Setup erstellen` mit eingebetteter fertiger `customer.bbmlic`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -16,6 +16,11 @@ Sie ergänzt:
 ---
 
 ## Aktueller Gesamtstand
+- PR #46 Bugfix (Testversion speichern ohne sichtbares Datumsfeld) ist umgesetzt:
+  - Bei `Lizenztyp = Testversion` setzt `buildLicenseEditorPayload` `valid_from` jetzt automatisch auf das technische Ausstellungsdatum (`YYYY-MM-DD`), wenn das Feld leer ist.
+  - `valid_until` bleibt bei Testversion leer; `trial_duration_days` bleibt der fachliche Laufzeitwert.
+  - Dadurch tritt beim Speichern/Erstellen der Testlizenz kein `valid_from required` mehr auf, obwohl `gueltig von/bis` in der Test-UI weiterhin nicht als Nutzerpflicht gezeigt wird.
+  - Der bestehende Testlaufzeit-Start bei erster Installation / erstem Start bleibt unveraendert.
 - Lizenzverwaltung Nachsteuerung fuer PR #46 ist umgesetzt:
   - Lizenzformular fuehrt jetzt zwei fachlich getrennte Wege ueber `Lizenztyp`: `Testversion` und `Vollversion`.
   - `Testversion` bleibt ohne Machine-ID, zeigt Testdauer, nutzt weiter `Lizenz erstellen` + `Kunden-Setup erstellen` mit eingebetteter fertiger `customer.bbmlic`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -21,6 +21,9 @@ Sie ergänzt:
   - `valid_until` bleibt bei Testversion leer; `trial_duration_days` bleibt der fachliche Laufzeitwert.
   - Dadurch tritt beim Speichern/Erstellen der Testlizenz kein `valid_from required` mehr auf, obwohl `gueltig von/bis` in der Test-UI weiterhin nicht als Nutzerpflicht gezeigt wird.
   - Der bestehende Testlaufzeit-Start bei erster Installation / erstem Start bleibt unveraendert.
+- PR #46 Bugfix (Testversion ohne validUntil im gesamten Erzeugungsweg) ist umgesetzt:
+  - Save-Payload erzwingt fuer Testversion intern `license_edition=test`, `license_binding=none`, `license_mode=soft`, `machine_id=""` und laesst `valid_until` leer.
+  - Damit wird Testversion ohne `validUntil` durch Save -> Generator-Payload -> Main-IPC konsistent akzeptiert; Vollversion ohne `validUntil` bleibt weiterhin Fehlerfall.
 - Lizenzverwaltung Nachsteuerung fuer PR #46 ist umgesetzt:
   - Lizenzformular fuehrt jetzt zwei fachlich getrennte Wege ueber `Lizenztyp`: `Testversion` und `Vollversion`.
   - `Testversion` bleibt ohne Machine-ID, zeigt Testdauer, nutzt weiter `Lizenz erstellen` + `Kunden-Setup erstellen` mit eingebetteter fertiger `customer.bbmlic`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -16,6 +16,13 @@ Sie ergänzt:
 ---
 
 ## Aktueller Gesamtstand
+- Lizenzverwaltung Nachsteuerung fuer PR #46 ist umgesetzt:
+  - Lizenzformular fuehrt jetzt zwei fachlich getrennte Wege ueber `Lizenztyp`: `Testversion` und `Vollversion`.
+  - `Testversion` bleibt ohne Machine-ID, zeigt Testdauer, nutzt weiter `Lizenz erstellen` + `Kunden-Setup erstellen` mit eingebetteter fertiger `customer.bbmlic`.
+  - `Vollversion` ist fest an Machine-Binding gekoppelt, blendet den freien Binding-Mix aus und fuehrt in den Schritten `Machine-Setup erstellen` -> `Lizenzanforderung importieren` -> `Antwortlizenz erstellen`.
+  - `Machine-Setup erstellen` baut bewusst ohne eingebettete `customer.bbmlic`; die Antwortlizenz wird weiterhin erst nach Import der Machine-ID ueber `Lizenz erstellen` erzeugt.
+  - Dist-/IPC-Flow wurde minimal erweitert, damit Kunden-Setups wahlweise mit (Testversion) oder ohne (Machine-Setup) eingebettete Lizenz gebaut werden koennen.
+  - Testabdeckung wurde fuer UI-Trennung, Payload-/Setup-Typ und Build-Embedding (mit/ohne `customer.bbmlic`) erweitert; `npm test` bleibt Pflicht.
 - Machine-Binding Schritt 3 (Antwortlizenz-UI-Fuehrung) ist umgesetzt:
   - Admin-Lizenzformular zeigt bei `Gerätebindung = An Machine-ID binden` den Hinweis `Gerätegebundene Vollversion` mit klarer Schrittfuehrung (Import Lizenzanforderung -> `Lizenz erstellen` -> Antwortlizenz).
   - Nach erfolgreichem `Lizenz erstellen` wird bei Vollversion + Machine-Binding + vorhandener Machine-ID zusaetzlich angezeigt: `Antwortlizenz wurde erstellt.` sowie `Diese .bbmlic-Datei an den Kunden zurückgeben.`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -24,6 +24,9 @@ Sie ergänzt:
 - PR #46 Bugfix (Testversion ohne validUntil im gesamten Erzeugungsweg) ist umgesetzt:
   - Save-Payload erzwingt fuer Testversion intern `license_edition=test`, `license_binding=none`, `license_mode=soft`, `machine_id=""` und laesst `valid_until` leer.
   - Damit wird Testversion ohne `validUntil` durch Save -> Generator-Payload -> Main-IPC konsistent akzeptiert; Vollversion ohne `validUntil` bleibt weiterhin Fehlerfall.
+- PR #46 Bugfix (Generator-Input fuer Testversion ohne validUntil-Feld) ist umgesetzt:
+  - Main-IPC `license:generate` schreibt fuer Testversion `validUntil` nicht mehr in die Input-JSON an den Generator.
+  - Die alte Hilfslogik zur Ableitung `validUntil` aus `validFrom + Dauer` wurde entfernt; kein Rueckfall auf das Altmodell.
 - Lizenzverwaltung Nachsteuerung fuer PR #46 ist umgesetzt:
   - Lizenzformular fuehrt jetzt zwei fachlich getrennte Wege ueber `Lizenztyp`: `Testversion` und `Vollversion`.
   - `Testversion` bleibt ohne Machine-ID, zeigt Testdauer, nutzt weiter `Lizenz erstellen` + `Kunden-Setup erstellen` mit eingebetteter fertiger `customer.bbmlic`.

--- a/scripts/dist.cjs
+++ b/scripts/dist.cjs
@@ -62,8 +62,11 @@ function buildCustomerDistConfig({
   baseVersion = "0.0.0",
   customerLicenseFile = "",
   customerSlug = "",
+  customerSetupType = "",
 } = {}) {
-  if (!customerLicenseFile) {
+  const setupType = String(customerSetupType || "").trim().toLowerCase();
+  const isCustomerMode = Boolean(customerLicenseFile) || setupType === "machine";
+  if (!isCustomerMode) {
     return {
       build: { ...baseBuild },
       outputDir: String(baseBuild?.directories?.output || "").trim() || "dist",
@@ -75,10 +78,12 @@ function buildCustomerDistConfig({
   const outputDir = path.join("dist", "customers", safeSlug);
   const artifactName = `BBM-${baseVersion}-${safeSlug}-Setup.exe`;
   const extraResources = Array.isArray(baseBuild.extraResources) ? [...baseBuild.extraResources] : [];
-  extraResources.push({
-    from: customerLicenseFile,
-    to: "license/customer.bbmlic",
-  });
+  if (customerLicenseFile) {
+    extraResources.push({
+      from: customerLicenseFile,
+      to: "license/customer.bbmlic",
+    });
+  }
 
   return {
     build: {
@@ -137,12 +142,14 @@ function runDist({ cwd = process.cwd(), env = process.env } = {}) {
   const prefix = isDev ? "BBM-DEV" : "BBM";
   const nsisName = `${prefix}-${baseVersion}-Setup.\${ext}`;
   const customerLicenseFile = String(env.BBM_CUSTOMER_LICENSE_FILE || "").trim();
+  const customerSetupType = String(env.BBM_CUSTOMER_SETUP_TYPE || "").trim();
   const customerSlug = sanitizeCustomerSlug(env.BBM_CUSTOMER_SLUG || env.BBM_CUSTOMER_NAME || "");
   const customerConfig = buildCustomerDistConfig({
     baseBuild,
     baseVersion,
     customerLicenseFile,
     customerSlug,
+    customerSetupType,
   });
 
   // Override-Config für electron-builder (als separate Config-Datei)
@@ -156,7 +163,7 @@ function runDist({ cwd = process.cwd(), env = process.env } = {}) {
       buildChannel: channel,
     },
     // ✅ pro Target eigene artifactName (kein ${target})
-    nsis: customerLicenseFile
+    nsis: customerConfig.artifactName
       ? { ...(customerConfig.build.nsis || {}) }
       : {
           ...(baseBuild.nsis || {}),
@@ -174,9 +181,10 @@ function runDist({ cwd = process.cwd(), env = process.env } = {}) {
   console.log(" appId:   ", appId);
   console.log(" Name:    ", productName);
   console.log(" NSIS:    ", customerConfig.artifactName || nsisName);
-  if (customerLicenseFile) {
+  if (customerConfig.artifactName) {
     console.log(" Kundenmodus: aktiv");
-    console.log(" Lizenzdatei: ", customerLicenseFile);
+    console.log(" Setup-Typ:   ", customerSetupType || (customerLicenseFile ? "test" : "customer"));
+    console.log(" Lizenzdatei: ", customerLicenseFile || "-");
     console.log(" Ausgabe:     ", customerConfig.outputDir);
   }
   console.log("======================================");

--- a/scripts/tests/distCustomerBuild.test.cjs
+++ b/scripts/tests/distCustomerBuild.test.cjs
@@ -44,6 +44,29 @@ async function runDistCustomerBuildTests(run) {
     assert.equal(out.build.npmRebuild, false);
     assert.equal(out.build.buildDependenciesFromSource, false);
   });
+
+  await run('dist.cjs: Machine-Setup ohne Lizenzdatei nutzt Kundenziel ohne customer.bbmlic', () => {
+    const out = buildCustomerDistConfig({
+      baseBuild: {
+        directories: { output: 'dist' },
+        extraResources: [{ from: 'dev/models', to: 'audio/models' }],
+        nsis: {},
+      },
+      baseVersion: '2.0.0',
+      customerLicenseFile: '',
+      customerSlug: 'K-100-Musterfirma-GmbH',
+      customerSetupType: 'machine',
+    });
+
+    assert.equal(out.outputDir, path.join('dist', 'customers', 'K-100-Musterfirma-GmbH'));
+    assert.equal(out.artifactName, 'BBM-2.0.0-K-100-Musterfirma-GmbH-Setup.exe');
+    const embedded = out.build.extraResources.find((entry) => entry.to === 'license/customer.bbmlic');
+    assert.equal(Boolean(embedded), false);
+    assert.equal(out.build.directories.output, path.join('dist', 'customers', 'K-100-Musterfirma-GmbH'));
+    assert.equal(out.build.nsis.artifactName, 'BBM-2.0.0-K-100-Musterfirma-GmbH-Setup.exe');
+    assert.equal(out.build.npmRebuild, false);
+    assert.equal(out.build.buildDependenciesFromSource, false);
+  });
 }
 
 module.exports = {

--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -530,7 +530,6 @@ async function runLicenseAdminDataflowTests(run) {
       inputs: {
         license_id: "LIC-TRIAL",
         product_scope_json: "scope-text",
-        valid_from: "2026-05-01",
         valid_until: "2026-12-31",
         license_edition: "test",
         license_binding: "none",
@@ -538,6 +537,7 @@ async function runLicenseAdminDataflowTests(run) {
       },
       now: fixedLocalDate,
     });
+    assert.equal(trialPayload.valid_from, "2026-04-26");
     assert.equal(trialPayload.valid_until, "");
     assert.equal(trialPayload.trial_duration_days, "60");
 

--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -524,6 +524,8 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(payload.valid_from, "2026-05-01");
     assert.equal(payload.valid_until, "2026-12-31");
     assert.equal(payload.license_mode, "full");
+    assert.equal(payload.license_edition, "full");
+    assert.equal(payload.license_binding, "machine");
 
     const trialPayload = buildLicenseEditorPayload({
       customer: { id: "customer-55" },
@@ -540,6 +542,10 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(trialPayload.valid_from, "2026-04-26");
     assert.equal(trialPayload.valid_until, "");
     assert.equal(trialPayload.trial_duration_days, "60");
+    assert.equal(trialPayload.license_mode, "soft");
+    assert.equal(trialPayload.license_edition, "test");
+    assert.equal(trialPayload.license_binding, "none");
+    assert.equal(trialPayload.machine_id, "");
 
     const customerPayload = buildCustomerEditorPayload({
       customer: { id: "c-44" },

--- a/scripts/tests/licenseIpcCustomerSetup.test.cjs
+++ b/scripts/tests/licenseIpcCustomerSetup.test.cjs
@@ -182,6 +182,25 @@ async function runLicenseIpcCustomerSetupTests(run) {
     });
   });
 
+  await run('licenseIpc: Vollversion ohne validUntil wird weiterhin abgewiesen', () => {
+    withLicenseIpcModule({}, (mod) => {
+      assert.throws(
+        () =>
+          mod._validateGenerationPayload({
+            customerName: 'Vollkunde',
+            licenseId: 'LIC-F-1',
+            edition: 'full',
+            binding: 'machine',
+            validFrom: '2026-06-01',
+            maxDevices: 1,
+            features: ['app'],
+            machineId: 'MID-F-1',
+          }),
+        /VALID_UNTIL_REQUIRED/
+      );
+    });
+  });
+
   await run('licenseIpc: exitCode 0 aber outputDir fehlt -> CUSTOMER_SETUP_ARTIFACT_NOT_FOUND', async () => {
     await withTempRepo(
       () => {},

--- a/scripts/tests/licenseIpcCustomerSetup.test.cjs
+++ b/scripts/tests/licenseIpcCustomerSetup.test.cjs
@@ -107,6 +107,19 @@ async function runLicenseIpcCustomerSetupTests(run) {
     });
   });
 
+  await run('licenseIpc: Machine-Setup erlaubt fehlende Lizenzdatei und fehlende Machine-ID', () => {
+    withLicenseIpcModule({}, (mod) => {
+      const payload = mod._validateCustomerSetupPayload({
+        customer: { customer_number: 'K-200', company_name: 'Maschine GmbH' },
+        license: { license_binding: 'machine', machine_id: '' },
+        setupType: 'machine',
+      });
+      assert.equal(payload.setupType, 'machine');
+      assert.equal(payload.licenseFilePath, '');
+      assert.equal(payload.customerSlug, 'K-200-Maschine-GmbH');
+    });
+  });
+
   await run('licenseIpc: resolveNodeExecutableForBuild bevorzugt npm_node_execpath', () => {
     withLicenseIpcModule({}, (mod) => {
       const resolved = mod.resolveNodeExecutableForBuild({
@@ -248,8 +261,37 @@ async function runLicenseIpcCustomerSetupTests(run) {
             assert.equal(fs.existsSync(res.logPath), true);
             assert.equal(res.cwd, repoRoot);
             assert.equal(res.env.BBM_CUSTOMER_LICENSE_FILE, licenseFilePath);
+            assert.equal(res.env.BBM_CUSTOMER_SETUP_TYPE, 'test');
             assert.equal(res.env.BBM_CUSTOMER_SLUG, 'K-12-Gamma-GmbH');
             assert.equal(res.env.BBM_CUSTOMER_NAME, 'Gamma GmbH');
+          }
+        );
+      }
+    );
+  });
+
+  await run('licenseIpc: Machine-Setup setzt keinen BBM_CUSTOMER_LICENSE_FILE Env-Wert', async () => {
+    await withTempRepo(
+      ({ repoRoot }) => {
+        const outDir = path.join(repoRoot, 'dist', 'customers', 'K-18-Machine-GmbH');
+        fs.mkdirSync(outDir, { recursive: true });
+        fs.writeFileSync(path.join(outDir, 'BBM-1.5.0-K-18-Machine-GmbH-Setup.exe'), 'bin', 'utf8');
+      },
+      async ({ repoRoot, licenseFilePath }) => {
+        await withLicenseIpcModule(
+          { cwd: repoRoot, spawnImpl: () => createFakeChild({ exitCode: 0 }) },
+          async (mod) => {
+            const res = await mod._runCustomerSetupBuild({
+              customer: { customer_number: 'K-18', company_name: 'Machine GmbH' },
+              license: { license_binding: 'machine', machine_id: '' },
+              setupType: 'machine',
+              licenseFilePath,
+            }, {
+              nodeResolver: () => ({ ok: true, nodeExecutable: 'node', trace: ['test'] }),
+            });
+            assert.equal(res.ok, true);
+            assert.equal(res.env.BBM_CUSTOMER_SETUP_TYPE, 'machine');
+            assert.equal(Boolean(res.env.BBM_CUSTOMER_LICENSE_FILE), false);
           }
         );
       }

--- a/scripts/tests/licenseIpcCustomerSetup.test.cjs
+++ b/scripts/tests/licenseIpcCustomerSetup.test.cjs
@@ -208,6 +208,15 @@ async function runLicenseIpcCustomerSetupTests(run) {
       source.includes('inputData.edition === "test" && inputData.binding === "none" ? {} : { validUntil: inputData.validUntil }'),
       true
     );
+    assert.equal(source.includes('inputData.trialDurationDays ? { trialDurationDays: inputData.trialDurationDays }'), true);
+  });
+
+  await run('licenseIpc: externe Generator-validUntil-Fehler werden fuer Testversion klar erkannt', () => {
+    withLicenseIpcModule({}, (mod) => {
+      assert.equal(mod._hasExternalGeneratorValidUntilMismatch('Pflichtfeld fehlt oder ist leer: validUntil'), true);
+      assert.equal(mod._hasExternalGeneratorValidUntilMismatch('VALID_UNTIL_REQUIRED'), true);
+      assert.equal(mod._hasExternalGeneratorValidUntilMismatch('alles ok'), false);
+    });
   });
 
   await run('licenseIpc: exitCode 0 aber outputDir fehlt -> CUSTOMER_SETUP_ARTIFACT_NOT_FOUND', async () => {

--- a/scripts/tests/licenseIpcCustomerSetup.test.cjs
+++ b/scripts/tests/licenseIpcCustomerSetup.test.cjs
@@ -201,6 +201,15 @@ async function runLicenseIpcCustomerSetupTests(run) {
     });
   });
 
+  await run('licenseIpc: kein validFrom+Testdauer-Fallback auf validUntil mehr vorhanden', () => {
+    const source = fs.readFileSync(path.join(REAL_REPO_ROOT, 'src/main/ipc/licenseIpc.js'), 'utf8');
+    assert.equal(source.includes('_computeValidUntil'), false);
+    assert.equal(
+      source.includes('inputData.edition === "test" && inputData.binding === "none" ? {} : { validUntil: inputData.validUntil }'),
+      true
+    );
+  });
+
   await run('licenseIpc: exitCode 0 aber outputDir fehlt -> CUSTOMER_SETUP_ARTIFACT_NOT_FOUND', async () => {
     await withTempRepo(
       () => {},

--- a/scripts/tests/licenseRequest.test.cjs
+++ b/scripts/tests/licenseRequest.test.cjs
@@ -182,9 +182,17 @@ async function runLicenseRequestTests(run) {
     const settingsSource = read("src/renderer/views/SettingsView.js");
     const licenseAdminSource = read("src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js");
     assert.equal(settingsSource.includes("Lizenzanforderung speichern"), true);
+    assert.equal(settingsSource.includes("Lizenz importieren"), true);
     assert.equal(settingsSource.includes("Lizenzanforderung wurde gespeichert."), true);
     assert.equal(settingsSource.includes("Lizenzanforderung konnte nicht gespeichert werden."), true);
+    assert.equal(settingsSource.includes("Antwortlizenz erhalten?"), true);
+    assert.equal(settingsSource.includes("Importieren Sie hier die .bbmlic-Datei"), true);
     assert.equal(licenseAdminSource.includes("Lizenzanforderung importieren"), true);
+    assert.equal(licenseAdminSource.includes("Gerätegebundene Vollversion:"), true);
+    assert.equal(licenseAdminSource.includes("Antwortlizenz wurde erstellt."), true);
+    assert.equal(licenseAdminSource.includes("Diese .bbmlic-Datei an den Kunden zurückgeben."), true);
+    assert.equal(licenseAdminSource.includes("Antwortlizenz erzeugen"), false);
+    assert.equal(licenseAdminSource.includes("Lizenz erstellen"), true);
     assert.equal(
       licenseAdminSource.includes("Lizenzanforderung importiert. Machine-ID wurde übernommen."),
       true

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -820,6 +820,10 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Ausgabeordner öffnen"), true);
     assert.equal(screenSource.includes("Lizenzdatei wird erzeugt ..."), true);
     assert.equal(screenSource.includes("Lizenzdatei wurde erzeugt."), true);
+    assert.equal(screenSource.includes("Gerätegebundene Vollversion:"), true);
+    assert.equal(screenSource.includes("Antwortlizenz wurde erstellt."), true);
+    assert.equal(screenSource.includes("Diese .bbmlic-Datei an den Kunden zurückgeben."), true);
+    assert.equal(screenSource.includes("Antwortlizenz erzeugen"), false);
     assert.equal(screenSource.includes("Produktumfang enthält keine erzeugbaren Features."), true);
     assert.equal(screenSource.includes("Machine-ID ist erforderlich, wenn die Lizenz an ein Gerät gebunden wird."), true);
     assert.equal(screenSource.includes("Bitte gültige Datumswerte eintragen."), true);
@@ -829,6 +833,12 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("\"Gerätebindung\""), true);
     assert.equal(screenSource.includes("licenseGenerate"), true);
     assert.equal(screenSource.includes("licenseOpenOutputDir"), true);
+  });
+
+  await run("SettingsView: Lizenzstatusbereich fuehrt Antwortlizenz-Import ohne neuen Mechanismus", () => {
+    assert.equal(settingsViewSource.includes("Antwortlizenz erhalten?"), true);
+    assert.equal(settingsViewSource.includes("Importieren Sie hier die .bbmlic-Datei"), true);
+    assert.equal(settingsViewSource.includes("Lizenz importieren"), true);
   });
 
   await run("Kundendetail: nach Kunde speichern ist Neue Lizenz direkt nutzbar", () => {

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -364,20 +364,38 @@ async function runLizenzverwaltungModuleTests(run) {
   });
 
   await run("Lizenzverwaltung: Build-Mapping fuer Kunden-Setup Payload", () => {
-    const payload = buildCustomerSetupPayload({
+    const testPayload = buildCustomerSetupPayload({
       customer: { customer_number: "K-100", company_name: "Musterfirma GmbH" },
       license: { license_file_path: "C:\\tmp\\customer.bbmlic" },
     });
-    assert.equal(payload.customer.customer_number, "K-100");
-    assert.equal(payload.license.license_file_path, "C:\\tmp\\customer.bbmlic");
-    assert.equal(payload.licenseFilePath, "C:\\tmp\\customer.bbmlic");
+    assert.equal(testPayload.customer.customer_number, "K-100");
+    assert.equal(testPayload.license.license_file_path, "C:\\tmp\\customer.bbmlic");
+    assert.equal(testPayload.licenseFilePath, "C:\\tmp\\customer.bbmlic");
+    assert.equal(testPayload.setupType, "test");
+
+    const machinePayload = buildCustomerSetupPayload({
+      customer: { customer_number: "K-100", company_name: "Musterfirma GmbH" },
+      license: { license_file_path: "C:\\tmp\\customer.bbmlic" },
+      setupType: "machine",
+    });
+    assert.equal(machinePayload.setupType, "machine");
+    assert.equal(machinePayload.licenseFilePath, "");
   });
 
   await run("Lizenzverwaltung UI: Kunden-Setup-Texte und Hinweise vorhanden", () => {
     assert.equal(screenSource.includes("Kunden-Setup erstellen"), true);
+    assert.equal(screenSource.includes("Machine-Setup erstellen"), true);
+    assert.equal(screenSource.includes("Machine-Setup wird erstellt ..."), true);
+    assert.equal(screenSource.includes("Machine-Setup wurde erstellt."), true);
+    assert.equal(screenSource.includes("Lizenztyp"), true);
+    assert.equal(screenSource.includes("Testversion"), true);
     assert.equal(screenSource.includes("Bitte zuerst die Lizenz erstellen."), true);
     assert.equal(screenSource.includes("Kunden-Setup wird erstellt ..."), true);
     assert.equal(screenSource.includes("Kunden-Setup wurde erstellt."), true);
+    assert.equal(screenSource.includes("Schritt 1: Machine-Setup erstellen"), true);
+    assert.equal(screenSource.includes("Schritt 2: Lizenzanforderung importieren"), true);
+    assert.equal(screenSource.includes("Schritt 3: Antwortlizenz erstellen"), true);
+    assert.equal(screenSource.includes("Dieses Setup enthält noch keine fertige Lizenz."), true);
     assert.equal(screenSource.includes("if (!res?.ok)"), true);
     assert.equal(screenSource.includes("stdout(last):"), true);
     assert.equal(screenSource.includes("stderr(last):"), true);
@@ -829,8 +847,8 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Bitte gültige Datumswerte eintragen."), true);
     assert.equal(screenSource.includes("Der Testzeitraum beginnt bei erster Installation / erstem Start."), true);
     assert.equal(screenSource.includes("Testzeitraum"), true);
-    assert.equal(screenSource.includes("\"Lizenzart\""), true);
-    assert.equal(screenSource.includes("\"Gerätebindung\""), true);
+    assert.equal(screenSource.includes("\"Lizenztyp\""), true);
+    assert.equal(screenSource.includes("Gerätebindung (automatisch)"), true);
     assert.equal(screenSource.includes("licenseGenerate"), true);
     assert.equal(screenSource.includes("licenseOpenOutputDir"), true);
   });

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -537,6 +537,7 @@ function _writeCustomerSetupBuildLog({
       `licenseFilePath: ${licenseFilePath || "-"}`,
       `exitCode: ${exitCode === null || exitCode === undefined ? "-" : exitCode}`,
       `env.BBM_CUSTOMER_LICENSE_FILE: ${envSnapshot.BBM_CUSTOMER_LICENSE_FILE || "-"}`,
+      `env.BBM_CUSTOMER_SETUP_TYPE: ${envSnapshot.BBM_CUSTOMER_SETUP_TYPE || "-"}`,
       `env.BBM_CUSTOMER_SLUG: ${envSnapshot.BBM_CUSTOMER_SLUG || "-"}`,
       `env.BBM_CUSTOMER_NAME: ${envSnapshot.BBM_CUSTOMER_NAME || "-"}`,
       `artifacts: ${artifacts.length ? artifacts.join(" | ") : "-"}`,
@@ -565,19 +566,21 @@ function _resolveCustomerSetupArtifactPath(outputDir, customerSlug) {
 function _validateCustomerSetupPayload(raw = {}) {
   const customer = raw?.customer && typeof raw.customer === "object" ? raw.customer : {};
   const license = raw?.license && typeof raw.license === "object" ? raw.license : {};
-  const licenseFilePath = String(raw?.licenseFilePath || raw?.license_file_path || "").trim();
-  if (!licenseFilePath) throw new Error("LICENSE_FILE_PATH_REQUIRED");
-  if (!fs.existsSync(licenseFilePath)) throw new Error("LICENSE_FILE_NOT_FOUND");
+  const setupType = String(raw?.setupType || raw?.setup_type || "").trim().toLowerCase() === "machine" ? "machine" : "test";
+  const licenseFilePath = setupType === "test" ? String(raw?.licenseFilePath || raw?.license_file_path || "").trim() : "";
+  if (setupType === "test" && !licenseFilePath) throw new Error("LICENSE_FILE_PATH_REQUIRED");
+  if (setupType === "test" && !fs.existsSync(licenseFilePath)) throw new Error("LICENSE_FILE_NOT_FOUND");
 
   const binding = String(license.license_binding || license.licenseBinding || "").trim().toLowerCase();
   const machineId = String(license.machine_id || license.machineId || "").trim();
-  if (binding === "machine" && !machineId) {
+  if (setupType !== "machine" && binding === "machine" && !machineId) {
     throw new Error("MACHINE_ID_REQUIRED_FOR_BINDING");
   }
 
   return {
     customer,
     license,
+    setupType,
     licenseFilePath,
     customerSlug: _buildCustomerSetupSlug(customer),
     customerName: String(customer.company_name || customer.companyName || "").trim(),
@@ -598,10 +601,15 @@ async function _runCustomerSetupBuild(payload = {}, options = {}) {
   const nodeExe = String(resolvedNode?.nodeExecutable || "").trim();
   const envForBuild = {
     ...process.env,
-    BBM_CUSTOMER_LICENSE_FILE: validated.licenseFilePath,
+    BBM_CUSTOMER_SETUP_TYPE: validated.setupType,
     BBM_CUSTOMER_SLUG: validated.customerSlug,
     BBM_CUSTOMER_NAME: validated.customerName,
   };
+  if (validated.setupType === "test" && validated.licenseFilePath) {
+    envForBuild.BBM_CUSTOMER_LICENSE_FILE = validated.licenseFilePath;
+  } else {
+    delete envForBuild.BBM_CUSTOMER_LICENSE_FILE;
+  }
   fs.mkdirSync(outputDir, { recursive: true });
   const logPath = path.join(outputDir, "customer-setup-build.log");
   const timeoutMs =
@@ -643,6 +651,7 @@ async function _runCustomerSetupBuild(payload = {}, options = {}) {
       logPath,
       env: {
         BBM_CUSTOMER_LICENSE_FILE: envForBuild.BBM_CUSTOMER_LICENSE_FILE,
+        BBM_CUSTOMER_SETUP_TYPE: envForBuild.BBM_CUSTOMER_SETUP_TYPE,
         BBM_CUSTOMER_SLUG: envForBuild.BBM_CUSTOMER_SLUG,
         BBM_CUSTOMER_NAME: envForBuild.BBM_CUSTOMER_NAME,
       },
@@ -710,6 +719,7 @@ async function _runCustomerSetupBuild(payload = {}, options = {}) {
         logPath,
         env: {
           BBM_CUSTOMER_LICENSE_FILE: envForBuild.BBM_CUSTOMER_LICENSE_FILE,
+          BBM_CUSTOMER_SETUP_TYPE: envForBuild.BBM_CUSTOMER_SETUP_TYPE,
           BBM_CUSTOMER_SLUG: envForBuild.BBM_CUSTOMER_SLUG,
           BBM_CUSTOMER_NAME: envForBuild.BBM_CUSTOMER_NAME,
         },
@@ -757,6 +767,7 @@ async function _runCustomerSetupBuild(payload = {}, options = {}) {
         logPath,
         env: {
           BBM_CUSTOMER_LICENSE_FILE: envForBuild.BBM_CUSTOMER_LICENSE_FILE,
+          BBM_CUSTOMER_SETUP_TYPE: envForBuild.BBM_CUSTOMER_SETUP_TYPE,
           BBM_CUSTOMER_SLUG: envForBuild.BBM_CUSTOMER_SLUG,
           BBM_CUSTOMER_NAME: envForBuild.BBM_CUSTOMER_NAME,
         },
@@ -783,6 +794,7 @@ async function _runCustomerSetupBuild(payload = {}, options = {}) {
         logPath,
         env: {
           BBM_CUSTOMER_LICENSE_FILE: envForBuild.BBM_CUSTOMER_LICENSE_FILE,
+          BBM_CUSTOMER_SETUP_TYPE: envForBuild.BBM_CUSTOMER_SETUP_TYPE,
           BBM_CUSTOMER_SLUG: envForBuild.BBM_CUSTOMER_SLUG,
           BBM_CUSTOMER_NAME: envForBuild.BBM_CUSTOMER_NAME,
         },

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -249,15 +249,6 @@ function _normalizeIsoDate(value) {
   return raw;
 }
 
-function _computeValidUntil(validFrom, durationDays) {
-  const start = _normalizeIsoDate(validFrom);
-  const days = Number(durationDays);
-  if (!start || !Number.isFinite(days) || days < 1) return "";
-  const dt = new Date(`${start}T00:00:00Z`);
-  dt.setUTCDate(dt.getUTCDate() + Math.floor(days));
-  return dt.toISOString().slice(0, 10);
-}
-
 function _normalizeTrialDurationDays(value) {
   const num = Number(value);
   if (!Number.isFinite(num)) return null;
@@ -273,12 +264,8 @@ function _validateGenerationPayload(raw = {}) {
   const edition = String(raw?.edition || "test").trim() || "test";
   const binding = String(raw?.binding || "").trim().toLowerCase() || "none";
   const validFrom = _normalizeIsoDate(raw?.validFrom);
-  const durationDays =
-    raw?.durationDays === "" || raw?.durationDays === null || raw?.durationDays === undefined
-      ? null
-      : Number(raw.durationDays);
   const explicitValidUntil = _normalizeIsoDate(raw?.validUntil);
-  const validUntil = explicitValidUntil || _computeValidUntil(validFrom, durationDays);
+  const validUntil = explicitValidUntil;
   const trialDurationDays = _normalizeTrialDurationDays(raw?.trialDurationDays);
   const maxDevices = Number(raw?.maxDevices);
   const features = Array.isArray(raw?.features)
@@ -315,7 +302,6 @@ function _validateGenerationPayload(raw = {}) {
     validFrom,
     validUntil: isTestLicense ? "" : validUntil,
     trialDurationDays: isTestLicense ? trialDurationDays : null,
-    durationDays: Number.isFinite(durationDays) && durationDays > 0 ? Math.floor(durationDays) : null,
     maxDevices: Math.floor(maxDevices),
     features,
     notes,
@@ -1075,7 +1061,7 @@ function registerLicenseDevGeneratorIpc() {
             edition: inputData.edition,
             binding: inputData.binding,
             validFrom: inputData.validFrom,
-            validUntil: inputData.validUntil,
+            ...(inputData.edition === "test" && inputData.binding === "none" ? {} : { validUntil: inputData.validUntil }),
             ...(inputData.trialDurationDays ? { trialDurationDays: inputData.trialDurationDays } : {}),
             maxDevices: inputData.maxDevices,
             features: inputData.features,

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -257,6 +257,16 @@ function _normalizeTrialDurationDays(value) {
   return days;
 }
 
+function _hasExternalGeneratorValidUntilMismatch(text) {
+  const upper = String(text || "").toUpperCase();
+  if (!upper) return false;
+  return (
+    upper.includes("VALIDUNTIL") ||
+    upper.includes("VALID_UNTIL") ||
+    upper.includes("PFLICHTFELD FEHLT ODER IST LEER")
+  );
+}
+
 function _validateGenerationPayload(raw = {}) {
   const product = String(raw?.product || "bbm-protokoll").trim() || "bbm-protokoll";
   const customerName = String(raw?.customerName || "").trim();
@@ -1040,12 +1050,13 @@ function registerLicenseDevGeneratorIpc() {
       return { ok: false, error: "LICENSE_GENERATION_NOT_ALLOWED" };
     }
 
+    let inputData = null;
     try {
       if (!fs.existsSync(LICENSE_TOOL_ROOT)) return { ok: false, error: "LICENSE_TOOL_NOT_FOUND" };
       if (!fs.existsSync(LICENSE_TOOL_SCRIPT)) return { ok: false, error: "LICENSE_TOOL_SCRIPT_MISSING" };
       if (!fs.existsSync(LICENSE_TOOL_PRIVATE_KEY)) return { ok: false, error: "PRIVATE_KEY_MISSING" };
 
-      const inputData = _validateGenerationPayload(raw || {});
+      inputData = _validateGenerationPayload(raw || {});
       await fs.promises.mkdir(LICENSE_TOOL_INPUT_DIR, { recursive: true });
       await fs.promises.mkdir(LICENSE_TOOL_OUTPUT_DIR, { recursive: true });
 
@@ -1079,6 +1090,15 @@ function registerLicenseDevGeneratorIpc() {
       const runResult = await _runLicenseTool(inputPath);
       const outputPath = _extractGeneratedPath(runResult, inputData);
       if (!outputPath) {
+        const generatorCombinedOutput = `${String(runResult?.stderr || "")}\n${String(runResult?.stdout || "")}`;
+        const isTestLicense = inputData.edition === "test" && inputData.binding === "none";
+        if (isTestLicense && _hasExternalGeneratorValidUntilMismatch(generatorCombinedOutput)) {
+          return {
+            ok: false,
+            error: "EXTERNAL_GENERATOR_INCOMPATIBLE_TEST_NO_VALID_UNTIL",
+            message: "Externer Lizenzgenerator ist nicht kompatibel mit Testversion ohne validUntil.",
+          };
+        }
         if (runResult?.timedOut) {
           return { ok: false, error: "GENERATOR_TIMEOUT" };
         }
@@ -1100,9 +1120,18 @@ function registerLicenseDevGeneratorIpc() {
         features: inputData.features,
       };
     } catch (err) {
+      const errorText = String(err?.message || err || "LICENSE_GENERATION_FAILED").trim() || "LICENSE_GENERATION_FAILED";
+      const isTestLicense = inputData?.edition === "test" && inputData?.binding === "none";
+      if (isTestLicense && _hasExternalGeneratorValidUntilMismatch(errorText)) {
+        return {
+          ok: false,
+          error: "EXTERNAL_GENERATOR_INCOMPATIBLE_TEST_NO_VALID_UNTIL",
+          message: "Externer Lizenzgenerator ist nicht kompatibel mit Testversion ohne validUntil.",
+        };
+      }
       return {
         ok: false,
-        error: String(err?.message || err || "LICENSE_GENERATION_FAILED").trim() || "LICENSE_GENERATION_FAILED",
+        error: errorText,
       };
     }
   });
@@ -1195,6 +1224,7 @@ module.exports = {
   registerLicenseIpc,
   _buildCustomerSetupSlug,
   _validateGenerationPayload,
+  _hasExternalGeneratorValidUntilMismatch,
   _buildLicenseRequestPayload,
   resolveNodeExecutableForBuild,
   _validateCustomerSetupPayload,

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -938,6 +938,7 @@ export default class LicenseAdminScreen {
       appendFieldRow("Legacy-Hinweis", legacyHint);
     }
 
+    let machineBindingHint = null;
     const syncScopeJson = () => {
       inputs.product_scope_json.value = JSON.stringify(buildStructuredProductScopeJson(scopeModel, scopeModel.previous));
     };
@@ -983,6 +984,12 @@ export default class LicenseAdminScreen {
       if (fieldRows.machine_id) {
         fieldRows.machine_id.row.style.display = isTestLicense ? "none" : "";
       }
+      const binding = String(inputs.license_binding?.value || "none").trim().toLowerCase();
+      const showMachineHint = !isTestLicense && binding === "machine";
+      if (machineBindingHint) {
+        machineBindingHint.style.display = showMachineHint ? "" : "none";
+        machineBindingHint.style.whiteSpace = showMachineHint ? "pre-line" : "normal";
+      }
     };
     inputs.license_binding?.addEventListener("change", syncMachineIdState);
     inputs.trial_duration_days?._durationSelect?.addEventListener("change", syncTrialDurationState);
@@ -1000,6 +1007,15 @@ export default class LicenseAdminScreen {
     licenseIdHint.textContent =
       "Wenn die Lizenz-ID leer ist, wird beim Erstellen automatisch eine ID erzeugt.";
     licenseIdHint.style.fontSize = "12px";
+    machineBindingHint = document.createElement("div");
+    machineBindingHint.style.fontSize = "12px";
+    machineBindingHint.style.padding = "8px";
+    machineBindingHint.style.border = "1px solid #cbd5e1";
+    machineBindingHint.style.borderRadius = "6px";
+    machineBindingHint.style.background = "#f8fafc";
+    machineBindingHint.style.display = "none";
+    machineBindingHint.textContent =
+      "Gerätegebundene Vollversion:\nImportieren Sie zuerst die Lizenzanforderung des Kunden.\nDanach erzeugen Sie mit „Lizenz erstellen“ die Antwortlizenz.";
 
     const actions = document.createElement("div");
     actions.style.display = "flex";
@@ -1201,7 +1217,14 @@ export default class LicenseAdminScreen {
           message.textContent = `Fehler: ${res?.error || "Lizenz konnte nicht erzeugt werden."}`;
           return;
         }
-        message.textContent = "Lizenzdatei wurde erzeugt.";
+        const isMachineResponseLicense =
+          generatorPayload.edition === "full" &&
+          generatorPayload.binding === "machine" &&
+          String(generatorPayload.machineId || "").trim();
+        message.textContent = isMachineResponseLicense
+          ? "Lizenzdatei wurde erzeugt.\nAntwortlizenz wurde erstellt.\nDiese .bbmlic-Datei an den Kunden zurückgeben."
+          : "Lizenzdatei wurde erzeugt.";
+        message.style.whiteSpace = "pre-line";
         const outputPath = String(res?.outputPath || "").trim();
         if (outputPath) {
           generationOutput.textContent = `Ausgabepfad: ${outputPath}`;
@@ -1235,7 +1258,7 @@ export default class LicenseAdminScreen {
     });
 
     actions.append(importRequestBtn, createBtn, createCustomerSetupBtn, backBtn, openOutputDirBtn);
-    container.append(header, context, form, licenseIdHint, actions, message, generationOutput, setupOutput);
+    container.append(header, context, form, licenseIdHint, machineBindingHint, actions, message, generationOutput, setupOutput);
   }
 
   async _render() {

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -152,12 +152,16 @@ export function buildLicenseEditorPayload({ license = {}, inputs = {}, customer 
   const customerId = assertCustomerContext(customer);
   const normalizedTrialDurationDays = normalizeTrialDurationDays(inputs.trial_duration_days, 30);
   const isTestLicense = String(inputs.license_edition || "").trim().toLowerCase() === "test";
+  const technicalValidFrom = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(
+    now.getDate()
+  ).padStart(2, "0")}`;
+  const validFromInput = String(inputs.valid_from || "").trim();
   return {
     id: license.id,
     customer_id: customerId,
     license_id: String(inputs.license_id || "").trim() || createGeneratedLicenseId(now),
     product_scope_json: String(inputs.product_scope_json || "").trim(),
-    valid_from: String(inputs.valid_from || "").trim(),
+    valid_from: isTestLicense ? validFromInput || technicalValidFrom : validFromInput,
     valid_until: isTestLicense ? "" : String(inputs.valid_until || "").trim(),
     trial_duration_days: isTestLicense ? String(normalizedTrialDurationDays) : "",
     license_mode: String(inputs.license_mode || "").trim(),
@@ -771,7 +775,9 @@ export default class LicenseAdminScreen {
         const trialHint = document.createElement("div");
         trialHint.style.fontSize = "12px";
         trialHint.style.opacity = "0.85";
-        trialHint.textContent = "Der Testzeitraum beginnt bei erster Installation / erstem Start.";
+        trialHint.style.whiteSpace = "pre-line";
+        trialHint.textContent =
+          "Der Testzeitraum beginnt bei erster Installation / erstem Start.\nTechnisches Ausstellungsdatum wird automatisch gesetzt.";
         input.append(trialTitle, durationSelect, customRow, trialHint);
         input._durationSelect = durationSelect;
         input._customInput = customInput;

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -152,6 +152,8 @@ export function buildLicenseEditorPayload({ license = {}, inputs = {}, customer 
   const customerId = assertCustomerContext(customer);
   const normalizedTrialDurationDays = normalizeTrialDurationDays(inputs.trial_duration_days, 30);
   const isTestLicense = String(inputs.license_edition || "").trim().toLowerCase() === "test";
+  const normalizedEdition = isTestLicense ? "test" : "full";
+  const normalizedBinding = isTestLicense ? "none" : "machine";
   const technicalValidFrom = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(
     now.getDate()
   ).padStart(2, "0")}`;
@@ -164,8 +166,10 @@ export function buildLicenseEditorPayload({ license = {}, inputs = {}, customer 
     valid_from: isTestLicense ? validFromInput || technicalValidFrom : validFromInput,
     valid_until: isTestLicense ? "" : String(inputs.valid_until || "").trim(),
     trial_duration_days: isTestLicense ? String(normalizedTrialDurationDays) : "",
-    license_mode: String(inputs.license_mode || "").trim(),
-    machine_id: String(inputs.machine_id || "").trim(),
+    license_mode: normalizedBinding === "machine" ? "full" : "soft",
+    license_edition: normalizedEdition,
+    license_binding: normalizedBinding,
+    machine_id: normalizedBinding === "machine" ? String(inputs.machine_id || "").trim() : "",
     license_file_path: valueOf(license, "license_file_path", "licenseFilePath"),
     license_file_created_at: valueOf(license, "license_file_created_at", "licenseFileCreatedAt"),
     notes: String(inputs.notes || "").trim(),
@@ -1189,9 +1193,7 @@ export default class LicenseAdminScreen {
             product_scope_json: inputs.product_scope_json.value,
             valid_from: inputs.valid_from.value,
             valid_until: inputs.valid_until.value,
-            license_mode: inputs.license_binding.value === "machine" ? "full" : "soft",
             license_edition: inputs.license_edition.value,
-            license_binding: inputs.license_binding.value,
             trial_duration_days:
               String(inputs.license_edition.value || "").trim().toLowerCase() === "test"
                 ? String(

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -335,11 +335,13 @@ function tailLines(value, maxLines = 6) {
   return lines.slice(-Math.max(1, maxLines)).join(" | ");
 }
 
-export function buildCustomerSetupPayload({ customer = {}, license = {} } = {}) {
-  const licenseFilePath = valueOf(license, "license_file_path", "licenseFilePath");
+export function buildCustomerSetupPayload({ customer = {}, license = {}, setupType = "test" } = {}) {
+  const normalizedSetupType = String(setupType || "").trim().toLowerCase() === "machine" ? "machine" : "test";
+  const licenseFilePath = normalizedSetupType === "test" ? valueOf(license, "license_file_path", "licenseFilePath") : "";
   return {
     customer,
     license,
+    setupType: normalizedSetupType,
     licenseFilePath,
   };
 }
@@ -678,8 +680,8 @@ export default class LicenseAdminScreen {
       ["license_id", "Lizenz-ID"],
       ["valid_from", "gueltig von"],
       ["valid_until", "gueltig bis"],
-      ["license_edition", "Lizenzart"],
-      ["license_binding", "Gerätebindung"],
+      ["license_edition", "Lizenztyp"],
+      ["license_binding", "Gerätebindung (automatisch)"],
       ["trial_duration_days", "Testzeitraum"],
       ["machine_id", "Machine-ID"],
       ["notes", "Notizen"],
@@ -711,7 +713,7 @@ export default class LicenseAdminScreen {
       if (key === "license_edition") {
         input = document.createElement("select");
         [
-          { value: "test", label: "Testlizenz" },
+          { value: "test", label: "Testversion" },
           { value: "full", label: "Vollversion" },
         ].forEach((entry) => {
           const option = document.createElement("option");
@@ -939,6 +941,8 @@ export default class LicenseAdminScreen {
     }
 
     let machineBindingHint = null;
+    let machineFlowHint = null;
+    let machineSetupHint = null;
     const syncScopeJson = () => {
       inputs.product_scope_json.value = JSON.stringify(buildStructuredProductScopeJson(scopeModel, scopeModel.previous));
     };
@@ -962,13 +966,16 @@ export default class LicenseAdminScreen {
         customInput.value = selector.value;
       }
     };
+    let syncActionButtonsState = () => {};
     const syncEditionUiState = () => {
       const edition = String(inputs.license_edition?.value || "test").trim().toLowerCase();
       const isTestLicense = edition === "test";
       if (isTestLicense) {
         inputs.license_binding.value = "none";
+      } else {
+        inputs.license_binding.value = "machine";
       }
-      inputs.license_binding.disabled = isTestLicense;
+      inputs.license_binding.disabled = true;
       syncMachineIdState();
       if (fieldRows.valid_from) {
         fieldRows.valid_from.title.textContent = isTestLicense ? "Ausgestellt am (technisch)" : "gueltig von";
@@ -984,12 +991,21 @@ export default class LicenseAdminScreen {
       if (fieldRows.machine_id) {
         fieldRows.machine_id.row.style.display = isTestLicense ? "none" : "";
       }
-      const binding = String(inputs.license_binding?.value || "none").trim().toLowerCase();
-      const showMachineHint = !isTestLicense && binding === "machine";
+      if (fieldRows.license_binding) {
+        fieldRows.license_binding.row.style.display = "none";
+      }
+      const showMachineHint = !isTestLicense;
       if (machineBindingHint) {
         machineBindingHint.style.display = showMachineHint ? "" : "none";
         machineBindingHint.style.whiteSpace = showMachineHint ? "pre-line" : "normal";
       }
+      if (machineFlowHint) {
+        machineFlowHint.style.display = showMachineHint ? "" : "none";
+      }
+      if (machineSetupHint) {
+        machineSetupHint.style.display = showMachineHint ? "" : "none";
+      }
+      syncActionButtonsState();
     };
     inputs.license_binding?.addEventListener("change", syncMachineIdState);
     inputs.trial_duration_days?._durationSelect?.addEventListener("change", syncTrialDurationState);
@@ -1016,6 +1032,20 @@ export default class LicenseAdminScreen {
     machineBindingHint.style.display = "none";
     machineBindingHint.textContent =
       "Gerätegebundene Vollversion:\nImportieren Sie zuerst die Lizenzanforderung des Kunden.\nDanach erzeugen Sie mit „Lizenz erstellen“ die Antwortlizenz.";
+    machineFlowHint = document.createElement("div");
+    machineFlowHint.style.fontSize = "12px";
+    machineFlowHint.style.padding = "8px";
+    machineFlowHint.style.border = "1px solid #cbd5e1";
+    machineFlowHint.style.borderRadius = "6px";
+    machineFlowHint.style.background = "#f8fafc";
+    machineFlowHint.style.display = "none";
+    machineFlowHint.style.whiteSpace = "pre-line";
+    machineFlowHint.textContent =
+      "Schritt 1: Machine-Setup erstellen\nSchritt 2: Lizenzanforderung importieren\nSchritt 3: Antwortlizenz erstellen";
+    machineSetupHint = document.createElement("div");
+    machineSetupHint.style.fontSize = "12px";
+    machineSetupHint.style.display = "none";
+    machineSetupHint.textContent = "Dieses Setup enthält noch keine fertige Lizenz.";
 
     const actions = document.createElement("div");
     actions.style.display = "flex";
@@ -1079,25 +1109,21 @@ export default class LicenseAdminScreen {
       }
     });
     openOutputDirBtn.style.display = "none";
-    const createCustomerSetupBtn = this._button("Kunden-Setup erstellen", async () => {
+    const runSetupBuild = async ({ setupType = "test" } = {}) => {
       const activeLicense = this.currentLicense || license || {};
       const payload = buildCustomerSetupPayload({
         customer: this.currentCustomer || {},
         license: activeLicense,
+        setupType,
       });
-      if (!String(payload.licenseFilePath || "").trim()) {
+      if (setupType === "test" && !String(payload.licenseFilePath || "").trim()) {
         message.textContent = "Bitte zuerst die Lizenz erstellen.";
         return;
       }
-      const binding = String(activeLicense.license_binding || activeLicense.licenseBinding || "").trim().toLowerCase();
-      const machineId = String(activeLicense.machine_id || activeLicense.machineId || "").trim();
-      if (binding === "machine" && !machineId) {
-        message.textContent = "Machine-ID ist erforderlich, wenn die Lizenz an ein Gerät gebunden wird.";
-        return;
-      }
       createCustomerSetupBtn.disabled = true;
+      createMachineSetupBtn.disabled = true;
       try {
-        message.textContent = "Kunden-Setup wird erstellt ...";
+        message.textContent = setupType === "machine" ? "Machine-Setup wird erstellt ..." : "Kunden-Setup wird erstellt ...";
         setupOutput.textContent = "";
         const res = await createCustomerSetup(payload);
         if (!res?.ok) {
@@ -1122,7 +1148,7 @@ export default class LicenseAdminScreen {
           setupOutput.textContent = diagnostics.join("\n");
           return;
         }
-        message.textContent = "Kunden-Setup wurde erstellt.";
+        message.textContent = setupType === "machine" ? "Machine-Setup wurde erstellt." : "Kunden-Setup wurde erstellt.";
         const outPath = String(res?.setupPath || res?.artifactPath || "").trim();
         const outDir = String(res?.outputDir || "").trim();
         setupOutput.textContent = outPath ? `Ausgabepfad: ${outPath}` : outDir ? `Ausgabepfad: ${outDir}` : "";
@@ -1136,8 +1162,11 @@ export default class LicenseAdminScreen {
         message.textContent = `Fehler: ${err?.message || err}`;
       } finally {
         createCustomerSetupBtn.disabled = false;
+        createMachineSetupBtn.disabled = false;
       }
-    });
+    };
+    const createCustomerSetupBtn = this._button("Kunden-Setup erstellen", async () => runSetupBuild({ setupType: "test" }));
+    const createMachineSetupBtn = this._button("Machine-Setup erstellen", async () => runSetupBuild({ setupType: "machine" }));
     createCustomerSetupBtn.disabled = !valueOf(license, "license_file_path", "licenseFilePath");
 
     const createBtn = this._button("Lizenz erstellen", async () => {
@@ -1247,9 +1276,30 @@ export default class LicenseAdminScreen {
         }
       } finally {
         createBtn.textContent = previousText;
-        createBtn.disabled = false;
+        syncActionButtonsState();
       }
     });
+
+    syncActionButtonsState = () => {
+      const edition = String(inputs.license_edition?.value || "test").trim().toLowerCase();
+      const machineId = String(inputs.machine_id?.value || "").trim();
+      const isFull = edition === "full";
+      const hasMachineId = !!machineId;
+      importRequestBtn.style.display = isFull ? "" : "none";
+      createMachineSetupBtn.style.display = isFull ? "" : "none";
+      createCustomerSetupBtn.style.display = isFull ? "none" : "";
+      if (isFull && !hasMachineId) {
+        createBtn.disabled = true;
+        createBtn.title = "Antwortlizenz erst nach Import einer Machine-ID erstellen.";
+      } else {
+        createBtn.disabled = false;
+        createBtn.title = "";
+      }
+    };
+    inputs.machine_id?.addEventListener("input", syncActionButtonsState);
+    inputs.license_edition?.addEventListener("change", syncActionButtonsState);
+    syncActionButtonsState();
+    syncEditionUiState();
 
     const backBtn = this._button("Zurueck", () => {
       this.currentLicense = null;
@@ -1257,8 +1307,20 @@ export default class LicenseAdminScreen {
       this._render();
     });
 
-    actions.append(importRequestBtn, createBtn, createCustomerSetupBtn, backBtn, openOutputDirBtn);
-    container.append(header, context, form, licenseIdHint, machineBindingHint, actions, message, generationOutput, setupOutput);
+    actions.append(importRequestBtn, createBtn, createCustomerSetupBtn, createMachineSetupBtn, backBtn, openOutputDirBtn);
+    container.append(
+      header,
+      context,
+      form,
+      licenseIdHint,
+      machineBindingHint,
+      machineFlowHint,
+      machineSetupHint,
+      actions,
+      message,
+      generationOutput,
+      setupOutput
+    );
   }
 
   async _render() {

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -519,9 +519,15 @@ export default class SettingsView {
     requestHint.style.opacity = "0.8";
     requestHint.textContent =
       "Diese Datei enthält die Machine-ID dieses Geräts und kann zur Erstellung einer gerätegebundenen Lizenz verwendet werden.";
+    const responseLicenseHint = document.createElement("div");
+    responseLicenseHint.style.fontSize = "11px";
+    responseLicenseHint.style.opacity = "0.9";
+    responseLicenseHint.style.whiteSpace = "pre-line";
+    responseLicenseHint.textContent =
+      "Antwortlizenz erhalten?\nImportieren Sie hier die .bbmlic-Datei, die Sie vom Anbieter erhalten haben.";
 
     buttonRow.append(btnImport, btnReload, btnCreateRequest);
-    statusCard.append(statusRow, messageEl, licenseBanner, infoGrid, requestTitle, requestHint, buttonRow);
+    statusCard.append(statusRow, messageEl, licenseBanner, infoGrid, requestTitle, requestHint, responseLicenseHint, buttonRow);
     wrap.append(statusCard, diagnosticsCard);
 
     const setBusy = (busy) => {


### PR DESCRIPTION
### Motivation
- Admins und Kunden sollen klar durch den Antwortlizenz-Ablauf geführt werden, nachdem eine Lizenzanforderung importiert und eine Lizenz erzeugt wurde, ohne den bestehenden Generator- oder Import-Flow zu verändern.

### Description
- Zeigt im Admin-Lizenzformular bei `Gerätebindung = An Machine-ID binden` einen kontextuellen Hinweis `Gerätegebundene Vollversion` mit der Anleitung: zuerst Lizenzanforderung importieren, dann mit `Lizenz erstellen` die Antwortlizenz erzeugen (`src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`).
- Ergänzt die Erfolgsmeldung nach erfolgreicher Erzeugung so, dass bei `Vollversion + Gerätebindung=machine + vorhandener Machine-ID` zusätzlich angezeigt wird: `Antwortlizenz wurde erstellt.` und `Diese .bbmlic-Datei an den Kunden zurückgeben.`, ohne einen neuen Button hinzuzufügen und ohne den Generator-IPC oder Flow zu ersetzen (`src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`).
- Ergänzt im Kunden-Lizenzstatusbereich einen Hinweis `Antwortlizenz erhalten?` mit der Anweisung, die vom Anbieter erhaltene `.bbmlic` über den bestehenden Import zu laden, ohne neuen Importmechanismus oder Navigation anzulegen (`src/renderer/views/SettingsView.js`).
- Aktualisiert prüfende Tests und Statusdokumentation; geänderte Dateien: `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`, `src/renderer/views/SettingsView.js`, `scripts/tests/licenseRequest.test.cjs`, `scripts/tests/lizenzverwaltungModule.test.cjs`, `STATUS.md`.

### Testing
- Ausgeführt: `npm test`; Ergebnis: alle Tests bestanden (`ok` / green). 
- Tests wurden erweitert, um das Vorhandensein der neuen UI-Texte sicherzustellen und zu prüfen, dass kein neuer Button `Antwortlizenz erzeugen` hinzugefügt wurde; die bestehenden Flows (`licenseGenerate`, Lizenzimport, `licenseVerifier`-Grenzen) blieben unverändert und die zugehörigen Tests sind grün.
- Repository-Checks: keine `.bbmlic` oder `bbm-license-request.json` Dateien wurden committed; Änderungen sind in den genannten Dateien begrenzt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0726bad7c8322b0a3c214c66b0156)