### PR TITLE
Lizenzverwaltung: Lizenzdatensätze in Admin-UI löschbar machen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -16,6 +16,13 @@ Sie ergänzt:
 ---
 
 ## Aktueller Gesamtstand
+- Lizenzverwaltung Loeschfunktion fuer Lizenzdatensaetze ist umgesetzt:
+  - Im Lizenzformular gibt es den Button `Lizenz löschen`, sichtbar nur bei bestehender gespeicherter Lizenz.
+  - Vor dem Loeschen erscheint die Sicherheitsabfrage mit Klartext, dass nur der Lizenzdatensatz in der Lizenzverwaltung entfernt wird.
+  - Nach Bestaetigung wird nur `license_records` geloescht; danach Rueckkehr ins Kundendetail mit Meldung `Lizenz wurde gelöscht.`.
+  - Bei Fehler erscheint `Lizenz konnte nicht gelöscht werden.`; bei Abbruch wird nichts geloescht.
+  - Neuer Main-Service `deleteLicenseRecord(id)` + IPC `license-admin:delete-license-record` + Preload `licenseAdminDeleteLicenseRecord(id)` + Renderer-Service `deleteLicense(record)` sind verbunden.
+  - Tests decken Main-Service-Loeschfall, fehlende ID, IPC-Registration/-Aufruf, Preload/API, Renderer-Service und UI-Texte ab; `npm test` bleibt gruen.
 - PR #46 Bugfix (Testversion speichern ohne sichtbares Datumsfeld) ist umgesetzt:
   - Bei `Lizenztyp = Testversion` setzt `buildLicenseEditorPayload` `valid_from` jetzt automatisch auf das technische Ausstellungsdatum (`YYYY-MM-DD`), wenn das Feld leer ist.
   - `valid_until` bleibt bei Testversion leer; `trial_duration_days` bleibt der fachliche Laufzeitwert.

--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -6,6 +6,7 @@ const { importEsmFromFile } = require("./_esmLoader.cjs");
 function createMemoryDb() {
   const customers = [];
   const licenses = [];
+  const history = [];
 
   function getCustomerById(id) {
     return customers.find((entry) => entry.id === id) || null;
@@ -35,6 +36,9 @@ function createMemoryDb() {
           if (text.includes("FROM license_customers")) {
             return [...customers];
           }
+          if (text.includes("FROM license_history")) {
+            return [...history];
+          }
           if (text.includes("FROM license_records") && text.includes("WHERE lr.customer_id = ?")) {
             return licenses.filter((entry) => entry.customer_id === arg).map(enrichLicense);
           }
@@ -57,6 +61,9 @@ function createMemoryDb() {
           }
           if (text.includes("SELECT * FROM license_records WHERE id = ?")) {
             return licenses.find((entry) => entry.id === arg) || undefined;
+          }
+          if (text.includes("SELECT * FROM license_history WHERE id = ?")) {
+            return history.find((entry) => entry.id === arg) || undefined;
           }
           return undefined;
         },
@@ -143,6 +150,18 @@ function createMemoryDb() {
               license_file_created_at,
               notes,
             });
+            return;
+          }
+          if (text.includes("DELETE FROM license_records WHERE id = ?")) {
+            const [id] = args;
+            const index = licenses.findIndex((entry) => entry.id === id);
+            if (index >= 0) licenses.splice(index, 1);
+            return;
+          }
+          if (text.includes("INSERT INTO license_history")) {
+            const [id, license_record_id, generated_at, product_scope_json, valid_until, output_path, notes] = args;
+            history.push({ id, license_record_id, generated_at, product_scope_json, valid_until, output_path, notes });
+            return;
           }
         },
       };
@@ -226,6 +245,73 @@ async function runLicenseAdminDataflowTests(run) {
       assert.equal(listedByCustomer[0].license_file_created_at, "2026-04-27T10:00:00.000Z");
       assert.equal(listedByCustomer[0].licenseFileCreatedAt, "2026-04-27T10:00:00.000Z");
       assert.equal(typeof listedByCustomer[0].product_scope_json, "string");
+    });
+  });
+
+  await run("Lizenzverwaltung Main-Service: deleteLicenseRecord loescht vorhandene Lizenz", () => {
+    withMockedDatabase((service) => {
+      const customer = service.saveCustomer({
+        customer_number: "K-102",
+        company_name: "Delete GmbH",
+      });
+      const savedLicense = service.saveLicense({
+        customer_id: customer.id,
+        product_scope_json: { standardumfang: ["app", "pdf", "export"] },
+        valid_from: "2026-02-01",
+        valid_until: "2026-12-31",
+        license_mode: "full",
+        license_edition: "full",
+        license_binding: "machine",
+        machine_id: "MID-DELETE-1",
+      });
+
+      const deleted = service.deleteLicenseRecord(savedLicense.id);
+      assert.equal(deleted.ok, true);
+      assert.equal(deleted.id, savedLicense.id);
+
+      const listedByCustomer = service.listLicensesByCustomer(customer.id);
+      assert.equal(listedByCustomer.length, 0);
+    });
+  });
+
+  await run("Lizenzverwaltung Main-Service: deleteLicenseRecord mit fehlender ID liefert klaren Fehler", () => {
+    withMockedDatabase((service) => {
+      assert.throws(() => service.deleteLicenseRecord(""), /license_record_id required/);
+    });
+  });
+
+  await run("Lizenzverwaltung Main-Service: deleteLicenseRecord laesst Kundendaten und Historie unberuehrt", () => {
+    withMockedDatabase((service) => {
+      const customer = service.saveCustomer({
+        customer_number: "K-103",
+        company_name: "History GmbH",
+      });
+      const savedLicense = service.saveLicense({
+        customer_id: customer.id,
+        product_scope_json: { standardumfang: ["app", "pdf", "export"] },
+        valid_from: "2026-03-01",
+        valid_until: "2026-12-31",
+        license_mode: "full",
+        license_edition: "full",
+        license_binding: "machine",
+        machine_id: "MID-DELETE-2",
+      });
+      const historyEntry = service.addHistoryEntry({
+        license_record_id: savedLicense.id,
+        generated_at: "2026-04-28T10:10:10.000Z",
+        product_scope_json: { standardumfang: ["app"] },
+        output_path: "C:\\license-tool\\output\\history.bbmlic",
+      });
+
+      service.deleteLicenseRecord(savedLicense.id);
+
+      const customers = service.listCustomers();
+      const history = service.listHistory();
+      assert.equal(customers.length, 1);
+      assert.equal(customers[0].id, customer.id);
+      assert.equal(history.length, 1);
+      assert.equal(history[0].id, historyEntry.id);
+      assert.equal(history[0].license_record_id, savedLicense.id);
     });
   });
 
@@ -371,6 +457,26 @@ async function runLicenseAdminDataflowTests(run) {
     assert.equal(received.license_file_path, "C:\\tmp\\camel-1.bbmlic");
     assert.equal(received.licenseFileCreatedAt, "2026-04-27T12:30:00.000Z");
     assert.equal(received.license_file_created_at, "2026-04-27T12:30:00.000Z");
+  });
+
+  await run("Lizenzverwaltung Renderer-Service: deleteLicense nutzt Preload-API", async () => {
+    const { deleteLicense } = await importEsmFromFile(
+      path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/licenseStorageService.js")
+    );
+
+    let receivedId = null;
+    global.window = {
+      bbmDb: {
+        licenseAdminDeleteLicenseRecord: async (id) => {
+          receivedId = id;
+          return { ok: true, id };
+        },
+      },
+    };
+
+    const result = await deleteLicense({ id: "lic-delete-1" });
+    assert.equal(receivedId, "lic-delete-1");
+    assert.equal(result.ok, true);
   });
 
   await run("Lizenzverwaltung normalizeLicenseRecord: snake_case und camelCase werden vollstaendig abgebildet", async () => {

--- a/scripts/tests/licenseIpcCustomerSetup.test.cjs
+++ b/scripts/tests/licenseIpcCustomerSetup.test.cjs
@@ -26,6 +26,8 @@ function createFakeChild({ exitCode = 0, stdout = '', stderr = '', error = null,
 function withLicenseIpcModule({ spawnImpl, cwd } = {}, fn) {
   const originalLoad = Module._load;
   const originalCwd = process.cwd();
+  const ipcHandlers = {};
+  const serviceCalls = [];
   if (cwd) process.chdir(cwd);
 
   Module._load = function patched(request, parent, isMain) {
@@ -34,7 +36,11 @@ function withLicenseIpcModule({ spawnImpl, cwd } = {}, fn) {
         app: { isPackaged: false, getVersion: () => '1.0.0' },
         BrowserWindow: { fromWebContents: () => null },
         dialog: {},
-        ipcMain: { handle: () => {} },
+        ipcMain: {
+          handle: (channel, handler) => {
+            ipcHandlers[channel] = handler;
+          },
+        },
         shell: { openPath: async () => '' },
       };
     }
@@ -60,6 +66,10 @@ function withLicenseIpcModule({ spawnImpl, cwd } = {}, fn) {
         listLicenses: () => [],
         listLicensesByCustomer: () => [],
         saveLicense: (l) => l,
+        deleteLicenseRecord: (id) => {
+          serviceCalls.push(id);
+          return { ok: true, id };
+        },
         listHistory: () => [],
         addHistoryEntry: (e) => e,
       };
@@ -70,7 +80,7 @@ function withLicenseIpcModule({ spawnImpl, cwd } = {}, fn) {
     const modPath = path.join(REAL_REPO_ROOT, 'src/main/ipc/licenseIpc.js');
     delete require.cache[require.resolve(modPath)];
     const mod = require(modPath);
-    return fn(mod);
+    return fn(mod, { ipcHandlers, serviceCalls });
   } finally {
     Module._load = originalLoad;
     if (cwd) process.chdir(originalCwd);
@@ -94,6 +104,16 @@ async function withTempRepo(setupFn, fn) {
 }
 
 async function runLicenseIpcCustomerSetupTests(run) {
+  await run('licenseIpc: license-admin delete-license-record ist registriert und ruft Service auf', async () => {
+    await withLicenseIpcModule({}, async (mod, ctx) => {
+      mod.registerLicenseIpc();
+      assert.equal(typeof ctx.ipcHandlers['license-admin:delete-license-record'], 'function');
+      const out = await ctx.ipcHandlers['license-admin:delete-license-record']({}, 'lic-77');
+      assert.equal(out.ok, true);
+      assert.equal(ctx.serviceCalls[0], 'lic-77');
+    });
+  });
+
   await run('licenseIpc: Kunden-Slug aus Kundennummer + Firmenname wird sicher gebaut', () => {
     withLicenseIpcModule({}, (mod) => {
       const slug = mod._buildCustomerSetupSlug({ customer_number: 'K-100', company_name: 'Musterfirma GmbH' });

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -717,6 +717,7 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(storageServiceSource.includes("licenseAdminSaveLicenseCustomer"), true);
     assert.equal(storageServiceSource.includes("licenseAdminListLicenseRecords"), true);
     assert.equal(storageServiceSource.includes("licenseAdminSaveLicenseRecord"), true);
+    assert.equal(storageServiceSource.includes("licenseAdminDeleteLicenseRecord"), true);
     assert.equal(storageServiceSource.includes("licenseAdminListLicenseHistory"), true);
     assert.equal(storageServiceSource.includes("licenseAdminAddLicenseHistoryEntry"), true);
     assert.equal(storageServiceSource.includes("ipcRenderer"), false);
@@ -731,6 +732,7 @@ async function runLizenzverwaltungModuleTests(run) {
   await run("Lizenzverwaltung: IPC-Handler fuer Admin-Lizenzen sind vorbereitet", () => {
     assert.equal(licenseIpcSource.includes('ipcMain.handle("license-admin:list-records"'), true);
     assert.equal(licenseIpcSource.includes('ipcMain.handle("license-admin:save-record"'), true);
+    assert.equal(licenseIpcSource.includes('ipcMain.handle("license-admin:delete-license-record"'), true);
   });
 
   await run("Lizenzverwaltung: IPC-Handler fuer Admin-Lizenzhistorie sind vorbereitet", () => {
@@ -744,6 +746,7 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(licenseIpcSource.includes("licenseAdminService.saveCustomer"), true);
     assert.equal(licenseIpcSource.includes("licenseAdminService.listLicenses"), true);
     assert.equal(licenseIpcSource.includes("licenseAdminService.saveLicense"), true);
+    assert.equal(licenseIpcSource.includes("licenseAdminService.deleteLicenseRecord"), true);
     assert.equal(licenseIpcSource.includes("licenseAdminService.listHistory"), true);
     assert.equal(licenseIpcSource.includes("licenseAdminService.addHistoryEntry"), true);
   });
@@ -764,6 +767,7 @@ async function runLizenzverwaltungModuleTests(run) {
       assert.equal(preloadSource.includes("licenseAdminSaveLicenseCustomer"), true);
       assert.equal(preloadSource.includes("licenseAdminListLicenseRecords"), true);
       assert.equal(preloadSource.includes("licenseAdminSaveLicenseRecord"), true);
+      assert.equal(preloadSource.includes("licenseAdminDeleteLicenseRecord"), true);
       assert.equal(preloadSource.includes("licenseAdminListLicenseHistory"), true);
       assert.equal(preloadSource.includes("licenseAdminAddLicenseHistoryEntry"), true);
     }
@@ -823,6 +827,10 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("Lizenzen dieses Kunden"), true);
     assert.equal(screenSource.includes("Kundendaten"), true);
     assert.equal(screenSource.includes("Neue Lizenz"), true);
+    assert.equal(screenSource.includes("Lizenz löschen"), true);
+    assert.equal(screenSource.includes("Lizenz wirklich löschen?"), true);
+    assert.equal(screenSource.includes("Lizenz wurde gelöscht."), true);
+    assert.equal(screenSource.includes("Lizenz konnte nicht gelöscht werden."), true);
     assert.equal(screenSource.includes("Zurueck zur Kundenliste"), true);
     assert.equal(screenSource.includes("Lizenz erstellen"), true);
     assert.equal(screenSource.includes("Lizenz speichern"), false);

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -1173,6 +1173,10 @@ function registerLicenseAdminDataIpc() {
     return licenseAdminService.saveLicense(license || {});
   });
 
+  ipcMain.handle("license-admin:delete-license-record", async (_event, id) => {
+    return licenseAdminService.deleteLicenseRecord(id);
+  });
+
   ipcMain.handle("license-admin:list-history", async () => {
     return licenseAdminService.listHistory();
   });

--- a/src/main/licensing/licenseAdminService.js
+++ b/src/main/licensing/licenseAdminService.js
@@ -327,6 +327,16 @@ function saveLicense(license = {}) {
   return db.prepare(`SELECT * FROM license_records WHERE id = ?`).get(record.id);
 }
 
+function deleteLicenseRecord(id) {
+  const normalizedId = _trimText(id);
+  if (!normalizedId) throw new Error("license_record_id required");
+  const db = _db();
+  const existing = db.prepare(`SELECT * FROM license_records WHERE id = ?`).get(normalizedId);
+  if (!existing) throw new Error("license_record_not_found");
+  db.prepare(`DELETE FROM license_records WHERE id = ?`).run(normalizedId);
+  return { ok: true, id: normalizedId };
+}
+
 function listHistory() {
   return _db().prepare(`SELECT * FROM license_history ORDER BY created_at DESC`).all();
 }
@@ -367,6 +377,7 @@ module.exports = {
   listLicenses,
   listLicensesByCustomer,
   saveLicense,
+  deleteLicenseRecord,
   listHistory,
   addHistoryEntry,
 };

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -209,6 +209,7 @@ contextBridge.exposeInMainWorld("bbmDb", {
   licenseAdminListLicenseRecordsByCustomer: (customerId) =>
     ipcRenderer.invoke("license-admin:list-records-by-customer", customerId),
   licenseAdminSaveLicenseRecord: (license) => ipcRenderer.invoke("license-admin:save-record", license),
+  licenseAdminDeleteLicenseRecord: (id) => ipcRenderer.invoke("license-admin:delete-license-record", id),
   licenseAdminListLicenseHistory: () => ipcRenderer.invoke("license-admin:list-history"),
   licenseAdminAddLicenseHistoryEntry: (entry) => ipcRenderer.invoke("license-admin:add-history-entry", entry),
   licenseAdminCreateCustomerSetup: (payload) => ipcRenderer.invoke("license-admin:create-customer-setup", payload),

--- a/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
@@ -50,6 +50,12 @@ export async function saveLicense(license) {
   return save(record);
 }
 
+export async function deleteLicense(record) {
+  const id = String(record?.id || "").trim();
+  const del = requireApiMethod("licenseAdminDeleteLicenseRecord");
+  return del(id);
+}
+
 export async function listHistory() {
   const list = requireApiMethod("licenseAdminListLicenseHistory");
   return list();

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -1,5 +1,6 @@
 import {
   createCustomerSetup,
+  deleteLicense,
   listCustomers,
   listLicensesByCustomer,
   saveCustomer,
@@ -422,7 +423,9 @@ export default class LicenseAdminScreen {
   constructor({ onBackToAdminbereich } = {}) {
     this.onBackToAdminbereich = onBackToAdminbereich;
     this.currentCustomer = null;
+    this.currentLicense = null;
     this.currentView = "customers";
+    this.flashMessage = "";
     this.root = null;
   }
 
@@ -506,6 +509,10 @@ export default class LicenseAdminScreen {
     const message = document.createElement("div");
     message.style.minHeight = "20px";
     message.style.fontSize = "13px";
+    if (this.flashMessage) {
+      message.textContent = this.flashMessage;
+      this.flashMessage = "";
+    }
 
     const fields = [
       ["customer_number", "Kundennummer"],
@@ -1178,6 +1185,26 @@ export default class LicenseAdminScreen {
     const createCustomerSetupBtn = this._button("Kunden-Setup erstellen", async () => runSetupBuild({ setupType: "test" }));
     const createMachineSetupBtn = this._button("Machine-Setup erstellen", async () => runSetupBuild({ setupType: "machine" }));
     createCustomerSetupBtn.disabled = !valueOf(license, "license_file_path", "licenseFilePath");
+    const deleteBtn = this._button("Lizenz löschen", async () => {
+      const activeLicense = this.currentLicense || license || {};
+      const licenseId = String(valueOf(activeLicense, "id") || "").trim();
+      if (!licenseId) return;
+      const confirmText =
+        "Lizenz wirklich löschen?\nDieser Vorgang löscht nur den Lizenzdatensatz in der Lizenzverwaltung.\nBereits erzeugte Lizenzdateien und Setups bleiben erhalten.";
+      const shouldDelete = globalThis?.window?.confirm ? window.confirm(confirmText) : true;
+      if (!shouldDelete) return;
+      try {
+        await deleteLicense(activeLicense);
+        this.currentLicense = null;
+        this.currentView = "customer-detail";
+        this.flashMessage = "Lizenz wurde gelöscht.";
+        await this._render();
+      } catch (_err) {
+        message.textContent = "Lizenz konnte nicht gelöscht werden.";
+      }
+    });
+    const hasExistingLicense = !!String(valueOf(license, "id") || "").trim();
+    deleteBtn.style.display = hasExistingLicense ? "" : "none";
 
     const createBtn = this._button("Lizenz erstellen", async () => {
       const previousText = createBtn.textContent;
@@ -1315,7 +1342,7 @@ export default class LicenseAdminScreen {
       this._render();
     });
 
-    actions.append(importRequestBtn, createBtn, createCustomerSetupBtn, createMachineSetupBtn, backBtn, openOutputDirBtn);
+    actions.append(importRequestBtn, createBtn, createCustomerSetupBtn, createMachineSetupBtn, deleteBtn, backBtn, openOutputDirBtn);
     container.append(
       header,
       context,


### PR DESCRIPTION
### Motivation
- Admins benötigen die Möglichkeit, einzelne Lizenzdatensätze aus der Lizenzverwaltung zu entfernen, ohne erzeugte Lizenzdateien, Kunden-Setups, Dist-Artefakte oder Historieneinträge zu löschen.

### Description
- Main-Service: `deleteLicenseRecord(id)` ergänzt, validiert die ID, löscht nur den Datensatz aus `license_records` und liefert `{ ok: true, id }` zurück (Datei: `src/main/licensing/licenseAdminService.js`).
- IPC / Preload / Renderer: IPC-Handler `license-admin:delete-license-record` hinzugefügt, Preload-API `licenseAdminDeleteLicenseRecord(id)` exponiert und Renderer-Service `deleteLicense(record)` implementiert (Dateien: `src/main/ipc/licenseIpc.js`, `src/main/preload.js`, `src/renderer/modules/lizenzverwaltung/licenseStorageService.js`).
- UI: Im `LicenseAdminScreen` wurde der Button `Lizenz löschen` im Lizenzformular ergänzt, er erscheint nur für bestehende Lizenzen, zeigt die geforderte Confirm-Meldung, löscht nach Bestätigung den Datensatz, kehrt zur Kundenansicht zurück und zeigt Erfolg-/Fehlermeldungen an (Datei: `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`).
- Tests & Doku: Tests für Main-Service, IPC-Registrierung, Preload/Renderer-Integration und UI-Texte erweitert; `STATUS.md` aktualisiert (Tests: `scripts/tests/licenseAdminDataflow.test.cjs`, `scripts/tests/licenseIpcCustomerSetup.test.cjs`, `scripts/tests/lizenzverwaltungModule.test.cjs`).

### Testing
- Es wurde die gesamte Test-Suite via `npm test` ausgeführt und alle Tests liefen grün (keine Fehler). 
- Ergänzte/ausgeführte Tests umfassen Main-Service-Delete-Fälle (Löschen, fehlende ID, Kunden/Historie unverändert) in `scripts/tests/licenseAdminDataflow.test.cjs`, IPC-Handler-Registrierung und Service-Aufruf in `scripts/tests/licenseIpcCustomerSetup.test.cjs` sowie Renderer-/UI-Prüfungen in `scripts/tests/lizenzverwaltungModule.test.cjs`, und alle prüfenden Cases sind erfolgreich gelaufen.
- Automated checks bestätigen, dass nur der DB-Datensatz entfernt wird und keine .bbmlic-/Setup-/Dist-/Generator- oder Verifier-Logik geändert wurde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ce663eac832291f745fc5360b945)