### PR TITLE
Machine-Setup: Lizenz-erforderlich-Startansicht ohne eingebettete Lizenz

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -16,6 +16,14 @@ Sie ergänzt:
 ---
 
 ## Aktueller Gesamtstand
+- Machine-Setup Startverhalten ohne Lizenz ist umgesetzt:
+  - Dist-Flow legt fuer Machine-Setups jetzt zusaetzlich `resources/license/customer-setup.json` ab (kein Ersatz fuer `customer.bbmlic`).
+  - App liest beim Start `customer-setup.json`; wenn `setupType=machine` und keine gueltige Lizenz vorhanden ist, wird statt Mutter-App-Start eine klare Ansicht `Lizenz erforderlich` gezeigt.
+  - Die Startansicht enthaelt den Text zur geraetegebundenen Vollversion und den Button `Lizenzanforderung speichern`, der den bestehenden Request-Flow nutzt.
+  - Testversion-Setup mit eingebetteter `customer.bbmlic` bleibt unveraendert; `licenseVerifier.js` wurde nicht geaendert.
+  - Tests fuer Dist-Ressourcen, Setup-Read und Start-UI-Indikatoren wurden ergaenzt; `npm test` ist weiterhin Pflicht.
+- Nächster offener Schritt: manuelle Prüfung eines erzeugten Machine-Setups (Installieren + Starten + Sichtprüfung der Lizenz-erforderlich-Ansicht).
+- Commit: `67e354d` (Machine-Setup Lizenz-erforderlich-Startansicht).
 - Lizenzverwaltung Loeschfunktion fuer Lizenzdatensaetze ist umgesetzt:
   - Im Lizenzformular gibt es den Button `Lizenz löschen`, sichtbar nur bei bestehender gespeicherter Lizenz.
   - Vor dem Loeschen erscheint die Sicherheitsabfrage mit Klartext, dass nur der Lizenzdatensatz in der Lizenzverwaltung entfernt wird.

--- a/scripts/dist.cjs
+++ b/scripts/dist.cjs
@@ -61,6 +61,7 @@ function buildCustomerDistConfig({
   baseBuild = {},
   baseVersion = "0.0.0",
   customerLicenseFile = "",
+  customerSetupFile = "",
   customerSlug = "",
   customerSetupType = "",
 } = {}) {
@@ -82,6 +83,12 @@ function buildCustomerDistConfig({
     extraResources.push({
       from: customerLicenseFile,
       to: "license/customer.bbmlic",
+    });
+  }
+  if (setupType === "machine" && customerSetupFile) {
+    extraResources.push({
+      from: customerSetupFile,
+      to: "license/customer-setup.json",
     });
   }
 
@@ -144,10 +151,25 @@ function runDist({ cwd = process.cwd(), env = process.env } = {}) {
   const customerLicenseFile = String(env.BBM_CUSTOMER_LICENSE_FILE || "").trim();
   const customerSetupType = String(env.BBM_CUSTOMER_SETUP_TYPE || "").trim();
   const customerSlug = sanitizeCustomerSlug(env.BBM_CUSTOMER_SLUG || env.BBM_CUSTOMER_NAME || "");
+  const customerName = String(env.BBM_CUSTOMER_NAME || "").trim();
+  const customerSetupMetaFile =
+    String(customerSetupType || "").trim().toLowerCase() === "machine"
+      ? path.join(repoRoot, "dist", `customer-setup-${Date.now()}.json`)
+      : "";
+  if (customerSetupMetaFile) {
+    writeJsonAtomic(customerSetupMetaFile, {
+      schemaVersion: 1,
+      setupType: "machine",
+      customerSlug,
+      customerName,
+      createdAt: new Date().toISOString(),
+    });
+  }
   const customerConfig = buildCustomerDistConfig({
     baseBuild,
     baseVersion,
     customerLicenseFile,
+    customerSetupFile: customerSetupMetaFile,
     customerSlug,
     customerSetupType,
   });
@@ -196,6 +218,11 @@ function runDist({ cwd = process.cwd(), env = process.env } = {}) {
     try {
       fs.unlinkSync(tmpConfigPath);
     } catch (_e) {}
+    if (customerSetupMetaFile) {
+      try {
+        fs.unlinkSync(customerSetupMetaFile);
+      } catch (_e) {}
+    }
     return Promise.resolve(1);
   }
 
@@ -215,6 +242,11 @@ function runDist({ cwd = process.cwd(), env = process.env } = {}) {
       try {
         fs.unlinkSync(tmpConfigPath);
       } catch (_e) {}
+      if (customerSetupMetaFile) {
+        try {
+          fs.unlinkSync(customerSetupMetaFile);
+        } catch (_e) {}
+      }
       resolve(1);
     });
 
@@ -223,6 +255,11 @@ function runDist({ cwd = process.cwd(), env = process.env } = {}) {
       try {
         fs.unlinkSync(tmpConfigPath);
       } catch (_e) {}
+      if (customerSetupMetaFile) {
+        try {
+          fs.unlinkSync(customerSetupMetaFile);
+        } catch (_e) {}
+      }
       resolve(code || 0);
     });
   });

--- a/scripts/tests/distCustomerBuild.test.cjs
+++ b/scripts/tests/distCustomerBuild.test.cjs
@@ -54,6 +54,7 @@ async function runDistCustomerBuildTests(run) {
       },
       baseVersion: '2.0.0',
       customerLicenseFile: '',
+      customerSetupFile: path.join('C:', 'tmp', 'customer-setup.json'),
       customerSlug: 'K-100-Musterfirma-GmbH',
       customerSetupType: 'machine',
     });
@@ -61,7 +62,10 @@ async function runDistCustomerBuildTests(run) {
     assert.equal(out.outputDir, path.join('dist', 'customers', 'K-100-Musterfirma-GmbH'));
     assert.equal(out.artifactName, 'BBM-2.0.0-K-100-Musterfirma-GmbH-Setup.exe');
     const embedded = out.build.extraResources.find((entry) => entry.to === 'license/customer.bbmlic');
+    const setupMeta = out.build.extraResources.find((entry) => entry.to === 'license/customer-setup.json');
     assert.equal(Boolean(embedded), false);
+    assert.equal(Boolean(setupMeta), true);
+    assert.equal(setupMeta.from.endsWith('customer-setup.json'), true);
     assert.equal(out.build.directories.output, path.join('dist', 'customers', 'K-100-Musterfirma-GmbH'));
     assert.equal(out.build.nsis.artifactName, 'BBM-2.0.0-K-100-Musterfirma-GmbH-Setup.exe');
     assert.equal(out.build.npmRebuild, false);

--- a/scripts/tests/licenseRequest.test.cjs
+++ b/scripts/tests/licenseRequest.test.cjs
@@ -170,6 +170,7 @@ async function runLicenseRequestTests(run) {
     const preloadSource = read("src/main/preload.js");
     assert.equal(preloadSource.includes("licenseCreateRequest"), true);
     assert.equal(preloadSource.includes('ipcRenderer.invoke("license:create-request"'), true);
+    assert.equal(preloadSource.includes('ipcRenderer.invoke("app:get-customer-setup"'), true);
   });
 
   await run("Preload: window.bbmDb.licenseAdminImportLicenseRequest ist vorhanden", () => {
@@ -180,6 +181,7 @@ async function runLicenseRequestTests(run) {
 
   await run("Renderer/UI: Texte fuer Lizenzanforderung sind vorhanden", () => {
     const settingsSource = read("src/renderer/views/SettingsView.js");
+    const mainSource = read("src/renderer/main.js");
     const licenseAdminSource = read("src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js");
     assert.equal(settingsSource.includes("Lizenzanforderung speichern"), true);
     assert.equal(settingsSource.includes("Lizenz importieren"), true);
@@ -209,6 +211,15 @@ async function runLicenseRequestTests(run) {
       licenseAdminSource.includes("Lizenzanforderung enthält keine Machine-ID."),
       true
     );
+    assert.equal(mainSource.includes("Lizenz erforderlich"), true);
+    assert.equal(mainSource.includes("Diese Installation ist für eine gerätegebundene Vollversion vorbereitet."), true);
+    assert.equal(mainSource.includes("Lizenzanforderung speichern"), true);
+  });
+
+  await run("Main/IPC: app:get-customer-setup ist registriert", () => {
+    const mainSource = read("src/main/main.js");
+    assert.equal(mainSource.includes('ipcMain.handle("app:get-customer-setup"'), true);
+    assert.equal(mainSource.includes("loadCustomerSetup"), true);
   });
 
   await run("Main/IPC: license-admin:import-license-request wird registriert", () => {

--- a/scripts/tests/licenseStorageBootstrap.test.cjs
+++ b/scripts/tests/licenseStorageBootstrap.test.cjs
@@ -105,6 +105,26 @@ async function runLicenseStorageBootstrapTests(run) {
       }
     );
   });
+
+  await run('Lizenz-Bootstrap: bundled customer-setup.json wird fuer Machine-Setup gelesen', () => {
+    withMockedLicenseStorage(
+      {
+        resourcesSetup: ({ resourcesPath }) => {
+          fs.writeFileSync(
+            path.join(resourcesPath, 'license', 'customer-setup.json'),
+            JSON.stringify({ schemaVersion: 1, setupType: 'machine', customerSlug: 'K-100', customerName: 'Muster GmbH' }),
+            'utf8'
+          );
+        },
+      },
+      ({ mod }) => {
+        const setup = mod.loadCustomerSetup();
+        assert.equal(setup.setupType, 'machine');
+        assert.equal(setup.customerSlug, 'K-100');
+        assert.equal(setup.customerName, 'Muster GmbH');
+      }
+    );
+  });
 }
 
 module.exports = {

--- a/src/main/licensing/licenseStorage.js
+++ b/src/main/licensing/licenseStorage.js
@@ -16,6 +16,12 @@ function getBundledCustomerLicensePath() {
   return path.join(resourcesPath, "license", "customer.bbmlic");
 }
 
+function getBundledCustomerSetupPath() {
+  const packagedResources = process.resourcesPath || path.join(app.getAppPath(), "resources");
+  const resourcesPath = app?.isPackaged ? packagedResources : path.join(app.getAppPath(), "resources");
+  return path.join(resourcesPath, "license", "customer-setup.json");
+}
+
 function _readJsonSafe(filePath) {
   try {
     const raw = fs.readFileSync(filePath, "utf8");
@@ -51,6 +57,26 @@ function loadLicense() {
     return bundledLicense;
   } catch (err) {
     console.error("[licenseStorage] load failed:", err?.message || err);
+    return null;
+  }
+}
+
+function loadCustomerSetup() {
+  try {
+    const filePath = getBundledCustomerSetupPath();
+    if (!fs.existsSync(filePath)) return null;
+    const parsed = _readJsonSafe(filePath);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    const setupType = String(parsed.setupType || parsed.setup_type || "").trim().toLowerCase();
+    return {
+      schemaVersion: Number(parsed.schemaVersion) || 1,
+      setupType: setupType === "machine" ? "machine" : "test",
+      customerSlug: String(parsed.customerSlug || parsed.customer_slug || "").trim(),
+      customerName: String(parsed.customerName || parsed.customer_name || "").trim(),
+      createdAt: String(parsed.createdAt || "").trim(),
+    };
+  } catch (err) {
+    console.error("[licenseStorage] loadCustomerSetup failed:", err?.message || err);
     return null;
   }
 }
@@ -110,4 +136,6 @@ module.exports = {
   deleteLicense,
   getLicenseFilePath,
   getBundledCustomerLicensePath,
+  getBundledCustomerSetupPath,
+  loadCustomerSetup,
 };

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -22,6 +22,7 @@ const { registerProjectTransferIpc } = require("./ipc/projectTransferIpc");
 const { registerLicenseIpc } = require("./ipc/licenseIpc");
 const { registerAudioIpc } = require("./ipc/audioIpc");
 const { checkLicense } = require("./licensing/licenseService");
+const { loadCustomerSetup } = require("./licensing/licenseStorage");
 const {
   toLicenseErrorPayload,
   isDevAudioOverrideEnabled,
@@ -664,6 +665,14 @@ app.whenReady().then(async () => {
       return { ok: true, version: app.getVersion() };
     } catch (err) {
       return { ok: false, error: err?.message || String(err), version: "" };
+    }
+  });
+
+  ipcMain.handle("app:get-customer-setup", () => {
+    try {
+      return { ok: true, setup: loadCustomerSetup() };
+    } catch (err) {
+      return { ok: false, error: err?.message || String(err), setup: null };
     }
   });
 

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -136,6 +136,7 @@ contextBridge.exposeInMainWorld("bbmDb", {
   appIsPackaged: () => ipcRenderer.invoke("app:isPackaged"),
   appGetBuildChannel: () => ipcRenderer.invoke("app:getBuildChannel"),
   appGetVersion: () => ipcRenderer.invoke("app:getVersion"),
+  appGetCustomerSetup: () => ipcRenderer.invoke("app:get-customer-setup"),
   openQuickAssist: () => ipcRenderer.invoke("app:openQuickAssist"),
 
   // ✅ Build-Kanal Umschalten (schreibt channel.json im Repo) – nur DEV-Umgebung

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -98,6 +98,98 @@ const writeUseNewCompanyWorkflowFlag = (value) => {
   }
 };
 
+const isMachineSetupWithoutLicense = async () => {
+  const api = window.bbmDb || {};
+  if (typeof api.licenseGetStatus !== "function") return false;
+  if (typeof api.appGetCustomerSetup !== "function") return false;
+  try {
+    const [licenseStatus, customerSetup] = await Promise.all([
+      api.licenseGetStatus(),
+      api.appGetCustomerSetup(),
+    ]);
+    const validLicense = !!licenseStatus?.ok && !!licenseStatus?.valid;
+    const setupType = String(customerSetup?.setup?.setupType || "").trim().toLowerCase();
+    return !validLicense && setupType === "machine";
+  } catch (_e) {
+    return false;
+  }
+};
+
+const renderMachineSetupLicenseRequired = () => {
+  const host = document.getElementById("content");
+  if (!host) {
+    throw new Error("Root-Container #content nicht gefunden");
+  }
+  host.innerHTML = "";
+  host.style.height = "100vh";
+  host.style.display = "flex";
+  host.style.alignItems = "center";
+  host.style.justifyContent = "center";
+  host.style.padding = "24px";
+  host.style.boxSizing = "border-box";
+  host.style.fontFamily = "Calibri, Arial, sans-serif";
+
+  const card = document.createElement("div");
+  card.style.width = "min(680px, 100%)";
+  card.style.border = "1px solid #cbd5e1";
+  card.style.borderRadius = "12px";
+  card.style.padding = "20px";
+  card.style.background = "#fff";
+  card.style.display = "grid";
+  card.style.gap = "12px";
+
+  const title = document.createElement("h1");
+  title.textContent = "Lizenz erforderlich";
+  title.style.margin = "0";
+  title.style.fontSize = "24px";
+
+  const text = document.createElement("div");
+  text.style.whiteSpace = "pre-line";
+  text.textContent =
+    "Diese Installation ist für eine gerätegebundene Vollversion vorbereitet.\nSpeichern Sie eine Lizenzanforderung und senden Sie diese Datei an den Anbieter.";
+
+  const status = document.createElement("div");
+  status.style.minHeight = "18px";
+  status.style.fontSize = "13px";
+  status.style.color = "#475569";
+
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.textContent = "Lizenzanforderung speichern";
+  btn.style.justifySelf = "start";
+  btn.onclick = async () => {
+    const api = window.bbmDb || {};
+    if (typeof api.licenseCreateRequest !== "function") {
+      status.textContent = "Lizenzanforderung ist in dieser App-Version nicht verfuegbar.";
+      status.style.color = "#b91c1c";
+      return;
+    }
+    status.textContent = "Lizenzanforderung wird gespeichert ...";
+    status.style.color = "#475569";
+    try {
+      const res = await api.licenseCreateRequest({});
+      if (res?.canceled) {
+        status.textContent = "Lizenzanforderung speichern abgebrochen.";
+        status.style.color = "#475569";
+        return;
+      }
+      if (!res?.ok) {
+        status.textContent = "Lizenzanforderung konnte nicht gespeichert werden.";
+        status.style.color = "#b91c1c";
+        return;
+      }
+      status.textContent = "Lizenzanforderung wurde gespeichert.";
+      status.style.color = "#166534";
+    } catch (_err) {
+      status.textContent = "Lizenzanforderung konnte nicht gespeichert werden.";
+      status.style.color = "#b91c1c";
+    }
+  };
+
+  card.append(title, text, btn, status);
+  host.appendChild(card);
+};
+
 const showStartupOverlay = ({ durationMs = 3000 } = {}) => {
   if (document.querySelector('[data-bbm-startup-overlay="true"]')) return;
 
@@ -953,6 +1045,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     topSection.replaceChildren(btnStart, btnProjects, btnFirmsBase, btnSettings, btnHelp);
     bottomSection.replaceChildren(btnQuit);
   };
+
+  if (await isMachineSetupWithoutLicense()) {
+    renderMachineSetupLicenseRequired();
+    return;
+  }
 
   await ensureInitialPrintLayoutDefaults();
 


### PR DESCRIPTION
### Motivation
- Machine-Setups sollen nach Installation nicht wie die Mutter-App starten, wenn keine gültige Lizenz vorhanden ist, sondern eine klare Aufforderung zur Lizenzanforderung anzeigen.
- Technisch soll dies über eine zusätzliche bundled Datei `resources/license/customer-setup.json` für Machine-Setups realisiert werden, ohne das Verhalten von Test-Setups oder den Lizenzverifier zu ändern.

### Description
- Build/Dist: `scripts/dist.cjs` erzeugt bei `setupType=machine` eine temporäre `customer-setup-*.json` und fügt sie als `extraResources -> license/customer-setup.json` ins Setup ein; Test-Setups und `customer.bbmlic` bleiben unverändert. 
- Storage/Main/IPC: `src/main/licensing/licenseStorage.js` erhält `getBundledCustomerSetupPath()` und `loadCustomerSetup()`; Main stellt `ipcMain.handle('app:get-customer-setup')` bereit. 
- Preload: `src/main/preload.js` exportiert `appGetCustomerSetup()` für den Renderer. 
- Renderer: `src/renderer/main.js` prüft beim Start per `licenseGetStatus()` + `appGetCustomerSetup()` und zeigt bei fehlender gültiger Lizenz und `setupType=machine` eine dedizierte Ansicht "Lizenz erforderlich" mit Text und Button "Lizenzanforderung speichern", der den vorhandenen Request-Flow (`licenseCreateRequest`) verwendet. 
- Tests & Doku: Relevante Tests erweitert/angepasst: `scripts/tests/distCustomerBuild.test.cjs`, `scripts/tests/licenseStorageBootstrap.test.cjs`, `scripts/tests/licenseRequest.test.cjs`; `STATUS.md` wurde aktualisiert.

### Testing
- Automatisierte Tests: `npm test` ausgeführt; alle Tests wurden erfolgreich bestanden (Ausgabe: "Alle Tests bestanden.").
- Spezifische Testfälle aktualisiert und geprüft: Dist-Build-Resource für Machine-Setups, `loadCustomerSetup()`-Bootstrap und Renderer/Preload/Main-Indikatoren für den neuen Start-Flow, alle grünen Tests.
- Manuell offen: das Erstellen eines tatsächlichen Machine-Setups, Installieren und visuelle Validierung der Startansicht wurde nicht in dieser Änderung manuell ausgeführt und bleibt als nächster Prüfschritt vermerkt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d600ab748322948417e34618c0bb)