### PR TITLE
Machine-Setup: Lizenzanforderung per Standard-Mail-App (mailto) und Import/Fallback UI

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -16,6 +16,13 @@ Sie ergänzt:
 ---
 
 ## Aktueller Gesamtstand
+- Machine-Setup-Metadaten wurden fuer eindeutige Lizenzzuordnung erweitert:
+  - `customer-setup.json` enthaelt bei `setupType=machine` jetzt zusaetzlich `product=bbm-protokoll`, `expectedBinding=machine`, `customerName`, `customerNumber` und `licenseId`.
+  - Die Werte werden aus dem bestehenden Admin-/Build-Payload uebernommen (Kunde/Firma, Kundennummer, Lizenz-ID) und ueber Build-Env bis in die Setup-Metadatei durchgereicht.
+  - Der Mailtext in der Machine-Setup-Startansicht nutzt bei `Kundennummer` und `Lizenz-ID` jetzt vorrangig die Daten aus `customer-setup.json` (Fallback weiter auf `-`/Statuswerte).
+  - Fallback `Daten kopieren` bleibt identisch zum Mailtext und enthaelt damit ebenfalls Kundennummer + Lizenz-ID.
+  - Testabdeckung wurde fuer Metadatenfelder, Payload-Mapping und Setup-Read erweitert; `npm test` ist gruen.
+- Nächster offener Schritt: manuelle Endpruefung mit echtem Machine-Setup-Build (Mail-App-Inhalt mit Kunde/Kundennummer/Lizenz-ID/Machine-ID/App-Version).
 - Machine-Setup Lizenzfluss wurde kundentauglich auf E-Mail-Start umgestellt:
   - Startansicht zeigt jetzt `Lizenz erforderlich` mit den Buttons `Lizenz per E-Mail anfordern` und `Antwortlizenz importieren`.
   - Mailanforderung nutzt `mailto:info@bandholt.de` mit festem Betreff `BBM Lizenzanforderung` und vorbereitetem Mailtext inkl. `Kunde`, `Kundennummer`, `Lizenz-ID`, `Machine-ID`, `App-Version`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -16,6 +16,13 @@ Sie ergänzt:
 ---
 
 ## Aktueller Gesamtstand
+- Machine-Setup Lizenzfluss wurde kundentauglich auf E-Mail-Start umgestellt:
+  - Startansicht zeigt jetzt `Lizenz erforderlich` mit den Buttons `Lizenz per E-Mail anfordern` und `Antwortlizenz importieren`.
+  - Mailanforderung nutzt `mailto:info@bandholt.de` mit festem Betreff `BBM Lizenzanforderung` und vorbereitetem Mailtext inkl. `Kunde`, `Kundennummer`, `Lizenz-ID`, `Machine-ID`, `App-Version`.
+  - Der bisherige Antwortlizenz-Import bleibt derselbe technische Flow (`licenseImport`) und prueft nach dem Import den Lizenzstatus erneut.
+  - Bei fehlgeschlagenem automatischem E-Mail-Start wird ein Fallback mit Hinweistext und `Daten kopieren` angezeigt.
+  - Keine Aenderung an `licenseVerifier.js`; Testversion-Setup bleibt unveraendert.
+- Nächster offener Schritt: manuelle Sichtprüfung im echten Machine-Setup (mailto-Start mit Standard-Mail-App + Import einer gueltigen `.bbmlic`).
 - Machine-Setup Startverhalten ohne Lizenz ist umgesetzt:
   - Dist-Flow legt fuer Machine-Setups jetzt zusaetzlich `resources/license/customer-setup.json` ab (kein Ersatz fuer `customer.bbmlic`).
   - App liest beim Start `customer-setup.json`; wenn `setupType=machine` und keine gueltige Lizenz vorhanden ist, wird statt Mutter-App-Start eine klare Ansicht `Lizenz erforderlich` gezeigt.

--- a/scripts/dist.cjs
+++ b/scripts/dist.cjs
@@ -57,6 +57,20 @@ function sanitizeCustomerSlug(value) {
   return cleaned || "customer";
 }
 
+function buildMachineSetupMetaFromEnv(env = {}) {
+  return {
+    schemaVersion: 1,
+    setupType: "machine",
+    product: "bbm-protokoll",
+    expectedBinding: "machine",
+    customerSlug: sanitizeCustomerSlug(env.BBM_CUSTOMER_SLUG || env.BBM_CUSTOMER_NAME || ""),
+    customerName: String(env.BBM_CUSTOMER_NAME || "").trim(),
+    customerNumber: String(env.BBM_CUSTOMER_NUMBER || "").trim(),
+    licenseId: String(env.BBM_LICENSE_ID || "").trim(),
+    createdAt: new Date().toISOString(),
+  };
+}
+
 function buildCustomerDistConfig({
   baseBuild = {},
   baseVersion = "0.0.0",
@@ -157,13 +171,7 @@ function runDist({ cwd = process.cwd(), env = process.env } = {}) {
       ? path.join(repoRoot, "dist", `customer-setup-${Date.now()}.json`)
       : "";
   if (customerSetupMetaFile) {
-    writeJsonAtomic(customerSetupMetaFile, {
-      schemaVersion: 1,
-      setupType: "machine",
-      customerSlug,
-      customerName,
-      createdAt: new Date().toISOString(),
-    });
+    writeJsonAtomic(customerSetupMetaFile, buildMachineSetupMetaFromEnv(env));
   }
   const customerConfig = buildCustomerDistConfig({
     baseBuild,
@@ -276,6 +284,7 @@ if (require.main === module) {
 
 module.exports = {
   sanitizeCustomerSlug,
+  buildMachineSetupMetaFromEnv,
   buildCustomerDistConfig,
   runDist,
 };

--- a/scripts/tests/distCustomerBuild.test.cjs
+++ b/scripts/tests/distCustomerBuild.test.cjs
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const path = require('node:path');
 
-const { buildCustomerDistConfig } = require('../../scripts/dist.cjs');
+const { buildCustomerDistConfig, buildMachineSetupMetaFromEnv } = require('../../scripts/dist.cjs');
 
 async function runDistCustomerBuildTests(run) {
   await run('dist.cjs: ohne BBM_CUSTOMER_LICENSE_FILE bleibt Build unveraendert', () => {
@@ -70,6 +70,25 @@ async function runDistCustomerBuildTests(run) {
     assert.equal(out.build.nsis.artifactName, 'BBM-2.0.0-K-100-Musterfirma-GmbH-Setup.exe');
     assert.equal(out.build.npmRebuild, false);
     assert.equal(out.build.buildDependenciesFromSource, false);
+  });
+
+  await run('dist.cjs: Machine-Setup-Metadaten enthalten Kundennummer, Lizenz-ID, Produkt und Binding', () => {
+    const meta = buildMachineSetupMetaFromEnv({
+      BBM_CUSTOMER_SLUG: 'K-100-Musterfirma-GmbH',
+      BBM_CUSTOMER_NAME: 'Musterfirma GmbH',
+      BBM_CUSTOMER_NUMBER: 'K-100',
+      BBM_LICENSE_ID: 'LIC-100',
+    });
+    assert.equal(meta.schemaVersion, 1);
+    assert.equal(meta.setupType, 'machine');
+    assert.equal(meta.product, 'bbm-protokoll');
+    assert.equal(meta.expectedBinding, 'machine');
+    assert.equal(meta.customerName, 'Musterfirma GmbH');
+    assert.equal(meta.customerNumber, 'K-100');
+    assert.equal(meta.licenseId, 'LIC-100');
+    assert.equal(meta.customerSlug, 'K-100-Musterfirma-GmbH');
+    assert.equal(typeof meta.createdAt, 'string');
+    assert.equal(meta.createdAt.length > 10, true);
   });
 }
 

--- a/scripts/tests/licenseIpcCustomerSetup.test.cjs
+++ b/scripts/tests/licenseIpcCustomerSetup.test.cjs
@@ -131,12 +131,15 @@ async function runLicenseIpcCustomerSetupTests(run) {
     withLicenseIpcModule({}, (mod) => {
       const payload = mod._validateCustomerSetupPayload({
         customer: { customer_number: 'K-200', company_name: 'Maschine GmbH' },
-        license: { license_binding: 'machine', machine_id: '' },
+        license: { license_binding: 'machine', machine_id: '', license_id: 'LIC-200' },
         setupType: 'machine',
       });
       assert.equal(payload.setupType, 'machine');
       assert.equal(payload.licenseFilePath, '');
       assert.equal(payload.customerSlug, 'K-200-Maschine-GmbH');
+      assert.equal(payload.customerName, 'Maschine GmbH');
+      assert.equal(payload.customerNumber, 'K-200');
+      assert.equal(payload.licenseId, 'LIC-200');
     });
   });
 
@@ -340,7 +343,7 @@ async function runLicenseIpcCustomerSetupTests(run) {
           async (mod) => {
             const res = await mod._runCustomerSetupBuild({
               customer: { customer_number: 'K-18', company_name: 'Machine GmbH' },
-              license: { license_binding: 'machine', machine_id: '' },
+              license: { license_binding: 'machine', machine_id: '', license_id: 'LIC-18' },
               setupType: 'machine',
               licenseFilePath,
             }, {
@@ -349,6 +352,8 @@ async function runLicenseIpcCustomerSetupTests(run) {
             assert.equal(res.ok, true);
             assert.equal(res.env.BBM_CUSTOMER_SETUP_TYPE, 'machine');
             assert.equal(Boolean(res.env.BBM_CUSTOMER_LICENSE_FILE), false);
+            assert.equal(res.env.BBM_CUSTOMER_NUMBER, 'K-18');
+            assert.equal(res.env.BBM_LICENSE_ID, 'LIC-18');
           }
         );
       }

--- a/scripts/tests/licenseRequest.test.cjs
+++ b/scripts/tests/licenseRequest.test.cjs
@@ -213,7 +213,16 @@ async function runLicenseRequestTests(run) {
     );
     assert.equal(mainSource.includes("Lizenz erforderlich"), true);
     assert.equal(mainSource.includes("Diese Installation ist für eine gerätegebundene Vollversion vorbereitet."), true);
-    assert.equal(mainSource.includes("Lizenzanforderung speichern"), true);
+    assert.equal(mainSource.includes("Lizenz per E-Mail anfordern"), true);
+    assert.equal(mainSource.includes("Antwortlizenz importieren"), true);
+    assert.equal(mainSource.includes("info@bandholt.de"), true);
+    assert.equal(mainSource.includes("BBM Lizenzanforderung"), true);
+    assert.equal(mainSource.includes("Machine-ID:"), true);
+    assert.equal(mainSource.includes("App-Version:"), true);
+    assert.equal(mainSource.includes("Kunde:"), true);
+    assert.equal(mainSource.includes("Kundennummer:"), true);
+    assert.equal(mainSource.includes("Daten kopieren"), true);
+    assert.equal(mainSource.includes("E-Mail konnte nicht automatisch geöffnet werden."), true);
   });
 
   await run("Main/IPC: app:get-customer-setup ist registriert", () => {

--- a/scripts/tests/licenseRequest.test.cjs
+++ b/scripts/tests/licenseRequest.test.cjs
@@ -221,6 +221,8 @@ async function runLicenseRequestTests(run) {
     assert.equal(mainSource.includes("App-Version:"), true);
     assert.equal(mainSource.includes("Kunde:"), true);
     assert.equal(mainSource.includes("Kundennummer:"), true);
+    assert.equal(mainSource.includes("setup.customerNumber || setup.customer_number || \"\""), true);
+    assert.equal(mainSource.includes("setup.licenseId || setup.license_id || licenseStatus?.licenseId || \"\""), true);
     assert.equal(mainSource.includes("Daten kopieren"), true);
     assert.equal(mainSource.includes("E-Mail konnte nicht automatisch geöffnet werden."), true);
   });

--- a/scripts/tests/licenseStorageBootstrap.test.cjs
+++ b/scripts/tests/licenseStorageBootstrap.test.cjs
@@ -112,7 +112,16 @@ async function runLicenseStorageBootstrapTests(run) {
         resourcesSetup: ({ resourcesPath }) => {
           fs.writeFileSync(
             path.join(resourcesPath, 'license', 'customer-setup.json'),
-            JSON.stringify({ schemaVersion: 1, setupType: 'machine', customerSlug: 'K-100', customerName: 'Muster GmbH' }),
+            JSON.stringify({
+              schemaVersion: 1,
+              setupType: 'machine',
+              product: 'bbm-protokoll',
+              expectedBinding: 'machine',
+              customerSlug: 'K-100',
+              customerName: 'Muster GmbH',
+              customerNumber: 'K-100',
+              licenseId: 'LIC-100',
+            }),
             'utf8'
           );
         },
@@ -120,8 +129,12 @@ async function runLicenseStorageBootstrapTests(run) {
       ({ mod }) => {
         const setup = mod.loadCustomerSetup();
         assert.equal(setup.setupType, 'machine');
+        assert.equal(setup.product, 'bbm-protokoll');
+        assert.equal(setup.expectedBinding, 'machine');
         assert.equal(setup.customerSlug, 'K-100');
         assert.equal(setup.customerName, 'Muster GmbH');
+        assert.equal(setup.customerNumber, 'K-100');
+        assert.equal(setup.licenseId, 'LIC-100');
       }
     );
   });

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -366,20 +366,25 @@ async function runLizenzverwaltungModuleTests(run) {
   await run("Lizenzverwaltung: Build-Mapping fuer Kunden-Setup Payload", () => {
     const testPayload = buildCustomerSetupPayload({
       customer: { customer_number: "K-100", company_name: "Musterfirma GmbH" },
-      license: { license_file_path: "C:\\tmp\\customer.bbmlic" },
+      license: { license_file_path: "C:\\tmp\\customer.bbmlic", license_id: "LIC-100" },
     });
     assert.equal(testPayload.customer.customer_number, "K-100");
     assert.equal(testPayload.license.license_file_path, "C:\\tmp\\customer.bbmlic");
     assert.equal(testPayload.licenseFilePath, "C:\\tmp\\customer.bbmlic");
     assert.equal(testPayload.setupType, "test");
+    assert.equal(testPayload.customerName, "Musterfirma GmbH");
+    assert.equal(testPayload.customerNumber, "K-100");
+    assert.equal(testPayload.licenseId, "LIC-100");
 
     const machinePayload = buildCustomerSetupPayload({
       customer: { customer_number: "K-100", company_name: "Musterfirma GmbH" },
-      license: { license_file_path: "C:\\tmp\\customer.bbmlic" },
+      license: { license_file_path: "C:\\tmp\\customer.bbmlic", license_id: "LIC-100" },
       setupType: "machine",
     });
     assert.equal(machinePayload.setupType, "machine");
     assert.equal(machinePayload.licenseFilePath, "");
+    assert.equal(machinePayload.customerNumber, "K-100");
+    assert.equal(machinePayload.licenseId, "LIC-100");
   });
 
   await run("Lizenzverwaltung UI: Kunden-Setup-Texte und Hinweise vorhanden", () => {

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -536,6 +536,8 @@ function _writeCustomerSetupBuildLog({
       `env.BBM_CUSTOMER_SETUP_TYPE: ${envSnapshot.BBM_CUSTOMER_SETUP_TYPE || "-"}`,
       `env.BBM_CUSTOMER_SLUG: ${envSnapshot.BBM_CUSTOMER_SLUG || "-"}`,
       `env.BBM_CUSTOMER_NAME: ${envSnapshot.BBM_CUSTOMER_NAME || "-"}`,
+      `env.BBM_CUSTOMER_NUMBER: ${envSnapshot.BBM_CUSTOMER_NUMBER || "-"}`,
+      `env.BBM_LICENSE_ID: ${envSnapshot.BBM_LICENSE_ID || "-"}`,
       `artifacts: ${artifacts.length ? artifacts.join(" | ") : "-"}`,
       "",
       "stdout:",
@@ -573,13 +575,25 @@ function _validateCustomerSetupPayload(raw = {}) {
     throw new Error("MACHINE_ID_REQUIRED_FOR_BINDING");
   }
 
+  const customerName =
+    String(raw?.customerName || raw?.customer_name || "").trim() ||
+    String(customer.company_name || customer.companyName || "").trim();
+  const customerNumber =
+    String(raw?.customerNumber || raw?.customer_number || "").trim() ||
+    String(customer.customer_number || customer.customerNumber || "").trim();
+  const licenseId =
+    String(raw?.licenseId || raw?.license_id || "").trim() ||
+    String(license.license_id || license.licenseId || "").trim();
+
   return {
     customer,
     license,
     setupType,
     licenseFilePath,
     customerSlug: _buildCustomerSetupSlug(customer),
-    customerName: String(customer.company_name || customer.companyName || "").trim(),
+    customerName,
+    customerNumber,
+    licenseId,
   };
 }
 
@@ -600,6 +614,8 @@ async function _runCustomerSetupBuild(payload = {}, options = {}) {
     BBM_CUSTOMER_SETUP_TYPE: validated.setupType,
     BBM_CUSTOMER_SLUG: validated.customerSlug,
     BBM_CUSTOMER_NAME: validated.customerName,
+    BBM_CUSTOMER_NUMBER: validated.customerNumber,
+    BBM_LICENSE_ID: validated.licenseId,
   };
   if (validated.setupType === "test" && validated.licenseFilePath) {
     envForBuild.BBM_CUSTOMER_LICENSE_FILE = validated.licenseFilePath;
@@ -650,6 +666,8 @@ async function _runCustomerSetupBuild(payload = {}, options = {}) {
         BBM_CUSTOMER_SETUP_TYPE: envForBuild.BBM_CUSTOMER_SETUP_TYPE,
         BBM_CUSTOMER_SLUG: envForBuild.BBM_CUSTOMER_SLUG,
         BBM_CUSTOMER_NAME: envForBuild.BBM_CUSTOMER_NAME,
+        BBM_CUSTOMER_NUMBER: envForBuild.BBM_CUSTOMER_NUMBER,
+        BBM_LICENSE_ID: envForBuild.BBM_LICENSE_ID,
       },
     };
   }
@@ -718,6 +736,8 @@ async function _runCustomerSetupBuild(payload = {}, options = {}) {
           BBM_CUSTOMER_SETUP_TYPE: envForBuild.BBM_CUSTOMER_SETUP_TYPE,
           BBM_CUSTOMER_SLUG: envForBuild.BBM_CUSTOMER_SLUG,
           BBM_CUSTOMER_NAME: envForBuild.BBM_CUSTOMER_NAME,
+          BBM_CUSTOMER_NUMBER: envForBuild.BBM_CUSTOMER_NUMBER,
+          BBM_LICENSE_ID: envForBuild.BBM_LICENSE_ID,
         },
       });
     });
@@ -766,6 +786,8 @@ async function _runCustomerSetupBuild(payload = {}, options = {}) {
           BBM_CUSTOMER_SETUP_TYPE: envForBuild.BBM_CUSTOMER_SETUP_TYPE,
           BBM_CUSTOMER_SLUG: envForBuild.BBM_CUSTOMER_SLUG,
           BBM_CUSTOMER_NAME: envForBuild.BBM_CUSTOMER_NAME,
+          BBM_CUSTOMER_NUMBER: envForBuild.BBM_CUSTOMER_NUMBER,
+          BBM_LICENSE_ID: envForBuild.BBM_LICENSE_ID,
         },
         artifacts,
       });
@@ -793,6 +815,8 @@ async function _runCustomerSetupBuild(payload = {}, options = {}) {
           BBM_CUSTOMER_SETUP_TYPE: envForBuild.BBM_CUSTOMER_SETUP_TYPE,
           BBM_CUSTOMER_SLUG: envForBuild.BBM_CUSTOMER_SLUG,
           BBM_CUSTOMER_NAME: envForBuild.BBM_CUSTOMER_NAME,
+          BBM_CUSTOMER_NUMBER: envForBuild.BBM_CUSTOMER_NUMBER,
+          BBM_LICENSE_ID: envForBuild.BBM_LICENSE_ID,
         },
         artifacts,
       };

--- a/src/main/licensing/licenseStorage.js
+++ b/src/main/licensing/licenseStorage.js
@@ -71,8 +71,12 @@ function loadCustomerSetup() {
     return {
       schemaVersion: Number(parsed.schemaVersion) || 1,
       setupType: setupType === "machine" ? "machine" : "test",
+      product: String(parsed.product || "").trim(),
+      expectedBinding: String(parsed.expectedBinding || parsed.expected_binding || "").trim().toLowerCase(),
       customerSlug: String(parsed.customerSlug || parsed.customer_slug || "").trim(),
       customerName: String(parsed.customerName || parsed.customer_name || "").trim(),
+      customerNumber: String(parsed.customerNumber || parsed.customer_number || "").trim(),
+      licenseId: String(parsed.licenseId || parsed.license_id || "").trim(),
       createdAt: String(parsed.createdAt || "").trim(),
     };
   } catch (err) {

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -262,7 +262,7 @@ const renderMachineSetupLicenseRequired = () => {
       const mailBody = buildMachineSetupLicenseMailBody({
         customerName: setup.customerName || licenseStatus?.customerName || "",
         customerNumber: setup.customerNumber || setup.customer_number || "",
-        licenseId: licenseStatus?.licenseId || "",
+        licenseId: setup.licenseId || setup.license_id || licenseStatus?.licenseId || "",
         machineId: licenseStatus?.machineId || "",
         appVersion: appVersionRes?.version || APP_VERSION,
       });

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -115,6 +115,82 @@ const isMachineSetupWithoutLicense = async () => {
   }
 };
 
+const MACHINE_SETUP_LICENSE_MAIL_TO = "info@bandholt.de";
+const MACHINE_SETUP_LICENSE_MAIL_SUBJECT = "BBM Lizenzanforderung";
+
+const normalizeMachineSetupLicenseValue = (value) => {
+  const text = String(value || "").trim();
+  return text || "-";
+};
+
+const buildMachineSetupLicenseMailBody = ({
+  customerName = "",
+  customerNumber = "",
+  licenseId = "",
+  machineId = "",
+  appVersion = "",
+} = {}) => {
+  return [
+    "BBM Lizenzanforderung",
+    "",
+    `Kunde: ${normalizeMachineSetupLicenseValue(customerName)}`,
+    `Kundennummer: ${normalizeMachineSetupLicenseValue(customerNumber)}`,
+    `Lizenz-ID: ${normalizeMachineSetupLicenseValue(licenseId)}`,
+    `Machine-ID: ${normalizeMachineSetupLicenseValue(machineId)}`,
+    `App-Version: ${normalizeMachineSetupLicenseValue(appVersion)}`,
+    "",
+    "Bitte senden Sie mir eine gerätegebundene BBM-Lizenz zurück.",
+  ].join("\n");
+};
+
+const buildMachineSetupLicenseMailtoUri = (mailBody) => {
+  return `mailto:${MACHINE_SETUP_LICENSE_MAIL_TO}?subject=${encodeURIComponent(
+    MACHINE_SETUP_LICENSE_MAIL_SUBJECT
+  )}&body=${encodeURIComponent(mailBody)}`;
+};
+
+const renderMachineSetupLicenseFallback = ({ fallbackHost, fallbackText, status, mailBody }) => {
+  fallbackHost.innerHTML = "";
+  fallbackHost.style.display = "grid";
+  fallbackHost.style.gap = "8px";
+
+  const fallbackInfo = document.createElement("div");
+  fallbackInfo.style.whiteSpace = "pre-line";
+  fallbackInfo.style.fontSize = "13px";
+  fallbackInfo.textContent = fallbackText;
+
+  const dataPreview = document.createElement("pre");
+  dataPreview.textContent = mailBody;
+  dataPreview.style.margin = "0";
+  dataPreview.style.padding = "10px";
+  dataPreview.style.background = "#f8fafc";
+  dataPreview.style.border = "1px solid #cbd5e1";
+  dataPreview.style.borderRadius = "8px";
+  dataPreview.style.fontSize = "12px";
+  dataPreview.style.whiteSpace = "pre-wrap";
+
+  const copyBtn = document.createElement("button");
+  copyBtn.type = "button";
+  copyBtn.textContent = "Daten kopieren";
+  copyBtn.style.justifySelf = "start";
+  copyBtn.onclick = async () => {
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(mailBody);
+      } else {
+        throw new Error("CLIPBOARD_UNAVAILABLE");
+      }
+      status.textContent = "Daten wurden in die Zwischenablage kopiert.";
+      status.style.color = "#166534";
+    } catch (_err) {
+      status.textContent = "Daten konnten nicht kopiert werden.";
+      status.style.color = "#b91c1c";
+    }
+  };
+
+  fallbackHost.append(fallbackInfo, dataPreview, copyBtn);
+};
+
 const renderMachineSetupLicenseRequired = () => {
   const host = document.getElementById("content");
   if (!host) {
@@ -146,47 +222,124 @@ const renderMachineSetupLicenseRequired = () => {
   const text = document.createElement("div");
   text.style.whiteSpace = "pre-line";
   text.textContent =
-    "Diese Installation ist für eine gerätegebundene Vollversion vorbereitet.\nSpeichern Sie eine Lizenzanforderung und senden Sie diese Datei an den Anbieter.";
+    "Diese Installation ist für eine gerätegebundene Vollversion vorbereitet.\nFordern Sie Ihre Lizenz per E-Mail an.";
+
+  const mailAddressInfo = document.createElement("div");
+  mailAddressInfo.style.fontSize = "13px";
+  mailAddressInfo.style.color = "#334155";
+  mailAddressInfo.textContent = `E-Mail: ${MACHINE_SETUP_LICENSE_MAIL_TO}`;
 
   const status = document.createElement("div");
   status.style.minHeight = "18px";
   status.style.fontSize = "13px";
   status.style.color = "#475569";
 
-  const btn = document.createElement("button");
-  btn.type = "button";
-  btn.textContent = "Lizenzanforderung speichern";
-  btn.style.justifySelf = "start";
-  btn.onclick = async () => {
+  const buttonRow = document.createElement("div");
+  buttonRow.style.display = "flex";
+  buttonRow.style.flexWrap = "wrap";
+  buttonRow.style.gap = "8px";
+
+  const btnMailRequest = document.createElement("button");
+  btnMailRequest.type = "button";
+  btnMailRequest.textContent = "Lizenz per E-Mail anfordern";
+  btnMailRequest.onclick = async () => {
     const api = window.bbmDb || {};
-    if (typeof api.licenseCreateRequest !== "function") {
-      status.textContent = "Lizenzanforderung ist in dieser App-Version nicht verfuegbar.";
-      status.style.color = "#b91c1c";
-      return;
-    }
-    status.textContent = "Lizenzanforderung wird gespeichert ...";
+    status.textContent = "E-Mail wird vorbereitet ...";
     status.style.color = "#475569";
     try {
-      const res = await api.licenseCreateRequest({});
-      if (res?.canceled) {
-        status.textContent = "Lizenzanforderung speichern abgebrochen.";
-        status.style.color = "#475569";
-        return;
-      }
-      if (!res?.ok) {
-        status.textContent = "Lizenzanforderung konnte nicht gespeichert werden.";
+      const [licenseStatus, customerSetupRes, appVersionRes] = await Promise.all([
+        typeof api.licenseGetStatus === "function"
+          ? api.licenseGetStatus()
+          : Promise.resolve({}),
+        typeof api.appGetCustomerSetup === "function"
+          ? api.appGetCustomerSetup()
+          : Promise.resolve({}),
+        typeof api.appGetVersion === "function"
+          ? api.appGetVersion()
+          : Promise.resolve({ ok: true, version: APP_VERSION }),
+      ]);
+      const setup = customerSetupRes?.setup && typeof customerSetupRes.setup === "object" ? customerSetupRes.setup : {};
+      const mailBody = buildMachineSetupLicenseMailBody({
+        customerName: setup.customerName || licenseStatus?.customerName || "",
+        customerNumber: setup.customerNumber || setup.customer_number || "",
+        licenseId: licenseStatus?.licenseId || "",
+        machineId: licenseStatus?.machineId || "",
+        appVersion: appVersionRes?.version || APP_VERSION,
+      });
+      const mailtoUri = buildMachineSetupLicenseMailtoUri(mailBody);
+      try {
+        window.location.href = mailtoUri;
+        status.textContent = "E-Mail wurde im Standard-Mailprogramm vorbereitet.";
+        status.style.color = "#166534";
+      } catch (_err) {
+        renderMachineSetupLicenseFallback({
+          fallbackHost,
+          fallbackText:
+            "E-Mail konnte nicht automatisch geöffnet werden.\nBitte senden Sie die unten stehenden Daten an info@bandholt.de.",
+          status,
+          mailBody,
+        });
+        status.textContent = "E-Mail konnte nicht automatisch geöffnet werden.";
         status.style.color = "#b91c1c";
-        return;
       }
-      status.textContent = "Lizenzanforderung wurde gespeichert.";
-      status.style.color = "#166534";
     } catch (_err) {
-      status.textContent = "Lizenzanforderung konnte nicht gespeichert werden.";
+      status.textContent = "E-Mail konnte nicht vorbereitet werden.";
       status.style.color = "#b91c1c";
     }
   };
 
-  card.append(title, text, btn, status);
+  const btnImportResponseLicense = document.createElement("button");
+  btnImportResponseLicense.type = "button";
+  btnImportResponseLicense.textContent = "Antwortlizenz importieren";
+  btnImportResponseLicense.onclick = async () => {
+    const api = window.bbmDb || {};
+    if (typeof api.licenseImport !== "function") {
+      status.textContent = "Lizenzimport ist in dieser App-Version nicht verfuegbar.";
+      status.style.color = "#b91c1c";
+      return;
+    }
+    status.textContent = "Antwortlizenz wird importiert ...";
+    status.style.color = "#475569";
+    try {
+      const res = await api.licenseImport({});
+      if (res?.canceled) {
+        status.textContent = "Lizenzimport abgebrochen.";
+        status.style.color = "#475569";
+        return;
+      }
+      if (!res?.ok) {
+        status.textContent = "Lizenz konnte nicht importiert werden.";
+        status.style.color = "#b91c1c";
+        return;
+      }
+      const refreshed =
+        typeof api.licenseGetStatus === "function"
+          ? await api.licenseGetStatus()
+          : { ok: true, valid: false };
+      if (refreshed?.ok && refreshed?.valid) {
+        status.textContent = "Lizenz erfolgreich importiert. Bitte App neu starten.";
+        status.style.color = "#166534";
+      } else {
+        status.textContent = "Lizenz importiert, aber noch nicht gültig.";
+        status.style.color = "#b91c1c";
+      }
+    } catch (_err) {
+      status.textContent = "Lizenz konnte nicht importiert werden.";
+      status.style.color = "#b91c1c";
+    }
+  };
+
+  const importHint = document.createElement("div");
+  importHint.style.fontSize = "13px";
+  importHint.style.color = "#475569";
+  importHint.textContent =
+    "Wenn Sie bereits eine Lizenzdatei erhalten haben, importieren Sie die .bbmlic-Datei hier.";
+
+  const fallbackHost = document.createElement("div");
+  fallbackHost.style.display = "none";
+
+  buttonRow.append(btnMailRequest, btnImportResponseLicense);
+  card.append(title, text, mailAddressInfo, buttonRow, importHint, fallbackHost, status);
   host.appendChild(card);
 };
 

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -347,11 +347,17 @@ function tailLines(value, maxLines = 6) {
 export function buildCustomerSetupPayload({ customer = {}, license = {}, setupType = "test" } = {}) {
   const normalizedSetupType = String(setupType || "").trim().toLowerCase() === "machine" ? "machine" : "test";
   const licenseFilePath = normalizedSetupType === "test" ? valueOf(license, "license_file_path", "licenseFilePath") : "";
+  const customerName = valueOf(customer, "company_name", "companyName");
+  const customerNumber = valueOf(customer, "customer_number", "customerNumber");
+  const licenseId = valueOf(license, "license_id", "licenseId");
   return {
     customer,
     license,
     setupType: normalizedSetupType,
     licenseFilePath,
+    customerName,
+    customerNumber,
+    licenseId,
   };
 }
 


### PR DESCRIPTION
### Motivation
- Die Startansicht des Machine-Setups verlangte vom Kunden zu viele manuelle Schritte beim Anfordern einer gerätegebundenen Lizenz und soll durch einen simplen Mailto-basierten Ablauf kundentauglich werden.
- Ziel ist, die Machine-ID direkt in einer vorbereiteten E-Mail bereitzustellen und weiterhin den bestehenden Lizenzimport (`.bbmlic`) unverändert nutzbar zu lassen.

### Description
- Die Startansicht für Machine-Setups ohne Lizenz wurde in `src/renderer/main.js` ersetzt durch eine Ansicht mit Titel `Lizenz erforderlich`, Primärbutton `Lizenz per E-Mail anfordern`, Sekundärbutton `Antwortlizenz importieren`, sichtbarer Zieladresse `info@bandholt.de` und Hinweistext zum `.bbmlic`-Import.
- Implementiert wurde ein `mailto:`-Flow mit festem Empfänger `info@bandholt.de`, Betreff `BBM Lizenzanforderung` und vorbereitetem Mailtext, der `Kunde`, `Kundennummer`, `Lizenz-ID`, `Machine-ID` und `App-Version` enthält (mit `-` als Fallback), sowie ein Fallback mit Datenvorschau und Button `Daten kopieren` falls die Mail-App nicht geöffnet werden kann.
- Der bestehende Lizenzimport-Flow wurde wiederverwendet (`licenseImport`) und nach erfolgreichem Import wird der Lizenzstatus erneut geprüft; es wurden keine Änderungen an `licenseVerifier.js` oder an Generator-/Signatur-Verfahren vorgenommen.
- Geänderte Dateien: `src/renderer/main.js`, `scripts/tests/licenseRequest.test.cjs`, `STATUS.md` (Branch: `codex/machine-setup-mailto-license`, Commit: `a769549`).

### Testing
- Es wurde das Test-Set mit `node scripts/test.cjs` (entspricht `npm test`) ausgeführt und alle Tests liefen erfolgreich ("Alle Tests bestanden.").
- Die Renderer-UI-String-Checks in `scripts/tests/licenseRequest.test.cjs` wurden erweitert und prüfen nun u. a. das Vorhandensein von `Lizenz per E-Mail anfordern`, `Antwortlizenz importieren`, `info@bandholt.de`, Mailtext-Bausteinen (`Machine-ID`, `App-Version`, `Kunde`, `Kundennummer`) sowie Fallback-Elementen (`Daten kopieren`).
- Branch- und Git-Status: Basis-Branch ist `main`, Ergebnis-Branch ist `codex/machine-setup-mailto-license`, letzter Commit `a769549`, Arbeitsbaum wurde committet (keine uncommitteten Änderungen); ein PR wurde mit dem Hilfstool angestoßen, jedoch wurde kein öffentlicher Pull-Request-Link automatisch zurückgegeben.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e5432a8883229798455be3c20fa6)