### PR TITLE
Lizenzverwaltung: Antwortlizenz per Outlook senden

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -16,6 +16,14 @@ Sie ergänzt:
 ---
 
 ## Aktueller Gesamtstand
+- Admin-Lizenzverwaltung kann die erzeugte Antwortlizenz jetzt direkt als Outlook-Entwurf vorbereiten:
+  - Neuer Button `Antwortlizenz per Outlook senden` im Lizenzeditor.
+  - Sichtbarkeit nur fuer Vollversion + vorhandenen `license_file_path` mit `.bbmlic`.
+  - Main-IPC `license-admin:send-response-license-mail` prueft Kunden-E-Mail, Dateipfad, Dateiendung und Datei-Existenz.
+  - Outlook-Entwurf wird unter Windows via PowerShell/COM erstellt (`Outlook.Application`, `CreateItem`, `Attachments.Add`, `Display()`), ohne automatisches Senden.
+  - Erfolgs-/Fehlermeldungen sind umgesetzt: `Outlook-Mail wurde vorbereitet.`, `Keine Kunden-E-Mail hinterlegt.`, `Antwortlizenz-Datei wurde nicht gefunden.`, `Outlook konnte nicht geöffnet werden.`.
+  - Fallback im UI bei Outlook-Fehler: `Ausgabeordner öffnen` und `Mailtext kopieren`.
+- Nächster offener Schritt: manuelle Endpruefung am Windows-Zielsystem mit installiertem Outlook (Entwurf anzeigen inkl. Anhang, ohne Auto-Send).
 - Admin-Lizenzverwaltung dokumentiert den Machine-Setup-Lebenszyklus jetzt direkt am Vollversions-Lizenzdatensatz:
   - `Machine-Setup erstellen` speichert vor dem Build zuerst einen Vollversionsdatensatz (`license_edition=full`, `license_binding=machine`, `license_mode=full`) im aktuellen Kundenkontext.
   - Wenn diese Vorab-Speicherung nicht moeglich ist, wird klar abgebrochen mit `Vollversion muss vor Machine-Setup gespeichert werden.`.

--- a/scripts/tests/licenseRequest.test.cjs
+++ b/scripts/tests/licenseRequest.test.cjs
@@ -66,6 +66,7 @@ function createDefaultStubs({
         listLicenses: () => [],
         listLicensesByCustomer: () => [],
         saveLicense: (v) => v,
+        deleteLicenseRecord: () => ({ ok: true }),
         listHistory: () => [],
         addHistoryEntry: (v) => v,
       },
@@ -179,6 +180,12 @@ async function runLicenseRequestTests(run) {
     assert.equal(preloadSource.includes('ipcRenderer.invoke("license-admin:import-license-request"'), true);
   });
 
+  await run("Preload: window.bbmDb.licenseAdminSendResponseLicenseMail ist vorhanden", () => {
+    const preloadSource = read("src/main/preload.js");
+    assert.equal(preloadSource.includes("licenseAdminSendResponseLicenseMail"), true);
+    assert.equal(preloadSource.includes('ipcRenderer.invoke("license-admin:send-response-license-mail"'), true);
+  });
+
   await run("Renderer/UI: Texte fuer Lizenzanforderung sind vorhanden", () => {
     const settingsSource = read("src/renderer/views/SettingsView.js");
     const mainSource = read("src/renderer/main.js");
@@ -190,6 +197,12 @@ async function runLicenseRequestTests(run) {
     assert.equal(settingsSource.includes("Antwortlizenz erhalten?"), true);
     assert.equal(settingsSource.includes("Importieren Sie hier die .bbmlic-Datei"), true);
     assert.equal(licenseAdminSource.includes("Lizenzanforderung importieren"), true);
+    assert.equal(licenseAdminSource.includes("Antwortlizenz per Outlook senden"), true);
+    assert.equal(licenseAdminSource.includes("Outlook-Mail wurde vorbereitet."), true);
+    assert.equal(licenseAdminSource.includes("Outlook konnte nicht geöffnet werden."), true);
+    assert.equal(licenseAdminSource.includes("Ausgabeordner öffnen"), true);
+    assert.equal(licenseAdminSource.includes("Mailtext kopieren"), true);
+    assert.equal(licenseAdminSource.includes("hasResponseLicenseFile"), true);
     assert.equal(licenseAdminSource.includes("Gerätegebundene Vollversion:"), true);
     assert.equal(licenseAdminSource.includes("Antwortlizenz wurde erstellt."), true);
     assert.equal(licenseAdminSource.includes("Diese .bbmlic-Datei an den Kunden zurückgeben."), true);
@@ -239,6 +252,23 @@ async function runLicenseRequestTests(run) {
       mod.registerLicenseIpc();
       assert.equal(handlers.has("license-admin:import-license-request"), true);
     });
+  });
+
+  await run("Main/IPC: license-admin:send-response-license-mail wird registriert", () => {
+    const { handlers, stubs } = createDefaultStubs({});
+    return withPatchedLicenseIpc(stubs, (mod) => {
+      mod.registerLicenseIpc();
+      assert.equal(handlers.has("license-admin:send-response-license-mail"), true);
+    });
+  });
+
+  await run("Main/IPC: Outlook-Draft nutzt Display() und nicht Send()", () => {
+    const ipcSource = read("src/main/ipc/licenseIpc.js");
+    assert.equal(ipcSource.includes("Keine Kunden-E-Mail hinterlegt."), true);
+    assert.equal(ipcSource.includes("Antwortlizenz-Datei wurde nicht gefunden."), true);
+    assert.equal(ipcSource.includes("Outlook konnte nicht geöffnet werden."), true);
+    assert.equal(ipcSource.includes("$mail.Display()"), true);
+    assert.equal(ipcSource.includes("$mail.Send()"), false);
   });
 
   await run("Main/IPC: gueltige Lizenzanforderung wird importiert", async () => {

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -23,6 +23,17 @@ const LICENSE_TOOL_INPUT_DIR = path.join(LICENSE_TOOL_ROOT, "input");
 const LICENSE_TOOL_OUTPUT_DIR = path.join(LICENSE_TOOL_ROOT, "output");
 const LICENSE_TOOL_SCRIPT = path.join(LICENSE_TOOL_ROOT, "generate-license.cjs");
 const LICENSE_TOOL_PRIVATE_KEY = path.join(LICENSE_TOOL_ROOT, "keys", "private_key.pem");
+const RESPONSE_LICENSE_MAIL_SUBJECT = "BBM Antwortlizenz";
+const RESPONSE_LICENSE_MAIL_BODY = [
+  "Guten Tag,",
+  "",
+  "anbei erhalten Sie Ihre BBM-Lizenzdatei.",
+  "",
+  "Bitte importieren Sie die angehängte .bbmlic-Datei in der Anwendung.",
+  "",
+  "Viele Grüße",
+  "Planungsbüro Steffen Bandholt",
+].join("\r\n");
 
 function _getExpiryInfo(validUntil) {
   const raw = String(validUntil || "").trim();
@@ -165,6 +176,90 @@ function _validateLicenseRequestPayload(payload, filePath = "") {
     notes,
     customerHint: String(parsed.customerHint || customerName).trim(),
   };
+}
+
+function _buildOutlookDraftScript() {
+  return [
+    'param(',
+    '  [string]$To = "",',
+    '  [string]$Subject = "",',
+    '  [string]$Body = "",',
+    '  [string]$AttachmentPath = ""',
+    ')',
+    '$ErrorActionPreference = "Stop"',
+    '$outlook = New-Object -ComObject Outlook.Application',
+    '$mail = $outlook.CreateItem(0)',
+    'if ($To) { $mail.To = $To }',
+    'if ($Subject) { $mail.Subject = $Subject }',
+    'if ($Body) { $mail.Body = $Body }',
+    'if ($AttachmentPath) { [void]$mail.Attachments.Add($AttachmentPath) }',
+    '$mail.Display()',
+    '',
+  ].join("\r\n");
+}
+
+async function _createOutlookResponseLicenseDraft({ to, subject, body, attachmentPath }) {
+  if (process.platform !== "win32") {
+    return { ok: false, error: "OUTLOOK_NOT_AVAILABLE" };
+  }
+  const tempDir = app.getPath("temp");
+  const scriptPath = path.join(tempDir, `bbm_license_outlook_${Date.now()}.ps1`);
+  fs.writeFileSync(scriptPath, _buildOutlookDraftScript(), "utf8");
+
+  const args = [
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-STA",
+    "-File",
+    scriptPath,
+    "-To",
+    String(to || "").trim(),
+    "-Subject",
+    String(subject || "").trim(),
+    "-Body",
+    String(body || ""),
+    "-AttachmentPath",
+    String(attachmentPath || "").trim(),
+  ];
+
+  const result = await new Promise((resolve) => {
+    let stderr = "";
+    let settled = false;
+    const child = spawn("powershell.exe", args, {
+      windowsHide: true,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      resolve({ ok: false, error: err?.message || String(err) });
+    });
+
+    if (child.stderr) {
+      child.stderr.on("data", (chunk) => {
+        stderr += String(chunk || "");
+      });
+    }
+
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      if (Number(code) === 0) {
+        resolve({ ok: true });
+      } else {
+        resolve({ ok: false, error: stderr.trim() || `POWERSHELL_EXIT_${code}` });
+      }
+    });
+  });
+
+  try {
+    fs.unlinkSync(scriptPath);
+  } catch (_err) {
+    // ignore
+  }
+  return result;
 }
 
 function _buildLicenseRequestPayload(raw = {}) {
@@ -1237,6 +1332,37 @@ function registerLicenseAdminDataIpc() {
         ok: false,
         error: String(err?.code || err?.message || "INVALID_FORMAT").trim() || "INVALID_FORMAT",
       };
+    }
+  });
+
+  ipcMain.handle("license-admin:send-response-license-mail", async (_event, payload) => {
+    try {
+      const customerEmail = String(payload?.customerEmail || "").trim();
+      if (!customerEmail) {
+        return { ok: false, error: "MISSING_CUSTOMER_EMAIL", message: "Keine Kunden-E-Mail hinterlegt." };
+      }
+
+      const licenseFilePath = String(payload?.licenseFilePath || "").trim();
+      if (!licenseFilePath || !licenseFilePath.toLowerCase().endsWith(".bbmlic") || !fs.existsSync(licenseFilePath)) {
+        return {
+          ok: false,
+          error: "RESPONSE_LICENSE_FILE_NOT_FOUND",
+          message: "Antwortlizenz-Datei wurde nicht gefunden.",
+        };
+      }
+
+      const draft = await _createOutlookResponseLicenseDraft({
+        to: customerEmail,
+        subject: RESPONSE_LICENSE_MAIL_SUBJECT,
+        body: RESPONSE_LICENSE_MAIL_BODY,
+        attachmentPath: licenseFilePath,
+      });
+      if (!draft?.ok) {
+        return { ok: false, error: "OUTLOOK_OPEN_FAILED", message: "Outlook konnte nicht geöffnet werden." };
+      }
+      return { ok: true, message: "Outlook-Mail wurde vorbereitet." };
+    } catch (_err) {
+      return { ok: false, error: "OUTLOOK_OPEN_FAILED", message: "Outlook konnte nicht geöffnet werden." };
     }
   });
 }

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -215,6 +215,8 @@ contextBridge.exposeInMainWorld("bbmDb", {
   licenseAdminAddLicenseHistoryEntry: (entry) => ipcRenderer.invoke("license-admin:add-history-entry", entry),
   licenseAdminCreateCustomerSetup: (payload) => ipcRenderer.invoke("license-admin:create-customer-setup", payload),
   licenseAdminImportLicenseRequest: () => ipcRenderer.invoke("license-admin:import-license-request"),
+  licenseAdminSendResponseLicenseMail: (payload) =>
+    ipcRenderer.invoke("license-admin:send-response-license-mail", payload),
 
   // DEV: Audio Override Status
   devAudioUnlockStatus: () => ipcRenderer.invoke("dev:audioUnlockStatus"),

--- a/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
@@ -71,3 +71,8 @@ export async function createCustomerSetup(payload) {
   const create = requireApiMethod("licenseAdminCreateCustomerSetup");
   return create(payload || {});
 }
+
+export async function sendResponseLicenseMail(payload) {
+  const send = requireApiMethod("licenseAdminSendResponseLicenseMail");
+  return send(payload || {});
+}

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -5,6 +5,7 @@ import {
   listLicensesByCustomer,
   saveCustomer,
   saveLicense,
+  sendResponseLicenseMail,
 } from "../licenseStorageService.js";
 
 const PRODUCT_KEY = "bbm-produktiv";
@@ -1278,6 +1279,59 @@ export default class LicenseAdminScreen {
       }
     });
     openOutputDirBtn.style.display = "none";
+    const copyMailTextBtn = this._button("Mailtext kopieren", async () => {
+      const mailText = [
+        "Guten Tag,",
+        "",
+        "anbei erhalten Sie Ihre BBM-Lizenzdatei.",
+        "",
+        "Bitte importieren Sie die angehängte .bbmlic-Datei in der Anwendung.",
+        "",
+        "Viele Grüße",
+        "Planungsbüro Steffen Bandholt",
+      ].join("\n");
+      try {
+        if (globalThis?.navigator?.clipboard?.writeText) {
+          await globalThis.navigator.clipboard.writeText(mailText);
+          message.textContent = "Mailtext wurde in die Zwischenablage kopiert.";
+          return;
+        }
+      } catch (_err) {
+        // fallback below
+      }
+      message.textContent = "Mailtext konnte nicht automatisch kopiert werden.";
+    });
+    copyMailTextBtn.style.display = "none";
+    const sendResponseLicenseMailBtn = this._button("Antwortlizenz per Outlook senden", async () => {
+      const activeCustomer = this.currentCustomer || customer || {};
+      const activeLicense = this.currentLicense || license || {};
+      const customerEmail = valueOf(activeCustomer, "email");
+      const licenseFilePath = valueOf(activeLicense, "license_file_path", "licenseFilePath");
+      try {
+        const res = await sendResponseLicenseMail({ customerEmail, licenseFilePath });
+        if (!res?.ok) {
+          message.textContent = res?.message || "Outlook konnte nicht geöffnet werden.";
+          if (licenseFilePath) {
+            openOutputDirBtn.dataset.outputPath = licenseFilePath;
+            openOutputDirBtn.style.display = "";
+            openOutputDirBtn.disabled = false;
+          }
+          copyMailTextBtn.style.display = "";
+          return;
+        }
+        message.textContent = res?.message || "Outlook-Mail wurde vorbereitet.";
+        copyMailTextBtn.style.display = "none";
+      } catch (_err) {
+        message.textContent = "Outlook konnte nicht geöffnet werden.";
+        if (licenseFilePath) {
+          openOutputDirBtn.dataset.outputPath = licenseFilePath;
+          openOutputDirBtn.style.display = "";
+          openOutputDirBtn.disabled = false;
+        }
+        copyMailTextBtn.style.display = "";
+      }
+    });
+    sendResponseLicenseMailBtn.style.display = "none";
     const buildCurrentEditorLicensePayload = (activeLicense = {}) =>
       buildLicenseEditorPayload({
         license: activeLicense,
@@ -1494,6 +1548,7 @@ export default class LicenseAdminScreen {
           openOutputDirBtn.style.display = "";
           openOutputDirBtn.disabled = false;
         }
+        copyMailTextBtn.style.display = "none";
       } catch (err) {
         if (String(err?.message || "") === "CUSTOMER_CONTEXT_REQUIRED") {
           message.textContent = "Fehler: Speichern ohne geoeffneten Kunden ist unmoeglich.";
@@ -1509,12 +1564,17 @@ export default class LicenseAdminScreen {
     syncActionButtonsState = () => {
       const edition = String(inputs.license_edition?.value || "test").trim().toLowerCase();
       const machineId = String(inputs.machine_id?.value || "").trim();
+      const activeLicense = this.currentLicense || license || {};
+      const licenseFilePath = valueOf(activeLicense, "license_file_path", "licenseFilePath");
       const isFull = edition === "full";
       const hasMachineId = !!machineId;
+      const hasResponseLicenseFile = !!licenseFilePath && licenseFilePath.toLowerCase().endsWith(".bbmlic");
       importRequestBtn.style.display = isFull ? "" : "none";
       importRequestFromMailBtn.style.display = isFull ? "" : "none";
+      sendResponseLicenseMailBtn.style.display = isFull && hasResponseLicenseFile ? "" : "none";
       if (!isFull) {
         importMailWrap.style.display = "none";
+        copyMailTextBtn.style.display = "none";
       }
       createMachineSetupBtn.style.display = isFull ? "" : "none";
       createCustomerSetupBtn.style.display = isFull ? "none" : "";
@@ -1541,11 +1601,13 @@ export default class LicenseAdminScreen {
       importRequestBtn,
       importRequestFromMailBtn,
       createBtn,
+      sendResponseLicenseMailBtn,
       createCustomerSetupBtn,
       createMachineSetupBtn,
       deleteBtn,
       backBtn,
-      openOutputDirBtn
+      openOutputDirBtn,
+      copyMailTextBtn
     );
     container.append(
       header,


### PR DESCRIPTION
### Motivation
- Nach dem Erzeugen einer Antwortlizenz soll die Admin-App dem Admin das Versenden per Outlook erleichtern, indem ein Outlook-Entwurf mit der erzeugten `.bbmlic` als Anhang vorbereitet wird, ohne die Mail automatisch zu senden.

### Description
- Neuer Main-IPC `license-admin:send-response-license-mail` implementiert, der `customerEmail` und `licenseFilePath` prüft (E-Mail vorhanden, Datei existiert, Endung `.bbmlic`) und unter Windows per PowerShell/COM einen Outlook-Entwurf erstellt (`Outlook.Application`, `CreateItem(0)`, `Attachments.Add`, `Display()`), wobei `Send()` nicht verwendet wird.
- Preload erweitert um `licenseAdminSendResponseLicenseMail` und Renderer-Service `sendResponseLicenseMail(payload)` angelegt, damit der Renderer die neue IPC verwenden kann (`src/main/preload.js`, `src/renderer/modules/lizenzverwaltung/licenseStorageService.js`).
- UI-Änderungen in `LicenseAdminScreen`: neuer Button `Antwortlizenz per Outlook senden` mit Sichtbarkeitsregeln (nur `Vollversion` und vorhandener `license_file_path` mit `.bbmlic`), Erfolgsmeldung `Outlook-Mail wurde vorbereitet.`, Fehlerbehandlung (`Keine Kunden-E-Mail hinterlegt.`, `Antwortlizenz-Datei wurde nicht gefunden.`, `Outlook konnte nicht geöffnet werden.`) und Fallback-Optionen `Ausgabeordner öffnen` und `Mailtext kopieren` bei Outlook-Problemen (`src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js`).
- PowerShell-Script-Builder und Spawn-Wrapper hinzugefügt, temporäre Skriptdatei wird erzeugt und nach Ausführung gelöscht (`src/main/ipc/licenseIpc.js`).
- Tests und Texte aktualisiert: `scripts/tests/licenseRequest.test.cjs` erweitert, `STATUS.md` dokumentiert die Änderung.
- Nicht verändert: `src/main/licensing/licenseVerifier.js`, Lizenzsignatur/-generator- und Machine-ID-Prüf-Logiken wurden nicht angetastet.

### Testing
- `npm test` wurde ausgeführt und alle Tests liefen erfolgreich (grün). 
- Test-Änderungen umfassen Prüfungen für die neue Preload-API (`licenseAdminSendResponseLicenseMail`), die IPC-Registrierung `license-admin:send-response-license-mail` und Source-Checks, dass der Outlook-Entwurf `Display()` verwendet und `Send()` nicht aufruft (`scripts/tests/licenseRequest.test.cjs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10e977d108322aea03cec7b2f9409)