### PR TITLE
Lizenzverwaltung aufräumen: Kunden bearbeiten/löschen, aktive Lizenz entfernen, Duplikate verhindern

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -821,3 +821,5 @@ Wichtig:
   - `siehe aktuellen Branch-Commit`
 - Hinweise:
   - Keine Lizenzdatei-Strukturreform, keine Modulfreischaltung und keine Sidebar-/Projektmodul-Aenderung
+
+- 2026-04-28: Lizenzverwaltung stabilisiert (lokale Lizenz entfernen, Kunden/Lizenzdatensatz löschen, Duplikatschutz, Diagnosefelder). Nächster Schritt: manuelle End-to-End-Prüfung laut Checkliste.

--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -168,6 +168,26 @@ function createMemoryDb() {
             });
             return;
           }
+          if (text.includes("DELETE FROM license_history WHERE license_record_id = ?")) {
+            const [licenseRecordId] = args;
+            for (let i = history.length - 1; i >= 0; i -= 1) {
+              if (history[i].license_record_id === licenseRecordId) history.splice(i, 1);
+            }
+            return;
+          }
+          if (text.includes("DELETE FROM license_records WHERE customer_id = ?")) {
+            const [customerId] = args;
+            for (let i = licenses.length - 1; i >= 0; i -= 1) {
+              if (licenses[i].customer_id === customerId) licenses.splice(i, 1);
+            }
+            return;
+          }
+          if (text.includes("DELETE FROM license_customers WHERE id = ?")) {
+            const [customerId] = args;
+            const idx = customers.findIndex((entry) => entry.id === customerId);
+            if (idx >= 0) customers.splice(idx, 1);
+            return;
+          }
           if (text.includes("DELETE FROM license_records WHERE id = ?")) {
             const [id] = args;
             const index = licenses.findIndex((entry) => entry.id === id);
@@ -296,7 +316,7 @@ async function runLicenseAdminDataflowTests(run) {
     });
   });
 
-  await run("Lizenzverwaltung Main-Service: deleteLicenseRecord laesst Kundendaten und Historie unberuehrt", () => {
+  await run("Lizenzverwaltung Main-Service: deleteLicenseRecord loescht zugehoerige Historie", () => {
     withMockedDatabase((service) => {
       const customer = service.saveCustomer({
         customer_number: "K-103",
@@ -325,13 +345,67 @@ async function runLicenseAdminDataflowTests(run) {
       const history = service.listHistory();
       assert.equal(customers.length, 1);
       assert.equal(customers[0].id, customer.id);
-      assert.equal(history.length, 1);
-      assert.equal(history[0].id, historyEntry.id);
-      assert.equal(history[0].license_record_id, savedLicense.id);
+      assert.equal(history.length, 0);
     });
   });
 
 
+
+
+  await run("Lizenzverwaltung Main-Service: Kunde bearbeiten aktualisiert Felder und behaelt id", () => {
+    withMockedDatabase((service) => {
+      const customer = service.saveCustomer({ customer_number: "K-500", company_name: "Alpha GmbH", email: "a@x.de" });
+      const updated = service.saveCustomer({
+        id: customer.id,
+        customer_number: "K-500-NEU",
+        company_name: "Alpha Neu GmbH",
+        contact_person: "Max",
+        email: "neu@x.de",
+        phone: "123",
+        notes: "note",
+      });
+      assert.equal(updated.id, customer.id);
+      assert.equal(updated.customer_number, "K-500-NEU");
+      assert.equal(updated.company_name, "Alpha Neu GmbH");
+      assert.equal(updated.email, "neu@x.de");
+    });
+  });
+
+  await run("Lizenzverwaltung Main-Service: Kunde bearbeiten behaelt zugeordnete Lizenzen", () => {
+    withMockedDatabase((service) => {
+      const customer = service.saveCustomer({ customer_number: "K-501", company_name: "Beta GmbH" });
+      service.saveLicense({
+        customer_id: customer.id,
+        product_scope_json: { standardumfang: ["app"] },
+        valid_from: "2026-01-01",
+        valid_until: "2026-12-31",
+        license_mode: "full",
+        license_edition: "full",
+        license_binding: "machine",
+        machine_id: "MID-501",
+      });
+      service.saveCustomer({ id: customer.id, customer_number: "K-501", company_name: "Beta Neu GmbH" });
+      const records = service.listLicensesByCustomer(customer.id);
+      assert.equal(records.length, 1);
+      assert.equal(records[0].customer_id, customer.id);
+    });
+  });
+
+  await run("Lizenzverwaltung Main-Service: Kunde loeschen entfernt Kunde + Lizenzen + Historie", () => {
+    withMockedDatabase((service) => {
+      const a = service.saveCustomer({ customer_number: "K-A", company_name: "A GmbH" });
+      const b = service.saveCustomer({ customer_number: "K-B", company_name: "B GmbH" });
+      const licA = service.saveLicense({ customer_id: a.id, product_scope_json: { standardumfang: ["app"] }, valid_from: "2026-01-01", valid_until: "2026-12-31", license_mode: "full", license_edition: "full", license_binding: "machine", machine_id: "MID-A" });
+      service.addHistoryEntry({ license_record_id: licA.id, generated_at: "2026-01-02T00:00:00.000Z", product_scope_json: { standardumfang: ["app"] } });
+      service.saveLicense({ customer_id: b.id, product_scope_json: { standardumfang: ["app"] }, valid_from: "2026-01-01", valid_until: "2026-12-31", license_mode: "full", license_edition: "full", license_binding: "machine", machine_id: "MID-B" });
+      service.deleteCustomer(a.id);
+      assert.equal(service.listCustomers().length, 1);
+      assert.equal(service.listCustomers()[0].id, b.id);
+      assert.equal(service.listLicensesByCustomer(a.id).length, 0);
+      assert.equal(service.listLicensesByCustomer(b.id).length, 1);
+      assert.equal(service.listHistory().length, 0);
+    });
+  });
   await run("Lizenzverwaltung normalizeCustomerRecord: snake_case und camelCase werden vollstaendig abgebildet", async () => {
     const { normalizeCustomerRecord } = await importEsmFromFile(
       path.join(process.cwd(), "src/renderer/modules/lizenzverwaltung/licenseRecords.js")

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -893,6 +893,13 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes('this.currentView = "customers";'), true);
     assert.equal(screenSource.includes('await this._render();'), true);
   });
+
+  await run("LicenseAdminScreen: Renderfehler wird abgefangen", () => {
+    assert.equal(screenSource.includes("async _safeRender()"), true);
+    assert.equal(screenSource.includes("Fehler beim Laden der Lizenzverwaltung"), true);
+    assert.equal(screenSource.includes("Erneut laden"), true);
+  });
+
   await run("SettingsView: Lizenzstatusbereich fuehrt Antwortlizenz-Import ohne neuen Mechanismus", () => {
     assert.equal(settingsViewSource.includes("Antwortlizenz erhalten?"), true);
     assert.equal(settingsViewSource.includes("Importieren Sie hier die .bbmlic-Datei"), true);

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -880,6 +880,19 @@ async function runLizenzverwaltungModuleTests(run) {
     assert.equal(screenSource.includes("licenseOpenOutputDir"), true);
   });
 
+
+
+  await run("LicenseAdminScreen: Kunde speichern rendert Detailansicht frisch", () => {
+    assert.equal(screenSource.includes('this.flashMessage = "Kunde gespeichert."'), true);
+    assert.equal(screenSource.includes('await this._render();'), true);
+  });
+
+  await run("LicenseAdminScreen: Kunde loeschen setzt State zurueck und rendert Kundenliste neu", () => {
+    assert.equal(screenSource.includes('this.currentCustomer = null;'), true);
+    assert.equal(screenSource.includes('this.currentLicense = null;'), true);
+    assert.equal(screenSource.includes('this.currentView = "customers";'), true);
+    assert.equal(screenSource.includes('await this._render();'), true);
+  });
   await run("SettingsView: Lizenzstatusbereich fuehrt Antwortlizenz-Import ohne neuen Mechanismus", () => {
     assert.equal(settingsViewSource.includes("Antwortlizenz erhalten?"), true);
     assert.equal(settingsViewSource.includes("Importieren Sie hier die .bbmlic-Datei"), true);
@@ -888,7 +901,7 @@ async function runLizenzverwaltungModuleTests(run) {
 
   await run("Kundendetail: nach Kunde speichern ist Neue Lizenz direkt nutzbar", () => {
     assert.equal(screenSource.includes("this.currentCustomer = saved;"), true);
-    assert.equal(screenSource.includes("newLicenseBtn.disabled = false;"), true);
+    assert.equal(screenSource.includes('this.flashMessage = "Kunde gespeichert.";'), true);
   });
 
 

--- a/scripts/tests/lizenzverwaltungModule.test.cjs
+++ b/scripts/tests/lizenzverwaltungModule.test.cjs
@@ -844,9 +844,10 @@ async function runLizenzverwaltungModuleTests(run) {
   await run("LicenseAdminScreen enthaelt kundenbezogene Lizenzfunktionen", () => {
     assert.equal(screenSource.includes("Lizenzen dieses Kunden"), true);
     assert.equal(screenSource.includes("Kundendaten"), true);
+    assert.equal(screenSource.includes("Kunde löschen"), true);
     assert.equal(screenSource.includes("Neue Lizenz"), true);
-    assert.equal(screenSource.includes("Lizenz löschen"), true);
-    assert.equal(screenSource.includes("Lizenz wirklich löschen?"), true);
+    assert.equal(screenSource.includes("Lizenzdatensatz löschen"), true);
+    assert.equal(screenSource.includes("Lizenzdatensatz wirklich löschen?"), true);
     assert.equal(screenSource.includes("Lizenz wurde gelöscht."), true);
     assert.equal(screenSource.includes("Lizenz konnte nicht gelöscht werden."), true);
     assert.equal(screenSource.includes("Zurueck zur Kundenliste"), true);

--- a/src/main/ipc/licenseIpc.js
+++ b/src/main/ipc/licenseIpc.js
@@ -1280,6 +1280,10 @@ function registerLicenseAdminDataIpc() {
     return licenseAdminService.saveCustomer(customer || {});
   });
 
+  ipcMain.handle("license-admin:delete-customer", async (_event, id) => {
+    return licenseAdminService.deleteCustomer(id);
+  });
+
   ipcMain.handle("license-admin:list-records", async () => {
     return licenseAdminService.listLicenses();
   });

--- a/src/main/licensing/licenseAdminService.js
+++ b/src/main/licensing/licenseAdminService.js
@@ -254,6 +254,11 @@ function saveLicense(license = {}) {
   if (!record.license_edition) throw new Error("license_edition required");
   if (!record.license_binding) throw new Error("license_binding required");
 
+  const existingById = db.prepare(`SELECT id FROM license_records WHERE id = ?`).get(record.id);
+  const existingByBusinessKey = db
+    .prepare(`SELECT id FROM license_records WHERE customer_id = ? AND lower(license_id) = lower(?)`)
+    .get(record.customer_id, record.license_id);
+  if (!existingById && existingByBusinessKey?.id) record.id = existingByBusinessKey.id;
   const existing = db.prepare(`SELECT id FROM license_records WHERE id = ?`).get(record.id);
   const now = _nowIso();
 
@@ -357,6 +362,7 @@ function deleteLicenseRecord(id) {
   const db = _db();
   const existing = db.prepare(`SELECT * FROM license_records WHERE id = ?`).get(normalizedId);
   if (!existing) throw new Error("license_record_not_found");
+  db.prepare(`DELETE FROM license_history WHERE license_record_id = ?`).run(normalizedId);
   db.prepare(`DELETE FROM license_records WHERE id = ?`).run(normalizedId);
   return { ok: true, id: normalizedId };
 }
@@ -395,9 +401,26 @@ function addHistoryEntry(entry = {}) {
   return db.prepare(`SELECT * FROM license_history WHERE id = ?`).get(record.id);
 }
 
+
+function deleteCustomer(id) {
+  const normalizedId = _trimText(id);
+  if (!normalizedId) throw new Error("customer_id required");
+  const db = _db();
+  const existing = db.prepare(`SELECT * FROM license_customers WHERE id = ?`).get(normalizedId);
+  if (!existing) throw new Error("customer_not_found");
+  const records = db.prepare(`SELECT id FROM license_records WHERE customer_id = ?`).all(normalizedId);
+  for (const row of records) {
+    db.prepare(`DELETE FROM license_history WHERE license_record_id = ?`).run(row.id);
+  }
+  db.prepare(`DELETE FROM license_records WHERE customer_id = ?`).run(normalizedId);
+  db.prepare(`DELETE FROM license_customers WHERE id = ?`).run(normalizedId);
+  return { ok: true, id: normalizedId };
+}
+
 module.exports = {
   listCustomers,
   saveCustomer,
+  deleteCustomer,
   listLicenses,
   listLicensesByCustomer,
   saveLicense,

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -206,6 +206,7 @@ contextBridge.exposeInMainWorld("bbmDb", {
   licenseOpenOutputDir: (data) => ipcRenderer.invoke("license:open-output-dir", data),
   licenseAdminListLicenseCustomers: () => ipcRenderer.invoke("license-admin:list-customers"),
   licenseAdminSaveLicenseCustomer: (customer) => ipcRenderer.invoke("license-admin:save-customer", customer),
+  licenseAdminDeleteLicenseCustomer: (id) => ipcRenderer.invoke("license-admin:delete-customer", id),
   licenseAdminListLicenseRecords: () => ipcRenderer.invoke("license-admin:list-records"),
   licenseAdminListLicenseRecordsByCustomer: (customerId) =>
     ipcRenderer.invoke("license-admin:list-records-by-customer", customerId),

--- a/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
+++ b/src/renderer/modules/lizenzverwaltung/licenseStorageService.js
@@ -34,6 +34,12 @@ export async function saveCustomer(customer) {
   return save(record);
 }
 
+export async function deleteCustomer(customer) {
+  const id = String(customer?.id || customer || "").trim();
+  const del = requireApiMethod("licenseAdminDeleteLicenseCustomer");
+  return del(id);
+}
+
 export async function listLicenses() {
   const list = requireApiMethod("licenseAdminListLicenseRecords");
   return list();

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -525,7 +525,7 @@ export default class LicenseAdminScreen {
       this._button("Neuer Kunde", () => {
         this.currentCustomer = null;
         this.currentView = "customer-detail";
-        this._render();
+        this._safeRender();
       }),
       this._button("Zurueck zum Adminbereich", () => {
         if (typeof this.onBackToAdminbereich === "function") this.onBackToAdminbereich();
@@ -544,7 +544,7 @@ export default class LicenseAdminScreen {
       row.onclick = () => {
         this.currentCustomer = customer;
         this.currentView = "customer-detail";
-        this._render();
+        this._safeRender();
       };
       [
         valueOf(customer, "customer_number", "customerNumber") || "-",
@@ -656,13 +656,13 @@ export default class LicenseAdminScreen {
       }
       this.currentView = "license-editor";
       this.currentLicense = null;
-      this._render();
+      this._safeRender();
     });
     newLicenseBtn.disabled = !this.currentCustomer?.id;
 
     const backBtn = this._button("Zurueck zur Kundenliste", () => {
       this.currentView = "customers";
-      this._render();
+      this._safeRender();
     });
 
     const deleteCustomerBtn = this._button("Kunde löschen", async () => {
@@ -738,7 +738,7 @@ export default class LicenseAdminScreen {
         const openBtn = this._button("Öffnen", () => {
           this.currentView = "license-editor";
           this.currentLicense = record;
-          this._render();
+          this._safeRender();
         });
         actionCell.appendChild(openBtn);
         row.appendChild(actionCell);
@@ -1621,7 +1621,7 @@ export default class LicenseAdminScreen {
     const backBtn = this._button("Zurueck", () => {
       this.currentLicense = null;
       this.currentView = "customer-detail";
-      this._render();
+      this._safeRender();
     });
 
     actions.append(
@@ -1664,6 +1664,19 @@ export default class LicenseAdminScreen {
     );
   }
 
+  _renderError(messageText) {
+    if (!this.root) return;
+    this.root.replaceChildren();
+    const box = document.createElement("div");
+    box.style.border = "1px solid #fecaca";
+    box.style.background = "#fef2f2";
+    box.style.padding = "10px";
+    box.style.borderRadius = "8px";
+    box.textContent = String(messageText || "Ansicht konnte nicht geladen werden.");
+    const retry = this._button("Erneut laden", () => this._safeRender());
+    this.root.append(box, retry);
+  }
+
   async _render() {
     if (!this.root) return;
     this.root.replaceChildren();
@@ -1678,11 +1691,22 @@ export default class LicenseAdminScreen {
     await this._renderCustomers(this.root);
   }
 
+  async _safeRender() {
+    try {
+      await this._render();
+    } catch (err) {
+      this.currentView = "customers";
+      this.currentCustomer = null;
+      this.currentLicense = null;
+      this._renderError(`Fehler beim Laden der Lizenzverwaltung: ${err?.message || err}`);
+    }
+  }
+
   render() {
     this.root = document.createElement("div");
     this.root.style.display = "grid";
     this.root.style.gap = "10px";
-    this._render();
+    this._safeRender();
     return this.root;
   }
 }

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -642,15 +642,8 @@ export default class LicenseAdminScreen {
           })
         );
         this.currentCustomer = saved;
-        newLicenseBtn.disabled = false;
-        message.textContent = "Kunde gespeichert.";
-        inputs.customer_number.value = valueOf(saved, "customer_number", "customerNumber") || "";
-        inputs.company_name.value = valueOf(saved, "company_name", "companyName") || "";
-        inputs.contact_person.value = valueOf(saved, "contact_person", "contactPerson") || "";
-        inputs.email.value = valueOf(saved, "email") || "";
-        inputs.phone.value = valueOf(saved, "phone") || "";
-        inputs.notes.value = valueOf(saved, "notes") || "";
-        await renderLicenses();
+        this.flashMessage = "Kunde gespeichert.";
+        await this._render();
       } catch (err) {
         message.textContent = `Fehler: ${err?.message || err}`;
       }

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -1,5 +1,6 @@
 import {
   createCustomerSetup,
+  deleteCustomer,
   deleteLicense,
   listCustomers,
   listLicensesByCustomer,
@@ -664,7 +665,26 @@ export default class LicenseAdminScreen {
       this._render();
     });
 
-    customerActions.append(saveBtn, backBtn);
+    const deleteCustomerBtn = this._button("Kunde löschen", async () => {
+      const customerId = String(this.currentCustomer?.id || "").trim();
+      if (!customerId) return;
+      const confirmText = "Kunde wirklich löschen?\nDabei werden auch die Lizenzdatensätze dieses Kunden gelöscht.\nErzeugte Lizenzdateien und Setups bleiben erhalten.";
+      const shouldDelete = globalThis?.window?.confirm ? window.confirm(confirmText) : true;
+      if (!shouldDelete) return;
+      try {
+        await deleteCustomer(this.currentCustomer);
+        this.currentCustomer = null;
+        this.currentLicense = null;
+        this.currentView = "customers";
+        this.flashMessage = "Kunde wurde gelöscht.";
+        await this._render();
+      } catch (err) {
+        message.textContent = `Fehler: ${err?.message || err}`;
+      }
+    });
+    deleteCustomerBtn.style.display = this.currentCustomer?.id ? "" : "none";
+
+    customerActions.append(saveBtn, deleteCustomerBtn, backBtn);
 
     const renderLicenses = async () => {
       licenseSection.replaceChildren();
@@ -740,6 +760,12 @@ export default class LicenseAdminScreen {
 
     const context = document.createElement("div");
     context.textContent = `Kundenkontext: ${customerLabel(customer || {})}`;
+    const diagnostics = document.createElement("pre");
+    diagnostics.style.fontSize = "12px";
+    diagnostics.style.background = "#f8fafc";
+    diagnostics.style.border = "1px solid #cbd5e1";
+    diagnostics.style.padding = "8px";
+    diagnostics.style.whiteSpace = "pre-wrap";
     const message = document.createElement("div");
     message.style.minHeight = "20px";
     message.style.fontSize = "13px";
@@ -757,6 +783,7 @@ export default class LicenseAdminScreen {
     machineBindingStatus.style.background = "#f8fafc";
 
     const license = this.currentLicense || {};
+    const activeLocalLicenseId = String(window?.bbmDb && (await window.bbmDb.licenseGetStatus?.())?.licenseId || "").trim();
     const parsedScope = parseProductScopeObject(valueOf(license, "product_scope_json", "productScope"));
 
     const fields = [
@@ -1450,12 +1477,12 @@ export default class LicenseAdminScreen {
     const createCustomerSetupBtn = this._button("Kunden-Setup erstellen", async () => runSetupBuild({ setupType: "test" }));
     const createMachineSetupBtn = this._button("Machine-Setup erstellen", async () => runSetupBuild({ setupType: "machine" }));
     createCustomerSetupBtn.disabled = !valueOf(license, "license_file_path", "licenseFilePath");
-    const deleteBtn = this._button("Lizenz löschen", async () => {
+    const deleteBtn = this._button("Lizenzdatensatz löschen", async () => {
       const activeLicense = this.currentLicense || license || {};
       const licenseId = String(valueOf(activeLicense, "id") || "").trim();
       if (!licenseId) return;
       const confirmText =
-        "Lizenz wirklich löschen?\nDieser Vorgang löscht nur den Lizenzdatensatz in der Lizenzverwaltung.\nBereits erzeugte Lizenzdateien und Setups bleiben erhalten.";
+        "Lizenzdatensatz wirklich löschen?\nDieser Vorgang löscht den Lizenzdatensatz inkl. Historie in der Lizenzverwaltung.\nBereits erzeugte Lizenzdateien und Setups bleiben erhalten.";
       const shouldDelete = globalThis?.window?.confirm ? window.confirm(confirmText) : true;
       if (!shouldDelete) return;
       try {
@@ -1609,9 +1636,20 @@ export default class LicenseAdminScreen {
       openOutputDirBtn,
       copyMailTextBtn
     );
+    diagnostics.textContent = [
+      `Lizenzdatensatz-ID: ${String(valueOf(license, "id") || "-")}`,
+      `Lizenz-ID: ${String(valueOf(license, "license_id", "licenseId") || "-")}`,
+      `Kunde: ${customerLabel(customer || {})}`,
+      `license_file_path: ${String(valueOf(license, "license_file_path", "licenseFilePath") || "-")}`,
+      `setup_file_path: ${String(valueOf(license, "setup_file_path", "setupFilePath") || "-")}`,
+      `setup_status: ${String(valueOf(license, "setup_status", "setupStatus") || "-")}`,
+      `aktive lokale Lizenz-ID: ${activeLocalLicenseId || "-"}`,
+    ].join("\n");
+
     container.append(
       header,
       context,
+      diagnostics,
       form,
       licenseIdHint,
       machineBindingHint,

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -627,22 +627,29 @@ export default class LicenseAdminScreen {
 
     const saveBtn = this._button("Kunde speichern", async () => {
       try {
+        const activeCustomer = this.currentCustomer || customer || {};
         const saved = await saveCustomer(
           buildCustomerEditorPayload({
-            customer,
+            customer: { id: activeCustomer.id },
             inputs: {
-              customer_number: inputs.customer_number.value,
-              company_name: inputs.company_name.value,
-              contact_person: inputs.contact_person.value,
-              email: inputs.email.value,
-              phone: inputs.phone.value,
-              notes: inputs.notes.value,
+              customer_number: String(inputs.customer_number.value || "").trim(),
+              company_name: String(inputs.company_name.value || "").trim(),
+              contact_person: String(inputs.contact_person.value || "").trim(),
+              email: String(inputs.email.value || "").trim(),
+              phone: String(inputs.phone.value || "").trim(),
+              notes: String(inputs.notes.value || "").trim(),
             },
           })
         );
         this.currentCustomer = saved;
         newLicenseBtn.disabled = false;
         message.textContent = "Kunde gespeichert.";
+        inputs.customer_number.value = valueOf(saved, "customer_number", "customerNumber") || "";
+        inputs.company_name.value = valueOf(saved, "company_name", "companyName") || "";
+        inputs.contact_person.value = valueOf(saved, "contact_person", "contactPerson") || "";
+        inputs.email.value = valueOf(saved, "email") || "";
+        inputs.phone.value = valueOf(saved, "phone") || "";
+        inputs.notes.value = valueOf(saved, "notes") || "";
         await renderLicenses();
       } catch (err) {
         message.textContent = `Fehler: ${err?.message || err}`;

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -499,6 +499,11 @@ export default class SettingsView {
     btnImport.textContent = "Lizenz importieren";
     applyPopupButtonStyle(btnImport, { variant: "primary" });
 
+    const btnRemoveActive = document.createElement("button");
+    btnRemoveActive.type = "button";
+    btnRemoveActive.textContent = "Aktive Lizenz entfernen";
+    applyPopupButtonStyle(btnRemoveActive, { variant: "danger" });
+
     const btnReload = document.createElement("button");
     btnReload.type = "button";
     btnReload.textContent = "Status aktualisieren";
@@ -526,7 +531,7 @@ export default class SettingsView {
     responseLicenseHint.textContent =
       "Antwortlizenz erhalten?\nImportieren Sie hier die .bbmlic-Datei, die Sie vom Anbieter erhalten haben.";
 
-    buttonRow.append(btnImport, btnReload, btnCreateRequest);
+    buttonRow.append(btnImport, btnRemoveActive, btnReload, btnCreateRequest);
     statusCard.append(statusRow, messageEl, licenseBanner, infoGrid, requestTitle, requestHint, responseLicenseHint, buttonRow);
     wrap.append(statusCard, diagnosticsCard);
 
@@ -534,6 +539,7 @@ export default class SettingsView {
       const isBusy = !!busy;
       btnImport.disabled = isBusy;
       btnReload.disabled = isBusy;
+      btnRemoveActive.disabled = isBusy;
       btnCreateRequest.disabled = isBusy;
       btnCopyDiagnostics.disabled = isBusy;
     };
@@ -583,6 +589,7 @@ export default class SettingsView {
         ? `\u00A9 BBM 2026 - v${versionLabel} | Lizenziert fuer: ${customerLabel}`
         : `\u00A9 BBM 2026 - v${versionLabel} | Keine gueltige Lizenz`;
 
+      btnRemoveActive.style.display = valid ? "" : "none";
       if (!valid && reason === "NO_LICENSE") {
         setMessage("Es ist aktuell keine Lizenz installiert. Bitte eine .bbmlic-Datei importieren.", false);
       } else if (isExpired) {
@@ -661,6 +668,29 @@ export default class SettingsView {
         helper.remove();
       }
       return ok;
+    };
+
+
+    btnRemoveActive.onclick = async () => {
+      if (typeof api.licenseDelete !== "function") {
+        setMessage("Lizenzentfernung ist in dieser App-Version nicht verfuegbar.", true);
+        return;
+      }
+      const confirmText = "Aktive lokale Lizenz wirklich entfernen?\nDanach benötigt diese Installation wieder eine gültige Lizenz.";
+      const shouldDelete = globalThis?.window?.confirm ? window.confirm(confirmText) : true;
+      if (!shouldDelete) return;
+      setBusy(true);
+      try {
+        const res = await api.licenseDelete();
+        if (!res?.ok) {
+          setMessage(res?.error || "Aktive Lizenz konnte nicht entfernt werden.", true);
+          return;
+        }
+        await loadStatus();
+        await loadDiagnostics();
+      } finally {
+        setBusy(false);
+      }
     };
 
     btnImport.onclick = async () => {


### PR DESCRIPTION
### Motivation
- Die Lizenzverwaltung muss vor weiteren Komfortfunktionen stabil und eindeutig funktionieren; insbesondere sollen aktive lokale Lizenzen entfernbar sein, Admin-Lizenzdatensätze und Kunden sauber löschbar sein, und doppelte Lizenzdatensätze verhindert werden.

### Description
- UI: In `SettingsView` wurde ein Button „Aktive Lizenz entfernen“ ergänzt, der nur bei aktiver Lizenz angezeigt wird und nach Bestätigung `licenseDelete` aufruft sowie Status/Diagnose neu lädt.
- Admin/UI: Im Admin-Lizenzbildschirm wurde die Aktion umbenannt zu „Lizenzdatensatz löschen“ und so erweitert, dass beim Löschen die zugehörige Historie entfernt wird; zusätzlich wurde im Lizenzdetail ein Diagnoseblock (Datensatz-ID, Lizenz-ID, Kunde, Pfade, setup_status, aktive lokale Lizenz-ID) angezeigt.
- Service/DB: In `licenseAdminService` wurde ein Duplikatschutz implementiert, der beim Speichern von Lizenzen identische `license_id` für denselben Kunden als Update behandelt statt ein Duplikat anzulegen, und es wurde `deleteCustomer` ergänzt, das Kunde + zugehörige Lizenzdatensätze + History löscht (ohne Artefaktdateien/Setups zu entfernen).
- IPC/Preload/Renderer: IPC-Handler und Preload-API für `delete-customer` wurden ergänzt und `licenseStorageService` um eine `deleteCustomer`-Funktion erweitert; Tests und renderer-UI-Strings wurden entsprechend angepasst (u. a. `scripts/tests/lizenzverwaltungModule.test.cjs`).

### Testing
- Automatisierte Tests: `npm test` wurde ausgeführt und alle Tests liefen grün (inkl. Lizenzverwaltungs-Tests in `scripts/tests/lizenzverwaltungModule.test.cjs`).
- Spezifische Prüfungen: bestehende Lizenzverwaltungs-Tests wurden angepasst (UI-Benennung + Erwartungen) und laufen erfolgreich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1265304708322ae42137251d927bc)