### PR TITLE
Lizenzverwaltung: einzelne Lizenzdatensätze in Kundendetail löschbar

### DIFF
--- a/scripts/tests/licenseAdminDataflow.test.cjs
+++ b/scripts/tests/licenseAdminDataflow.test.cjs
@@ -544,16 +544,19 @@ async function runLicenseAdminDataflowTests(run) {
     );
 
     let receivedId = null;
+    let calls = 0;
     global.window = {
       bbmDb: {
         licenseAdminDeleteLicenseRecord: async (id) => {
+          calls += 1;
           receivedId = id;
           return { ok: true, id };
         },
       },
     };
 
-    const result = await deleteLicense({ id: "lic-delete-1" });
+    const result = await deleteLicense({ id: "  lic-delete-1  " });
+    assert.equal(calls, 1);
     assert.equal(receivedId, "lic-delete-1");
     assert.equal(result.ok, true);
   });

--- a/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
+++ b/src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js
@@ -720,7 +720,25 @@ export default class LicenseAdminScreen {
           this.currentLicense = record;
           this._render();
         });
-        actionCell.appendChild(openBtn);
+        const deleteBtn = this._button("Löschen", async (event) => {
+          event?.stopPropagation?.();
+          const licenseIdText = String(valueOf(record, "license_id", "licenseId") || valueOf(record, "id") || "").trim();
+          const confirmText =
+            `Lizenz ${licenseIdText || "(ohne ID)"} wirklich löschen? Diese Aktion entfernt nur den Lizenzdatensatz aus der Verwaltung, nicht bereits erzeugte .bbmlic-Dateien.`;
+          const shouldDelete = globalThis?.window?.confirm ? window.confirm(confirmText) : true;
+          if (!shouldDelete) return;
+          try {
+            await deleteLicense(record);
+            if (this.currentLicense?.id === record?.id) {
+              this.currentLicense = null;
+            }
+            message.textContent = "Lizenz wurde gelöscht.";
+            await renderLicenses();
+          } catch (err) {
+            message.textContent = `Fehler: ${err?.message || err}`;
+          }
+        });
+        actionCell.append(openBtn, deleteBtn);
         row.appendChild(actionCell);
         tbody.appendChild(row);
       }


### PR DESCRIPTION
### Motivation
- Ermöglichen, dass in der Kunden-Detailansicht jede einzelne Lizenz explizit löschbar ist, dabei eine klare Sicherheitsabfrage verwendet wird und nach erfolgreichem Löschen die Liste neu geladen sowie `currentLicense` zurückgesetzt wird, ohne Kunden-Löschlogik zu berühren.

### Description
- UI: In `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js` wurde in der Tabelle „Lizenzen dieses Kunden“ ein `Löschen`-Button neben `Öffnen` ergänzt, der Event-Propagation verhindert und ein Bestätigungs-Dialog nutzt (`window.confirm`).
- Löschablauf: Bei Bestätigung wird `deleteLicense(record)` aufgerufen, bei Erfolg wird `message` aktualisiert, `renderLicenses()` neu ausgeführt und `this.currentLicense` zurückgesetzt, falls die gelöschte Lizenz aktuell selektiert war, und Fehler werden im bestehenden `message`-Element angezeigt.
- Text der Sicherheitsabfrage ist wie gefordert: `Lizenz <Lizenz-ID> wirklich löschen? Diese Aktion entfernt nur den Lizenzdatensatz aus der Verwaltung, nicht bereits erzeugte .bbmlic-Dateien.`
- Tests: `scripts/tests/licenseAdminDataflow.test.cjs` wurde ergänzt, damit der Renderer-Service-`deleteLicense` zusätzlich prüft, dass die aufgerufene Preload-API `licenseAdminDeleteLicenseRecord` genau einmal aufgerufen wird und die übergebene `id` getrimmt behandelt wird.

### Testing
- Die erweiterte Testsuite wurde lokal ausgeführt mit `npm test` und alle Tests liefen erfolgreich (grün), inklusive der geänderten `licenseAdminDataflow`-Tests.
- Betroffene / geänderte Dateien während der Validierung: `src/renderer/modules/lizenzverwaltung/screens/LicenseAdminScreen.js` und `scripts/tests/licenseAdminDataflow.test.cjs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d10255348322b28fbc2542254c75)