### PR TITLE
Add project firms mini calibrator v1

### DIFF
--- a/scripts/tests/projectFirmsMiniCalibrator.test.cjs
+++ b/scripts/tests/projectFirmsMiniCalibrator.test.cjs
@@ -1,0 +1,177 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+function createFakeNode(tag) {
+  const listeners = new Map();
+  const node = {
+    tagName: String(tag || "").toUpperCase(),
+    children: [],
+    dataset: {},
+    style: {
+      setProperty(name, value) {
+        this[String(name)] = String(value);
+      },
+      removeProperty(name) {
+        delete this[String(name)];
+      },
+    },
+    value: "",
+    type: "",
+    inputMode: "",
+    placeholder: "",
+    disabled: false,
+    textContent: "",
+    append(...items) {
+      for (const item of items) {
+        if (item == null) continue;
+        this.children.push(item);
+      }
+    },
+    appendChild(item) {
+      if (item != null) this.children.push(item);
+      return item;
+    },
+    addEventListener(type, handler) {
+      const list = listeners.get(type) || [];
+      list.push(handler);
+      listeners.set(type, list);
+    },
+    dispatchEvent(evt) {
+      const type = String(evt?.type || "");
+      const list = listeners.get(type) || [];
+      for (const handler of list.slice()) handler.call(this, evt);
+      return true;
+    },
+    click() {
+      return this.dispatchEvent({ type: "click" });
+    },
+    querySelectorAll(selector) {
+      const wanted = String(selector || "").trim().toUpperCase();
+      const out = [];
+      const walk = (n) => {
+        if (!n) return;
+        if (!wanted || wanted === "*" || n.tagName === wanted) out.push(n);
+        for (const c of n.children || []) walk(c);
+      };
+      walk(this);
+      return out;
+    },
+  };
+  return node;
+}
+
+function createFakeDocument() {
+  return {
+    createElement(tag) {
+      return createFakeNode(tag);
+    },
+    body: createFakeNode("body"),
+  };
+}
+
+function findNodesByTag(node, tagName) {
+  return node?.querySelectorAll ? node.querySelectorAll(tagName) : [];
+}
+
+function findFirstButtonByText(root, text) {
+  const buttons = findNodesByTag(root, "button");
+  return buttons.find((b) => String(b.textContent || "") === text) || null;
+}
+
+function findInputs(root) {
+  return findNodesByTag(root, "input");
+}
+
+async function runProjectFirmsMiniCalibratorTests(run) {
+  const mod = await importEsmFromFile(
+    path.join(__dirname, "../../src/renderer/layoutTools/projectFirmsMiniCalibratorV1.js")
+  );
+
+  await run("ProjectFirmsMiniCalibrator: load/save/reset nutzt tableLayouts* fuer project_firms UI/portrait", async () => {
+    const previousDocument = global.document;
+    const previousWindow = global.window;
+    global.document = createFakeDocument();
+
+    const calls = [];
+    const api = {
+      tableLayoutsGetOne: async (payload) => {
+        calls.push({ type: "getOne", payload });
+        return {
+          ok: true,
+          data: {
+            source: "stored",
+            effectiveLayout: {
+              columns: [
+                { key: "shortName", label: "Kurzbez.", uiWidth: "160px", pdfWidth: "23mm", headerLines: ["Kurzbez."] },
+                { key: "role", label: "Funktion/Gewerk", uiWidth: "1fr", pdfWidth: "auto", headerLines: ["Funktion/Gewerk"] },
+                { key: "active", label: "Aktiv", uiWidth: "70px", pdfWidth: "15mm", headerLines: ["Aktiv"] },
+              ],
+            },
+          },
+        };
+      },
+      tableLayoutsSave: async (payload) => {
+        calls.push({ type: "save", payload });
+        return { ok: true, data: {} };
+      },
+      tableLayoutsReset: async (payload) => {
+        calls.push({ type: "reset", payload });
+        return { ok: true, data: { removed: 1 } };
+      },
+    };
+    global.window = { bbmDb: api };
+
+    try {
+      const calibrator = mod.createProjectFirmsMiniCalibratorV1({ api });
+      const loadRes = await calibrator.load();
+      assert.equal(loadRes.ok, true);
+
+      assert.deepEqual(calls[0], {
+        type: "getOne",
+        payload: { moduleId: "projektverwaltung", tableKey: "project_firms", orientation: "portrait" },
+      });
+
+      const inputs = findInputs(calibrator.root);
+      assert.equal(inputs.length >= 3, true);
+
+      // Reihenfolge: shortName, role, active (wie im UI gebaut).
+      assert.equal(inputs[0].value, "160");
+      assert.equal(inputs[1].value, ""); // role bleibt flexibel (1fr)
+      assert.equal(inputs[2].value, "70");
+
+      // Setze role als fixe Breite und speichere.
+      inputs[1].value = "320";
+      const btnSave = findFirstButtonByText(calibrator.root, "Speichern");
+      assert.ok(btnSave, "Speichern button missing");
+      btnSave.click();
+      // click ist sync, save async -> direkt auf save() gehen fuer determinismus
+      await calibrator.save();
+
+      const saveCall = calls.find((c) => c.type === "save");
+      assert.ok(saveCall, "save call missing");
+      assert.deepEqual(saveCall.payload.moduleId, "projektverwaltung");
+      assert.deepEqual(saveCall.payload.tableKey, "project_firms");
+      assert.deepEqual(saveCall.payload.orientation, "portrait");
+      assert.equal(saveCall.payload.layout.columns[0].uiWidth, "160px");
+      assert.equal(saveCall.payload.layout.columns[1].uiWidth, "320px");
+      assert.equal(saveCall.payload.layout.columns[2].uiWidth, "70px");
+
+      // Reset nutzt identity und laedt neu.
+      await calibrator.reset();
+      const resetCall = calls.find((c) => c.type === "reset");
+      assert.ok(resetCall, "reset call missing");
+      assert.deepEqual(resetCall.payload, {
+        moduleId: "projektverwaltung",
+        tableKey: "project_firms",
+        orientation: "portrait",
+      });
+    } finally {
+      global.document = previousDocument;
+      global.window = previousWindow;
+    }
+  });
+}
+
+module.exports = { runProjectFirmsMiniCalibratorTests };
+

--- a/src/renderer/layoutTools/projectFirmsMiniCalibratorV1.js
+++ b/src/renderer/layoutTools/projectFirmsMiniCalibratorV1.js
@@ -1,0 +1,360 @@
+// DEV-only Mini-Kalibrator V1: project_firms UI-Spaltenbreiten.
+//
+// Wichtig:
+// - Dieses Modul ist nur ein UI-Helper. Persistenz erfolgt ausschliesslich ueber
+//   vorhandene tableLayouts-IPC Funktionen (window.bbmDb.tableLayouts*).
+// - Die aufrufende Stelle (z.B. SettingsView) muss die Sichtbarkeit DEV-only guarden.
+
+const PROJECT_FIRMS_IDENTITY = Object.freeze({
+  moduleId: "projektverwaltung",
+  tableKey: "project_firms",
+  orientation: "portrait",
+});
+
+function _normalizeText(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function _cloneJson(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function _parsePxNumber(value) {
+  const text = _normalizeText(value).toLowerCase();
+  const m = text.match(/^(\d+)(?:\.\d+)?px$/);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isFinite(n) ? n : null;
+}
+
+function _formatUiWidthPx(n) {
+  const value = Math.floor(Number(n));
+  if (!Number.isFinite(value) || value <= 0) return "";
+  return `${value}px`;
+}
+
+function _findColumn(columns, key) {
+  return Array.isArray(columns) ? columns.find((col) => String(col?.key || "") === key) || null : null;
+}
+
+function _extractUiWidths(columns) {
+  const shortName = _findColumn(columns, "shortName");
+  const role = _findColumn(columns, "role");
+  const active = _findColumn(columns, "active");
+
+  const roleWidthRaw = _normalizeText(role?.uiWidth);
+  const rolePx = _parsePxNumber(roleWidthRaw);
+
+  return {
+    shortNamePx: _parsePxNumber(_normalizeText(shortName?.uiWidth)),
+    // role ist default "1fr" (flex). Im Mini-Kalibrator bleibt das als leeres Feld
+    // abbildbar. Beim Speichern wird leer wieder auf "1fr" gesetzt.
+    rolePx,
+    roleIsFlex: !!roleWidthRaw && roleWidthRaw.toLowerCase().endsWith("fr") && rolePx == null,
+    activePx: _parsePxNumber(_normalizeText(active?.uiWidth)),
+  };
+}
+
+function _applyUiWidths(columns, widths) {
+  const next = Array.isArray(columns) ? columns.map((col) => _cloneJson(col)) : [];
+  for (const col of next) {
+    const key = String(col?.key || "");
+    if (key === "shortName") col.uiWidth = _formatUiWidthPx(widths.shortNamePx);
+    if (key === "active") col.uiWidth = _formatUiWidthPx(widths.activePx);
+    if (key === "role") {
+      // Wenn kein Wert gesetzt ist, behalten wir den flex-default.
+      col.uiWidth = widths.rolePx ? _formatUiWidthPx(widths.rolePx) : "1fr";
+    }
+  }
+  return next;
+}
+
+function _validateWidths(widths) {
+  const errors = {};
+
+  const checkFixed = (name, value, { min = 20, max = 600 } = {}) => {
+    const n = Math.floor(Number(value));
+    if (!Number.isFinite(n) || n <= 0) {
+      errors[name] = "Bitte eine Zahl > 0 eingeben.";
+      return;
+    }
+    if (n < min || n > max) {
+      errors[name] = `Bitte zwischen ${min} und ${max} px eingeben.`;
+    }
+  };
+
+  checkFixed("shortNamePx", widths.shortNamePx, { min: 40, max: 400 });
+  checkFixed("activePx", widths.activePx, { min: 30, max: 200 });
+
+  // role darf leer bleiben (flex). Wenn gesetzt, dann plausibel.
+  if (widths.rolePx != null && String(widths.rolePx).trim() !== "") {
+    checkFixed("rolePx", widths.rolePx, { min: 80, max: 800 });
+  }
+
+  return { ok: Object.keys(errors).length === 0, errors };
+}
+
+export function createProjectFirmsMiniCalibratorV1({ api } = {}) {
+  const resolvedApi = api || (typeof window !== "undefined" ? window.bbmDb : null) || {};
+
+  const root = document.createElement("div");
+  root.dataset.tableCalibrator = "project_firms_v1";
+  root.style.display = "grid";
+  root.style.gap = "10px";
+  root.style.fontFamily = "var(--bbm-font-ui)";
+
+  const title = document.createElement("div");
+  title.textContent = "Tabellen-Kalibrator V1";
+  title.style.fontWeight = "900";
+  title.style.fontSize = "16px";
+  title.style.color = "#0f172a";
+
+  const hint = document.createElement("div");
+  hint.textContent = "DEV-only. Bearbeitet nur die UI-Spaltenbreiten der Projekt-Firmenliste (project_firms).";
+  hint.style.fontSize = "12px";
+  hint.style.color = "#64748b";
+  hint.style.lineHeight = "1.35";
+
+  const meta = document.createElement("div");
+  meta.style.fontSize = "12px";
+  meta.style.color = "#334155";
+  meta.textContent = "Tabelle: Projekt-Firmenliste | Variante: UI (portrait)";
+
+  const errorBox = document.createElement("div");
+  errorBox.style.fontSize = "12px";
+  errorBox.style.color = "#b91c1c";
+  errorBox.style.minHeight = "16px";
+
+  const form = document.createElement("div");
+  form.style.display = "grid";
+  form.style.gap = "8px";
+  form.style.border = "1px solid #e2e8f0";
+  form.style.borderRadius = "10px";
+  form.style.padding = "10px";
+  form.style.background = "#f8fafc";
+
+  const mkRow = (labelText, input, noteText = "") => {
+    const row = document.createElement("div");
+    row.style.display = "grid";
+    row.style.gridTemplateColumns = "220px 140px 1fr";
+    row.style.gap = "10px";
+    row.style.alignItems = "center";
+
+    const label = document.createElement("div");
+    label.textContent = labelText;
+    label.style.fontWeight = "800";
+    label.style.fontSize = "12px";
+    label.style.color = "#0f172a";
+
+    const note = document.createElement("div");
+    note.textContent = noteText;
+    note.style.fontSize = "12px";
+    note.style.color = "#64748b";
+
+    row.append(label, input, note);
+    return row;
+  };
+
+  const mkNumber = (placeholder = "") => {
+    const el = document.createElement("input");
+    el.type = "number";
+    el.inputMode = "numeric";
+    el.min = "1";
+    el.step = "1";
+    el.placeholder = placeholder;
+    el.style.width = "100%";
+    el.style.padding = "6px 8px";
+    el.style.border = "1px solid #cbd5e1";
+    el.style.borderRadius = "8px";
+    el.style.fontSize = "12px";
+    return el;
+  };
+
+  const inpShortName = mkNumber("px");
+  const inpRole = mkNumber("leer = flex (1fr)");
+  const inpActive = mkNumber("px");
+
+  const readWidthsFromInputs = () => {
+    const parseNumOrNull = (value) => {
+      const text = _normalizeText(value);
+      if (!text) return null;
+      const n = Math.floor(Number(text));
+      return Number.isFinite(n) ? n : null;
+    };
+    return {
+      shortNamePx: parseNumOrNull(inpShortName.value),
+      rolePx: parseNumOrNull(inpRole.value),
+      activePx: parseNumOrNull(inpActive.value),
+    };
+  };
+
+  const state = {
+    busy: false,
+    loadedColumns: [],
+    loadedSource: "default",
+  };
+
+  const setBusy = (busy) => {
+    state.busy = !!busy;
+    inpShortName.disabled = state.busy;
+    inpRole.disabled = state.busy;
+    inpActive.disabled = state.busy;
+    btnSave.disabled = state.busy;
+    btnReset.disabled = state.busy;
+    btnReload.disabled = state.busy;
+  };
+
+  const setError = (text) => {
+    errorBox.textContent = _normalizeText(text);
+  };
+
+  const btnBar = document.createElement("div");
+  btnBar.style.display = "flex";
+  btnBar.style.gap = "8px";
+  btnBar.style.justifyContent = "flex-end";
+
+  const mkBtn = (text, variant = "normal") => {
+    const el = document.createElement("button");
+    el.type = "button";
+    el.textContent = text;
+    el.style.padding = "7px 10px";
+    el.style.borderRadius = "10px";
+    el.style.fontWeight = "800";
+    el.style.fontSize = "12px";
+    el.style.border = "1px solid #cbd5e1";
+    el.style.background = variant === "primary" ? "#2563eb" : "#fff";
+    el.style.color = variant === "primary" ? "#fff" : "#0f172a";
+    el.style.cursor = "pointer";
+    return el;
+  };
+
+  const btnReload = mkBtn("Laden");
+  const btnReset = mkBtn("Reset");
+  const btnSave = mkBtn("Speichern", "primary");
+
+  const applyToInputs = (columns) => {
+    const widths = _extractUiWidths(columns);
+    inpShortName.value = widths.shortNamePx != null ? String(widths.shortNamePx) : "";
+    inpActive.value = widths.activePx != null ? String(widths.activePx) : "";
+    // role: flex bleibt leer, px wird gesetzt.
+    inpRole.value = widths.rolePx != null ? String(widths.rolePx) : "";
+  };
+
+  const load = async () => {
+    if (state.busy) return { ok: false, error: "busy" };
+    setError("");
+    setBusy(true);
+    try {
+      if (typeof resolvedApi?.tableLayoutsGetOne !== "function") {
+        return { ok: false, error: "Table-Layout-IPC nicht verfügbar." };
+      }
+      const res = await resolvedApi.tableLayoutsGetOne(PROJECT_FIRMS_IDENTITY);
+      if (!res?.ok) return { ok: false, error: res?.error || "Layout konnte nicht geladen werden." };
+      const effective = res?.data?.effectiveLayout || res?.data?.defaultLayout || null;
+      const cols = Array.isArray(effective?.columns) ? effective.columns : [];
+      if (!cols.length) return { ok: false, error: "Keine Spaltendaten gefunden." };
+      state.loadedColumns = _cloneJson(cols);
+      state.loadedSource = String(res?.data?.source || "default");
+      applyToInputs(state.loadedColumns);
+      return { ok: true, data: { source: state.loadedSource } };
+    } catch (e) {
+      return { ok: false, error: e?.message || String(e) };
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const save = async () => {
+    if (state.busy) return { ok: false, error: "busy" };
+    setError("");
+    const widths = readWidthsFromInputs();
+    const validation = _validateWidths(widths);
+    if (!validation.ok) {
+      setError(Object.values(validation.errors)[0] || "Ungültiger Wert");
+      return { ok: false, error: "validation" };
+    }
+
+    setBusy(true);
+    try {
+      if (typeof resolvedApi?.tableLayoutsSave !== "function") {
+        return { ok: false, error: "Table-Layout-IPC nicht verfügbar." };
+      }
+      const base = state.loadedColumns.length ? state.loadedColumns : [];
+      const nextColumns = _applyUiWidths(base, widths);
+      const res = await resolvedApi.tableLayoutsSave({
+        ...PROJECT_FIRMS_IDENTITY,
+        layout: {
+          columns: nextColumns,
+        },
+      });
+      if (!res?.ok) return { ok: false, error: res?.error || "Speichern fehlgeschlagen." };
+      // Nach erfolgreichem Speichern: Werte frisch laden, damit Defaults/Normalization sichtbar werden.
+      await load();
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: e?.message || String(e) };
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const reset = async () => {
+    if (state.busy) return { ok: false, error: "busy" };
+    setError("");
+    setBusy(true);
+    try {
+      if (typeof resolvedApi?.tableLayoutsReset !== "function") {
+        return { ok: false, error: "Table-Layout-IPC nicht verfügbar." };
+      }
+      const res = await resolvedApi.tableLayoutsReset(PROJECT_FIRMS_IDENTITY);
+      if (!res?.ok) return { ok: false, error: res?.error || "Reset fehlgeschlagen." };
+      await load();
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: e?.message || String(e) };
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  btnReload.addEventListener("click", () => {
+    void load().then((res) => {
+      if (!res?.ok) setError(res?.error || "Laden fehlgeschlagen.");
+    });
+  });
+  btnSave.addEventListener("click", () => {
+    void save().then((res) => {
+      if (!res?.ok && res?.error && res.error !== "validation") setError(res?.error);
+    });
+  });
+  btnReset.addEventListener("click", () => {
+    void reset().then((res) => {
+      if (!res?.ok) setError(res?.error || "Reset fehlgeschlagen.");
+    });
+  });
+
+  // Sofortiges Feedback bei Eingaben: Fehlermeldung leeren.
+  for (const el of [inpShortName, inpRole, inpActive]) {
+    el.addEventListener("input", () => setError(""));
+  }
+
+  form.append(
+    mkRow("Kurzbez. / shortName", inpShortName, "Pixelbreite (z.B. 160)"),
+    mkRow("Funktion/Gewerk / role", inpRole, "leer lassen = flexibel (1fr)"),
+    mkRow("Aktiv / active", inpActive, "Pixelbreite (z.B. 70)")
+  );
+
+  btnBar.append(btnReload, btnReset, btnSave);
+
+  root.append(title, hint, meta, errorBox, form, btnBar);
+
+  return {
+    root,
+    load,
+    save,
+    reset,
+    identity: PROJECT_FIRMS_IDENTITY,
+  };
+}
+

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -14,6 +14,7 @@ import {
   parseCssColor,
 } from "../theme/themes.js";
 import { createDictationDevSection } from "../modules/audio/index.js";
+import { createProjectFirmsMiniCalibratorV1 } from "../layoutTools/projectFirmsMiniCalibratorV1.js";
 
 const DEFAULT_V2_PRE_REMARKS_TEXT =
   "folgende Punkte gelten als fest vereinbart, Diesen Text anpassen unter Einstellungen - Druckeinstellungen - Vorbemergung";
@@ -5003,6 +5004,15 @@ export default class SettingsView {
     const api = window.bbmDb || {};
     const has = (name) => typeof api?.[name] === "function";
     const DEV_AUDIO_DICTATION_UNLOCK_KEY = "dev.audioDictationUnlock";
+    const isDevBuildChannel = async () => {
+      if (!has("appGetBuildChannel")) return false;
+      try {
+        const res = await api.appGetBuildChannel();
+        return !!res?.ok && String(res.channel || "").trim().toUpperCase() === "DEV";
+      } catch (_e) {
+        return false;
+      }
+    };
     const clampInt = (val, min, max, fallback) => {
       const n = Math.floor(Number(val));
       if (!Number.isFinite(n) || n <= 0) return fallback;
@@ -5064,6 +5074,10 @@ export default class SettingsView {
     const dictationDevCard = mkCard(
       "Diktat-Testfreigabe",
       "Aktiviert Diktat unabhängig von der Lizenz für Entwicklung und Prüfung."
+    );
+    const tableCalibratorCard = mkCard(
+      "Tabellen-Kalibrator V1",
+      "DEV-only: Mini-Kalibrator fuer project_firms (UI-Spaltenbreiten)."
     );
     const btn = (label, primary = false) => {
       const el = document.createElement("button");
@@ -5174,6 +5188,42 @@ export default class SettingsView {
       mkRow("Naechste Version", nextVersionValue),
       (() => { const row = document.createElement("div"); row.style.display = "flex"; row.style.gap = "8px"; row.append(bumpBtn, set100Btn); return row; })(),
       versionStatus
+    );
+
+    // ------------------------------------------------------------
+    // DEV-only: Mini-Kalibrator V1 (project_firms UI-Spaltenbreiten)
+    // ------------------------------------------------------------
+    const tableCalibratorStatus = document.createElement("div");
+    tableCalibratorStatus.style.fontSize = "12px";
+    tableCalibratorStatus.style.minHeight = "16px";
+    tableCalibratorStatus.style.color = "#4b5563";
+
+    const openTableCalibratorBtn = btn("Oeffnen", true);
+    openTableCalibratorBtn.onclick = async () => {
+      const devChannel = await isDevBuildChannel();
+      if (!devChannel) {
+        tableCalibratorStatus.textContent = "Nicht verfuegbar (nur DEV-Build-Kanal).";
+        return;
+      }
+      if (!has("tableLayoutsGetOne") || !has("tableLayoutsSave") || !has("tableLayoutsReset")) {
+        tableCalibratorStatus.textContent = "Table-Layout-IPC ist nicht verfuegbar.";
+        return;
+      }
+      tableCalibratorStatus.textContent = "";
+      const calibrator = createProjectFirmsMiniCalibratorV1({ api });
+      await calibrator.load();
+      this._openSettingsModal({
+        title: "Tabellen-Kalibrator V1",
+        content: [calibrator.root],
+        closeOnly: true,
+      });
+    };
+
+    tableCalibratorCard.box.append(
+      mkRow("Tabelle", "Projekt-Firmenliste (project_firms)"),
+      mkRow("Variante", "UI / portrait"),
+      mkRow("", openTableCalibratorBtn),
+      mkRow("", tableCalibratorStatus)
     );
 
     const dbText = document.createElement("pre");
@@ -5392,12 +5442,14 @@ export default class SettingsView {
       el.style.color = active ? "white" : "#1565c0";
       el.style.borderColor = active ? "rgba(25,118,210,0.65)" : "rgba(0,0,0,0.18)";
     };
+    const devBuildChannel = await isDevBuildChannel();
     const tabs = [
       { key: "version", label: "Versionierung", el: versionCard.box },
       { key: "db", label: "DB-Diagnose", el: dbCard.box },
       { key: "tops", label: "Protokoll-Textgrenzen", el: topsCard.box },
       { key: "dictation", label: "Diktat-Testfreigabe", el: dictationDevCard.box },
       { key: "theme", label: "Farbschema", el: themeCard.box },
+      ...(devBuildChannel ? [{ key: "tableCal", label: "Tabellen-Kalibrator V1", el: tableCalibratorCard.box }] : []),
     ];
     const tabHead = document.createElement("div");
     tabHead.style.display = "flex";
@@ -5426,13 +5478,15 @@ export default class SettingsView {
       tabButtons.set(key, b);
       return b;
     };
-    tabHead.append(
-      addTabBtn("Versionierung", "version"),
-      addTabBtn("DB-Diagnose", "db"),
-      addTabBtn("Protokoll-Textgrenzen", "tops"),
-      addTabBtn("Diktat-Testfreigabe", "dictation"),
-      addTabBtn("Farbschema", "theme")
-    );
+    const tabButtonsToAdd = [
+      ["Versionierung", "version"],
+      ["DB-Diagnose", "db"],
+      ["Protokoll-Textgrenzen", "tops"],
+      ["Diktat-Testfreigabe", "dictation"],
+      ["Farbschema", "theme"],
+      ...(devBuildChannel ? [["Tabellen-Kalibrator V1", "tableCal"]] : []),
+    ];
+    tabHead.append(...tabButtonsToAdd.map(([label, key]) => addTabBtn(label, key)));
     tabBody.append(...tabs.map((t) => t.el));
     section.append(tabHead, tabBody);
 


### PR DESCRIPTION
Ergaenzt einen DEV-only Mini-Kalibrator V1 fuer project_firms UI-Spaltenbreiten. Nutzt vorhandene tableLayouts-Technik fuer Laden, Speichern und Reset. Keine TOP-, PDF- oder Druckweg-Aenderungen. npm test gruen.