### PR TITLE
ui(protokoll): TOP-Liste Metaspalte rechts + DEV Tabellen-Kalibrator

### DIFF
--- a/src/renderer/layoutTools/DevTableCalibrator.js
+++ b/src/renderer/layoutTools/DevTableCalibrator.js
@@ -1,0 +1,710 @@
+// DEV-only helper for table layout calibration.
+//
+// Goals:
+// - Keep calibration UI out of module screens (Protokoll, etc.)
+// - Use the existing tableLayouts IPC API (GetOne/Save/Reset/ListDefinitions)
+// - Provide a registry-based picker so users don't need to know internal table keys
+//
+// This module intentionally stays UI-framework-free (plain DOM).
+
+function _clampText(v) {
+  return String(v ?? "").trim();
+}
+
+function _dispatchTableLayoutChanged(identity = {}) {
+  try {
+    window.dispatchEvent(
+      new CustomEvent("bbm:tableLayoutChanged", {
+        detail: {
+          moduleId: String(identity.moduleId || "").trim(),
+          tableKey: String(identity.tableKey || "").trim(),
+          orientation: String(identity.orientation || "portrait").trim(),
+        },
+      })
+    );
+  } catch (_err) {
+    // ignore
+  }
+}
+
+function _mkTextInput({ placeholder = "" } = {}) {
+  const el = document.createElement("input");
+  el.type = "text";
+  el.placeholder = placeholder;
+  el.style.width = "100%";
+  el.style.boxSizing = "border-box";
+  el.style.padding = "6px 8px";
+  el.style.border = "1px solid rgba(0,0,0,0.18)";
+  el.style.borderRadius = "8px";
+  el.style.fontSize = "12px";
+  el.autocomplete = "off";
+  el.spellcheck = false;
+  return el;
+}
+
+function _mkButton({ label, variant = "neutral", applyPopupButtonStyle }) {
+  const el = document.createElement("button");
+  el.type = "button";
+  el.textContent = label;
+  applyPopupButtonStyle(el, { variant });
+  return el;
+}
+
+function _mkRow({ labelText, cols = [], width = "260px", hintText = "" } = {}) {
+  const row = document.createElement("div");
+  row.style.display = "grid";
+  row.style.gridTemplateColumns = `${width} ${cols.map(() => "1fr").join(" ")}`.trim();
+  row.style.gap = "10px";
+  row.style.alignItems = "center";
+
+  const label = document.createElement("div");
+  label.textContent = labelText;
+  label.style.fontWeight = "700";
+  label.style.fontSize = "12px";
+  label.style.color = "#334155";
+  row.appendChild(label);
+
+  for (const node of cols) row.appendChild(node);
+
+  if (hintText) {
+    const hint = document.createElement("div");
+    hint.textContent = hintText;
+    hint.style.fontSize = "12px";
+    hint.style.opacity = "0.75";
+    // if hints are used, caller should include it as an explicit column
+    row.appendChild(hint);
+  }
+
+  return row;
+}
+
+async function _openProtokollTopsCalibrator({ api, has, openSettingsModal, applyPopupCardStyle, applyPopupButtonStyle } = {}) {
+  const identity = Object.freeze({
+    moduleId: "protokoll",
+    tableKey: "protokoll_tops",
+    orientation: "portrait",
+  });
+
+  const {
+    extractProtokollTopsEditorValues,
+    buildProtokollTopsLayoutOverlay,
+    validateProtokollTopsEditorValues,
+  } = await import("../../shared/tableLayouts/protokollTopsLayout.js");
+
+  const wrap = document.createElement("div");
+  wrap.style.display = "grid";
+  wrap.style.gap = "10px";
+  wrap.style.minWidth = "min(860px, calc(100vw - 80px))";
+  wrap.style.maxWidth = "980px";
+
+  const head = document.createElement("div");
+  head.style.display = "grid";
+  head.style.gap = "2px";
+  const title = document.createElement("div");
+  title.textContent = "Tabellen-Kalibrator (DEV-only) – TOP-Liste";
+  title.style.fontWeight = "900";
+  const sub = document.createElement("div");
+  sub.textContent = "Tabelle: protokoll_tops (UI + PDF). Speichern schreibt Layoutwerte dauerhaft.";
+  sub.style.fontSize = "12px";
+  sub.style.opacity = "0.8";
+  head.append(title, sub);
+
+  const card = document.createElement("div");
+  applyPopupCardStyle(card);
+  card.style.padding = "10px 12px";
+  card.style.display = "grid";
+  card.style.gap = "10px";
+
+  const uiNumberWidth = _mkTextInput({ placeholder: "z.B. 64px" });
+  const uiMetaWidth = _mkTextInput({ placeholder: "z.B. 74px" });
+  const pdfNumberWidth = _mkTextInput({ placeholder: "z.B. 23mm" });
+  const pdfMetaWidth = _mkTextInput({ placeholder: "z.B. 15ch" });
+
+  const msg = document.createElement("div");
+  msg.style.fontSize = "12px";
+  msg.style.minHeight = "18px";
+  msg.style.color = "#334155";
+
+  const load = async () => {
+    if (!has("tableLayoutsGetOne")) {
+      msg.textContent = "tableLayoutsGetOne fehlt.";
+      msg.style.color = "#9d1c1c";
+      return false;
+    }
+    const res = await api.tableLayoutsGetOne(identity);
+    if (!res?.ok) {
+      msg.textContent = res?.error || "Layout konnte nicht geladen werden.";
+      msg.style.color = "#9d1c1c";
+      return false;
+    }
+    const layout = res?.data?.effectiveLayout || res?.data?.defaultLayout || null;
+    const values = extractProtokollTopsEditorValues(layout || {});
+    uiNumberWidth.value = _clampText(values.uiNumberWidth || "");
+    uiMetaWidth.value = _clampText(values.uiMetaWidth || "");
+    pdfNumberWidth.value = _clampText(values.pdfNumberWidth || "");
+    pdfMetaWidth.value = _clampText(values.pdfMetaWidth || "");
+    msg.textContent = "Layout geladen.";
+    msg.style.color = "#334155";
+    return true;
+  };
+
+  const apply = async ({ reset = false } = {}) => {
+    if (reset) {
+      if (!has("tableLayoutsReset")) {
+        msg.textContent = "tableLayoutsReset fehlt.";
+        msg.style.color = "#9d1c1c";
+        return false;
+      }
+      const resReset = await api.tableLayoutsReset({ ...identity, scopeType: "global" });
+      if (!resReset?.ok) {
+        msg.textContent = resReset?.error || "Reset fehlgeschlagen.";
+        msg.style.color = "#9d1c1c";
+        return false;
+      }
+      _dispatchTableLayoutChanged(identity);
+      msg.textContent = "Reset ausgeführt (Defaults aktiv).";
+      msg.style.color = "#334155";
+      await load();
+      return true;
+    }
+
+    if (!has("tableLayoutsSave")) {
+      msg.textContent = "tableLayoutsSave fehlt.";
+      msg.style.color = "#9d1c1c";
+      return false;
+    }
+
+    const draft = {
+      orientation: "portrait",
+      uiNumberWidth: _clampText(uiNumberWidth.value),
+      uiMetaWidth: _clampText(uiMetaWidth.value),
+      pdfNumberWidth: _clampText(pdfNumberWidth.value),
+      pdfMetaWidth: _clampText(pdfMetaWidth.value),
+    };
+    const validated = validateProtokollTopsEditorValues(draft, "portrait");
+    if (!validated?.isValid) {
+      msg.textContent = "Ungültige Werte. Beispiele: 64px, 23mm, 15ch";
+      msg.style.color = "#9d1c1c";
+      return false;
+    }
+    const layout = buildProtokollTopsLayoutOverlay(validated.values, validated.values.orientation);
+
+    const resSave = await api.tableLayoutsSave({
+      ...identity,
+      scopeType: "global",
+      layout,
+    });
+    if (!resSave?.ok) {
+      msg.textContent = resSave?.error || "Speichern fehlgeschlagen.";
+      msg.style.color = "#9d1c1c";
+      return false;
+    }
+    _dispatchTableLayoutChanged(identity);
+    msg.textContent = "Gespeichert und angewendet.";
+    msg.style.color = "#334155";
+    return true;
+  };
+
+  const btnRow = document.createElement("div");
+  btnRow.style.display = "flex";
+  btnRow.style.gap = "8px";
+  btnRow.style.flexWrap = "wrap";
+
+  const bLoad = _mkButton({ label: "Laden", variant: "neutral", applyPopupButtonStyle });
+  bLoad.onclick = async () => void (await load());
+  const bApply = _mkButton({ label: "Anwenden (Speichern)", variant: "primary", applyPopupButtonStyle });
+  bApply.onclick = async () => void (await apply({ reset: false }));
+  const bReset = _mkButton({ label: "Reset (Defaults)", variant: "danger", applyPopupButtonStyle });
+  bReset.onclick = async () => void (await apply({ reset: true }));
+  btnRow.append(bLoad, bApply, bReset);
+
+  card.append(
+    _mkRow({ labelText: "UI: Nummernspalte", cols: [uiNumberWidth, (() => { const h = document.createElement("div"); h.textContent = "z.B. 64px"; h.style.fontSize = "12px"; h.style.opacity = "0.75"; return h; })()], width: "220px" }),
+    _mkRow({ labelText: "UI: Metaspalte", cols: [uiMetaWidth, (() => { const h = document.createElement("div"); h.textContent = "z.B. 74px"; h.style.fontSize = "12px"; h.style.opacity = "0.75"; return h; })()], width: "220px" }),
+    _mkRow({ labelText: "PDF: Nummernspalte", cols: [pdfNumberWidth, (() => { const h = document.createElement("div"); h.textContent = "z.B. 23mm"; h.style.fontSize = "12px"; h.style.opacity = "0.75"; return h; })()], width: "220px" }),
+    _mkRow({ labelText: "PDF: Metaspalte", cols: [pdfMetaWidth, (() => { const h = document.createElement("div"); h.textContent = "z.B. 15ch"; h.style.fontSize = "12px"; h.style.opacity = "0.75"; return h; })()], width: "220px" }),
+    btnRow,
+    msg
+  );
+
+  wrap.append(head, card);
+  openSettingsModal({
+    title: "Tabellen-Kalibrator (DEV-only)",
+    content: [wrap],
+    closeOnly: true,
+  });
+
+  await load(); 
+} 
+ 
+async function _openProtokollParticipantsCalibrator({ 
+  api, 
+  has, 
+  openSettingsModal, 
+  applyPopupCardStyle, 
+  applyPopupButtonStyle, 
+} = {}) { 
+  const identity = Object.freeze({ 
+    moduleId: "protokoll", 
+    tableKey: "protokoll_participants", 
+    orientation: "portrait", 
+  }); 
+ 
+  const { validateTableLayoutColumns, buildTableLayoutOverlayFromColumns } = await import( 
+    "../../shared/tableLayouts/protokollTopsLayout.js" 
+  ); 
+ 
+  const keys = ["name", "function", "company", "contact", "attendance"]; 
+ 
+  const wrap = document.createElement("div"); 
+  wrap.style.display = "grid"; 
+  wrap.style.gap = "10px"; 
+  wrap.style.minWidth = "min(920px, calc(100vw - 80px))"; 
+  wrap.style.maxWidth = "1040px"; 
+ 
+  const head = document.createElement("div"); 
+  head.style.display = "grid"; 
+  head.style.gap = "2px"; 
+  const title = document.createElement("div"); 
+  title.textContent = "Tabellen-Kalibrator (DEV-only) â€“ Teilnehmerliste (PDF)"; 
+  title.style.fontWeight = "900"; 
+  const sub = document.createElement("div"); 
+  sub.textContent = "Tabelle: protokoll_participants (nur PDF-Breiten). Speichern schreibt Layoutwerte dauerhaft."; 
+  sub.style.fontSize = "12px"; 
+  sub.style.opacity = "0.8"; 
+  head.append(title, sub); 
+ 
+  const card = document.createElement("div"); 
+  applyPopupCardStyle(card); 
+  card.style.padding = "10px 12px"; 
+  card.style.display = "grid"; 
+  card.style.gap = "10px"; 
+ 
+  const inputs = new Map(); 
+  for (const key of keys) inputs.set(key, _mkTextInput({ placeholder: "z.B. 36mm" })); 
+ 
+  const msg = document.createElement("div"); 
+  msg.style.fontSize = "12px"; 
+  msg.style.minHeight = "18px"; 
+  msg.style.color = "#334155"; 
+ 
+  let lastLoadedColumns = []; 
+  let fallbackColumns = []; 
+ 
+  const load = async () => { 
+    if (!has("tableLayoutsGetOne")) { 
+      msg.textContent = "tableLayoutsGetOne fehlt."; 
+      msg.style.color = "#9d1c1c"; 
+      return false; 
+    } 
+    const res = await api.tableLayoutsGetOne(identity); 
+    if (!res?.ok) { 
+      msg.textContent = res?.error || "Layout konnte nicht geladen werden."; 
+      msg.style.color = "#9d1c1c"; 
+      return false; 
+    } 
+    const effective = res?.data?.effectiveLayout || null; 
+    const def = res?.data?.defaultLayout || null; 
+    lastLoadedColumns = Array.isArray(effective?.columns) 
+      ? effective.columns 
+      : Array.isArray(def?.columns) 
+        ? def.columns 
+        : []; 
+    fallbackColumns = Array.isArray(def?.columns) ? def.columns : []; 
+ 
+    const byKey = new Map(); 
+    for (const col of lastLoadedColumns) byKey.set(String(col?.key || ""), col); 
+    for (const key of keys) { 
+      const col = byKey.get(key) || {}; 
+      const input = inputs.get(key); 
+      if (input) input.value = _clampText(col.pdfWidth || ""); 
+    } 
+    msg.textContent = "Layout geladen."; 
+    msg.style.color = "#334155"; 
+    return true; 
+  }; 
+ 
+  const apply = async ({ reset = false } = {}) => { 
+    if (reset) { 
+      if (!has("tableLayoutsReset")) { 
+        msg.textContent = "tableLayoutsReset fehlt."; 
+        msg.style.color = "#9d1c1c"; 
+        return false; 
+      } 
+      const resReset = await api.tableLayoutsReset({ ...identity, scopeType: "global" }); 
+      if (!resReset?.ok) { 
+        msg.textContent = resReset?.error || "Reset fehlgeschlagen."; 
+        msg.style.color = "#9d1c1c"; 
+        return false; 
+      } 
+      _dispatchTableLayoutChanged(identity); 
+      msg.textContent = "Reset ausgefÃ¼hrt (Defaults aktiv)."; 
+      msg.style.color = "#334155"; 
+      await load(); 
+      return true; 
+    } 
+ 
+    if (!has("tableLayoutsSave")) { 
+      msg.textContent = "tableLayoutsSave fehlt."; 
+      msg.style.color = "#9d1c1c"; 
+      return false; 
+    } 
+ 
+    const updated = (Array.isArray(lastLoadedColumns) ? lastLoadedColumns : []).map((c) => ({ ...(c || {}) })); 
+    const byKey = new Map(); 
+    for (const col of updated) byKey.set(String(col?.key || ""), col); 
+    for (const key of keys) { 
+      const col = byKey.get(key); 
+      if (!col) continue; 
+      col.pdfWidth = _clampText(inputs.get(key)?.value || ""); 
+    } 
+ 
+    const validated = validateTableLayoutColumns(updated, fallbackColumns); 
+    if (!validated?.isValid) { 
+      msg.textContent = "UngÃ¼ltige Werte. Beispiele: 36mm, 45mm, 110px"; 
+      msg.style.color = "#9d1c1c"; 
+      return false; 
+    } 
+ 
+    const layout = buildTableLayoutOverlayFromColumns(validated.columns, "portrait", { fallbackColumns }); 
+    const resSave = await api.tableLayoutsSave({ ...identity, scopeType: "global", layout }); 
+    if (!resSave?.ok) { 
+      msg.textContent = resSave?.error || "Speichern fehlgeschlagen."; 
+      msg.style.color = "#9d1c1c"; 
+      return false; 
+    } 
+    _dispatchTableLayoutChanged(identity); 
+    msg.textContent = "Gespeichert und angewendet."; 
+    msg.style.color = "#334155"; 
+    return true; 
+  }; 
+ 
+  const btnRow = document.createElement("div"); 
+  btnRow.style.display = "flex"; 
+  btnRow.style.gap = "8px"; 
+  btnRow.style.flexWrap = "wrap"; 
+  const bLoad = _mkButton({ label: "Laden", variant: "neutral", applyPopupButtonStyle }); 
+  bLoad.onclick = async () => void (await load()); 
+  const bApply = _mkButton({ label: "Anwenden (Speichern)", variant: "primary", applyPopupButtonStyle }); 
+  bApply.onclick = async () => void (await apply({ reset: false })); 
+  const bReset = _mkButton({ label: "Reset (Defaults)", variant: "danger", applyPopupButtonStyle }); 
+  bReset.onclick = async () => void (await apply({ reset: true })); 
+  btnRow.append(bLoad, bApply, bReset); 
+ 
+  const mkHint = (t) => { 
+    const h = document.createElement("div"); 
+    h.textContent = t; 
+    h.style.fontSize = "12px"; 
+    h.style.opacity = "0.75"; 
+    return h; 
+  }; 
+ 
+  card.append( 
+    _mkRow({ labelText: "PDF: Name", cols: [inputs.get("name"), mkHint("z.B. 36mm")], width: "220px" }), 
+    _mkRow({ labelText: "PDF: Funktion", cols: [inputs.get("function"), mkHint("z.B. 36mm")], width: "220px" }), 
+    _mkRow({ labelText: "PDF: Firma", cols: [inputs.get("company"), mkHint("z.B. 30mm")], width: "220px" }), 
+    _mkRow({ labelText: "PDF: Telefon / E-Mail", cols: [inputs.get("contact"), mkHint("z.B. 45mm")], width: "220px" }), 
+    _mkRow({ labelText: "PDF: Anwesend / Verteiler", cols: [inputs.get("attendance"), mkHint("z.B. 26mm")], width: "220px" }), 
+    btnRow, 
+    msg 
+  ); 
+ 
+  wrap.append(head, card); 
+  openSettingsModal({ title: "Tabellen-Kalibrator (DEV-only)", content: [wrap], closeOnly: true }); 
+  await load(); 
+} 
+ 
+async function _openTodoPrintCalibrator({ 
+  api, 
+  has, 
+  openSettingsModal, 
+  applyPopupCardStyle, 
+  applyPopupButtonStyle, 
+} = {}) { 
+  const identity = Object.freeze({ 
+    moduleId: "protokoll", 
+    tableKey: "print.todo.todoTable", 
+    orientation: "portrait", 
+  }); 
+ 
+  const zones = [ 
+    { key: "top", label: "TOP" }, 
+    { key: "kurztext", label: "Kurztext" }, 
+    { key: "status", label: "Status" }, 
+    { key: "fertig_bis", label: "Fertig bis" }, 
+    { key: "ampel", label: "Ampel" }, 
+  ]; 
+ 
+  const wrap = document.createElement("div"); 
+  wrap.style.display = "grid"; 
+  wrap.style.gap = "10px"; 
+  wrap.style.minWidth = "min(980px, calc(100vw - 80px))"; 
+  wrap.style.maxWidth = "1120px"; 
+ 
+  const head = document.createElement("div"); 
+  head.style.display = "grid"; 
+  head.style.gap = "2px"; 
+  const title = document.createElement("div"); 
+  title.textContent = "Tabellen-Kalibrator (DEV-only) â€“ ToDo-Liste (PDF)"; 
+  title.style.fontWeight = "900"; 
+  const sub = document.createElement("div"); 
+  sub.textContent = "Tabelle: print.todo.todoTable (nur PDF rootVars). Speichern schreibt Layoutwerte dauerhaft."; 
+  sub.style.fontSize = "12px"; 
+  sub.style.opacity = "0.8"; 
+  head.append(title, sub); 
+ 
+  const card = document.createElement("div"); 
+  applyPopupCardStyle(card); 
+  card.style.padding = "10px 12px"; 
+  card.style.display = "grid"; 
+  card.style.gap = "10px"; 
+ 
+  const inputs = new Map(); 
+  for (const z of zones) { 
+    inputs.set(z.key, { 
+      widthEl: _mkTextInput({ placeholder: "z.B. 21mm" }), 
+      insetEl: _mkTextInput({ placeholder: "z.B. 1mm" }), 
+      fontEl: _mkTextInput({ placeholder: "z.B. 11pt" }), 
+    }); 
+  } 
+ 
+  const msg = document.createElement("div"); 
+  msg.style.fontSize = "12px"; 
+  msg.style.minHeight = "18px"; 
+  msg.style.color = "#334155"; 
+ 
+  let lastLoadedLayout = null; 
+ 
+  const load = async () => { 
+    if (!has("tableLayoutsGetOne")) { 
+      msg.textContent = "tableLayoutsGetOne fehlt."; 
+      msg.style.color = "#9d1c1c"; 
+      return false; 
+    } 
+    const res = await api.tableLayoutsGetOne(identity); 
+    if (!res?.ok) { 
+      msg.textContent = res?.error || "Layout konnte nicht geladen werden."; 
+      msg.style.color = "#9d1c1c"; 
+      return false; 
+    } 
+    const layout = res?.data?.effectiveLayout || res?.data?.defaultLayout || null; 
+    lastLoadedLayout = layout && typeof layout === "object" ? layout : null; 
+    const rootVars = layout?.pdf?.rootVars && typeof layout.pdf.rootVars === "object" ? layout.pdf.rootVars : {}; 
+ 
+    for (const z of zones) { 
+      const bag = inputs.get(z.key); 
+      if (!bag) continue; 
+      bag.widthEl.value = _clampText(rootVars[`--bbm-todo-col-${z.key}-width`] || ""); 
+      bag.insetEl.value = _clampText(rootVars[`--bbm-todo-col-${z.key}-padding-inline`] || ""); 
+      bag.fontEl.value = _clampText(rootVars[`--bbm-todo-col-${z.key}-font-size`] || ""); 
+    } 
+ 
+    msg.textContent = "Layout geladen."; 
+    msg.style.color = "#334155"; 
+    return true; 
+  }; 
+ 
+  const apply = async ({ reset = false } = {}) => { 
+    if (reset) { 
+      if (!has("tableLayoutsReset")) { 
+        msg.textContent = "tableLayoutsReset fehlt."; 
+        msg.style.color = "#9d1c1c"; 
+        return false; 
+      } 
+      const resReset = await api.tableLayoutsReset({ ...identity, scopeType: "global" }); 
+      if (!resReset?.ok) { 
+        msg.textContent = resReset?.error || "Reset fehlgeschlagen."; 
+        msg.style.color = "#9d1c1c"; 
+        return false; 
+      } 
+      _dispatchTableLayoutChanged(identity); 
+      msg.textContent = "Reset ausgefÃ¼hrt (Defaults aktiv)."; 
+      msg.style.color = "#334155"; 
+      await load(); 
+      return true; 
+    } 
+ 
+    if (!has("tableLayoutsSave")) { 
+      msg.textContent = "tableLayoutsSave fehlt."; 
+      msg.style.color = "#9d1c1c"; 
+      return false; 
+    } 
+ 
+    const pdfRootVars = { ...(lastLoadedLayout?.pdf?.rootVars || {}) }; 
+    for (const z of zones) { 
+      const bag = inputs.get(z.key); 
+      if (!bag) continue; 
+      pdfRootVars[`--bbm-todo-col-${z.key}-width`] = _clampText(bag.widthEl.value); 
+      pdfRootVars[`--bbm-todo-col-${z.key}-padding-inline`] = _clampText(bag.insetEl.value); 
+      pdfRootVars[`--bbm-todo-col-${z.key}-font-size`] = _clampText(bag.fontEl.value); 
+    } 
+ 
+    const layout = { variant: "portrait", pdf: { rootVars: pdfRootVars } }; 
+    const resSave = await api.tableLayoutsSave({ ...identity, scopeType: "global", layout }); 
+    if (!resSave?.ok) { 
+      msg.textContent = resSave?.error || "Speichern fehlgeschlagen."; 
+      msg.style.color = "#9d1c1c"; 
+      return false; 
+    } 
+    _dispatchTableLayoutChanged(identity); 
+    msg.textContent = "Gespeichert und angewendet."; 
+    msg.style.color = "#334155"; 
+    return true; 
+  }; 
+ 
+  const btnRow = document.createElement("div"); 
+  btnRow.style.display = "flex"; 
+  btnRow.style.gap = "8px"; 
+  btnRow.style.flexWrap = "wrap"; 
+  const bLoad = _mkButton({ label: "Laden", variant: "neutral", applyPopupButtonStyle }); 
+  bLoad.onclick = async () => void (await load()); 
+  const bApply = _mkButton({ label: "Anwenden (Speichern)", variant: "primary", applyPopupButtonStyle }); 
+  bApply.onclick = async () => void (await apply({ reset: false })); 
+  const bReset = _mkButton({ label: "Reset (Defaults)", variant: "danger", applyPopupButtonStyle }); 
+  bReset.onclick = async () => void (await apply({ reset: true })); 
+  btnRow.append(bLoad, bApply, bReset); 
+ 
+  const grid = document.createElement("div"); 
+  grid.style.display = "grid"; 
+  grid.style.gap = "10px"; 
+  for (const z of zones) { 
+    const bag = inputs.get(z.key); 
+    if (!bag) continue; 
+    grid.appendChild( 
+      _mkRow({ 
+        labelText: `PDF: ${z.label}`, 
+        cols: [bag.widthEl, bag.insetEl, bag.fontEl], 
+        width: "220px", 
+      }) 
+    ); 
+  } 
+ 
+  const hints = document.createElement("div"); 
+  hints.style.fontSize = "12px"; 
+  hints.style.opacity = "0.75"; 
+  hints.textContent = "Spalten: Breite (mm), Innenabstand (mm), Schrift (pt). Beispiele: 21mm / 1mm / 11pt"; 
+ 
+  card.append(grid, hints, btnRow, msg); 
+  wrap.append(head, card); 
+  openSettingsModal({ title: "Tabellen-Kalibrator (DEV-only)", content: [wrap], closeOnly: true }); 
+  await load(); 
+} 
+
+// Public: build the DEV-only "Tabellen" card content for Settings > Entwicklung 
+export async function buildDevTableCalibratorCard({ 
+  api, 
+  has, 
+  applyPopupCardStyle,
+  applyPopupButtonStyle,
+  openSettingsModal,
+} = {}) {
+  const wrap = document.createElement("div");
+  wrap.style.display = "grid";
+  wrap.style.gap = "8px";
+
+  const quick = document.createElement("div");
+  quick.style.display = "flex";
+  quick.style.gap = "8px";
+  quick.style.flexWrap = "wrap";
+
+  const bTops = _mkButton({ label: "TOP-Liste (protokoll_tops)", variant: "primary", applyPopupButtonStyle });
+  bTops.onclick = async () => void (await _openProtokollTopsCalibrator({ api, has, openSettingsModal, applyPopupCardStyle, applyPopupButtonStyle }));
+  const bTopsAll = _mkButton({ label: "TOP-Liste alle (topsAll) – nutzt protokoll_tops", variant: "neutral", applyPopupButtonStyle });
+  bTopsAll.onclick = async () => void (await _openProtokollTopsCalibrator({ api, has, openSettingsModal, applyPopupCardStyle, applyPopupButtonStyle }));
+
+  const bParticipants = _mkButton({ label: "Teilnehmerliste (protokoll_participants)", variant: "neutral", applyPopupButtonStyle }); 
+  bParticipants.onclick = async () => 
+    void (await _openProtokollParticipantsCalibrator({ api, has, openSettingsModal, applyPopupCardStyle, applyPopupButtonStyle })); 
+ 
+  const bTodo = _mkButton({ label: "ToDo-Liste (print.todo.todoTable)", variant: "neutral", applyPopupButtonStyle }); 
+  bTodo.onclick = async () => 
+    void (await _openTodoPrintCalibrator({ api, has, openSettingsModal, applyPopupCardStyle, applyPopupButtonStyle })); 
+ 
+  quick.append(bTops, bTopsAll, bParticipants, bTodo); 
+
+  const head = document.createElement("div");
+  head.textContent = "Registrierte Tabellen (aus der Registry):";
+  head.style.fontSize = "12px";
+  head.style.fontWeight = "800";
+  head.style.opacity = "0.9";
+
+  const search = _mkTextInput({ placeholder: "Tabelle suchen (Name oder tableKey)..." });
+  const list = document.createElement("div");
+  list.style.display = "grid";
+  list.style.gap = "6px";
+
+  let defs = [];
+  const render = () => {
+    const q = String(search.value || "").trim().toLowerCase();
+    list.replaceChildren();
+    const items = Array.isArray(defs) ? defs : [];
+    const filtered = q
+      ? items.filter((d) => {
+          const t = `${d.moduleLabel || d.moduleId || ""} ${d.tableLabel || ""} ${d.tableKey || ""}`.toLowerCase();
+          return t.includes(q);
+        })
+      : items;
+
+    for (const def of filtered.slice(0, 80)) {
+      const row = document.createElement("button");
+      row.type = "button";
+      row.style.textAlign = "left";
+      row.style.padding = "8px 10px";
+      row.style.borderRadius = "10px";
+      row.style.border = "1px solid rgba(0,0,0,0.12)";
+      row.style.background = "rgba(255,255,255,0.65)";
+      row.style.cursor = "pointer";
+      row.style.display = "grid";
+      row.style.gap = "2px";
+
+      const line1 = document.createElement("div");
+      line1.textContent = `${String(def.moduleLabel || def.moduleId || "Modul")}: ${String(def.tableLabel || def.tableKey)}`;
+      line1.style.fontWeight = "800";
+      line1.style.fontSize = "12px";
+
+      const line2 = document.createElement("div");
+      line2.textContent = `tableKey: ${String(def.tableKey)} | moduleId: ${String(def.moduleId)} | UI: ${def.uiAvailable ? "ja" : "nein"} | PDF: ${def.pdfAvailable ? "ja" : "nein"}`;
+      line2.style.fontSize = "12px";
+      line2.style.opacity = "0.78";
+
+      row.append(line1, line2);
+      row.onclick = async () => {
+        // For now, keep "Tops" as dedicated pilot calibrator.
+        if (def.moduleId === "protokoll" && def.tableKey === "protokoll_tops") {
+          await _openProtokollTopsCalibrator({ api, has, openSettingsModal, applyPopupCardStyle, applyPopupButtonStyle });
+          return;
+        }
+        if (def.moduleId === "protokoll" && def.tableKey === "protokoll_participants") { 
+          await _openProtokollParticipantsCalibrator({ api, has, openSettingsModal, applyPopupCardStyle, applyPopupButtonStyle }); 
+          return; 
+        } 
+        if (def.moduleId === "protokoll" && def.tableKey === "print.todo.todoTable") { 
+          await _openTodoPrintCalibrator({ api, has, openSettingsModal, applyPopupCardStyle, applyPopupButtonStyle }); 
+          return; 
+        } 
+        // For other tables, we currently just show the identity. (Next step: generic editor) 
+        const info = document.createElement("div"); 
+        info.textContent = `Noch nicht angebunden: moduleId=${def.moduleId}, tableKey=${def.tableKey}`; 
+        info.style.fontSize = "12px"; 
+        info.style.opacity = "0.85";
+        openSettingsModal({ title: "Tabellen-Kalibrator (DEV-only)", content: [info], closeOnly: true });
+      };
+      list.appendChild(row);
+    }
+  };
+
+  search.addEventListener("input", () => render());
+
+  if (has("tableLayoutsListDefinitions")) {
+    try {
+      const res = await api.tableLayoutsListDefinitions();
+      defs = res?.ok && Array.isArray(res.data) ? res.data : [];
+    } catch (_err) {
+      defs = [];
+    }
+  }
+  render();
+
+  wrap.append(quick, head, search, list);
+  return wrap;
+}

--- a/src/renderer/modules/protokoll/screens/TopsScreen.js
+++ b/src/renderer/modules/protokoll/screens/TopsScreen.js
@@ -222,6 +222,7 @@ export default class TopsScreen {
       onLayoutZoneClick: (zoneKey) => this._setDevLayoutZone(zoneKey),
     });
     this.sheetPaper.appendChild(this.topsList.root);
+    this._bindTableLayoutChangeListener();
     void this._loadTopListLayout();
   }
 
@@ -646,6 +647,13 @@ export default class TopsScreen {
     this._topRulesOverlay = null;
   }
 
+  destroy() {
+    if (this._onTableLayoutChanged && typeof window?.removeEventListener === "function") {
+      window.removeEventListener("bbm:tableLayoutChanged", this._onTableLayoutChanged);
+    }
+    this._onTableLayoutChanged = null;
+  }
+
   _syncListState() {
     if (!(this.topsList instanceof TopsList)) return;
     this.topsList.setItems(
@@ -657,6 +665,19 @@ export default class TopsScreen {
 
   _getTopListLayoutApi() {
     return globalThis.window?.bbmDb || null;
+  }
+
+  _bindTableLayoutChangeListener() {
+    if (typeof window === "undefined" || !window?.addEventListener) return;
+    if (this._onTableLayoutChanged) return;
+    this._onTableLayoutChanged = (evt) => {
+      const d = evt?.detail || {};
+      if (String(d.moduleId || "") !== "protokoll") return;
+      if (String(d.tableKey || "") !== "protokoll_tops") return;
+      if (String(d.orientation || "portrait") !== "portrait") return;
+      void this._loadTopListLayout();
+    };
+    window.addEventListener("bbm:tableLayoutChanged", this._onTableLayoutChanged);
   }
 
   _applyTopListLayout(layout) {

--- a/src/renderer/modules/protokoll/styles/tops.css
+++ b/src/renderer/modules/protokoll/styles/tops.css
@@ -5,15 +5,17 @@
   --bbm-tops-list-number-col: 64px;
   --bbm-tops-meta-col-min: 70px;
   --bbm-tops-meta-col-max: 90px;
-  --bbm-tops-list-meta-col: 74px;
+  /* UI TOP-Liste: Metaspalte soll am rechten Rand stehen und Werte voll sichtbar halten. */
+  --bbm-tops-list-meta-col: 25mm;
   --bbm-tops-accent-green: #1b8f3a;
   --bbm-top-text-font-family: "Noto Sans", Arial, sans-serif;
   --bbm-top-short-font-size: 10pt;
   --bbm-top-long-font-size: 9.5pt;
   --bbm-top-text-line-height: 1.35;
   --bbm-top-text-pad-x: 5px;
-  --bbm-top-short-measure: 72ch;
-  --bbm-top-long-measure: 77ch;
+  /* UI: Gegenstandsspalte wirkt breiter, ohne Grid/Meta/PDF zu aendern. */
+  --bbm-top-short-measure: 97ch;
+  --bbm-top-long-measure: 102ch;
   --bbm-top-long-edit-measure: 65ch;
   --bbm-top-short-input-measure: 62ch;
 }
@@ -401,6 +403,12 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
   background: linear-gradient(180deg, #eef6f6 0%, #e6eff0 100%);
   border: 1px solid #cad9db;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  /* Ensure the meta column stays as the right-most grid column in the normal UI list. */
+  --bbm-tops-list-grid-columns: var(--bbm-tops-list-number-col, 64px) minmax(0, 1fr)
+    minmax(var(--bbm-tops-list-meta-col, 25mm), 40mm);
+  /* Ensure the list uses the full available paper width so the meta column can "stick" to the right edge. */
+  width: 100%;
+  box-sizing: border-box;
 }
 
 [data-bbm-tops-list-v2="true"][data-dev-layout-mode="true"] .bbm-tops-list-layout-zone {
@@ -455,6 +463,8 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
   cursor: pointer;
   background: linear-gradient(180deg, #fcfefe 0%, #f4f8f8 100%);
   box-shadow: 0 1px 0 rgba(15, 23, 42, 0.03);
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .bbm-tops-list-row[data-top-level="1"] {
@@ -524,13 +534,23 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
 
 .bbm-tops-list-row-grid {
   display: grid;
-  grid-template-columns: var(
-    --bbm-tops-list-grid-columns,
-    var(--bbm-tops-list-number-col, 64px) var(--bbm-tops-list-text-col, minmax(0, 1fr))
-      minmax(50px, var(--bbm-tops-list-meta-col, 74px))
-  );
+  /*
+    IMPORTANT (UI hotfix):
+    Keep the TOP list as a stable 3-column grid:
+    1) number (fixed)
+    2) text (flexible, fills remaining space)
+    3) meta (fixed/min width)
+
+    We intentionally DO NOT use --bbm-tops-list-grid-columns / --bbm-tops-list-text-col here,
+    because persisted layout values may turn the text track into a fixed width which prevents
+    the meta column from sticking to the right edge.
+  */
+  grid-template-columns: var(--bbm-tops-list-number-col, 64px) minmax(0, 1fr)
+    minmax(50px, var(--bbm-tops-list-meta-col, 74px));
   gap: 8px;
   align-items: start;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .bbm-tops-list-row-number {
@@ -615,7 +635,7 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
 }
 
 .bbm-tops-list-row:not([data-top-level="1"]) .bbm-tops-list-row-title {
-  max-inline-size: 82ch;
+  max-inline-size: 107ch;
 }
 
 .bbm-tops-list-row-title[data-tone="blue"] {
@@ -654,7 +674,7 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
 .bbm-tops-list-row-preview {
   margin-top: 4px;
   /* DEV-Layout: keep preview in sync with the text-zone font size when overridden. */
-  font-size: var(--bbm-tops-list-text-font-size, var(--bbm-top-long-font-size));
+  font-size: var(--bbm-tops-list-text-font-size, var(--bbm-top-short-font-size));
   line-height: var(--bbm-top-text-line-height);
   font-family: var(--bbm-top-text-font-family);
   max-inline-size: var(--bbm-top-long-measure);
@@ -666,7 +686,7 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
 
 .bbm-tops-list-row:not([data-top-level="1"]) .bbm-tops-list-row-preview {
   font-size: var(--bbm-top-short-font-size);
-  max-inline-size: 82ch;
+  max-inline-size: 107ch;
 }
 
 /* DEV-Layout override: when the text-zone font variable is set, keep the preview in sync. */
@@ -687,7 +707,7 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
 }
 
 .bbm-tops-list-row:not([data-top-level="1"]) .bbm-tops-list-row-text {
-  max-inline-size: min(100%, 82ch);
+  max-inline-size: min(100%, 107ch);
 }
 
 .bbm-tops-list-row-preview[data-has-preview="false"] {
@@ -701,7 +721,9 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
   gap: 2px;
   min-width: 0;
   width: 100%;
-  transform: translateX(-2mm);
+  justify-self: stretch;
+  transform: none;
+  justify-items: end;
 }
 
 .bbm-tops-list-row-meta-line {
@@ -717,6 +739,7 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-align: right;
 }
 
 .bbm-tops-list-row-meta-line-status,
@@ -1296,7 +1319,8 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
   opacity: 0.72;
 }
 
-@media (max-width: 900px) {
+/* Keep meta column on the right for normal window sizes; only collapse on very small widths. */
+@media (max-width: 640px) {
   .bbm-tops-header-meta-legend {
     display: none !important;
   }

--- a/src/renderer/print/print.css
+++ b/src/renderer/print/print.css
@@ -166,29 +166,44 @@ body[data-orientation="portrait"] .measureRoot,
 
 .todoTable th:nth-child(1),
 .todoTable td:nth-child(1) {
-  width: 12%;
+  width: var(--bbm-todo-col-top-width, 12%);
+  padding-left: var(--bbm-todo-col-top-padding-inline, 1mm);
+  padding-right: var(--bbm-todo-col-top-padding-inline, 1mm);
+  font-size: var(--bbm-todo-col-top-font-size, inherit);
   white-space: nowrap;
 }
 
 .todoTable th:nth-child(2),
 .todoTable td:nth-child(2) {
-  width: 48%;
+  width: var(--bbm-todo-col-kurztext-width, 48%);
+  padding-left: var(--bbm-todo-col-kurztext-padding-inline, 1mm);
+  padding-right: var(--bbm-todo-col-kurztext-padding-inline, 1mm);
+  font-size: var(--bbm-todo-col-kurztext-font-size, inherit);
 }
 
 .todoTable th:nth-child(3),
 .todoTable td:nth-child(3) {
-  width: 18%;
+  width: var(--bbm-todo-col-status-width, 18%);
+  padding-left: var(--bbm-todo-col-status-padding-inline, 1mm);
+  padding-right: var(--bbm-todo-col-status-padding-inline, 1mm);
+  font-size: var(--bbm-todo-col-status-font-size, inherit);
 }
 
 .todoTable th:nth-child(4),
 .todoTable td:nth-child(4) {
-  width: 14%;
+  width: var(--bbm-todo-col-fertig_bis-width, 14%);
+  padding-left: var(--bbm-todo-col-fertig_bis-padding-inline, 1mm);
+  padding-right: var(--bbm-todo-col-fertig_bis-padding-inline, 1mm);
+  font-size: var(--bbm-todo-col-fertig_bis-font-size, inherit);
   white-space: nowrap;
 }
 
 .todoTable th:nth-child(5),
 .todoTable td:nth-child(5) {
-  width: 8%;
+  width: var(--bbm-todo-col-ampel-width, 8%);
+  padding-left: var(--bbm-todo-col-ampel-padding-inline, 1mm);
+  padding-right: var(--bbm-todo-col-ampel-padding-inline, 1mm);
+  font-size: var(--bbm-todo-col-ampel-font-size, inherit);
   text-align: center;
 }
 

--- a/src/renderer/print/printApp.js
+++ b/src/renderer/print/printApp.js
@@ -1795,6 +1795,20 @@ async function handleInit(payload) {
     app.innerHTML = "";
     app.appendChild(root);
 
+    // Ensure stored ToDo table layout is applied to the print root (PDF + preview),
+    // so width/inset/font settings take effect for the real output.
+    if (typeof window?.bbmPrint?.tableLayoutsGetOne === "function") {
+      try {
+        const resTodo = await window.bbmPrint.tableLayoutsGetOne({
+          tableKey: "print.todo.todoTable",
+          moduleId: "protokoll",
+          orientation,
+        });
+        const todoLayout = resTodo?.ok ? resTodo?.data?.effectiveLayout || resTodo?.data?.defaultLayout || null : null;
+        if (todoLayout) _applyTodoVarsFromLayout(root, todoLayout);
+      } catch (_e) {}
+    }
+
     if (isDevLayoutPreview) {
       // DEV-only: ensure the participants layout is loaded and applied so save/load works
       // even when the print payload did not include tableLayouts for this table yet.
@@ -2714,6 +2728,17 @@ function _applyParticipantsNameVarsFromLayout(root, layout) {
     if (fontPt != null) {
       root.style.setProperty(`--bbm-part-col-${_participantsVarPrefix(zone)}-font-size`, `${_formatMm(fontPt)}pt`);
     }
+  }
+}
+
+function _applyTodoVarsFromLayout(root, layout) {
+  if (!root?.style) return;
+  const rootVars = layout?.pdf?.rootVars || {};
+  if (!rootVars || typeof rootVars !== "object") return;
+  for (const [key, value] of Object.entries(rootVars)) {
+    if (!key || typeof key !== "string") continue;
+    if (value == null) continue;
+    root.style.setProperty(key, String(value));
   }
 }
 

--- a/src/renderer/tops/styles/tops.css
+++ b/src/renderer/tops/styles/tops.css
@@ -2,6 +2,9 @@
 
 :root {
   --bbm-tops-doc-width: 940px;
+  --bbm-tops-list-number-col: 64px;
+  /* UI TOP-Liste: Metaspalte soll am rechten Rand stehen und Werte voll sichtbar halten. */
+  --bbm-tops-list-meta-col: 25mm;
   --bbm-tops-meta-col-min: 70px;
   --bbm-tops-meta-col-max: 90px;
   --bbm-tops-accent-green: #1b8f3a;
@@ -10,8 +13,9 @@
   --bbm-top-long-font-size: 9.5pt;
   --bbm-top-text-line-height: 1.35;
   --bbm-top-text-pad-x: 5px;
-  --bbm-top-short-measure: 72ch;
-  --bbm-top-long-measure: 77ch;
+  /* UI: Gegenstandsspalte wirkt breiter, ohne Grid/Meta/PDF zu aendern. */
+  --bbm-top-short-measure: 97ch;
+  --bbm-top-long-measure: 102ch;
   --bbm-top-long-edit-measure: 65ch;
   --bbm-top-short-input-measure: 62ch;
 }
@@ -224,6 +228,12 @@
 [data-bbm-tops-list-v2="true"] {
   margin: 0;
   padding: 10px 0 12px;
+  /* Ensure the meta column stays as the right-most grid column in the normal UI list. */
+  --bbm-tops-list-grid-columns: var(--bbm-tops-list-number-col, 64px) minmax(0, 1fr)
+    minmax(var(--bbm-tops-list-meta-col, 25mm), 40mm);
+  /* Ensure the list uses the full available paper width so the meta column can "stick" to the right edge. */
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .bbm-tops-list-row {
@@ -234,6 +244,8 @@
   border: 1px solid #dfe7f1;
   cursor: pointer;
   background: #fff;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .bbm-tops-list-row[data-top-level="1"] {
@@ -287,9 +299,13 @@
 
 .bbm-tops-list-row-grid {
   display: grid;
-  grid-template-columns: 64px minmax(0, 1fr) minmax(35px, 55px);
+  /* Keep legacy TOP list row as a stable 3-column grid (number | flexible text | meta). */
+  grid-template-columns: var(--bbm-tops-list-number-col, 64px) minmax(0, 1fr)
+    minmax(50px, var(--bbm-tops-list-meta-col, 74px));
   gap: 8px;
   align-items: start;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .bbm-tops-list-row-number {
@@ -334,7 +350,7 @@
 
 .bbm-tops-list-row-preview {
   margin-top: 4px;
-  font-size: var(--bbm-top-long-font-size);
+  font-size: var(--bbm-top-short-font-size);
   line-height: var(--bbm-top-text-line-height);
   font-family: var(--bbm-top-text-font-family);
   max-inline-size: var(--bbm-top-long-measure);
@@ -362,7 +378,9 @@
   gap: 2px;
   min-width: 0;
   width: 100%;
-  transform: translateX(-4mm);
+  justify-self: stretch;
+  transform: none;
+  justify-items: end;
 }
 
 .bbm-tops-list-row-meta-line {
@@ -377,6 +395,11 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Align meta values to the right edge of the meta column. */
+.bbm-tops-list-row-meta-text {
+  text-align: right;
 }
 
 .bbm-tops-list-row-ampel {
@@ -805,7 +828,8 @@
   opacity: 0.72;
 }
 
-@media (max-width: 900px) {
+/* Keep meta column on the right for normal window sizes; only collapse on very small widths. */
+@media (max-width: 640px) {
   .bbm-tops-header-meta-legend {
     display: none !important;
   }

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -5052,6 +5052,706 @@ export default class SettingsView {
       return { box, title, hint };
     };
 
+    const dispatchTableLayoutChanged = (identity = {}) => {
+      try {
+        window.dispatchEvent(
+          new CustomEvent("bbm:tableLayoutChanged", {
+            detail: {
+              moduleId: String(identity.moduleId || "").trim(),
+              tableKey: String(identity.tableKey || "").trim(),
+              orientation: String(identity.orientation || "portrait").trim(),
+            },
+          })
+        );
+      } catch (_err) {
+        // ignore
+      }
+    };
+
+    const openProtokollTopsCalibrator = async () => {
+      const identity = Object.freeze({
+        moduleId: "protokoll",
+        tableKey: "protokoll_tops",
+        orientation: "portrait",
+      });
+
+      const {
+        extractProtokollTopsEditorValues,
+        buildProtokollTopsLayoutOverlay,
+        validateProtokollTopsEditorValues,
+      } = await import("../../shared/tableLayouts/protokollTopsLayout.js");
+
+      const clampText = (v) => String(v ?? "").trim();
+      const mkInputRow = (labelText, inputEl, hintText = "") => {
+        const row = document.createElement("div");
+        row.style.display = "grid";
+        row.style.gridTemplateColumns = "220px 180px 1fr";
+        row.style.gap = "10px";
+        row.style.alignItems = "center";
+
+        const label = document.createElement("div");
+        label.textContent = labelText;
+        label.style.fontWeight = "700";
+        label.style.fontSize = "12px";
+        label.style.color = "#334155";
+
+        const hint = document.createElement("div");
+        hint.textContent = hintText;
+        hint.style.fontSize = "12px";
+        hint.style.opacity = "0.75";
+
+        row.append(label, inputEl, hint);
+        return row;
+      };
+
+      const wrap = document.createElement("div");
+      wrap.style.display = "grid";
+      wrap.style.gap = "10px";
+      wrap.style.minWidth = "min(860px, calc(100vw - 80px))";
+      wrap.style.maxWidth = "980px";
+
+      const head = document.createElement("div");
+      head.style.display = "grid";
+      head.style.gap = "2px";
+      const title = document.createElement("div");
+      title.textContent = "Tabellen-Kalibrator (DEV-only) – TOP-Liste";
+      title.style.fontWeight = "900";
+      const sub = document.createElement("div");
+      sub.textContent = "Tabelle: protokoll_tops (UI + PDF). Speichern schreibt Layoutwerte dauerhaft.";
+      sub.style.fontSize = "12px";
+      sub.style.opacity = "0.8";
+      head.append(title, sub);
+
+      const card = document.createElement("div");
+      applyPopupCardStyle(card);
+      card.style.padding = "10px 12px";
+      card.style.display = "grid";
+      card.style.gap = "10px";
+
+      const uiNumberWidth = document.createElement("input");
+      uiNumberWidth.type = "text";
+      uiNumberWidth.placeholder = "z.B. 64px";
+      const uiMetaWidth = document.createElement("input");
+      uiMetaWidth.type = "text";
+      uiMetaWidth.placeholder = "z.B. 74px";
+      const pdfNumberWidth = document.createElement("input");
+      pdfNumberWidth.type = "text";
+      pdfNumberWidth.placeholder = "z.B. 23mm";
+      const pdfMetaWidth = document.createElement("input");
+      pdfMetaWidth.type = "text";
+      pdfMetaWidth.placeholder = "z.B. 15ch";
+
+      for (const el of [uiNumberWidth, uiMetaWidth, pdfNumberWidth, pdfMetaWidth]) {
+        el.style.width = "100%";
+        el.style.boxSizing = "border-box";
+        el.style.padding = "6px 8px";
+        el.style.border = "1px solid rgba(0,0,0,0.18)";
+        el.style.borderRadius = "8px";
+        el.style.fontSize = "12px";
+        el.autocomplete = "off";
+        el.spellcheck = false;
+      }
+
+      const msg = document.createElement("div");
+      msg.style.fontSize = "12px";
+      msg.style.minHeight = "18px";
+      msg.style.color = "#334155";
+
+      const load = async () => {
+        if (!has("tableLayoutsGetOne")) {
+          msg.textContent = "tableLayoutsGetOne fehlt.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+        const res = await api.tableLayoutsGetOne(identity);
+        if (!res?.ok) {
+          msg.textContent = res?.error || "Layout konnte nicht geladen werden.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+        const layout = res?.data?.effectiveLayout || res?.data?.defaultLayout || null;
+        const values = extractProtokollTopsEditorValues(layout || {});
+        uiNumberWidth.value = clampText(values.uiNumberWidth || "");
+        uiMetaWidth.value = clampText(values.uiMetaWidth || "");
+        pdfNumberWidth.value = clampText(values.pdfNumberWidth || "");
+        pdfMetaWidth.value = clampText(values.pdfMetaWidth || "");
+        msg.textContent = "Layout geladen.";
+        msg.style.color = "#334155";
+        return true;
+      };
+
+      const apply = async ({ reset = false } = {}) => {
+        if (reset) {
+          if (!has("tableLayoutsReset")) {
+            msg.textContent = "tableLayoutsReset fehlt.";
+            msg.style.color = "#9d1c1c";
+            return false;
+          }
+          const resReset = await api.tableLayoutsReset({ ...identity, scopeType: "global" });
+          if (!resReset?.ok) {
+            msg.textContent = resReset?.error || "Reset fehlgeschlagen.";
+            msg.style.color = "#9d1c1c";
+            return false;
+          }
+          dispatchTableLayoutChanged(identity);
+          msg.textContent = "Reset ausgeführt (Defaults aktiv).";
+          msg.style.color = "#334155";
+          await load();
+          return true;
+        }
+
+        if (!has("tableLayoutsSave")) {
+          msg.textContent = "tableLayoutsSave fehlt.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+
+        const draft = {
+          orientation: "portrait",
+          uiNumberWidth: clampText(uiNumberWidth.value),
+          uiMetaWidth: clampText(uiMetaWidth.value),
+          pdfNumberWidth: clampText(pdfNumberWidth.value),
+          pdfMetaWidth: clampText(pdfMetaWidth.value),
+        };
+        const validated = validateProtokollTopsEditorValues(draft, "portrait");
+        if (!validated?.isValid) {
+          msg.textContent = "Ungültige Werte. Beispiele: 64px, 23mm, 15ch";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+        const layout = buildProtokollTopsLayoutOverlay(validated.values, validated.values.orientation);
+
+        const resSave = await api.tableLayoutsSave({
+          ...identity,
+          scopeType: "global",
+          layout,
+        });
+        if (!resSave?.ok) {
+          msg.textContent = resSave?.error || "Speichern fehlgeschlagen.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+        dispatchTableLayoutChanged(identity);
+        msg.textContent = "Gespeichert und angewendet.";
+        msg.style.color = "#334155";
+        return true;
+      };
+
+      const btnRow = document.createElement("div");
+      btnRow.style.display = "flex";
+      btnRow.style.gap = "8px";
+      btnRow.style.flexWrap = "wrap";
+
+      const bLoad = document.createElement("button");
+      bLoad.type = "button";
+      bLoad.textContent = "Laden";
+      applyPopupButtonStyle(bLoad, { variant: "neutral" });
+      bLoad.onclick = async () => void (await load());
+
+      const bApply = document.createElement("button");
+      bApply.type = "button";
+      bApply.textContent = "Anwenden (Speichern)";
+      applyPopupButtonStyle(bApply, { variant: "primary" });
+      bApply.onclick = async () => void (await apply({ reset: false }));
+
+      const bReset = document.createElement("button");
+      bReset.type = "button";
+      bReset.textContent = "Reset (Defaults)";
+      applyPopupButtonStyle(bReset, { variant: "danger" });
+      bReset.onclick = async () => void (await apply({ reset: true }));
+
+      btnRow.append(bLoad, bApply, bReset);
+
+      card.append(
+        mkInputRow("UI: Nummernspalte", uiNumberWidth, "z.B. 64px"),
+        mkInputRow("UI: Metaspalte", uiMetaWidth, "z.B. 74px"),
+        mkInputRow("PDF: Nummernspalte", pdfNumberWidth, "z.B. 23mm"),
+        mkInputRow("PDF: Metaspalte", pdfMetaWidth, "z.B. 15ch"),
+        btnRow,
+        msg
+      );
+
+      wrap.append(head, card);
+
+      this._openSettingsModal({
+        title: "Tabellen-Kalibrator (DEV-only)",
+        content: [wrap],
+        closeOnly: true,
+      });
+
+      await load();
+    };
+
+    const openProtokollParticipantsCalibrator = async () => {
+      const identity = Object.freeze({
+        moduleId: "protokoll",
+        tableKey: "protokoll_participants",
+        orientation: "portrait",
+      });
+
+      const { validateTableLayoutColumns, buildTableLayoutOverlayFromColumns } = await import(
+        "../../shared/tableLayouts/protokollTopsLayout.js"
+      );
+
+      const clampText = (v) => String(v ?? "").trim();
+      const keys = ["name", "function", "company", "contact", "attendance"];
+      const labels = Object.freeze({
+        name: "Name",
+        function: "Funktion",
+        company: "Firma",
+        contact: "Telefon / E-Mail",
+        attendance: "Anwesend / Verteiler",
+      });
+
+      const mkInputRow = (labelText, inputEl, hintText = "") => {
+        const row = document.createElement("div");
+        row.style.display = "grid";
+        row.style.gridTemplateColumns = "220px 180px 1fr";
+        row.style.gap = "10px";
+        row.style.alignItems = "center";
+
+        const label = document.createElement("div");
+        label.textContent = labelText;
+        label.style.fontWeight = "700";
+        label.style.fontSize = "12px";
+        label.style.color = "#334155";
+
+        const hint = document.createElement("div");
+        hint.textContent = hintText;
+        hint.style.fontSize = "12px";
+        hint.style.opacity = "0.75";
+
+        row.append(label, inputEl, hint);
+        return row;
+      };
+
+      const wrap = document.createElement("div");
+      wrap.style.display = "grid";
+      wrap.style.gap = "10px";
+      wrap.style.minWidth = "min(920px, calc(100vw - 80px))";
+      wrap.style.maxWidth = "1040px";
+
+      const head = document.createElement("div");
+      head.style.display = "grid";
+      head.style.gap = "2px";
+      const title = document.createElement("div");
+      title.textContent = "Tabellen-Kalibrator (DEV-only) – Teilnehmerliste (PDF)";
+      title.style.fontWeight = "900";
+      const sub = document.createElement("div");
+      sub.textContent = "Tabelle: protokoll_participants (nur PDF-Breiten). Speichern schreibt Layoutwerte dauerhaft.";
+      sub.style.fontSize = "12px";
+      sub.style.opacity = "0.8";
+      head.append(title, sub);
+
+      const card = document.createElement("div");
+      applyPopupCardStyle(card);
+      card.style.padding = "10px 12px";
+      card.style.display = "grid";
+      card.style.gap = "10px";
+
+      const inputs = new Map();
+      for (const key of keys) {
+        const el = document.createElement("input");
+        el.type = "text";
+        el.placeholder = "z.B. 36mm";
+        el.style.width = "100%";
+        el.style.boxSizing = "border-box";
+        el.style.padding = "6px 8px";
+        el.style.border = "1px solid rgba(0,0,0,0.18)";
+        el.style.borderRadius = "8px";
+        el.style.fontSize = "12px";
+        el.autocomplete = "off";
+        el.spellcheck = false;
+        inputs.set(key, el);
+      }
+
+      const msg = document.createElement("div");
+      msg.style.fontSize = "12px";
+      msg.style.minHeight = "18px";
+      msg.style.color = "#334155";
+
+      let lastLoadedColumns = [];
+      let fallbackColumns = [];
+
+      const load = async () => {
+        if (!has("tableLayoutsGetOne")) {
+          msg.textContent = "tableLayoutsGetOne fehlt.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+        const res = await api.tableLayoutsGetOne(identity);
+        if (!res?.ok) {
+          msg.textContent = res?.error || "Layout konnte nicht geladen werden.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+        const effective = res?.data?.effectiveLayout || null;
+        const def = res?.data?.defaultLayout || null;
+        lastLoadedColumns = Array.isArray(effective?.columns) ? effective.columns : Array.isArray(def?.columns) ? def.columns : [];
+        fallbackColumns = Array.isArray(def?.columns) ? def.columns : [];
+
+        const byKey = new Map();
+        for (const col of lastLoadedColumns) byKey.set(String(col?.key || ""), col);
+        for (const key of keys) {
+          const col = byKey.get(key) || {};
+          const input = inputs.get(key);
+          if (input) input.value = clampText(col.pdfWidth || "");
+        }
+        msg.textContent = "Layout geladen.";
+        msg.style.color = "#334155";
+        return true;
+      };
+
+      const apply = async ({ reset = false } = {}) => {
+        if (reset) {
+          if (!has("tableLayoutsReset")) {
+            msg.textContent = "tableLayoutsReset fehlt.";
+            msg.style.color = "#9d1c1c";
+            return false;
+          }
+          const resReset = await api.tableLayoutsReset({ ...identity, scopeType: "global" });
+          if (!resReset?.ok) {
+            msg.textContent = resReset?.error || "Reset fehlgeschlagen.";
+            msg.style.color = "#9d1c1c";
+            return false;
+          }
+          dispatchTableLayoutChanged(identity);
+          msg.textContent = "Reset ausgeführt (Defaults aktiv).";
+          msg.style.color = "#334155";
+          await load();
+          return true;
+        }
+
+        if (!has("tableLayoutsSave")) {
+          msg.textContent = "tableLayoutsSave fehlt.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+
+        const updated = (Array.isArray(lastLoadedColumns) ? lastLoadedColumns : []).map((c) => ({ ...(c || {}) }));
+        const byKey = new Map();
+        for (const col of updated) byKey.set(String(col?.key || ""), col);
+        for (const key of keys) {
+          const col = byKey.get(key);
+          if (!col) continue;
+          col.pdfWidth = clampText(inputs.get(key)?.value || "");
+        }
+
+        const validated = validateTableLayoutColumns(updated, fallbackColumns);
+        if (!validated?.isValid) {
+          msg.textContent = "Ungültige Werte. Beispiele: 36mm, 45mm, 110px";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+
+        const layout = buildTableLayoutOverlayFromColumns(validated.columns, "portrait", {
+          fallbackColumns,
+        });
+
+        const resSave = await api.tableLayoutsSave({
+          ...identity,
+          scopeType: "global",
+          layout,
+        });
+        if (!resSave?.ok) {
+          msg.textContent = resSave?.error || "Speichern fehlgeschlagen.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+        dispatchTableLayoutChanged(identity);
+        msg.textContent = "Gespeichert und angewendet.";
+        msg.style.color = "#334155";
+        return true;
+      };
+
+      const btnRow = document.createElement("div");
+      btnRow.style.display = "flex";
+      btnRow.style.gap = "8px";
+      btnRow.style.flexWrap = "wrap";
+
+      const bLoad = document.createElement("button");
+      bLoad.type = "button";
+      bLoad.textContent = "Laden";
+      applyPopupButtonStyle(bLoad, { variant: "neutral" });
+      bLoad.onclick = async () => void (await load());
+
+      const bApply = document.createElement("button");
+      bApply.type = "button";
+      bApply.textContent = "Anwenden (Speichern)";
+      applyPopupButtonStyle(bApply, { variant: "primary" });
+      bApply.onclick = async () => void (await apply({ reset: false }));
+
+      const bReset = document.createElement("button");
+      bReset.type = "button";
+      bReset.textContent = "Reset (Defaults)";
+      applyPopupButtonStyle(bReset, { variant: "danger" });
+      bReset.onclick = async () => void (await apply({ reset: true }));
+
+      btnRow.append(bLoad, bApply, bReset);
+
+      card.append(
+        mkInputRow("PDF: Name", inputs.get("name"), "z.B. 36mm"),
+        mkInputRow("PDF: Funktion", inputs.get("function"), "z.B. 36mm"),
+        mkInputRow("PDF: Firma", inputs.get("company"), "z.B. 30mm"),
+        mkInputRow("PDF: Telefon / E-Mail", inputs.get("contact"), "z.B. 45mm"),
+        mkInputRow("PDF: Anwesend / Verteiler", inputs.get("attendance"), "z.B. 26mm"),
+        btnRow,
+        msg
+      );
+
+      wrap.append(head, card);
+
+      this._openSettingsModal({
+        title: "Tabellen-Kalibrator (DEV-only)",
+        content: [wrap],
+        closeOnly: true,
+      });
+
+      await load();
+    };
+
+    const openTodoPrintCalibrator = async () => {
+      const identity = Object.freeze({
+        moduleId: "protokoll",
+        tableKey: "print.todo.todoTable",
+        orientation: "portrait",
+      });
+
+      const clampText = (v) => String(v ?? "").trim();
+      const zones = [
+        { key: "top", label: "TOP" },
+        { key: "kurztext", label: "Kurztext" },
+        { key: "status", label: "Status" },
+        { key: "fertig_bis", label: "Fertig bis" },
+        { key: "ampel", label: "Ampel" },
+      ];
+
+      const mkInputRow = (labelText, inputEl, hintText = "") => {
+        const row = document.createElement("div");
+        row.style.display = "grid";
+        row.style.gridTemplateColumns = "220px 180px 1fr";
+        row.style.gap = "10px";
+        row.style.alignItems = "center";
+
+        const label = document.createElement("div");
+        label.textContent = labelText;
+        label.style.fontWeight = "700";
+        label.style.fontSize = "12px";
+        label.style.color = "#334155";
+
+        const hint = document.createElement("div");
+        hint.textContent = hintText;
+        hint.style.fontSize = "12px";
+        hint.style.opacity = "0.75";
+
+        row.append(label, inputEl, hint);
+        return row;
+      };
+
+      const wrap = document.createElement("div");
+      wrap.style.display = "grid";
+      wrap.style.gap = "10px";
+      wrap.style.minWidth = "min(980px, calc(100vw - 80px))";
+      wrap.style.maxWidth = "1120px";
+
+      const head = document.createElement("div");
+      head.style.display = "grid";
+      head.style.gap = "2px";
+      const title = document.createElement("div");
+      title.textContent = "Tabellen-Kalibrator (DEV-only) – ToDo-Liste (PDF)";
+      title.style.fontWeight = "900";
+      const sub = document.createElement("div");
+      sub.textContent = "Tabelle: print.todo.todoTable (nur PDF rootVars). Speichern schreibt Layoutwerte dauerhaft.";
+      sub.style.fontSize = "12px";
+      sub.style.opacity = "0.8";
+      head.append(title, sub);
+
+      const card = document.createElement("div");
+      applyPopupCardStyle(card);
+      card.style.padding = "10px 12px";
+      card.style.display = "grid";
+      card.style.gap = "10px";
+
+      const inputs = new Map();
+      for (const z of zones) {
+        const widthEl = document.createElement("input");
+        widthEl.type = "text";
+        widthEl.placeholder = "z.B. 21mm";
+        const insetEl = document.createElement("input");
+        insetEl.type = "text";
+        insetEl.placeholder = "z.B. 1mm";
+        const fontEl = document.createElement("input");
+        fontEl.type = "text";
+        fontEl.placeholder = "z.B. 11pt";
+
+        for (const el of [widthEl, insetEl, fontEl]) {
+          el.style.width = "100%";
+          el.style.boxSizing = "border-box";
+          el.style.padding = "6px 8px";
+          el.style.border = "1px solid rgba(0,0,0,0.18)";
+          el.style.borderRadius = "8px";
+          el.style.fontSize = "12px";
+          el.autocomplete = "off";
+          el.spellcheck = false;
+        }
+        inputs.set(z.key, { widthEl, insetEl, fontEl });
+      }
+
+      const msg = document.createElement("div");
+      msg.style.fontSize = "12px";
+      msg.style.minHeight = "18px";
+      msg.style.color = "#334155";
+
+      let lastLoadedLayout = null;
+
+      const load = async () => {
+        if (!has("tableLayoutsGetOne")) {
+          msg.textContent = "tableLayoutsGetOne fehlt.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+        const res = await api.tableLayoutsGetOne(identity);
+        if (!res?.ok) {
+          msg.textContent = res?.error || "Layout konnte nicht geladen werden.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+        const layout = res?.data?.effectiveLayout || res?.data?.defaultLayout || null;
+        lastLoadedLayout = layout && typeof layout === "object" ? layout : null;
+        const rootVars = (layout?.pdf?.rootVars && typeof layout.pdf.rootVars === "object") ? layout.pdf.rootVars : {};
+
+        for (const z of zones) {
+          const bag = inputs.get(z.key);
+          if (!bag) continue;
+          bag.widthEl.value = clampText(rootVars[`--bbm-todo-col-${z.key}-width`] || "");
+          bag.insetEl.value = clampText(rootVars[`--bbm-todo-col-${z.key}-padding-inline`] || "");
+          bag.fontEl.value = clampText(rootVars[`--bbm-todo-col-${z.key}-font-size`] || "");
+        }
+
+        msg.textContent = "Layout geladen.";
+        msg.style.color = "#334155";
+        return true;
+      };
+
+      const apply = async ({ reset = false } = {}) => {
+        if (reset) {
+          if (!has("tableLayoutsReset")) {
+            msg.textContent = "tableLayoutsReset fehlt.";
+            msg.style.color = "#9d1c1c";
+            return false;
+          }
+          const resReset = await api.tableLayoutsReset({ ...identity, scopeType: "global" });
+          if (!resReset?.ok) {
+            msg.textContent = resReset?.error || "Reset fehlgeschlagen.";
+            msg.style.color = "#9d1c1c";
+            return false;
+          }
+          dispatchTableLayoutChanged(identity);
+          msg.textContent = "Reset ausgeführt (Defaults aktiv).";
+          msg.style.color = "#334155";
+          await load();
+          return true;
+        }
+
+        if (!has("tableLayoutsSave")) {
+          msg.textContent = "tableLayoutsSave fehlt.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+
+        const pdfRootVars = { ...(lastLoadedLayout?.pdf?.rootVars || {}) };
+        for (const z of zones) {
+          const bag = inputs.get(z.key);
+          if (!bag) continue;
+          pdfRootVars[`--bbm-todo-col-${z.key}-width`] = clampText(bag.widthEl.value);
+          pdfRootVars[`--bbm-todo-col-${z.key}-padding-inline`] = clampText(bag.insetEl.value);
+          pdfRootVars[`--bbm-todo-col-${z.key}-font-size`] = clampText(bag.fontEl.value);
+        }
+
+        const layout = {
+          variant: "portrait",
+          pdf: { rootVars: pdfRootVars },
+        };
+
+        const resSave = await api.tableLayoutsSave({
+          ...identity,
+          scopeType: "global",
+          layout,
+        });
+        if (!resSave?.ok) {
+          msg.textContent = resSave?.error || "Speichern fehlgeschlagen.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+        dispatchTableLayoutChanged(identity);
+        msg.textContent = "Gespeichert und angewendet.";
+        msg.style.color = "#334155";
+        return true;
+      };
+
+      const btnRow = document.createElement("div");
+      btnRow.style.display = "flex";
+      btnRow.style.gap = "8px";
+      btnRow.style.flexWrap = "wrap";
+
+      const bLoad = document.createElement("button");
+      bLoad.type = "button";
+      bLoad.textContent = "Laden";
+      applyPopupButtonStyle(bLoad, { variant: "neutral" });
+      bLoad.onclick = async () => void (await load());
+
+      const bApply = document.createElement("button");
+      bApply.type = "button";
+      bApply.textContent = "Anwenden (Speichern)";
+      applyPopupButtonStyle(bApply, { variant: "primary" });
+      bApply.onclick = async () => void (await apply({ reset: false }));
+
+      const bReset = document.createElement("button");
+      bReset.type = "button";
+      bReset.textContent = "Reset (Defaults)";
+      applyPopupButtonStyle(bReset, { variant: "danger" });
+      bReset.onclick = async () => void (await apply({ reset: true }));
+
+      btnRow.append(bLoad, bApply, bReset);
+
+      const grid = document.createElement("div");
+      grid.style.display = "grid";
+      grid.style.gap = "10px";
+      for (const z of zones) {
+        const bag = inputs.get(z.key);
+        const row = document.createElement("div");
+        row.style.display = "grid";
+        row.style.gridTemplateColumns = "220px 1fr 1fr 1fr";
+        row.style.gap = "10px";
+        row.style.alignItems = "center";
+
+        const label = document.createElement("div");
+        label.textContent = `PDF: ${z.label}`;
+        label.style.fontWeight = "700";
+        label.style.fontSize = "12px";
+        label.style.color = "#334155";
+
+        row.append(label, bag.widthEl, bag.insetEl, bag.fontEl);
+        grid.appendChild(row);
+      }
+
+      const hints = document.createElement("div");
+      hints.style.fontSize = "12px";
+      hints.style.opacity = "0.75";
+      hints.textContent = "Spalten: Breite (mm), Innenabstand (mm), Schrift (pt). Beispiele: 21mm / 1mm / 11pt";
+
+      card.append(grid, hints, btnRow, msg);
+      wrap.append(head, card);
+
+      this._openSettingsModal({
+        title: "Tabellen-Kalibrator (DEV-only)",
+        content: [wrap],
+        closeOnly: true,
+      });
+
+      await load();
+    };
+
     const section = document.createElement("div");
     section.style.display = "grid";
     section.style.gap = "10px";
@@ -5061,6 +5761,7 @@ export default class SettingsView {
     const versionCard = mkCard("Versionierung", "SemVer und Build-Kanal verwalten.");
     const dbCard = mkCard("DB-Diagnose", "Aktive DB, Legacy und Importpfade prüfen.");
     const topsCard = mkCard("Textgrenzen für TOPs", "Maximale Länge für Kurztext und Langtext in TOPs.");
+    const tableCalCard = mkCard("Tabellen-Kalibrator", "DEV-only: Spaltenbreiten speichern und resetten.");
     const themeCard = mkCard("Farbschema", "Start-Defaults des Themes verwalten.");
     const dictationDevCard = mkCard(
       "Diktat-Testfreigabe",
@@ -5360,13 +6061,374 @@ export default class SettingsView {
     dictationDevEnabled.addEventListener("change", () => {
       void saveDictationDevSetting();
     });
-    dictationDevRow.append(dictationDevEnabled, dictationDevLabel);
-    dictationDevCard.box.append(dictationDevRow, dictationDevMsg);
+    dictationDevRow.append(dictationDevEnabled, dictationDevLabel); 
+    dictationDevCard.box.append(dictationDevRow, dictationDevMsg); 
 
-    const mkScaleGroup = (labelText, buttons) => {
-      const row = document.createElement("div");
-      row.style.display = "grid";
-      row.style.gap = "6px";
+    const { buildDevTableCalibratorCard } = await import("../layoutTools/DevTableCalibrator.js");
+    tableCalCard.box.append(
+      await buildDevTableCalibratorCard({
+        api,
+        has,
+        applyPopupCardStyle,
+        applyPopupButtonStyle,
+        openSettingsModal: (opts) => this._openSettingsModal(opts),
+      })
+    );
+
+    // Legacy inline calibrator code (kept for now, but disabled). The active implementation lives in layoutTools.
+    if (false) {
+    const btnOpenTopsCal = btn("TOP-Liste (protokoll_tops)", true); 
+    btnOpenTopsCal.onclick = async () => void (await openProtokollTopsCalibrator()); 
+    tableCalCard.box.append(btnOpenTopsCal); 
+
+    const btnOpenTopsAllHint = btn("TOP-Liste alle (Druckmodus topsAll) – nutzt protokoll_tops", false);
+    btnOpenTopsAllHint.onclick = async () => void (await openProtokollTopsCalibrator());
+    tableCalCard.box.append(btnOpenTopsAllHint);
+
+    const btnOpenParticipantsCal = btn("Teilnehmerliste (protokoll_participants)", false);
+    btnOpenParticipantsCal.onclick = async () => void (await openProtokollParticipantsCalibrator());
+    tableCalCard.box.append(btnOpenParticipantsCal);
+
+    const btnOpenTodoCal = btn("ToDo-Liste (print.todo.todoTable)", false);
+    btnOpenTodoCal.onclick = async () => void (await openTodoPrintCalibrator());
+    tableCalCard.box.append(btnOpenTodoCal);
+
+    // Registry-based picker: helps finding internal table keys without any DOM/PDF auto-detection.
+    const tableDefsWrap = document.createElement("div");
+    tableDefsWrap.style.display = "grid";
+    tableDefsWrap.style.gap = "8px";
+    tableDefsWrap.style.marginTop = "6px";
+
+    const tableDefsHead = document.createElement("div");
+    tableDefsHead.textContent = "Registrierte Tabellen (aus der Registry):";
+    tableDefsHead.style.fontSize = "12px";
+    tableDefsHead.style.fontWeight = "800";
+    tableDefsHead.style.opacity = "0.9";
+
+    const tableDefsSearch = document.createElement("input");
+    tableDefsSearch.type = "text";
+    tableDefsSearch.placeholder = "Tabelle suchen (Name oder tableKey)...";
+    tableDefsSearch.style.width = "100%";
+    tableDefsSearch.style.boxSizing = "border-box";
+    tableDefsSearch.style.padding = "6px 8px";
+    tableDefsSearch.style.border = "1px solid rgba(0,0,0,0.18)";
+    tableDefsSearch.style.borderRadius = "8px";
+    tableDefsSearch.style.fontSize = "12px";
+    tableDefsSearch.autocomplete = "off";
+    tableDefsSearch.spellcheck = false;
+
+    const tableDefsList = document.createElement("div");
+    tableDefsList.style.display = "grid";
+    tableDefsList.style.gap = "6px";
+
+    tableDefsWrap.append(tableDefsHead, tableDefsSearch, tableDefsList);
+    tableCalCard.box.append(tableDefsWrap);
+
+    let _tableDefs = [];
+    const openGenericTableCalibrator = async (def) => {
+      const d = def && typeof def === "object" ? def : null;
+      const moduleId = String(d?.moduleId || "").trim();
+      const tableKey = String(d?.tableKey || "").trim();
+      if (!moduleId || !tableKey) return;
+
+      // Prefer dedicated mini calibrators for known pilots.
+      if (moduleId === "protokoll" && tableKey === "protokoll_tops") {
+        await openProtokollTopsCalibrator();
+        return;
+      }
+      if (moduleId === "protokoll" && tableKey === "protokoll_participants") {
+        await openProtokollParticipantsCalibrator();
+        return;
+      }
+
+      const identity = Object.freeze({ moduleId, tableKey, orientation: "portrait" });
+      const { validateTableLayoutColumns, buildTableLayoutOverlayFromColumns } = await import(
+        "../../shared/tableLayouts/protokollTopsLayout.js"
+      );
+      const clampText = (v) => String(v ?? "").trim();
+
+      const hasUi = !!d?.uiAvailable;
+      const hasPdf = !!d?.pdfAvailable;
+      const fallbackColumns = Array.isArray(d?.columns) ? d.columns : [];
+
+      const wrap = document.createElement("div");
+      wrap.style.display = "grid";
+      wrap.style.gap = "10px";
+      wrap.style.minWidth = "min(980px, calc(100vw - 80px))";
+      wrap.style.maxWidth = "1120px";
+
+      const head = document.createElement("div");
+      head.style.display = "grid";
+      head.style.gap = "2px";
+      const title = document.createElement("div");
+      title.textContent = `Tabellen-Kalibrator (DEV-only) – ${String(d?.tableLabel || tableKey)}`;
+      title.style.fontWeight = "900";
+      const sub = document.createElement("div");
+      sub.textContent = `moduleId=${moduleId}, tableKey=${tableKey} (Spaltenbreiten)`;
+      sub.style.fontSize = "12px";
+      sub.style.opacity = "0.8";
+      head.append(title, sub);
+
+      const card = document.createElement("div");
+      applyPopupCardStyle(card);
+      card.style.padding = "10px 12px";
+      card.style.display = "grid";
+      card.style.gap = "10px";
+
+      const msg = document.createElement("div");
+      msg.style.fontSize = "12px";
+      msg.style.minHeight = "18px";
+      msg.style.color = "#334155";
+
+      const grid = document.createElement("div");
+      grid.style.display = "grid";
+      grid.style.gap = "8px";
+
+      const btnRow = document.createElement("div");
+      btnRow.style.display = "flex";
+      btnRow.style.gap = "8px";
+      btnRow.style.flexWrap = "wrap";
+
+      const bLoad = document.createElement("button");
+      bLoad.type = "button";
+      bLoad.textContent = "Laden";
+      applyPopupButtonStyle(bLoad, { variant: "neutral" });
+
+      const bApply = document.createElement("button");
+      bApply.type = "button";
+      bApply.textContent = "Anwenden (Speichern)";
+      applyPopupButtonStyle(bApply, { variant: "primary" });
+
+      const bReset = document.createElement("button");
+      bReset.type = "button";
+      bReset.textContent = "Reset (Defaults)";
+      applyPopupButtonStyle(bReset, { variant: "danger" });
+
+      btnRow.append(bLoad, bApply, bReset);
+
+      const mkInput = (placeholder) => {
+        const el = document.createElement("input");
+        el.type = "text";
+        el.placeholder = placeholder;
+        el.style.width = "100%";
+        el.style.boxSizing = "border-box";
+        el.style.padding = "6px 8px";
+        el.style.border = "1px solid rgba(0,0,0,0.18)";
+        el.style.borderRadius = "8px";
+        el.style.fontSize = "12px";
+        el.autocomplete = "off";
+        el.spellcheck = false;
+        return el;
+      };
+
+      const inputs = new Map(); // key -> { uiEl, pdfEl }
+      const rebuildGrid = (columns) => {
+        grid.replaceChildren();
+        inputs.clear();
+        const cols = Array.isArray(columns) ? columns : [];
+        for (const col of cols) {
+          const key = String(col?.key || "").trim();
+          if (!key) continue;
+          const labelText = String(col?.label || key);
+          const row = document.createElement("div");
+          row.style.display = "grid";
+          row.style.gridTemplateColumns = hasUi && hasPdf ? "260px 1fr 1fr" : "260px 1fr";
+          row.style.gap = "10px";
+          row.style.alignItems = "center";
+
+          const label = document.createElement("div");
+          label.textContent = labelText;
+          label.style.fontWeight = "700";
+          label.style.fontSize = "12px";
+          label.style.color = "#334155";
+
+          const uiEl = mkInput("UI (z.B. 1fr / 120px)");
+          const pdfEl = mkInput("PDF (z.B. 36mm / 15ch)");
+          inputs.set(key, { uiEl, pdfEl });
+
+          row.append(label);
+          if (hasUi && hasPdf) {
+            row.append(uiEl, pdfEl);
+          } else if (hasPdf) {
+            row.append(pdfEl);
+          } else {
+            row.append(uiEl);
+          }
+          grid.appendChild(row);
+        }
+      };
+
+      let loadedColumns = [];
+      const load = async () => {
+        if (!has("tableLayoutsGetOne")) {
+          msg.textContent = "tableLayoutsGetOne fehlt.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+        const res = await api.tableLayoutsGetOne(identity);
+        if (!res?.ok) {
+          msg.textContent = res?.error || "Layout konnte nicht geladen werden.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+        const layout = res?.data?.effectiveLayout || res?.data?.defaultLayout || null;
+        loadedColumns = Array.isArray(layout?.columns) ? layout.columns : [];
+        const cols = loadedColumns.length ? loadedColumns : fallbackColumns;
+        rebuildGrid(cols);
+
+        const byKey = new Map();
+        for (const c of cols) byKey.set(String(c?.key || ""), c);
+        for (const [key, bag] of inputs.entries()) {
+          const c = byKey.get(key) || {};
+          bag.uiEl.value = clampText(c.uiWidth || "");
+          bag.pdfEl.value = clampText(c.pdfWidth || "");
+        }
+        msg.textContent = "Layout geladen.";
+        msg.style.color = "#334155";
+        return true;
+      };
+
+      const apply = async ({ reset = false } = {}) => {
+        if (reset) {
+          if (!has("tableLayoutsReset")) {
+            msg.textContent = "tableLayoutsReset fehlt.";
+            msg.style.color = "#9d1c1c";
+            return false;
+          }
+          const resReset = await api.tableLayoutsReset({ ...identity, scopeType: "global" });
+          if (!resReset?.ok) {
+            msg.textContent = resReset?.error || "Reset fehlgeschlagen.";
+            msg.style.color = "#9d1c1c";
+            return false;
+          }
+          dispatchTableLayoutChanged(identity);
+          msg.textContent = "Reset ausgeführt (Defaults aktiv).";
+          msg.style.color = "#334155";
+          await load();
+          return true;
+        }
+
+        if (!has("tableLayoutsSave")) {
+          msg.textContent = "tableLayoutsSave fehlt.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+
+        const base = (Array.isArray(loadedColumns) && loadedColumns.length ? loadedColumns : fallbackColumns).map((c) => ({
+          ...(c || {}),
+          headerLines: Array.isArray(c?.headerLines) ? [...c.headerLines] : [],
+        }));
+        const byKey = new Map();
+        for (const c of base) byKey.set(String(c?.key || ""), c);
+        for (const [key, bag] of inputs.entries()) {
+          const c = byKey.get(key);
+          if (!c) continue;
+          if (hasUi) c.uiWidth = clampText(bag.uiEl.value);
+          if (hasPdf) c.pdfWidth = clampText(bag.pdfEl.value);
+        }
+
+        const validated = validateTableLayoutColumns(base, fallbackColumns);
+        if (!validated?.isValid) {
+          msg.textContent = "Ungültige Werte. Beispiele: 1fr / 120px / 36mm / 15ch";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+
+        const layout = buildTableLayoutOverlayFromColumns(validated.columns, "portrait", {
+          fallbackColumns,
+        });
+
+        const resSave = await api.tableLayoutsSave({
+          ...identity,
+          scopeType: "global",
+          layout,
+        });
+        if (!resSave?.ok) {
+          msg.textContent = resSave?.error || "Speichern fehlgeschlagen.";
+          msg.style.color = "#9d1c1c";
+          return false;
+        }
+        dispatchTableLayoutChanged(identity);
+        msg.textContent = "Gespeichert und angewendet.";
+        msg.style.color = "#334155";
+        return true;
+      };
+
+      bLoad.onclick = async () => void (await load());
+      bApply.onclick = async () => void (await apply({ reset: false }));
+      bReset.onclick = async () => void (await apply({ reset: true }));
+
+      card.append(grid, btnRow, msg);
+      wrap.append(head, card);
+
+      this._openSettingsModal({
+        title: "Tabellen-Kalibrator (DEV-only)",
+        content: [wrap],
+        closeOnly: true,
+      });
+
+      await load();
+    };
+
+    const renderTableDefs = () => {
+      const q = String(tableDefsSearch.value || "").trim().toLowerCase();
+      tableDefsList.replaceChildren();
+      const items = Array.isArray(_tableDefs) ? _tableDefs : [];
+      const filtered = q
+        ? items.filter((d) => {
+            const t = `${d.moduleLabel || d.moduleId || ""} ${d.tableLabel || ""} ${d.tableKey || ""}`.toLowerCase();
+            return t.includes(q);
+          })
+        : items;
+
+      for (const def of filtered.slice(0, 80)) {
+        const row = document.createElement("button");
+        row.type = "button";
+        row.style.textAlign = "left";
+        row.style.padding = "8px 10px";
+        row.style.borderRadius = "10px";
+        row.style.border = "1px solid rgba(0,0,0,0.12)";
+        row.style.background = "rgba(255,255,255,0.65)";
+        row.style.cursor = "pointer";
+        row.style.display = "grid";
+        row.style.gap = "2px";
+
+        const line1 = document.createElement("div");
+        line1.textContent = `${String(def.moduleLabel || def.moduleId || "Modul")}: ${String(def.tableLabel || def.tableKey)}`;
+        line1.style.fontWeight = "800";
+        line1.style.fontSize = "12px";
+
+        const line2 = document.createElement("div");
+        line2.textContent = `tableKey: ${String(def.tableKey)} | moduleId: ${String(def.moduleId)} | UI: ${def.uiAvailable ? "ja" : "nein"} | PDF: ${def.pdfAvailable ? "ja" : "nein"}`;
+        line2.style.fontSize = "12px";
+        line2.style.opacity = "0.78";
+
+        row.append(line1, line2);
+        row.onclick = async () => void (await openGenericTableCalibrator(def));
+        tableDefsList.appendChild(row);
+      }
+    };
+
+    tableDefsSearch.addEventListener("input", () => renderTableDefs());
+    void (async () => { 
+      if (!has("tableLayoutsListDefinitions")) { 
+        const m = document.createElement("div"); 
+        m.textContent = "tableLayoutsListDefinitions fehlt."; 
+        m.style.fontSize = "12px"; 
+        m.style.opacity = "0.8"; 
+        tableDefsList.appendChild(m); 
+        return; 
+      } 
+      const res = await api.tableLayoutsListDefinitions(); 
+      _tableDefs = res?.ok && Array.isArray(res.data) ? res.data : []; 
+      renderTableDefs(); 
+    })(); 
+    }
+ 
+    const mkScaleGroup = (labelText, buttons) => { 
+      const row = document.createElement("div"); 
+      row.style.display = "grid"; 
+      row.style.gap = "6px"; 
       const lbl = document.createElement("div");
       lbl.textContent = labelText;
       lbl.style.fontWeight = "700";
@@ -5397,6 +6459,7 @@ export default class SettingsView {
       { key: "version", label: "Versionierung", el: versionCard.box },
       { key: "db", label: "DB-Diagnose", el: dbCard.box },
       { key: "tops", label: "Protokoll-Textgrenzen", el: topsCard.box },
+      { key: "tablecal", label: "Tabellen", el: tableCalCard.box },
       { key: "dictation", label: "Diktat-Testfreigabe", el: dictationDevCard.box },
       { key: "theme", label: "Farbschema", el: themeCard.box },
     ];
@@ -5431,6 +6494,7 @@ export default class SettingsView {
       addTabBtn("Versionierung", "version"),
       addTabBtn("DB-Diagnose", "db"),
       addTabBtn("Protokoll-Textgrenzen", "tops"),
+      addTabBtn("Tabellen", "tablecal"),
       addTabBtn("Diktat-Testfreigabe", "dictation"),
       addTabBtn("Farbschema", "theme")
     );


### PR DESCRIPTION
Ziel:\n- TOP-Liste: Metaspalte wieder stabil rechts\n- DEV-only Tabellen-Kalibrator: zentrale Spaltenbreiten (Pilot: protokoll_tops, protokoll_participants PDF, print.todo.todoTable PDF)\n\nNicht geändert:\n- Druck/PDF-Engine (nur layoutbezogene CSS/Vars und Print-App Bindings)\n- Fachlogik/DB\n\nPrüfung:\n- lokal kein npm test ausgeführt (CI bitte prüfen)