### PR TITLE
Stabilize main tests after PR70 sync

### DIFF
--- a/scripts/tests/drucklayoutModule.test.cjs
+++ b/scripts/tests/drucklayoutModule.test.cjs
@@ -46,7 +46,7 @@ async function runDrucklayoutModuleTests(run) {
     const settingsSource = read("src/renderer/views/SettingsView.js");
     const moduleCatalogSource = read("src/renderer/app/modules/moduleCatalog.js");
     assert.equal(settingsSource.includes("Drucklayout"), true);
-    assert.equal(settingsSource.includes("createDrucklayoutDevScreen"), true);
+    assert.equal(settingsSource.includes("layoutTitle.textContent = \"Drucklayout\""), true);
     assert.equal(moduleCatalogSource.includes("drucklayout"), false);
   });
 

--- a/scripts/tests/licenseDoubleClickImport.test.cjs
+++ b/scripts/tests/licenseDoubleClickImport.test.cjs
@@ -87,7 +87,7 @@ async function runLicenseDoubleClickImportTests(run) {
     const mainSource = read("src/main/main.js");
     const ipcSource = read("src/main/ipc/licenseIpc.js");
     assert.equal(ipcSource.includes("function importLicenseFromFilePath(filePath)"), true);
-    assert.equal(ipcSource.includes("return importLicenseFromFilePath(filePath);"), true);
+    assert.equal(ipcSource.includes("return importLicenseFromFilePath(result.filePaths[0]);"), true);
     assert.equal(mainSource.includes("importLicenseFromFilePath(filePath)"), true);
   });
 
@@ -102,11 +102,12 @@ async function runLicenseDoubleClickImportTests(run) {
   await run("Lizenzfenster: Hinweis auf Doppelklick ist vorhanden", () => {
     const settingsSource = read("src/renderer/views/SettingsView.js");
     assert.equal(
-      settingsSource.includes("Sie können eine erhaltene .bbmlic-Datei auch direkt per Doppelklick öffnen."),
+      settingsSource.includes(".bbmlic-Datei direkt per Doppelklick oeffnen"),
       true
     );
-    assert.equal(settingsSource.includes("Lizenz wurde erfolgreich importiert."), true);
-    assert.equal(settingsSource.includes("Lizenzdatei konnte nicht importiert werden."), true);
+    const mainSource = read("src/main/main.js");
+    assert.equal(mainSource.includes("Lizenz wurde erfolgreich importiert."), true);
+    assert.equal(mainSource.includes("Lizenzdatei konnte nicht importiert werden."), true);
   });
 
   await run("Testversionen bleiben unveraendert abgesichert", () => {

--- a/scripts/tests/topsScreen.integration.test.cjs
+++ b/scripts/tests/topsScreen.integration.test.cjs
@@ -1238,7 +1238,7 @@ async function runTopsScreenIntegrationTests(run) {
     }
   });
 
-  await run("Tops v2 Integration: Kurztext-Laenge ist fuer Level 2-4 in der UI auf 82ch gesetzt", () => {
+  await run("Tops v2 Integration: Kurztext-Laenge ist fuer Level 2-4 in der UI auf 107ch gesetzt", () => {
     const topsCss = fs.readFileSync(
       path.join(__dirname, "../../src/renderer/modules/protokoll/styles/tops.css"),
       "utf8"
@@ -1260,14 +1260,14 @@ async function runTopsScreenIntegrationTests(run) {
       true
     );
     assert.equal(
-      topsCss.includes(".bbm-tops-list-row:not([data-top-level=\"1\"]) .bbm-tops-list-row-preview {\n  font-size: var(--bbm-top-short-font-size);\n  max-inline-size: 82ch;"),
+      topsCss.includes(".bbm-tops-list-row:not([data-top-level=\"1\"]) .bbm-tops-list-row-preview {\n  font-size: var(--bbm-top-short-font-size);\n  max-inline-size: 107ch;"),
       true
     );
     assert.equal(
       topsCss.includes(".bbm-tops-workbench-editbox:not([data-top-level=\"1\"]) .editbox-textarea"),
       true
     );
-    assert.equal(topsCss.includes("82ch"), true);
+    assert.equal(topsCss.includes("107ch"), true);
   });
 
   await run("Tops v2 Integration: ToDo- und Beschluss-Symbole folgen dem Draft in der Metazeile", () => {

--- a/src/renderer/views/SettingsView.js
+++ b/src/renderer/views/SettingsView.js
@@ -4714,6 +4714,12 @@ export default class SettingsView {
     note.textContent =
       "Lizenzstatus wird hier nur angezeigt. Lizenzverwaltung und Generator sind in die externe Lizenz-App ausgelagert.";
 
+    const doubleClickHint = document.createElement("div");
+    doubleClickHint.style.fontSize = "12px";
+    doubleClickHint.style.lineHeight = "1.45";
+    doubleClickHint.style.opacity = "0.82";
+    doubleClickHint.textContent = "Hinweis: Sie koennen eine erhaltene .bbmlic-Datei direkt per Doppelklick oeffnen und importieren.";
+
     const status = document.createElement("div");
     status.style.padding = "8px 10px";
     status.style.border = "1px solid rgba(0,0,0,0.08)";
@@ -4762,7 +4768,7 @@ export default class SettingsView {
     };
 
     btnReload.addEventListener("click", loadStatus);
-    card.append(title, note, status, btnReload);
+    card.append(title, note, doubleClickHint, status, btnReload);
     wrap.append(card);
 
     void loadStatus();


### PR DESCRIPTION
### Motivation
- After the recent cleanup merges (PR #70) a few tests became outdated and failed because the codebase moved to new UI values and slightly changed call-sites; the goal is to bring only the failing tests back in sync with the current code without functional or architectural changes. 
- Only the currently red tests should be fixed; no new features, refactors, module activations or dependency changes were introduced.

### Description
- Updated the TOPs integration test to expect the current short-text UI width `107ch` and renamed the test to reflect that value in `scripts/tests/topsScreen.integration.test.cjs`. 
- Adjusted the Drucklayout DEV-only assertion to read the actual SettingsView entry point (`layoutTitle.textContent = "Drucklayout"`) rather than an older helper check in `scripts/tests/drucklayoutModule.test.cjs`. 
- Aligned the license double-click import test to the actual IPC import call-site by checking for the `importLicenseFromFilePath(result.filePaths[0])` usage in `scripts/tests/licenseDoubleClickImport.test.cjs`. 
- Added a concise double-click hint to the existing license status area in `src/renderer/views/SettingsView.js` and adapted the test to assert the updated hint text location/phrase; no Settings structure or license flow logic was changed.

### Testing
- Ran `npm test` and confirmed the targeted failing tests are now green (TOPs width, Drucklayout DEV-only, license import call-site and license hint). 
- The overall test run still shows unrelated DB/native failures in several Print/TableLayout tests caused by `better-sqlite3` Node-ABI/native build mismatches in this environment and these errors were not part of the requested fixes. 
- No additional automated tests were added or removed; only the minimal test expectations and the small UI hint were changed and the test suite was re-run to verify the fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06f7389e808322b894cb84b6868434)