### PR TITLE
M1: Restarbeiten-Modulhülle im Modulrahmen anbinden

### DIFF
--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -18,6 +18,7 @@ const { runTopServiceHierarchyTests } = require("./tests/topServiceHierarchy.tes
 const { runProtokollRouterFallbackTests } = require("./tests/protokollRouterFallback.test.cjs");
 const { runProtokollProjectEntryRoutingTests } = require("./tests/protokollProjectEntryRouting.test.cjs");
 const { runProjektverwaltungModuleTests } = require("./tests/projektverwaltungModule.test.cjs");
+const { runRestarbeitenModuleTests } = require("./tests/restarbeitenModule.test.cjs");
 const { runHomeViewTests } = require("./tests/homeView.test.cjs");
 const { runProjectSettingsIpcTests } = require("./tests/projectSettingsIpc.test.cjs");
 const { runSettingsUserProfileSourceTests } = require("./tests/settingsUserProfileSource.test.cjs");
@@ -111,6 +112,7 @@ async function main() {
   await runProtokollRouterFallbackTests(run);
   await runProtokollProjectEntryRoutingTests(run);
   await runProjektverwaltungModuleTests(run);
+  await runRestarbeitenModuleTests(run);
   await runHomeViewTests(run);
   await runProjectSettingsIpcTests(run);
   await runSettingsUserProfileSourceTests(run);

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1,0 +1,60 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+async function runRestarbeitenModuleTests(run) {
+  const [restarbeitenModule, screenResolver, workspaceModule] = await Promise.all([
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/restarbeiten/index.js")),
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/app/modules/moduleEntryScreenResolver.js")),
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js")),
+  ]);
+
+  await run("Restarbeiten: Modulentry hat erwartete Struktur", () => {
+    const entry = restarbeitenModule.getRestarbeitenModuleEntry();
+    assert.equal(entry.moduleId, "restarbeiten");
+    assert.equal(entry.moduleLabel, "Restarbeiten");
+    assert.equal(entry.workScreenId, "restarbeitenWork");
+    assert.equal(entry.navigation.project[0].key, "restarbeiten");
+    assert.equal(entry.navigation.project[0].label, "Restarbeiten");
+    assert.equal(entry.navigation.project[0].moduleId, "restarbeiten");
+    assert.equal(entry.navigation.project[0].workScreenId, "restarbeitenWork");
+    assert.equal(entry.navigation.project[0].section, "restarbeiten");
+  });
+
+  await run("Restarbeiten: Workscreen ist ueber Resolver aufloesbar", () => {
+    const entry = restarbeitenModule.getRestarbeitenModuleEntry();
+    const resolved = screenResolver.resolveModuleWorkScreenFromEntry(entry);
+    assert.equal(typeof resolved, "function");
+  });
+
+  await run("ProjectWorkspaceScreen: Sonderfaelle und generische Module bleiben funktionsfaehig", async () => {
+    const calls = [];
+    const screen = new workspaceModule.default({
+      router: {
+        currentProjectId: "22",
+        async showProjectFirms(projectId) {
+          calls.push({ type: "firms", projectId });
+        },
+        async openProjectModule(projectId, moduleId, options) {
+          calls.push({ type: "module", projectId, moduleId, options });
+          return { ok: true };
+        },
+      },
+      projectId: "22",
+      project: { id: "22", name: "Test" },
+    });
+
+    assert.equal(await screen.openProjectModule("projectFirms"), true);
+    assert.equal(await screen.openProjectModule("protokoll"), true);
+    assert.equal(await screen.openProjectModule("restarbeiten"), true);
+
+    assert.equal(calls.some((c) => c.type === "firms"), true);
+    assert.equal(calls.some((c) => c.type === "module" && c.moduleId === "protokoll"), true);
+    assert.equal(calls.some((c) => c.type === "module" && c.moduleId === "restarbeiten"), true);
+
+    const restCall = calls.find((c) => c.type === "module" && c.moduleId === "restarbeiten");
+    assert.equal(restCall.options.project.id, "22");
+  });
+}
+
+module.exports = { runRestarbeitenModuleTests };

--- a/src/renderer/app/modules/moduleCatalog.js
+++ b/src/renderer/app/modules/moduleCatalog.js
@@ -2,11 +2,19 @@ import {
   getProtokollModuleEntry,
   PROTOKOLL_MODULE_ID,
 } from "../../modules/protokoll/index.js";
+import {
+  getRestarbeitenModuleEntry,
+  RESTARBEITEN_MODULE_ID,
+} from "../../modules/restarbeiten/index.js";
 
 const AVAILABLE_MODULE_ENTRIES = Object.freeze([
   Object.freeze({
     moduleId: PROTOKOLL_MODULE_ID,
     entry: getProtokollModuleEntry(),
+  }),
+  Object.freeze({
+    moduleId: RESTARBEITEN_MODULE_ID,
+    entry: getRestarbeitenModuleEntry(),
   }),
 ]);
 

--- a/src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js
@@ -158,7 +158,11 @@ export default class ProjectWorkspaceScreen {
       return await this._openProtocolModule(projectId);
     }
 
-    return false;
+    if (typeof this.router?.openProjectModule !== "function") return false;
+    const result = await this.router.openProjectModule(projectId, normalizedModuleId, {
+      project: this.project || null,
+    });
+    return typeof result === "object" ? !!result?.ok : result !== false;
   }
 
   _renderModuleTiles(container) {

--- a/src/renderer/modules/restarbeiten/index.js
+++ b/src/renderer/modules/restarbeiten/index.js
@@ -1,0 +1,39 @@
+import RestarbeitenScreen from "./screens/RestarbeitenScreen.js";
+import { RESTARBEITEN_WORK_SCREEN_ID } from "./screens/index.js";
+
+export const RESTARBEITEN_MODULE_ID = "restarbeiten";
+export const RESTARBEITEN_MODULE_LABEL = "Restarbeiten";
+export const RESTARBEITEN_NAV_ENTRY_KEY = "restarbeiten";
+
+function buildRestarbeitenModuleScreens() {
+  return Object.freeze({
+    [RESTARBEITEN_WORK_SCREEN_ID]: RestarbeitenScreen,
+  });
+}
+
+function buildRestarbeitenModuleNavigation() {
+  return Object.freeze({
+    project: Object.freeze([
+      Object.freeze({
+        key: RESTARBEITEN_NAV_ENTRY_KEY,
+        label: RESTARBEITEN_MODULE_LABEL,
+        moduleId: RESTARBEITEN_MODULE_ID,
+        workScreenId: RESTARBEITEN_WORK_SCREEN_ID,
+        section: "restarbeiten",
+      }),
+    ]),
+  });
+}
+
+export function getRestarbeitenModuleEntry() {
+  return Object.freeze({
+    moduleId: RESTARBEITEN_MODULE_ID,
+    moduleLabel: RESTARBEITEN_MODULE_LABEL,
+    workScreenId: RESTARBEITEN_WORK_SCREEN_ID,
+    screens: buildRestarbeitenModuleScreens(),
+    navigation: buildRestarbeitenModuleNavigation(),
+  });
+}
+
+export { RestarbeitenScreen, RESTARBEITEN_WORK_SCREEN_ID };
+export * from "./screens/index.js";

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -1,0 +1,36 @@
+function normalizeText(value) {
+  return String(value || "").trim();
+}
+
+export default class RestarbeitenScreen {
+  constructor({ router, projectId, project, moduleId } = {}) {
+    this.router = router || null;
+    this.projectId = projectId || null;
+    this.project = project || null;
+    this.moduleId = moduleId || "restarbeiten";
+  }
+
+  render() {
+    const root = document.createElement("div");
+    root.style.display = "grid";
+    root.style.gap = "8px";
+
+    const title = document.createElement("h2");
+    title.textContent = "Restarbeiten";
+    title.style.margin = "0";
+
+    const context = document.createElement("div");
+    const effectiveProjectId = normalizeText(this.projectId || this.project?.id || "");
+    context.textContent = effectiveProjectId
+      ? `Projektkontext: #${effectiveProjectId}`
+      : "Projektkontext: nicht gesetzt";
+
+    const hint = document.createElement("p");
+    hint.style.margin = "0";
+    hint.textContent =
+      "Modul vorbereitet. Die fachliche Restarbeitenliste folgt in einem späteren Paket.";
+
+    root.append(title, context, hint);
+    return root;
+  }
+}

--- a/src/renderer/modules/restarbeiten/screens/index.js
+++ b/src/renderer/modules/restarbeiten/screens/index.js
@@ -1,0 +1,3 @@
+export { default as RestarbeitenScreen } from "./RestarbeitenScreen.js";
+
+export const RESTARBEITEN_WORK_SCREEN_ID = "restarbeitenWork";


### PR DESCRIPTION
### Motivation
- Vorbereitung des neuen Fachmoduls `restarbeiten` als kleine, isolierte Modulhülle, damit das Modul später sicher in den bestehenden Modulrahmen angedockt werden kann.
- Keine fachliche Implementierung oder Architekturänderungen: Ziel ist nur ein sauberer Einstiegspunkt und Erreichbarkeit über bestehende Resolver/Router-Mechanik.

### Description
- Neues Modul mit Entry und Screens angelegt: `src/renderer/modules/restarbeiten/index.js`, `src/renderer/modules/restarbeiten/screens/index.js` und `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js` mit `getRestarbeitenModuleEntry()` und Konstanten `RESTARBEITEN_MODULE_ID`, `RESTARBEITEN_MODULE_LABEL` und `RESTARBEITEN_WORK_SCREEN_ID`.
- Modulkatalog minimal erweitert: `getRestarbeitenModuleEntry()` in `AVAILABLE_MODULE_ENTRIES` in `src/renderer/app/modules/moduleCatalog.js` aufgenommen ohne Änderung der produktiven Default-Freigabe (aktive Module bleiben unverändert).
- `ProjectWorkspaceScreen.openProjectModule(moduleId)` in `src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js` minimal erweitert, so dass außer den bisherigen Sonderfällen `projectFirms` und `protokoll` jetzt generisch `router.openProjectModule(projectId, normalizedModuleId, { project })` verwendet werden kann.
- Kleine paketbezogene Tests ergänzt und eingebunden: `scripts/tests/restarbeitenModule.test.cjs` und Einbindung in `scripts/test.cjs`; keine Datenbank-/Migrations- oder Lizenzänderungen vorgenommen.

### Testing
- `npm test` ausgeführt; die neuen M1-bezogenen Prüfungen für `restarbeiten` liefen erfolgreich und zeigen: Modulentry korrekt, Workscreen über Resolver auflösbar und `ProjectWorkspaceScreen.openProjectModule(...)` öffnet generisch (grün für die neuen/angepassten Tests).
- Der vollständige Testlauf in der aktuellen CI-/Container-Umgebung schlägt an mehreren DB-nahen Tests fehl wegen einer bekannten `better-sqlite3`/Node-ABI-Inkompatibilität; diese Fehler sind umgebungsbedingt und nicht auf die M1-Änderungen zurückzuführen.
- Test-Command: `npm test` (siehe Testergebnis für Details).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078c8ebb608322aa76087e52ec0909)