### PR TITLE
M2: Make `restarbeiten` activatable in license/freischalt model

### DIFF
--- a/scripts/tests/licenseFeatureGuards.test.cjs
+++ b/scripts/tests/licenseFeatureGuards.test.cjs
@@ -157,7 +157,7 @@ async function runLicenseFeatureGuardTests(run) {
     global.window = {
       bbmDb: {
         async licenseGetStatus() {
-          return { ok: true, valid: true, modules: ["protokoll"] };
+          return { ok: true, valid: true, modules: ["restarbeiten"] };
         },
       },
     };
@@ -165,13 +165,25 @@ async function runLicenseFeatureGuardTests(run) {
     try {
       const activeIds = await mod.refreshCachedActiveModuleAccess({ force: true });
       assert.equal(Array.isArray(activeIds), true);
-      assert.equal(mod.isModuleActive("protokoll"), true);
+      assert.equal(mod.isModuleActive("restarbeiten"), true);
+      assert.equal(mod.isModuleActive("protokoll"), false);
       assert.equal(mod.isModuleActive("audio"), false);
+
+      global.window.bbmDb.licenseGetStatus = async () => ({
+        ok: true,
+        valid: true,
+        modules: ["protokoll", "restarbeiten"],
+      });
+      const bothIds = await mod.refreshCachedActiveModuleAccess({ force: true });
+      assert.equal(Array.isArray(bothIds), true);
+      assert.equal(mod.isModuleActive("protokoll"), true);
+      assert.equal(mod.isModuleActive("restarbeiten"), true);
 
       global.window.bbmDb.licenseGetStatus = async () => ({ ok: true, valid: true, modules: [] });
       const inactiveIds = await mod.refreshCachedActiveModuleAccess({ force: true });
       assert.equal(Array.isArray(inactiveIds), true);
       assert.equal(mod.isModuleActive("protokoll"), false);
+      assert.equal(mod.isModuleActive("restarbeiten"), false);
     } finally {
       global.window = previousWindow;
     }

--- a/scripts/tests/licenseStandardFeatures.test.cjs
+++ b/scripts/tests/licenseStandardFeatures.test.cjs
@@ -100,6 +100,44 @@ async function runLicenseStandardFeaturesTests(run) {
     assert.throws(() => svc.requireFeature("protokoll"), /FEATURE_NOT_ALLOWED:protokoll/);
   });
 
+
+  await run("Lizenzmodell: RESTARBEITEN als Modul ist erlaubt", () => {
+    const svc = loadLicenseServiceWithStatus({
+      valid: true,
+      reason: "OK",
+      license: { modules: ["restarbeiten"], features: [] },
+    });
+    assert.equal(svc.requireFeature("restarbeiten"), true);
+  });
+
+  await run("Lizenzmodell: Protokoll und Restarbeiten sind gemeinsam erlaubt", () => {
+    const svc = loadLicenseServiceWithStatus({
+      valid: true,
+      reason: "OK",
+      license: { modules: ["protokoll", "restarbeiten"], features: [] },
+    });
+    assert.equal(svc.requireFeature("protokoll"), true);
+    assert.equal(svc.requireFeature("restarbeiten"), true);
+  });
+
+  await run("Lizenzmodell: Restarbeiten bleibt ohne Modulfreigabe gesperrt", () => {
+    const svc = loadLicenseServiceWithStatus({
+      valid: true,
+      reason: "OK",
+      license: { modules: [], features: [] },
+    });
+    assert.throws(() => svc.requireFeature("restarbeiten"), /FEATURE_NOT_ALLOWED:restarbeiten/);
+  });
+
+  await run("Lizenzmodell: Legacy-Features aktivieren nur Protokoll, nicht Restarbeiten", () => {
+    const svc = loadLicenseServiceWithStatus({
+      valid: true,
+      reason: "OK",
+      license: { features: ["protokoll"] },
+    });
+    assert.equal(svc.requireFeature("protokoll"), true);
+    assert.throws(() => svc.requireFeature("restarbeiten"), /FEATURE_NOT_ALLOWED:restarbeiten/);
+  });
   await run("Lizenzmodell: Legacy ohne modules-Feld erkennt protokoll ueber features", () => {
     const svc = loadLicenseServiceWithStatus({
       valid: true,

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -55,6 +55,22 @@ async function runRestarbeitenModuleTests(run) {
     const restCall = calls.find((c) => c.type === "module" && c.moduleId === "restarbeiten");
     assert.equal(restCall.options.project.id, "22");
   });
+
+  await run("Restarbeiten: Modulkatalog leitet Restarbeiten gezielt ab", async () => {
+    const moduleCatalog = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/app/modules/moduleCatalog.js")
+    );
+
+    assert.deepEqual(moduleCatalog.getDerivedActiveModuleIds(["restarbeiten"]), ["restarbeiten"]);
+
+    const derivedCatalog = moduleCatalog.getDerivedActiveModuleCatalog(["restarbeiten"]);
+    assert.equal(Array.isArray(derivedCatalog), true);
+    assert.equal(derivedCatalog.length, 1);
+    assert.equal(derivedCatalog[0].moduleId, "restarbeiten");
+
+    assert.deepEqual(moduleCatalog.getActiveModuleIds(), ["protokoll"]);
+  });
+
 }
 
 module.exports = { runRestarbeitenModuleTests };

--- a/src/main/licensing/licenseFeatures.js
+++ b/src/main/licensing/licenseFeatures.js
@@ -1,5 +1,6 @@
 const LICENSE_MODULES = Object.freeze({
   PROTOKOLL: "protokoll",
+  RESTARBEITEN: "restarbeiten",
 });
 
 const LICENSE_FEATURES = Object.freeze({
@@ -60,7 +61,9 @@ function normalizeLicensedModules(modules, features) {
   const seen = new Set();
   rawModules.forEach((value) => {
     const mod = _normalizeFeatureValue(value);
-    if (!mod || mod !== LICENSE_MODULES.PROTOKOLL || seen.has(mod)) return;
+    const isAllowedModule =
+      mod === LICENSE_MODULES.PROTOKOLL || mod === LICENSE_MODULES.RESTARBEITEN;
+    if (!mod || !isAllowedModule || seen.has(mod)) return;
     seen.add(mod);
     normalized.push(mod);
   });
@@ -74,7 +77,8 @@ function normalizeLicensedModules(modules, features) {
 }
 
 function isLicensedModule(moduleId) {
-  return _normalizeFeatureValue(moduleId) === LICENSE_MODULES.PROTOKOLL;
+  const normalized = _normalizeFeatureValue(moduleId);
+  return normalized === LICENSE_MODULES.PROTOKOLL || normalized === LICENSE_MODULES.RESTARBEITEN;
 }
 
 function isLicensedProduct(product) {


### PR DESCRIPTION
### Motivation
- Enable the existing module hull `restarbeiten` to be controlled by the current license/freischalt model without changing default productive behavior or introducing new license architecture.

### Description
- Add `RESTARBEITEN: "restarbeiten"` to `LICENSE_MODULES` and update `normalizeLicensedModules()` to accept `restarbeiten` in addition to `protokoll` while still removing duplicates and discarding unknown modules. (`src/main/licensing/licenseFeatures.js`)
- Update `isLicensedModule()` to return true for both `protokoll` and `restarbeiten`. (`src/main/licensing/licenseFeatures.js`)
- Keep the legacy `features` fallback behavior limited to `protokoll` so `restarbeiten` is not implicitly enabled by legacy aliases. (`src/main/licensing/licenseFeatures.js`)
- Add and adjust tests to cover the new cases: `scripts/tests/licenseStandardFeatures.test.cjs`, `scripts/tests/licenseFeatureGuards.test.cjs`, and `scripts/tests/restarbeitenModule.test.cjs` to validate license normalization, renderer module access state, and module catalog derivation for `restarbeiten`.

### Testing
- Executed `npm test`; the overall run in this environment reported failures caused by a known native module (`better-sqlite3`) / Node-ABI mismatch and is therefore red for unrelated DB tests.
- M2-relevant tests and assertions ran within that test run and passed, specifically:
  - License normalization and `requireFeature("restarbeiten")` for `modules: ["restarbeiten"]` and combined `modules: ["protokoll","restarbeiten"]`.
  - `moduleAccessState.refreshCachedActiveModuleAccess()` recognizes `restarbeiten` as active when `licenseGetStatus()` returns `modules: ["restarbeiten"]`, recognizes both modules when both are present, and shows none when `modules: []`.
  - Modulkatalog derivation: `getDerivedActiveModuleIds(["restarbeiten"])` and `getDerivedActiveModuleCatalog(["restarbeiten"])` behave as expected and the productive default remains `protokoll`.
- No other application code (DB, migrations, module business logic, printing, dictation, etc.) was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0791477f0883229d488d7ceec83ae7)