### PR TITLE
M3: Restarbeiten-Datenmodell und minimale Repo-Basis vorbereiten

### DIFF
--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -238,3 +238,9 @@ Dabei gilt:
 - keine Parallelplaene anlegen
 - keine Fortschritte groesser schreiben, als sie technisch sind
 
+
+
+### M3 Restarbeiten-Datenmodell (neu)
+- Datenmodell vorbereitet: `restarbeiten_items`, `restarbeiten_project_settings`, `restarbeiten_attachments`.
+- Fotoregeln in Repo-Basis vorbereitet: max. 3 je Restarbeit, genau ein Hauptfoto.
+- Bildverarbeitung folgt in spaeterem Schritt.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -19,6 +19,7 @@ const { runProtokollRouterFallbackTests } = require("./tests/protokollRouterFall
 const { runProtokollProjectEntryRoutingTests } = require("./tests/protokollProjectEntryRouting.test.cjs");
 const { runProjektverwaltungModuleTests } = require("./tests/projektverwaltungModule.test.cjs");
 const { runRestarbeitenModuleTests } = require("./tests/restarbeitenModule.test.cjs");
+const { runRestarbeitenDataModelTests } = require("./tests/restarbeitenDataModel.test.cjs");
 const { runHomeViewTests } = require("./tests/homeView.test.cjs");
 const { runProjectSettingsIpcTests } = require("./tests/projectSettingsIpc.test.cjs");
 const { runSettingsUserProfileSourceTests } = require("./tests/settingsUserProfileSource.test.cjs");
@@ -113,6 +114,7 @@ async function main() {
   await runProtokollProjectEntryRoutingTests(run);
   await runProjektverwaltungModuleTests(run);
   await runRestarbeitenModuleTests(run);
+  await runRestarbeitenDataModelTests(run);
   await runHomeViewTests(run);
   await runProjectSettingsIpcTests(run);
   await runSettingsUserProfileSourceTests(run);

--- a/scripts/tests/restarbeitenDataModel.test.cjs
+++ b/scripts/tests/restarbeitenDataModel.test.cjs
@@ -44,8 +44,8 @@ async function runRestarbeitenDataModelTests(run) {
 
   await run("Projektbezug und running_number je Projekt", async () => withTemp(({ db, repo }) => {
     const conn = db.initDatabase();
-    conn.prepare("INSERT INTO projects (id, title) VALUES (?, ?)").run("p1", "P1");
-    conn.prepare("INSERT INTO projects (id, title) VALUES (?, ?)").run("p2", "P2");
+    conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p1", "P1");
+    conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p2", "P2");
     repo.createRestarbeitItem({ project_id: "p1", short_text: "A" });
     repo.createRestarbeitItem({ project_id: "p1", short_text: "B" });
     repo.createRestarbeitItem({ project_id: "p2", short_text: "C" });
@@ -57,8 +57,8 @@ async function runRestarbeitenDataModelTests(run) {
 
   await run("Verortung und Settings", async () => withTemp(({ db, repo }) => {
     const conn = db.initDatabase();
-    conn.prepare("INSERT INTO projects (id, title) VALUES (?, ?)").run("p1", "P1");
-    conn.prepare("INSERT INTO projects (id, title) VALUES (?, ?)").run("p2", "P2");
+    conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p1", "P1");
+    conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p2", "P2");
     const item = repo.createRestarbeitItem({ project_id: "p1", location_level_1: "Haus A", location_level_2: "EG", location_level_3: "WE 1", location_level_4: "Kueche", status: "unbekannt" });
     assert.equal(item.location_level_1, "Haus A");
     assert.equal(item.location_level_4, "Kueche");
@@ -74,7 +74,7 @@ async function runRestarbeitenDataModelTests(run) {
 
   await run("Foto-Regeln inkl. primary und max 3", async () => withTemp(({ db, repo }) => {
     const conn = db.initDatabase();
-    conn.prepare("INSERT INTO projects (id, title) VALUES (?, ?)").run("p1", "P1");
+    conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p1", "P1");
     const item = repo.createRestarbeitItem({ project_id: "p1", short_text: "R1" });
     const a1 = repo.addRestarbeitAttachment({ restarbeit_id: item.id, project_id: "p1", file_path: "/a.jpg" });
     assert.equal(a1.is_primary, 1);

--- a/scripts/tests/restarbeitenDataModel.test.cjs
+++ b/scripts/tests/restarbeitenDataModel.test.cjs
@@ -1,0 +1,95 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Module = require("node:module");
+
+async function withTemp(fn) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-restarbeiten-"));
+  const userDataPath = path.join(tmpRoot, "userData");
+  fs.mkdirSync(userDataPath, { recursive: true });
+  const originalLoad = Module._load;
+  Module._load = function patched(request, parent, isMain) {
+    if (request === "electron" && String(parent?.filename || "").endsWith(path.join("db", "database.js"))) {
+      return { app: { getPath: (n) => (n === "userData" ? userDataPath : ""), isPackaged: true } };
+    }
+    return originalLoad.apply(this, arguments);
+  };
+  try {
+    const dbPath = path.join(process.cwd(), "src/main/db/database.js");
+    const repoPath = path.join(process.cwd(), "src/main/db/restarbeitenRepo.js");
+    delete require.cache[require.resolve(dbPath)];
+    delete require.cache[require.resolve(repoPath)];
+    const db = require(dbPath);
+    const repo = require(repoPath);
+    return await fn({ db, repo });
+  } finally {
+    try { require(path.join(process.cwd(), "src/main/db/database.js")).closeDatabase(); } catch (_) {}
+    Module._load = originalLoad;
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+async function runRestarbeitenDataModelTests(run) {
+  await run("Restarbeiten Schema wird angelegt", async () => withTemp(({ db }) => {
+    const conn = db.initDatabase();
+    for (const t of ["restarbeiten_items", "restarbeiten_project_settings", "restarbeiten_attachments"]) {
+      assert.ok(conn.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(t));
+    }
+    const cols = conn.prepare("PRAGMA table_info(restarbeiten_items)").all().map((c) => c.name);
+    ["project_id","running_number","location_level_1","location_level_2","location_level_3","location_level_4","short_text","long_text","status","due_date","responsible_project_firm_id","responsible_label","archived_at","created_at","updated_at"].forEach((c)=>assert.ok(cols.includes(c)));
+    const aCols = conn.prepare("PRAGMA table_info(restarbeiten_attachments)").all().map((c) => c.name);
+    ["restarbeit_id","file_path","thumbnail_path","sort_order","is_primary"].forEach((c)=>assert.ok(aCols.includes(c)));
+  }));
+
+  await run("Projektbezug und running_number je Projekt", async () => withTemp(({ db, repo }) => {
+    const conn = db.initDatabase();
+    conn.prepare("INSERT INTO projects (id, title) VALUES (?, ?)").run("p1", "P1");
+    conn.prepare("INSERT INTO projects (id, title) VALUES (?, ?)").run("p2", "P2");
+    repo.createRestarbeitItem({ project_id: "p1", short_text: "A" });
+    repo.createRestarbeitItem({ project_id: "p1", short_text: "B" });
+    repo.createRestarbeitItem({ project_id: "p2", short_text: "C" });
+    const p1 = repo.listRestarbeitItems("p1");
+    assert.equal(p1.length, 2);
+    assert.deepEqual(p1.map((x) => x.running_number), [1,2]);
+    assert.equal(repo.listRestarbeitItems("p2")[0].running_number, 1);
+  }));
+
+  await run("Verortung und Settings", async () => withTemp(({ db, repo }) => {
+    const conn = db.initDatabase();
+    conn.prepare("INSERT INTO projects (id, title) VALUES (?, ?)").run("p1", "P1");
+    conn.prepare("INSERT INTO projects (id, title) VALUES (?, ?)").run("p2", "P2");
+    const item = repo.createRestarbeitItem({ project_id: "p1", location_level_1: "Haus A", location_level_2: "EG", location_level_3: "WE 1", location_level_4: "Kueche", status: "unbekannt" });
+    assert.equal(item.location_level_1, "Haus A");
+    assert.equal(item.location_level_4, "Kueche");
+    assert.equal(item.status, "offen");
+    const s1 = repo.getRestarbeitProjectSettings("p1");
+    const s2 = repo.getRestarbeitProjectSettings("p2");
+    assert.equal(s1.level_1_label, "Haus");
+    assert.equal(s1.level_2_label, "Geschoss");
+    assert.equal(s1.level_3_label, "Einheit");
+    assert.equal(s1.level_4_label, "Raum");
+    assert.notEqual(s1.project_id, s2.project_id);
+  }));
+
+  await run("Foto-Regeln inkl. primary und max 3", async () => withTemp(({ db, repo }) => {
+    const conn = db.initDatabase();
+    conn.prepare("INSERT INTO projects (id, title) VALUES (?, ?)").run("p1", "P1");
+    const item = repo.createRestarbeitItem({ project_id: "p1", short_text: "R1" });
+    const a1 = repo.addRestarbeitAttachment({ restarbeit_id: item.id, project_id: "p1", file_path: "/a.jpg" });
+    assert.equal(a1.is_primary, 1);
+    const a2 = repo.addRestarbeitAttachment({ restarbeit_id: item.id, project_id: "p1", file_path: "/b.jpg", sort_order: 2 });
+    const a3 = repo.addRestarbeitAttachment({ restarbeit_id: item.id, project_id: "p1", file_path: "/c.jpg", sort_order: 3, is_primary: true });
+    const list1 = repo.listRestarbeitAttachments(item.id);
+    assert.equal(list1.length, 3);
+    assert.equal(list1.filter((x) => x.is_primary === 1).length, 1);
+    assert.equal(list1[0].id, a3.id);
+    assert.throws(() => repo.addRestarbeitAttachment({ restarbeit_id: item.id, project_id: "p1", file_path: "/d.jpg" }), /max 3/);
+    repo.setPrimaryRestarbeitAttachment(item.id, a2.id);
+    const list2 = repo.listRestarbeitAttachments(item.id);
+    assert.equal(list2[0].id, a2.id);
+    assert.equal(list2.filter((x) => x.is_primary === 1).length, 1);
+  }));
+}
+
+module.exports = { runRestarbeitenDataModelTests };

--- a/src/main/db/database.js
+++ b/src/main/db/database.js
@@ -1260,6 +1260,151 @@ function ensureLicenseAdminSchema(dbConn) {
   }
 }
 
+
+function ensureRestarbeitenSchema(dbConn) {
+  if (!tableExists(dbConn, "restarbeiten_items")) {
+    dbConn.exec(`
+      CREATE TABLE IF NOT EXISTS restarbeiten_items (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        running_number INTEGER NOT NULL,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        location_level_1 TEXT,
+        location_level_2 TEXT,
+        location_level_3 TEXT,
+        location_level_4 TEXT,
+        short_text TEXT NOT NULL DEFAULT '',
+        long_text TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'offen',
+        due_date TEXT,
+        responsible_project_firm_id TEXT,
+        responsible_label TEXT,
+        source TEXT NOT NULL DEFAULT 'desktop',
+        import_batch_id TEXT,
+        archived_at TEXT,
+        completed_at TEXT,
+        verified_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+        FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+        FOREIGN KEY (responsible_project_firm_id) REFERENCES project_firms(id) ON DELETE SET NULL
+      );
+    `);
+  } else {
+    const addCol = (name, sqlType) => {
+      if (!columnExists(dbConn, "restarbeiten_items", name)) {
+        dbConn.exec(`ALTER TABLE restarbeiten_items ADD COLUMN ${name} ${sqlType};`);
+      }
+    };
+
+    addCol("project_id", "TEXT");
+    addCol("running_number", "INTEGER");
+    addCol("sort_order", "INTEGER NOT NULL DEFAULT 0");
+    addCol("location_level_1", "TEXT");
+    addCol("location_level_2", "TEXT");
+    addCol("location_level_3", "TEXT");
+    addCol("location_level_4", "TEXT");
+    addCol("short_text", "TEXT NOT NULL DEFAULT ''");
+    addCol("long_text", "TEXT NOT NULL DEFAULT ''");
+    addCol("status", "TEXT NOT NULL DEFAULT 'offen'");
+    addCol("due_date", "TEXT");
+    addCol("responsible_project_firm_id", "TEXT");
+    addCol("responsible_label", "TEXT");
+    addCol("source", "TEXT NOT NULL DEFAULT 'desktop'");
+    addCol("import_batch_id", "TEXT");
+    addCol("archived_at", "TEXT");
+    addCol("completed_at", "TEXT");
+    addCol("verified_at", "TEXT");
+    addCol("created_at", "TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))");
+    addCol("updated_at", "TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))");
+  }
+
+  if (!tableExists(dbConn, "restarbeiten_project_settings")) {
+    dbConn.exec(`
+      CREATE TABLE IF NOT EXISTS restarbeiten_project_settings (
+        project_id TEXT PRIMARY KEY,
+        level_1_label TEXT NOT NULL DEFAULT 'Haus',
+        level_2_label TEXT NOT NULL DEFAULT 'Geschoss',
+        level_3_label TEXT NOT NULL DEFAULT 'Einheit',
+        level_4_label TEXT NOT NULL DEFAULT 'Raum',
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+        FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+      );
+    `);
+  } else {
+    const addCol = (name, sqlType) => {
+      if (!columnExists(dbConn, "restarbeiten_project_settings", name)) {
+        dbConn.exec(`ALTER TABLE restarbeiten_project_settings ADD COLUMN ${name} ${sqlType};`);
+      }
+    };
+
+    addCol("project_id", "TEXT");
+    addCol("level_1_label", "TEXT NOT NULL DEFAULT 'Haus'");
+    addCol("level_2_label", "TEXT NOT NULL DEFAULT 'Geschoss'");
+    addCol("level_3_label", "TEXT NOT NULL DEFAULT 'Einheit'");
+    addCol("level_4_label", "TEXT NOT NULL DEFAULT 'Raum'");
+    addCol("created_at", "TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))");
+    addCol("updated_at", "TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))");
+  }
+
+  if (!tableExists(dbConn, "restarbeiten_attachments")) {
+    dbConn.exec(`
+      CREATE TABLE IF NOT EXISTS restarbeiten_attachments (
+        id TEXT PRIMARY KEY,
+        restarbeit_id TEXT NOT NULL,
+        project_id TEXT NOT NULL,
+        file_path TEXT NOT NULL,
+        thumbnail_path TEXT,
+        file_name TEXT,
+        original_file_name TEXT,
+        mime_type TEXT,
+        caption TEXT,
+        sort_order INTEGER NOT NULL DEFAULT 1,
+        is_primary INTEGER NOT NULL DEFAULT 0,
+        source TEXT NOT NULL DEFAULT 'desktop',
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+        FOREIGN KEY (restarbeit_id) REFERENCES restarbeiten_items(id) ON DELETE CASCADE,
+        FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+      );
+    `);
+  } else {
+    const addCol = (name, sqlType) => {
+      if (!columnExists(dbConn, "restarbeiten_attachments", name)) {
+        dbConn.exec(`ALTER TABLE restarbeiten_attachments ADD COLUMN ${name} ${sqlType};`);
+      }
+    };
+
+    addCol("restarbeit_id", "TEXT");
+    addCol("project_id", "TEXT");
+    addCol("file_path", "TEXT");
+    addCol("thumbnail_path", "TEXT");
+    addCol("file_name", "TEXT");
+    addCol("original_file_name", "TEXT");
+    addCol("mime_type", "TEXT");
+    addCol("caption", "TEXT");
+    addCol("sort_order", "INTEGER NOT NULL DEFAULT 1");
+    addCol("is_primary", "INTEGER NOT NULL DEFAULT 0");
+    addCol("source", "TEXT NOT NULL DEFAULT 'desktop'");
+    addCol("created_at", "TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))");
+    addCol("updated_at", "TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))");
+  }
+
+  dbConn.exec(`
+    CREATE INDEX IF NOT EXISTS idx_restarbeiten_items_project_id ON restarbeiten_items(project_id);
+    CREATE INDEX IF NOT EXISTS idx_restarbeiten_items_project_status ON restarbeiten_items(project_id, status);
+    CREATE INDEX IF NOT EXISTS idx_restarbeiten_items_project_due_date ON restarbeiten_items(project_id, due_date);
+    CREATE INDEX IF NOT EXISTS idx_restarbeiten_items_project_archive ON restarbeiten_items(project_id, archived_at);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_restarbeiten_items_project_running_number ON restarbeiten_items(project_id, running_number);
+    CREATE INDEX IF NOT EXISTS idx_restarbeiten_attachments_restarbeit_id ON restarbeiten_attachments(restarbeit_id);
+    CREATE INDEX IF NOT EXISTS idx_restarbeiten_attachments_project_id ON restarbeiten_attachments(project_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_restarbeiten_attachments_one_primary
+    ON restarbeiten_attachments(restarbeit_id)
+    WHERE is_primary = 1;
+  `);
+}
+
 function ensureDictionarySchema(dbConn) {
   if (!tableExists(dbConn, "dictionary_suggestions")) {
     dbConn.exec(`
@@ -1611,6 +1756,7 @@ function ensureSchema(dbConn) {
 
   ensureDictionarySchema(dbConn);
   ensureTableLayoutsSchema(dbConn);
+  ensureRestarbeitenSchema(dbConn);
   ensureAppSettingsSchema(dbConn);
   ensureLicenseAdminSchema(dbConn);
 }

--- a/src/main/db/restarbeitenRepo.js
+++ b/src/main/db/restarbeitenRepo.js
@@ -1,0 +1,194 @@
+const crypto = require("node:crypto");
+const { initDatabase } = require("./database");
+
+const ALLOWED_STATUS = new Set([
+  "offen",
+  "in_arbeit",
+  "erledigt_gemeldet",
+  "geprueft_erledigt",
+  "zurueckgewiesen",
+]);
+
+function toText(value) {
+  if (value == null) return null;
+  const out = String(value).trim();
+  return out || null;
+}
+
+function reqText(value, name) {
+  const out = toText(value);
+  if (!out) throw new Error(`${name} required`);
+  return out;
+}
+
+function normalizeStatus(value) {
+  const clean = toText(value);
+  if (!clean) return "offen";
+  return ALLOWED_STATUS.has(clean) ? clean : "offen";
+}
+
+function ensureRestarbeitProjectSettings(projectId) {
+  const db = initDatabase();
+  const pid = reqText(projectId, "projectId");
+  db.prepare(`
+    INSERT INTO restarbeiten_project_settings (project_id)
+    VALUES (?)
+    ON CONFLICT(project_id) DO NOTHING
+  `).run(pid);
+}
+
+function getRestarbeitProjectSettings(projectId) {
+  const db = initDatabase();
+  const pid = reqText(projectId, "projectId");
+  ensureRestarbeitProjectSettings(pid);
+  return db.prepare(`SELECT * FROM restarbeiten_project_settings WHERE project_id = ?`).get(pid);
+}
+
+function createRestarbeitItem(payload = {}) {
+  const db = initDatabase();
+  const pid = reqText(payload.project_id, "project_id");
+  const now = new Date().toISOString();
+  const nextRunning = db
+    .prepare(`SELECT COALESCE(MAX(running_number), 0) + 1 AS next_no FROM restarbeiten_items WHERE project_id = ?`)
+    .get(pid)?.next_no;
+  const runningNumber = Number.isInteger(payload.running_number) && payload.running_number > 0
+    ? payload.running_number
+    : nextRunning;
+
+  const id = toText(payload.id) || crypto.randomUUID();
+  const sortOrder = Number.isFinite(Number(payload.sort_order)) ? Number(payload.sort_order) : 0;
+  const data = {
+    id,
+    project_id: pid,
+    running_number: runningNumber,
+    sort_order: sortOrder,
+    location_level_1: toText(payload.location_level_1),
+    location_level_2: toText(payload.location_level_2),
+    location_level_3: toText(payload.location_level_3),
+    location_level_4: toText(payload.location_level_4),
+    short_text: toText(payload.short_text) || "",
+    long_text: toText(payload.long_text) || "",
+    status: normalizeStatus(payload.status),
+    due_date: toText(payload.due_date),
+    responsible_project_firm_id: toText(payload.responsible_project_firm_id),
+    responsible_label: toText(payload.responsible_label),
+    source: toText(payload.source) || "desktop",
+    import_batch_id: toText(payload.import_batch_id),
+    archived_at: toText(payload.archived_at),
+    completed_at: toText(payload.completed_at),
+    verified_at: toText(payload.verified_at),
+    created_at: now,
+    updated_at: now,
+  };
+
+  db.prepare(`
+    INSERT INTO restarbeiten_items (
+      id, project_id, running_number, sort_order,
+      location_level_1, location_level_2, location_level_3, location_level_4,
+      short_text, long_text, status, due_date,
+      responsible_project_firm_id, responsible_label, source, import_batch_id,
+      archived_at, completed_at, verified_at, created_at, updated_at
+    ) VALUES (
+      @id, @project_id, @running_number, @sort_order,
+      @location_level_1, @location_level_2, @location_level_3, @location_level_4,
+      @short_text, @long_text, @status, @due_date,
+      @responsible_project_firm_id, @responsible_label, @source, @import_batch_id,
+      @archived_at, @completed_at, @verified_at, @created_at, @updated_at
+    )
+  `).run(data);
+  return db.prepare(`SELECT * FROM restarbeiten_items WHERE id = ?`).get(id);
+}
+
+function listRestarbeitItems(projectId, { includeArchived = false } = {}) {
+  const db = initDatabase();
+  const pid = reqText(projectId, "projectId");
+  const where = includeArchived ? "" : "AND archived_at IS NULL";
+  return db.prepare(`
+    SELECT * FROM restarbeiten_items
+    WHERE project_id = ? ${where}
+    ORDER BY sort_order ASC, running_number ASC, created_at ASC
+  `).all(pid);
+}
+
+function addRestarbeitAttachment(payload = {}) {
+  const db = initDatabase();
+  const restarbeitId = reqText(payload.restarbeit_id, "restarbeit_id");
+  const projectId = reqText(payload.project_id, "project_id");
+  const filePath = reqText(payload.file_path, "file_path");
+
+  const count = db.prepare(`SELECT COUNT(*) AS c FROM restarbeiten_attachments WHERE restarbeit_id = ?`).get(restarbeitId)?.c || 0;
+  if (count >= 3) throw new Error("max 3 attachments per restarbeit");
+
+  const hasPrimary = db.prepare(`SELECT 1 FROM restarbeiten_attachments WHERE restarbeit_id = ? AND is_primary = 1 LIMIT 1`).get(restarbeitId);
+  const shouldPrimary = count === 0 ? 1 : (payload.is_primary ? 1 : 0);
+  const id = toText(payload.id) || crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  const tx = db.transaction(() => {
+    if (shouldPrimary || !hasPrimary) {
+      db.prepare(`UPDATE restarbeiten_attachments SET is_primary = 0, updated_at = ? WHERE restarbeit_id = ?`).run(now, restarbeitId);
+    }
+    db.prepare(`
+      INSERT INTO restarbeiten_attachments (
+        id, restarbeit_id, project_id, file_path, thumbnail_path, file_name,
+        original_file_name, mime_type, caption, sort_order, is_primary, source, created_at, updated_at
+      ) VALUES (
+        @id, @restarbeit_id, @project_id, @file_path, @thumbnail_path, @file_name,
+        @original_file_name, @mime_type, @caption, @sort_order, @is_primary, @source, @created_at, @updated_at
+      )
+    `).run({
+      id,
+      restarbeit_id: restarbeitId,
+      project_id: projectId,
+      file_path: filePath,
+      thumbnail_path: toText(payload.thumbnail_path),
+      file_name: toText(payload.file_name),
+      original_file_name: toText(payload.original_file_name),
+      mime_type: toText(payload.mime_type),
+      caption: toText(payload.caption),
+      sort_order: Number.isFinite(Number(payload.sort_order)) ? Number(payload.sort_order) : 1,
+      is_primary: shouldPrimary,
+      source: toText(payload.source) || "desktop",
+      created_at: now,
+      updated_at: now,
+    });
+  });
+
+  tx();
+  return db.prepare(`SELECT * FROM restarbeiten_attachments WHERE id = ?`).get(id);
+}
+
+function setPrimaryRestarbeitAttachment(restarbeitId, attachmentId) {
+  const db = initDatabase();
+  const rid = reqText(restarbeitId, "restarbeitId");
+  const aid = reqText(attachmentId, "attachmentId");
+  const now = new Date().toISOString();
+  const found = db.prepare(`SELECT id FROM restarbeiten_attachments WHERE id = ? AND restarbeit_id = ?`).get(aid, rid);
+  if (!found) throw new Error("attachment not found");
+
+  const tx = db.transaction(() => {
+    db.prepare(`UPDATE restarbeiten_attachments SET is_primary = 0, updated_at = ? WHERE restarbeit_id = ?`).run(now, rid);
+    db.prepare(`UPDATE restarbeiten_attachments SET is_primary = 1, updated_at = ? WHERE id = ?`).run(now, aid);
+  });
+  tx();
+}
+
+function listRestarbeitAttachments(restarbeitId) {
+  const db = initDatabase();
+  const rid = reqText(restarbeitId, "restarbeitId");
+  return db.prepare(`
+    SELECT * FROM restarbeiten_attachments
+    WHERE restarbeit_id = ?
+    ORDER BY is_primary DESC, sort_order ASC, created_at ASC
+  `).all(rid);
+}
+
+module.exports = {
+  ensureRestarbeitProjectSettings,
+  getRestarbeitProjectSettings,
+  createRestarbeitItem,
+  listRestarbeitItems,
+  addRestarbeitAttachment,
+  setPrimaryRestarbeitAttachment,
+  listRestarbeitAttachments,
+};


### PR DESCRIPTION
### Motivation
- Vorbereitung des Datenmodells für das Fachmodul `restarbeiten`, damit spätere UI-/Foto-/Import-Funktionen auf einer stabilen DB-/Repo-Basis aufbauen können.
- Änderungen klein und risikoarm halten: nur DB-Schema, minimale Repository-API und Tests, keine UI/IPC/Build- oder Dependency-Änderungen.

### Description
- Ergänzt `ensureRestarbeitenSchema(dbConn)` in `src/main/db/database.js` und in `ensureSchema(dbConn)` registriert, mit den Tabellen `restarbeiten_items`, `restarbeiten_project_settings` und `restarbeiten_attachments`, den geforderten Spalten, Foreign Keys und Indizes (inkl. eindeutiger Index `project_id+running_number` und Partial-Index für genau ein `is_primary=1`).
- Neu: `src/main/db/restarbeitenRepo.js` mit Funktionen `ensureRestarbeitProjectSettings`, `getRestarbeitProjectSettings`, `createRestarbeitItem`, `listRestarbeitItems`, `addRestarbeitAttachment`, `setPrimaryRestarbeitAttachment`, `listRestarbeitAttachments`; enthält Status-Normalisierung und Foto-Regeln (max. 3 Anhänge, erstes Bild auto-primary, Umschalten primary).
- Tests: Neue Testdatei `scripts/tests/restarbeitenDataModel.test.cjs` angelegt und in `scripts/test.cjs` eingebunden, um Schema-, Projektbezug-, Verortungs- und Foto-Regeln zu prüfen.
- Kleine Planpflege: `docs/MODULARISIERUNGSPLAN.md` um M3-Notiz ergänzt.

### Testing
- `npm test` ausgeführt; die Test-Suite startete und viele bestehende Unit-Tests liefen erfolgreich in dieser Umgebung.
- DB-gebundene Tests (inkl. der neuen Restarbeiten-Tests) konnten in dieser Cloud-Umgebung nicht vollständig grün ausgeführt werden wegen eines nativen Modul-/Node-ABI-Problems mit `better-sqlite3` (`NODE_MODULE_VERSION`-Mismatch / `Module did not self-register`), wodurch die DB-Initialisierung fehlschlug; das ist ein Umgebungs-/Rebuild-Problem, nicht direkt ein Code-Designfehler.
- Resultat: Tests wurden ausgeführt, viele bestehende JS-Tests OK, die neuen DB-Tests sind vorhanden, konnten aber hier wegen des `better-sqlite3`-Abi-Problems nicht validiert und sollten in einer kompatiblen Umgebung oder nach Rebuild von nativen Modulen erneut geprüft.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a079b98c81883229e63ea0678ca9d91)