### PR TITLE
Run tests under Electron Node runtime to stabilize native modules

### DIFF
--- a/ZUERST_LESEN_Codex.md
+++ b/ZUERST_LESEN_Codex.md
@@ -912,3 +912,12 @@ Ein wesentlicher Zielzustand ist erst dann erreicht, wenn der Modulrahmen fachli
 Die dafür nötige Freigabelogik gehört in den App-Kern und den Modulrahmen. Die Fachlogik bleibt in den Modulen.
 
 
+
+---
+
+## Testlaufzeit-Hinweis (native Electron-Abhängigkeiten)
+
+- Der offizielle Testlauf ist `npm test`.
+- `npm test` läuft über Electron im Node-Modus (`ELECTRON_RUN_AS_NODE=1`).
+- Grund: Native Electron-Abhängigkeiten wie `better-sqlite3` müssen mit passender ABI geladen werden.
+- Nicht manuell zwischen Node- und Electron-Rebuilds für denselben Standard-Testlauf hin- und herschalten.

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "start:raw": "set ELECTRON_RUN_AS_NODE=&& electron .",
     "pack": "electron-builder --dir",
     "dist": "node scripts/dist.cjs",
-    "test": "node scripts/test.cjs",
+    "test": "node scripts/runElectronNodeTest.cjs",
     "lint": "eslint \"src/**/*.js\"",
     "lint:fix": "eslint \"src/**/*.js\" --fix",
     "fix:electron-deps": "electron-builder install-app-deps",
-    "postinstall": "electron-builder install-app-deps"
+    "postinstall": "electron-builder install-app-deps",
+    "test:node": "node scripts/test.cjs"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/scripts/runElectronNodeTest.cjs
+++ b/scripts/runElectronNodeTest.cjs
@@ -1,0 +1,34 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const isWindows = process.platform === "win32";
+const electronBinary = path.resolve(
+  __dirname,
+  "..",
+  "node_modules",
+  ".bin",
+  isWindows ? "electron.cmd" : "electron",
+);
+
+if (!fs.existsSync(electronBinary)) {
+  console.error(`Fehler: Electron-Binary nicht gefunden unter ${electronBinary}`);
+  process.exit(1);
+}
+
+const testScript = path.resolve(__dirname, "test.cjs");
+const child = spawnSync(electronBinary, [testScript], {
+  env: {
+    ...process.env,
+    ELECTRON_RUN_AS_NODE: "1",
+  },
+  stdio: "inherit",
+});
+
+if (child.error) {
+  console.error("Fehler: Testlauf mit Electron konnte nicht gestartet werden.");
+  console.error(child.error?.message || child.error);
+  process.exit(1);
+}
+
+process.exit(typeof child.status === "number" ? child.status : 1);

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -49,6 +49,7 @@ const { runLicenseFeatureGuardTests } = require("./tests/licenseFeatureGuards.te
 const { runLicenseStandardFeaturesTests } = require("./tests/licenseStandardFeatures.test.cjs");
 const { runFeatureGuardEnforcementTests } = require("./tests/featureGuardEnforcement.test.cjs");
 const { runLicensePresentationTests } = require("./tests/licensePresentation.test.cjs");
+const { runNativeTestRuntimeTests } = require("./tests/nativeTestRuntime.test.cjs");
 
 let failed = false;
 
@@ -144,6 +145,7 @@ async function main() {
   await runLicenseStandardFeaturesTests(run); 
   await runFeatureGuardEnforcementTests(run); 
   await runLicensePresentationTests(run); 
+  await runNativeTestRuntimeTests(run);
 
   if (failed) {
     process.exitCode = 1;

--- a/scripts/tests/licenseStorageBootstrap.test.cjs
+++ b/scripts/tests/licenseStorageBootstrap.test.cjs
@@ -17,9 +17,12 @@ function withMockedLicenseStorage({ userDataSetup, resourcesSetup }, fn) {
   if (typeof resourcesSetup === 'function') resourcesSetup({ userDataPath, resourcesPath, appPath });
 
   const originalLoad = Module._load;
-  const hadResourcesPath = Object.prototype.hasOwnProperty.call(process, 'resourcesPath');
-  const originalResourcesPath = process.resourcesPath;
-  process.resourcesPath = resourcesPath;
+  const originalResourcesPathDescriptor = Object.getOwnPropertyDescriptor(process, 'resourcesPath');
+  Object.defineProperty(process, 'resourcesPath', {
+    value: resourcesPath,
+    configurable: true,
+    writable: true,
+  });
 
   Module._load = function patched(request, parent, isMain) {
     if (request === 'electron' && String(parent?.filename || '').endsWith('licenseStorage.js')) {
@@ -44,14 +47,10 @@ function withMockedLicenseStorage({ userDataSetup, resourcesSetup }, fn) {
     return fn({ mod, userDataPath, resourcesPath });
   } finally {
     Module._load = originalLoad;
-    if (hadResourcesPath) {
-      process.resourcesPath = originalResourcesPath;
+    if (originalResourcesPathDescriptor) {
+      Object.defineProperty(process, 'resourcesPath', originalResourcesPathDescriptor);
     } else {
-      try {
-        delete process.resourcesPath;
-      } catch {
-        process.resourcesPath = undefined;
-      }
+      delete process.resourcesPath;
     }
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   }

--- a/scripts/tests/licenseStorageBootstrap.test.cjs
+++ b/scripts/tests/licenseStorageBootstrap.test.cjs
@@ -17,6 +17,10 @@ function withMockedLicenseStorage({ userDataSetup, resourcesSetup }, fn) {
   if (typeof resourcesSetup === 'function') resourcesSetup({ userDataPath, resourcesPath, appPath });
 
   const originalLoad = Module._load;
+  const hadResourcesPath = Object.prototype.hasOwnProperty.call(process, 'resourcesPath');
+  const originalResourcesPath = process.resourcesPath;
+  process.resourcesPath = resourcesPath;
+
   Module._load = function patched(request, parent, isMain) {
     if (request === 'electron' && String(parent?.filename || '').endsWith('licenseStorage.js')) {
       return {
@@ -40,6 +44,15 @@ function withMockedLicenseStorage({ userDataSetup, resourcesSetup }, fn) {
     return fn({ mod, userDataPath, resourcesPath });
   } finally {
     Module._load = originalLoad;
+    if (hadResourcesPath) {
+      process.resourcesPath = originalResourcesPath;
+    } else {
+      try {
+        delete process.resourcesPath;
+      } catch {
+        process.resourcesPath = undefined;
+      }
+    }
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   }
 }

--- a/scripts/tests/nativeTestRuntime.test.cjs
+++ b/scripts/tests/nativeTestRuntime.test.cjs
@@ -1,0 +1,31 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function runNativeTestRuntimeTests(run) {
+  run("Native Test Runtime: package scripts und Wrapper bleiben stabil", () => {
+    const repoRoot = path.resolve(__dirname, "..", "..");
+    const packageJsonPath = path.join(repoRoot, "package.json");
+    const wrapperPath = path.join(repoRoot, "scripts", "runElectronNodeTest.cjs");
+
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    const wrapperContent = fs.readFileSync(wrapperPath, "utf8");
+
+    assert.ok(pkg.scripts?.test, "package.json scripts.test fehlt");
+    assert.equal(pkg.scripts.test, "node scripts/runElectronNodeTest.cjs");
+    assert.notEqual(pkg.scripts.test, "node scripts/test.cjs");
+
+    assert.ok(pkg.scripts?.["test:node"], "package.json scripts.test:node fehlt");
+    assert.equal(pkg.scripts["test:node"], "node scripts/test.cjs");
+
+    assert.match(wrapperContent, /ELECTRON_RUN_AS_NODE/);
+    assert.match(wrapperContent, /test\.cjs/);
+    assert.doesNotMatch(wrapperContent, /require\(["']better-sqlite3["']\)/);
+    assert.doesNotMatch(wrapperContent, /electron-builder install-app-deps/);
+
+    assert.equal(pkg.scripts.postinstall, "electron-builder install-app-deps");
+    assert.equal(pkg.scripts["fix:electron-deps"], "electron-builder install-app-deps");
+  });
+}
+
+module.exports = { runNativeTestRuntimeTests };


### PR DESCRIPTION
### Motivation
- Tests were running under plain Node and caused `better-sqlite3` ABI/`NODE_MODULE_VERSION` mismatches for native Electron modules, so the standard `npm test` must run with Electron's Node runtime.

### Description
- Add `scripts/runElectronNodeTest.cjs`, a CommonJS wrapper that locates the local Electron binary (`node_modules/.bin/electron` / `.cmd`), sets `ELECTRON_RUN_AS_NODE=1`, spawns `electron scripts/test.cjs` with `spawnSync` and `stdio: "inherit"`, and forwards child exit codes and clear error messages.
- Update `package.json` to set `test` to `node scripts/runElectronNodeTest.cjs` and add `test:node` as `node scripts/test.cjs`, while leaving `postinstall` and `fix:electron-deps` unchanged.
- Add a static protection test `scripts/tests/nativeTestRuntime.test.cjs` and wire it into `scripts/test.cjs`; the test statically verifies the `package.json` scripts and wrapper contents without executing the wrapper or requiring native modules.
- Add a short guidance note to `ZUERST_LESEN_Codex.md` that `npm test` runs over Electron in Node-mode and why (native ABI stability), and avoid other changes such as dependency or package-lock updates.

### Testing
- Ran `npm test`, which invoked `node scripts/runElectronNodeTest.cjs` successfully and attempted to start the local Electron binary.  
- The wrapper ran but Electron aborted immediately in this CI environment due to a missing system library (`libatk-1.0.so.0`), so the full JS test suite could not complete.  
- The static protection test was added and designed to be executed by the test runner, but could not be observed here because Electron failed early; no changes were made to dependencies or `package-lock.json` during verification.  
- Result: wrapper and package changes behave as intended, but full test execution is blocked by missing native system libs in the environment (actionable note: install required GTK/ATK libs on the runner to run Electron end-to-end).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081e5a3794832283c41b991f5354a0)