### PR TITLE
M3.1: Add item_class (rest|mangel) to Restarbeiten data model

### DIFF
--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -242,5 +242,7 @@ Dabei gilt:
 
 ### M3 Restarbeiten-Datenmodell (neu)
 - Datenmodell vorbereitet: `restarbeiten_items`, `restarbeiten_project_settings`, `restarbeiten_attachments`.
+- Restarbeiten-Datenmodell enthaelt `item_class` mit den Werten `rest` und `mangel`; Default ist `rest`.
+- Darstellung von `item_class` in UI/PDF folgt in einem spaeteren Schritt.
 - Fotoregeln in Repo-Basis vorbereitet: max. 3 je Restarbeit, genau ein Hauptfoto.
 - Bildverarbeitung folgt in spaeterem Schritt.

--- a/scripts/tests/restarbeitenDataModel.test.cjs
+++ b/scripts/tests/restarbeitenDataModel.test.cjs
@@ -37,7 +37,7 @@ async function runRestarbeitenDataModelTests(run) {
       assert.ok(conn.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(t));
     }
     const cols = conn.prepare("PRAGMA table_info(restarbeiten_items)").all().map((c) => c.name);
-    ["project_id","running_number","location_level_1","location_level_2","location_level_3","location_level_4","short_text","long_text","status","due_date","responsible_project_firm_id","responsible_label","archived_at","created_at","updated_at"].forEach((c)=>assert.ok(cols.includes(c)));
+    ["project_id","running_number","location_level_1","location_level_2","location_level_3","location_level_4","short_text","long_text","item_class","status","due_date","responsible_project_firm_id","responsible_label","archived_at","created_at","updated_at"].forEach((c)=>assert.ok(cols.includes(c)));
     const aCols = conn.prepare("PRAGMA table_info(restarbeiten_attachments)").all().map((c) => c.name);
     ["restarbeit_id","file_path","thumbnail_path","sort_order","is_primary"].forEach((c)=>assert.ok(aCols.includes(c)));
   }));
@@ -70,6 +70,29 @@ async function runRestarbeitenDataModelTests(run) {
     assert.equal(s1.level_3_label, "Einheit");
     assert.equal(s1.level_4_label, "Raum");
     assert.notEqual(s1.project_id, s2.project_id);
+  }));
+
+  await run("item_class default, akzeptierte Werte und Normalisierung", async () => withTemp(({ db, repo }) => {
+    const conn = db.initDatabase();
+    conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p1", "P1");
+
+    const d = repo.createRestarbeitItem({ project_id: "p1", short_text: "Default" });
+    const m = repo.createRestarbeitItem({ project_id: "p1", short_text: "Mangel", item_class: "mangel" });
+    const upperM = repo.createRestarbeitItem({ project_id: "p1", short_text: "Upper", item_class: "MANGEL" });
+    const mixedR = repo.createRestarbeitItem({ project_id: "p1", short_text: "Mixed", item_class: "Rest" });
+    const invalid = repo.createRestarbeitItem({ project_id: "p1", short_text: "Invalid", item_class: "abc" });
+    const empty = repo.createRestarbeitItem({ project_id: "p1", short_text: "Empty", item_class: "   " });
+
+    assert.equal(d.item_class, "rest");
+    assert.equal(m.item_class, "mangel");
+    assert.equal(upperM.item_class, "mangel");
+    assert.equal(mixedR.item_class, "rest");
+    assert.equal(invalid.item_class, "rest");
+    assert.equal(empty.item_class, "rest");
+
+    const list = repo.listRestarbeitItems("p1");
+    assert.ok(list.every((row) => typeof row.item_class === "string"));
+    assert.equal(list.find((row) => row.id === m.id)?.item_class, "mangel");
   }));
 
   await run("Foto-Regeln inkl. primary und max 3", async () => withTemp(({ db, repo }) => {

--- a/src/main/db/database.js
+++ b/src/main/db/database.js
@@ -1275,6 +1275,7 @@ function ensureRestarbeitenSchema(dbConn) {
         location_level_4 TEXT,
         short_text TEXT NOT NULL DEFAULT '',
         long_text TEXT NOT NULL DEFAULT '',
+        item_class TEXT NOT NULL DEFAULT 'rest',
         status TEXT NOT NULL DEFAULT 'offen',
         due_date TEXT,
         responsible_project_firm_id TEXT,
@@ -1306,6 +1307,7 @@ function ensureRestarbeitenSchema(dbConn) {
     addCol("location_level_4", "TEXT");
     addCol("short_text", "TEXT NOT NULL DEFAULT ''");
     addCol("long_text", "TEXT NOT NULL DEFAULT ''");
+    addCol("item_class", "TEXT NOT NULL DEFAULT 'rest'");
     addCol("status", "TEXT NOT NULL DEFAULT 'offen'");
     addCol("due_date", "TEXT");
     addCol("responsible_project_firm_id", "TEXT");

--- a/src/main/db/restarbeitenRepo.js
+++ b/src/main/db/restarbeitenRepo.js
@@ -8,6 +8,7 @@ const ALLOWED_STATUS = new Set([
   "geprueft_erledigt",
   "zurueckgewiesen",
 ]);
+const ALLOWED_ITEM_CLASSES = new Set(["rest", "mangel"]);
 
 function toText(value) {
   if (value == null) return null;
@@ -25,6 +26,13 @@ function normalizeStatus(value) {
   const clean = toText(value);
   if (!clean) return "offen";
   return ALLOWED_STATUS.has(clean) ? clean : "offen";
+}
+
+function normalizeRestarbeitItemClass(value) {
+  const clean = toText(value);
+  if (!clean) return "rest";
+  const normalized = clean.toLowerCase();
+  return ALLOWED_ITEM_CLASSES.has(normalized) ? normalized : "rest";
 }
 
 function ensureRestarbeitProjectSettings(projectId) {
@@ -68,6 +76,7 @@ function createRestarbeitItem(payload = {}) {
     location_level_4: toText(payload.location_level_4),
     short_text: toText(payload.short_text) || "",
     long_text: toText(payload.long_text) || "",
+    item_class: normalizeRestarbeitItemClass(payload.item_class),
     status: normalizeStatus(payload.status),
     due_date: toText(payload.due_date),
     responsible_project_firm_id: toText(payload.responsible_project_firm_id),
@@ -85,13 +94,13 @@ function createRestarbeitItem(payload = {}) {
     INSERT INTO restarbeiten_items (
       id, project_id, running_number, sort_order,
       location_level_1, location_level_2, location_level_3, location_level_4,
-      short_text, long_text, status, due_date,
+      short_text, long_text, item_class, status, due_date,
       responsible_project_firm_id, responsible_label, source, import_batch_id,
       archived_at, completed_at, verified_at, created_at, updated_at
     ) VALUES (
       @id, @project_id, @running_number, @sort_order,
       @location_level_1, @location_level_2, @location_level_3, @location_level_4,
-      @short_text, @long_text, @status, @due_date,
+      @short_text, @long_text, @item_class, @status, @due_date,
       @responsible_project_firm_id, @responsible_label, @source, @import_batch_id,
       @archived_at, @completed_at, @verified_at, @created_at, @updated_at
     )


### PR DESCRIPTION
### Motivation
- Restarbeiten benötigen eine einfache Klassifizierung (`rest` vs. `mangel`) im Datenmodell mit dem Default `rest` und defensiver Normalisierung, damit Repo- und Listenfunktionen konsistent mit diesem Feld arbeiten.

### Description
- Erweiterung der DB-Schemafunktion `ensureRestarbeitenSchema(dbConn)` um die Spalte `item_class TEXT NOT NULL DEFAULT 'rest'` sowohl im `CREATE TABLE`-Pfad als auch im `ALTER TABLE ... ADD COLUMN`-Pfad (Datei `src/main/db/database.js`).
- Im Repository (`src/main/db/restarbeitenRepo.js`) wurde `ALLOWED_ITEM_CLASSES` und `normalizeRestarbeitItemClass(value)` ergänzt und `createRestarbeitItem(payload)` schreibt jetzt `item_class` (case-insensitive Normalisierung, erlaubte Werte: `rest`, `mangel`, Fallback `rest`), wobei `listRestarbeitItems(...)` das Feld über `SELECT *` mitliefert.
- Tests wurden ergänzt/erweitert in `scripts/tests/restarbeitenDataModel.test.cjs` und prüfen Schema, Default-Verhalten, explizites `mangel`, Normalisierungen (`MANGEL`, `Rest`, ungültig, leer) sowie die Auslieferung von `item_class` durch die Listenfunktion.
- Kurze Planpflege in `docs/MODULARISIERUNGSPLAN.md` mit Hinweis auf das neue Feld und seine Werte.
- Änderungen sind auf dem Branch `m3-1-restarbeiten-item-class` committed.

### Testing
- Ich habe versucht `npm test` in der Arbeitsumgebung auszuführen; der Testlauf bricht in diesem Container ab, weil die native Electron-Systembibliothek fehlt (`error while loading shared libraries: libatk-1.0.so.0`).
- Die neuen/erweiterten Unit-Tests liegen in `scripts/tests/restarbeitenDataModel.test.cjs` und decken Schema-Prüfung, Default-, Normalisierungs- und Listenfälle ab; sie müssen in einer Umgebung mit funktionaler Electron-Umgebung (oder CI mit den nötigen systemlibs) ausgeführt, um grün bestätigt zu werden.
- Bestehende Restarbeiten-Tests wurden nicht entfernt und bleiben im Testfile erhalten; keine weiteren automatischen Tests wurden verändert.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082e9f2f6c8322a1a4d7fce7758348)