### PR TITLE
Fix Windows launch path in Electron Node test wrapper

### DIFF
--- a/scripts/runElectronNodeTest.cjs
+++ b/scripts/runElectronNodeTest.cjs
@@ -3,21 +3,31 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
 const isWindows = process.platform === "win32";
-const electronBinary = path.resolve(
-  __dirname,
-  "..",
-  "node_modules",
-  ".bin",
-  isWindows ? "electron.cmd" : "electron",
-);
+const electronCandidates = isWindows
+  ? [
+      path.resolve(__dirname, "..", "node_modules", "electron", "dist", "electron.exe"),
+      path.resolve(__dirname, "..", "node_modules", ".bin", "electron.cmd"),
+    ]
+  : [path.resolve(__dirname, "..", "node_modules", ".bin", "electron")];
 
-if (!fs.existsSync(electronBinary)) {
-  console.error(`Fehler: Electron-Binary nicht gefunden unter ${electronBinary}`);
+const electronBinary = electronCandidates.find((candidate) => fs.existsSync(candidate));
+
+if (!electronBinary) {
+  console.error("Fehler: Kein Electron-Binary gefunden. Gepruefte Kandidaten:");
+  for (const candidate of electronCandidates) {
+    console.error(`- ${candidate}`);
+  }
   process.exit(1);
 }
 
 const testScript = path.resolve(__dirname, "test.cjs");
-const child = spawnSync(electronBinary, [testScript], {
+const useCmdLauncher = isWindows && electronBinary.toLowerCase().endsWith(".cmd");
+const spawnCommand = useCmdLauncher ? "cmd.exe" : electronBinary;
+const spawnArgs = useCmdLauncher
+  ? ["/d", "/s", "/c", `"${electronBinary}" "${testScript}"`]
+  : [testScript];
+
+const child = spawnSync(spawnCommand, spawnArgs, {
   env: {
     ...process.env,
     ELECTRON_RUN_AS_NODE: "1",

--- a/scripts/tests/nativeTestRuntime.test.cjs
+++ b/scripts/tests/nativeTestRuntime.test.cjs
@@ -19,6 +19,9 @@ function runNativeTestRuntimeTests(run) {
     assert.equal(pkg.scripts["test:node"], "node scripts/test.cjs");
 
     assert.match(wrapperContent, /ELECTRON_RUN_AS_NODE/);
+    assert.match(wrapperContent, /electron\.exe/);
+    assert.match(wrapperContent, /".bin"/);
+    assert.match(wrapperContent, /"electron"/);
     assert.match(wrapperContent, /test\.cjs/);
     assert.doesNotMatch(wrapperContent, /require\(["']better-sqlite3["']\)/);
     assert.doesNotMatch(wrapperContent, /electron-builder install-app-deps/);


### PR DESCRIPTION
### Motivation
- The Electron Node test wrapper failed on Windows because the wrapper attempted to spawn `node_modules/.bin/electron.cmd` directly, which can produce `EINVAL` on Windows; the goal is to prefer the real `electron.exe` and fall back to `.cmd` only when necessary.
- Keep the wrapper behavior stable for other platforms and preserve existing invariants (`ELECTRON_RUN_AS_NODE`, `spawnSync`, `stdio: "inherit"`, calling `scripts/test.cjs`, and propagating the child exit code).

### Description
- Updated `scripts/runElectronNodeTest.cjs` to probe a list of candidates and pick the first existing binary, using Windows candidates in this order: `node_modules/electron/dist/electron.exe`, then `node_modules/.bin/electron.cmd`, and on non-Windows use `node_modules/.bin/electron`.
- When `.cmd` must be used on Windows, start it robustly via `cmd.exe /d /s /c` instead of spawning the `.cmd` directly; otherwise spawn the binary directly with the test script argument.
- Kept `ELECTRON_RUN_AS_NODE=1`, `child_process.spawnSync`, `stdio: "inherit"`, and child exit code forwarding unchanged.
- Adjusted `scripts/tests/nativeTestRuntime.test.cjs` to assert the new wrapper invariants (presence of `electron.exe` candidate and `.bin`/`electron` markers, still checking for `ELECTRON_RUN_AS_NODE`, `test.cjs`, no `better-sqlite3` require, and no `electron-builder install-app-deps` in the wrapper).

### Testing
- Ran the wrapper runtime unit checks by executing the test helper via `node -e "const { runNativeTestRuntimeTests } = require('./scripts/tests/nativeTestRuntime.test.cjs'); ..."`, and the updated protection tests passed.
- Ran the full test script directly with `node scripts/test.cjs` in the container and the project unit test suite executed successfully (Linux environment tests passed unrelated to the Windows-specific change).
- Ran `npm test` which executes the wrapper (`node scripts/runElectronNodeTest.cjs`); it failed in this Linux container because `node_modules/electron/dist/electron` cannot start here due to missing system libraries (`libatk-1.0.so.0`), demonstrating the failure is an environment limitation and not the wrapper logic.
- Result: automated wrapper/unit checks passed; end-to-end `npm test` cannot be validated in this Linux CI container due to missing native GUI dependencies, so a Windows-local `npm test` run is still recommended to validate the real-world fallback behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0835e35ee0832289807d19d4e2e7f9)