### PR TITLE
M5 Restarbeiten anlegen und bearbeiten

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1990,3 +1990,8 @@ Wichtig:
   - DEV- und Produktivsichtung im laufenden App-Kontext mit vorhandenem und optional userseitig abgelegtem Whisper-Modell.
 - Risiken/Hinweise:
   - `npm test` ist in dieser Umgebung weiterhin durch das bereits bekannte `better-sqlite3`-Native-Modul blockiert; die Audio-Subtests selbst laufen gruen.
+- Restarbeiten M5 ist jetzt umgesetzt:
+  - Restarbeiten koennen neu angelegt, ausgewaehlt und in einer Editbox-Grundform bearbeitet werden
+  - Speichern laedt die Liste erneut und haelt die Auswahl konsistent
+  - Foto-/Diktat-/Druck-/Mail-/Loesch- und Archivpfade bleiben ausserhalb dieses Pakets
+  - `npm test` laeuft gruen

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -251,3 +251,9 @@ Dabei gilt:
 - Restarbeiten laden im Projektkontext über IPC (`restarbeiten:listByProject`, `restarbeiten:getProjectSettings`).
 - Renderer zeigt erste einfache Listenstruktur mit den Hauptspalten Nr./Datum, Verortung, Restarbeit, Status.
 - Bearbeitung, Editbox, Fotos, Druck, Mail und Diktat folgen in späteren Schritten.
+### M5 Restarbeiten anlegen, auswaehlen und Editbox-Grundform speichern (neu)
+- Restarbeiten koennen jetzt ueber IPC und Datasource neu angelegt und aktualisiert werden.
+- Der Screen zeigt eine auswaehlbare Liste, markiert die Auswahl und blendet die Editbox erst bei Auswahl ein.
+- Die Editbox-Grundform deckt `item_class`, `status`, Verortung, Kurz-/Langtext, Faelligkeitsdatum und Verantwortlichen-Label ab.
+- Speichern laedt die Liste erneut und haelt die Auswahl konsistent.
+- Foto-/Diktat-/Druck-/Mail-/Loesch- und Archivpfade bleiben weiterhin ausserhalb dieses Pakets.

--- a/scripts/tests/restarbeitenDataModel.test.cjs
+++ b/scripts/tests/restarbeitenDataModel.test.cjs
@@ -143,6 +143,13 @@ async function runRestarbeitenDataModelTests(run) {
     assert.equal(String(repo.listRestarbeitItems("p1")[0].id), String(item.id));
   }));
 
+  await run("Restarbeit Update wirft bei unbekannter ID", async () => withTemp(({ db, repo }) => {
+    const conn = db.initDatabase();
+    conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p1", "P1");
+    assert.throws(() => repo.updateRestarbeitItem("unbekannt", { short_text: "x" }), /restarbeit not found/);
+    assert.throws(() => repo.updateRestarbeitItem("unbekannt", {}), /restarbeit not found/);
+  }));
+
   await run("Foto-Regeln inkl. primary und max 3", async () => withTemp(({ db, repo }) => {
     const conn = db.initDatabase();
     conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p1", "P1");

--- a/scripts/tests/restarbeitenDataModel.test.cjs
+++ b/scripts/tests/restarbeitenDataModel.test.cjs
@@ -95,6 +95,54 @@ async function runRestarbeitenDataModelTests(run) {
     assert.equal(list.find((row) => row.id === m.id)?.item_class, "mangel");
   }));
 
+  await run("Restarbeit Update normalisiert Felder und schuetzt Kernfelder", async () => withTemp(({ db, repo }) => {
+    const conn = db.initDatabase();
+    conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p1", "P1");
+    conn.prepare("INSERT INTO project_firms (id, project_id, name) VALUES (?, ?, ?)").run("f1", "p1", "Firma A");
+    conn.prepare("INSERT INTO project_firms (id, project_id, name) VALUES (?, ?, ?)").run("f2", "p1", "Firma B");
+    const item = repo.createRestarbeitItem({
+      project_id: "p1",
+      short_text: "Alt",
+      long_text: "Lang alt",
+      item_class: "rest",
+      status: "offen",
+      due_date: "2026-05-16",
+      responsible_project_firm_id: "f1",
+      responsible_label: "Firma A",
+    });
+
+    const updated = repo.updateRestarbeitItem(item.id, {
+      project_id: "p2",
+      running_number: 99,
+      created_at: "2000-01-01",
+      location_level_1: "Haus B",
+      location_level_2: "EG",
+      location_level_3: "W1",
+      location_level_4: "Kueche",
+      short_text: "Neu",
+      long_text: "Lang neu",
+      item_class: "MANGEL",
+      status: "unbekannt",
+      due_date: "2026-06-01",
+      responsible_project_firm_id: "f2",
+      responsible_label: "Firma B",
+    });
+
+    assert.equal(updated.project_id, "p1");
+    assert.equal(updated.running_number, item.running_number);
+    assert.equal(updated.created_at, item.created_at);
+    assert.equal(updated.location_level_1, "Haus B");
+    assert.equal(updated.location_level_4, "Kueche");
+    assert.equal(updated.short_text, "Neu");
+    assert.equal(updated.long_text, "Lang neu");
+    assert.equal(updated.item_class, "mangel");
+    assert.equal(updated.status, "offen");
+    assert.equal(updated.due_date, "2026-06-01");
+    assert.equal(updated.responsible_project_firm_id, "f2");
+    assert.equal(updated.responsible_label, "Firma B");
+    assert.equal(String(repo.listRestarbeitItems("p1")[0].id), String(item.id));
+  }));
+
   await run("Foto-Regeln inkl. primary und max 3", async () => withTemp(({ db, repo }) => {
     const conn = db.initDatabase();
     conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p1", "P1");

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -304,6 +304,42 @@ async function runRestarbeitenModuleTests(run) {
     }
   });
 
+  await run("M5 Screen: fehlender Projektkontext zeigt nur den Kontext-Hinweis", async () => {
+    const prevWindow = globalThis.window;
+    const prevDocument = globalThis.document;
+    globalThis.window = {
+      bbmDb: {
+        restarbeitenGetProjectSettings: async () => ({ ok: true, settings: {} }),
+        restarbeitenListByProject: async () => ({ ok: true, items: [] }),
+        restarbeitenCreateItem: async () => ({ ok: true, item: { id: "x" } }),
+        restarbeitenUpdateItem: async () => ({ ok: true, item: { id: "x" } }),
+      },
+    };
+    globalThis.document = createFakeDocument();
+
+    try {
+      const screen = new (
+        await importEsmFromFile(
+          path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js")
+        )
+      ).default({});
+
+      const root = screen.render();
+      assert.equal(root.children.length >= 3, true);
+      assert.match(screen.listHost.children[0].textContent, /Kein Projektkontext/);
+      assert.equal(screen.editHost.children.length, 0);
+      assert.equal(screen.headerHost.children[0].children[1].disabled, true);
+
+      await screen.load();
+      assert.match(screen.listHost.children[0].textContent, /Kein Projektkontext/);
+      assert.equal(screen.editHost.children.length, 0);
+      assert.notEqual(screen.listHost.children[0].textContent, "Für dieses Projekt sind noch keine Restarbeiten vorhanden.");
+    } finally {
+      globalThis.window = prevWindow;
+      globalThis.document = prevDocument;
+    }
+  });
+
   await run("M4 ViewModel: Mapping fuer Anzeigezeilen", async () => {
     const vm = await importEsmFromFile(
       path.join(__dirname, "../../src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js")

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1,7 +1,100 @@
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
+const Module = require("node:module");
 const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+function withPatchedRestarbeitenIpc(stubs, fn) {
+  const originalLoad = Module._load;
+  Module._load = function patched(request, parent, isMain) {
+    const fromRestarbeitenIpc = String(parent?.filename || "").endsWith(path.join("ipc", "restarbeitenIpc.js"));
+    if (fromRestarbeitenIpc && request === "electron") return stubs.electron;
+    if (fromRestarbeitenIpc && request === "../db/restarbeitenRepo") return stubs.restarbeitenRepo;
+    return originalLoad.apply(this, arguments);
+  };
+
+  try {
+    const modPath = path.join(__dirname, "../../src/main/ipc/restarbeitenIpc.js");
+    delete require.cache[require.resolve(modPath)];
+    const mod = require(modPath);
+    return fn(mod);
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+function createFakeDocument() {
+  const createNode = (tag, doc) => {
+    const node = {
+      tagName: String(tag || "").toUpperCase(),
+      ownerDocument: doc,
+      children: [],
+      style: {},
+      dataset: {},
+      className: "",
+      textContent: "",
+      disabled: false,
+      value: "",
+      type: "",
+      rows: 0,
+      append(...nodes) {
+        for (const child of nodes) {
+          if (child && typeof child === "object") child.parentElement = this;
+          this.children.push(child);
+        }
+      },
+      appendChild(nodeChild) {
+        if (nodeChild && typeof nodeChild === "object") nodeChild.parentElement = this;
+        this.children.push(nodeChild);
+        return nodeChild;
+      },
+      replaceChildren(...nodes) {
+        this.children = [...nodes];
+        for (const child of this.children) {
+          if (child && typeof child === "object") child.parentElement = this;
+        }
+      },
+      setAttribute(name, value) {
+        this[String(name)] = String(value);
+      },
+      addEventListener(type, handler) {
+        if (!this._listeners) this._listeners = {};
+        if (!this._listeners[type]) this._listeners[type] = [];
+        this._listeners[type].push(handler);
+      },
+      dispatchEvent(event) {
+        const evt = event || {};
+        const type = String(evt.type || "");
+        for (const handler of this._listeners?.[type] || []) {
+          handler.call(this, evt);
+        }
+        return true;
+      },
+      click() {
+        if (typeof this.onclick === "function") this.onclick({ type: "click", preventDefault() {} });
+        this.dispatchEvent({ type: "click", preventDefault() {} });
+      },
+      classList: {
+        add() {},
+        remove() {},
+        toggle() {},
+      },
+    };
+    return node;
+  };
+
+  const doc = {
+    activeElement: null,
+    createElement(tag) {
+      return createNode(tag, doc);
+    },
+    body: null,
+    head: null,
+  };
+  doc.body = createNode("body", doc);
+  doc.head = createNode("head", doc);
+  return doc;
+}
 
 async function runRestarbeitenModuleTests(run) {
   const [restarbeitenModule, screenResolver, workspaceModule] = await Promise.all([
@@ -59,7 +152,9 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(main, /registerRestarbeitenIpc/);
     assert.match(preload, /restarbeitenListByProject/);
     assert.match(preload, /restarbeitenGetProjectSettings/);
-    assert.doesNotMatch(ipc, /restarbeiten:create|restarbeiten:update|restarbeiten:delete/);
+    assert.match(preload, /restarbeitenCreateItem/);
+    assert.match(preload, /restarbeitenUpdateItem/);
+    assert.doesNotMatch(ipc, /restarbeiten:delete|restarbeiten:archive|restarbeiten:attachment/);
   });
 
   await run("M4 Screen-Grenzen: sync render, load-Methode, 4 Spalten, kein innerHTML-Datenbau", () => {
@@ -69,15 +164,144 @@ async function runRestarbeitenModuleTests(run) {
     assert.doesNotMatch(content, /async\s+render\s*\(/);
     assert.match(content, /render\s*\(/);
     assert.match(content, /async\s+load\s*\(/);
-    assert.match(content, /Kein Projektkontext für Restarbeiten vorhanden\./);
-    assert.match(content, /Restarbeiten werden geladen…/);
-    assert.match(content, /Für dieses Projekt sind noch keine Restarbeiten vorhanden\./);
+    assert.match(content, /\+ Restarbeit/);
+    assert.match(content, /Restarbeiten werden geladen/);
+    assert.match(content, /Restarbeiten vorhanden/);
     assert.match(content, /Nr\. \/ Datum/);
     assert.match(content, /Verortung/);
     assert.match(content, /Restarbeit/);
     assert.match(content, /Status/);
     assert.doesNotMatch(content, /tr\.innerHTML|innerHTML\s*=\s*\[/);
-    assert.doesNotMatch(content, /Diktat|Foto|Druck|Mail|Editbox|Neu|Löschen/);
+    assert.doesNotMatch(content, /Diktat|Foto|Druck|Mail|Loeschen|Archivieren/);
+  });
+
+  await run("M5 Repo/IPC/Preload/DataSource: Create und Update sind verdrahtet", async () => {
+    const repo = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js")
+    );
+    const ipcSource = fs.readFileSync(path.join(__dirname, "../../src/main/ipc/restarbeitenIpc.js"), "utf8");
+    const preload = fs.readFileSync(path.join(__dirname, "../../src/main/preload.js"), "utf8");
+
+    assert.match(ipcSource, /restarbeiten:createItem/);
+    assert.match(ipcSource, /restarbeiten:updateItem/);
+    assert.match(preload, /restarbeitenCreateItem/);
+    assert.match(preload, /restarbeitenUpdateItem/);
+
+    const calls = [];
+    const prevWindow = globalThis.window;
+    globalThis.window = {
+      bbmDb: {
+        restarbeitenCreateItem: async (payload) => {
+          calls.push({ type: "create", payload });
+          return { ok: true, item: { id: "new-1", project_id: payload.projectId, short_text: payload.short_text || "" } };
+        },
+        restarbeitenUpdateItem: async (payload) => {
+          calls.push({ type: "update", payload });
+          return { ok: true, item: { id: payload.id, short_text: payload.patch.short_text || "" } };
+        },
+        restarbeitenListByProject: async () => ({ ok: true, items: [] }),
+        restarbeitenGetProjectSettings: async () => ({ ok: true, settings: {} }),
+      },
+    };
+
+    try {
+      const created = await repo.createRestarbeitItem("p-1", { short_text: "Neu", item_class: "mangel" });
+      const updated = await repo.updateRestarbeitItem("new-1", { short_text: "Neu 2", status: "unbekannt" });
+      assert.equal(created.id, "new-1");
+      assert.equal(updated.id, "new-1");
+      assert.equal(calls[0].type, "create");
+      assert.equal(calls[0].payload.projectId, "p-1");
+      assert.equal(calls[1].type, "update");
+      assert.equal(calls[1].payload.id, "new-1");
+      assert.equal(calls[1].payload.patch.short_text, "Neu 2");
+    } finally {
+      globalThis.window = prevWindow;
+    }
+  });
+
+  await run("M5 Screen: Neu, Auswahl, Editbox, Speichern", async () => {
+    const prevWindow = globalThis.window;
+    const prevDocument = globalThis.document;
+    const calls = [];
+    const items = [
+      {
+        id: "r-1",
+        running_number: 1,
+        created_at: "2026-05-16",
+        location_level_1: "Haus A",
+        short_text: "Alt",
+        long_text: "Lang",
+        item_class: "rest",
+        status: "offen",
+      },
+    ];
+    globalThis.window = {
+      bbmDb: {
+        restarbeitenGetProjectSettings: async () => ({ ok: true, settings: { level_1_label: "Haus" } }),
+        restarbeitenListByProject: async () => ({ ok: true, items: items.map((item) => ({ ...item })) }),
+        restarbeitenCreateItem: async (payload) => {
+          calls.push({ type: "create", payload });
+          const created = {
+            id: "r-2",
+            running_number: 2,
+            created_at: "2026-05-16",
+            short_text: "",
+            long_text: "",
+            item_class: "rest",
+            status: "offen",
+          };
+          items.push(created);
+          return {
+            ok: true,
+            item: { ...created },
+          };
+        },
+        restarbeitenUpdateItem: async (payload) => {
+          calls.push({ type: "update", payload });
+          const target = items.find((item) => String(item.id) === String(payload.id));
+          if (target) Object.assign(target, payload.patch || {});
+          return { ok: true, item: { id: payload.id, ...payload.patch } };
+        },
+      },
+    };
+    const fakeDoc = createFakeDocument();
+    globalThis.document = fakeDoc;
+
+    try {
+      const screen = new (
+        await importEsmFromFile(
+          path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js")
+        )
+      ).default({
+        projectId: "p-1",
+      });
+
+      const root = screen.render();
+      assert.equal(root.children.length >= 3, true);
+      await screen.load();
+
+      assert.equal(screen.listHost.children[0].tagName, "TABLE");
+      const row = screen.listHost.children[0].children[1].children[0];
+      row.dispatchEvent({ type: "click" });
+      assert.equal(screen.selectedItemId, "r-1");
+      assert.equal(screen.editbox.fields.short_text.value, "Alt");
+
+      screen.editbox.fields.short_text.value = "Neu";
+      screen.editbox.fields.long_text.value = "Lang 2";
+      screen.editbox.fields.item_class.value = "mangel";
+      screen.editbox.fields.status.value = "in_arbeit";
+      await screen.editbox.onSave(screen.editbox.getDraft());
+
+      assert.equal(calls.find((call) => call.type === "update")?.payload.id, "r-1");
+      assert.equal(calls.find((call) => call.type === "update")?.payload.patch.short_text, "Neu");
+
+      await screen._createRestarbeit();
+      assert.equal(calls.find((call) => call.type === "create")?.payload.projectId, "p-1");
+      assert.equal(screen.selectedItemId, "r-2");
+    } finally {
+      globalThis.window = prevWindow;
+      globalThis.document = prevDocument;
+    }
   });
 
   await run("M4 ViewModel: Mapping fuer Anzeigezeilen", async () => {
@@ -103,7 +327,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(item.locationLine1, "Haus A / EG");
     assert.equal(item.workLine2, "nachstellen");
     assert.match(item.statusLine1, /Mangel/);
-    assert.match(item.statusLine1, /geprüft erledigt/);
+    assert.match(item.statusLine1, /gepr[üu]ft erledigt/);
     assert.equal(item.statusLine2, "2026-05-20");
     assert.equal(item.statusLine3, "Firma Test");
 

--- a/src/main/db/restarbeitenRepo.js
+++ b/src/main/db/restarbeitenRepo.js
@@ -139,15 +139,18 @@ function createRestarbeitItem(projectIdOrPayload = {}, payload = {}) {
 function updateRestarbeitItem(id, patch = {}) {
   const db = initDatabase();
   const rid = reqText(id, "id");
+  const existing = db.prepare(`SELECT * FROM restarbeiten_items WHERE id = ?`).get(rid);
+  if (!existing) throw new Error("restarbeit not found");
+
   const data = buildRestarbeitUpdatePatch(patch);
   const keys = Object.keys(data);
   if (!keys.length) {
-    return db.prepare(`SELECT * FROM restarbeiten_items WHERE id = ?`).get(rid);
+    return existing;
   }
 
   const setClause = keys.map((key) => `${key} = @${key}`).join(", ");
   const now = new Date().toISOString();
-  db.prepare(`
+  const result = db.prepare(`
     UPDATE restarbeiten_items
     SET ${setClause},
         updated_at = @updated_at
@@ -158,7 +161,13 @@ function updateRestarbeitItem(id, patch = {}) {
     ...data,
   });
 
-  return db.prepare(`SELECT * FROM restarbeiten_items WHERE id = ?`).get(rid);
+  if (!result || Number(result.changes || 0) < 1) {
+    throw new Error("restarbeit not found");
+  }
+
+  const updated = db.prepare(`SELECT * FROM restarbeiten_items WHERE id = ?`).get(rid);
+  if (!updated) throw new Error("restarbeit not found");
+  return updated;
 }
 
 function listRestarbeitItems(projectId, { includeArchived = false } = {}) {

--- a/src/main/db/restarbeitenRepo.js
+++ b/src/main/db/restarbeitenRepo.js
@@ -35,6 +35,26 @@ function normalizeRestarbeitItemClass(value) {
   return ALLOWED_ITEM_CLASSES.has(normalized) ? normalized : "rest";
 }
 
+function buildRestarbeitUpdatePatch(patch = {}) {
+  const out = {};
+
+  if (patch.location_level_1 !== undefined) out.location_level_1 = toText(patch.location_level_1);
+  if (patch.location_level_2 !== undefined) out.location_level_2 = toText(patch.location_level_2);
+  if (patch.location_level_3 !== undefined) out.location_level_3 = toText(patch.location_level_3);
+  if (patch.location_level_4 !== undefined) out.location_level_4 = toText(patch.location_level_4);
+  if (patch.short_text !== undefined) out.short_text = toText(patch.short_text) || "";
+  if (patch.long_text !== undefined) out.long_text = toText(patch.long_text) || "";
+  if (patch.item_class !== undefined) out.item_class = normalizeRestarbeitItemClass(patch.item_class);
+  if (patch.status !== undefined) out.status = normalizeStatus(patch.status);
+  if (patch.due_date !== undefined) out.due_date = toText(patch.due_date);
+  if (patch.responsible_project_firm_id !== undefined) {
+    out.responsible_project_firm_id = toText(patch.responsible_project_firm_id);
+  }
+  if (patch.responsible_label !== undefined) out.responsible_label = toText(patch.responsible_label);
+
+  return out;
+}
+
 function ensureRestarbeitProjectSettings(projectId) {
   const db = initDatabase();
   const pid = reqText(projectId, "projectId");
@@ -52,40 +72,48 @@ function getRestarbeitProjectSettings(projectId) {
   return db.prepare(`SELECT * FROM restarbeiten_project_settings WHERE project_id = ?`).get(pid);
 }
 
-function createRestarbeitItem(payload = {}) {
+function createRestarbeitItem(projectIdOrPayload = {}, payload = {}) {
   const db = initDatabase();
-  const pid = reqText(payload.project_id, "project_id");
+  const sourcePayload =
+    projectIdOrPayload && typeof projectIdOrPayload === "object" && !Array.isArray(projectIdOrPayload)
+      ? projectIdOrPayload
+      : payload;
+  const pidCandidate =
+    typeof projectIdOrPayload === "string" || typeof projectIdOrPayload === "number"
+      ? projectIdOrPayload
+      : sourcePayload.project_id ?? sourcePayload.projectId;
+  const pid = reqText(pidCandidate, "project_id");
   const now = new Date().toISOString();
   const nextRunning = db
     .prepare(`SELECT COALESCE(MAX(running_number), 0) + 1 AS next_no FROM restarbeiten_items WHERE project_id = ?`)
     .get(pid)?.next_no;
-  const runningNumber = Number.isInteger(payload.running_number) && payload.running_number > 0
-    ? payload.running_number
+  const runningNumber = Number.isInteger(sourcePayload.running_number) && sourcePayload.running_number > 0
+    ? sourcePayload.running_number
     : nextRunning;
 
-  const id = toText(payload.id) || crypto.randomUUID();
-  const sortOrder = Number.isFinite(Number(payload.sort_order)) ? Number(payload.sort_order) : 0;
+  const id = toText(sourcePayload.id) || crypto.randomUUID();
+  const sortOrder = Number.isFinite(Number(sourcePayload.sort_order)) ? Number(sourcePayload.sort_order) : 0;
   const data = {
     id,
     project_id: pid,
     running_number: runningNumber,
     sort_order: sortOrder,
-    location_level_1: toText(payload.location_level_1),
-    location_level_2: toText(payload.location_level_2),
-    location_level_3: toText(payload.location_level_3),
-    location_level_4: toText(payload.location_level_4),
-    short_text: toText(payload.short_text) || "",
-    long_text: toText(payload.long_text) || "",
-    item_class: normalizeRestarbeitItemClass(payload.item_class),
-    status: normalizeStatus(payload.status),
-    due_date: toText(payload.due_date),
-    responsible_project_firm_id: toText(payload.responsible_project_firm_id),
-    responsible_label: toText(payload.responsible_label),
-    source: toText(payload.source) || "desktop",
-    import_batch_id: toText(payload.import_batch_id),
-    archived_at: toText(payload.archived_at),
-    completed_at: toText(payload.completed_at),
-    verified_at: toText(payload.verified_at),
+    location_level_1: toText(sourcePayload.location_level_1),
+    location_level_2: toText(sourcePayload.location_level_2),
+    location_level_3: toText(sourcePayload.location_level_3),
+    location_level_4: toText(sourcePayload.location_level_4),
+    short_text: toText(sourcePayload.short_text) || "",
+    long_text: toText(sourcePayload.long_text) || "",
+    item_class: normalizeRestarbeitItemClass(sourcePayload.item_class),
+    status: normalizeStatus(sourcePayload.status),
+    due_date: toText(sourcePayload.due_date),
+    responsible_project_firm_id: toText(sourcePayload.responsible_project_firm_id),
+    responsible_label: toText(sourcePayload.responsible_label),
+    source: toText(sourcePayload.source) || "desktop",
+    import_batch_id: toText(sourcePayload.import_batch_id),
+    archived_at: toText(sourcePayload.archived_at),
+    completed_at: toText(sourcePayload.completed_at),
+    verified_at: toText(sourcePayload.verified_at),
     created_at: now,
     updated_at: now,
   };
@@ -106,6 +134,31 @@ function createRestarbeitItem(payload = {}) {
     )
   `).run(data);
   return db.prepare(`SELECT * FROM restarbeiten_items WHERE id = ?`).get(id);
+}
+
+function updateRestarbeitItem(id, patch = {}) {
+  const db = initDatabase();
+  const rid = reqText(id, "id");
+  const data = buildRestarbeitUpdatePatch(patch);
+  const keys = Object.keys(data);
+  if (!keys.length) {
+    return db.prepare(`SELECT * FROM restarbeiten_items WHERE id = ?`).get(rid);
+  }
+
+  const setClause = keys.map((key) => `${key} = @${key}`).join(", ");
+  const now = new Date().toISOString();
+  db.prepare(`
+    UPDATE restarbeiten_items
+    SET ${setClause},
+        updated_at = @updated_at
+    WHERE id = @id
+  `).run({
+    id: rid,
+    updated_at: now,
+    ...data,
+  });
+
+  return db.prepare(`SELECT * FROM restarbeiten_items WHERE id = ?`).get(rid);
 }
 
 function listRestarbeitItems(projectId, { includeArchived = false } = {}) {
@@ -196,6 +249,7 @@ module.exports = {
   ensureRestarbeitProjectSettings,
   getRestarbeitProjectSettings,
   createRestarbeitItem,
+  updateRestarbeitItem,
   listRestarbeitItems,
   addRestarbeitAttachment,
   setPrimaryRestarbeitAttachment,

--- a/src/main/ipc/restarbeitenIpc.js
+++ b/src/main/ipc/restarbeitenIpc.js
@@ -41,6 +41,34 @@ function registerRestarbeitenIpc({ ipcMain }) {
       return { ok: false, error: error?.message || "Restarbeiten-Einstellungen konnten nicht geladen werden." };
     }
   });
+
+  ipcMain.handle("restarbeiten:createItem", async (_event, payload) => {
+    try {
+      const projectId = normalizeProjectId(payload);
+      if (!projectId) throw new Error("projectId erforderlich");
+      const data = payload && typeof payload === "object" ? { ...payload } : {};
+      delete data.projectId;
+      delete data.project_id;
+      delete data.id;
+      const item = repo.createRestarbeitItem(projectId, data);
+      return { ok: true, item };
+    } catch (error) {
+      return { ok: false, error: error?.message || "Restarbeit konnte nicht angelegt werden." };
+    }
+  });
+
+  ipcMain.handle("restarbeiten:updateItem", async (_event, payload) => {
+    try {
+      const source = payload && typeof payload === "object" ? payload : {};
+      const id = String(source.id ?? source.restarbeitId ?? source.restarbeit_id ?? "").trim();
+      if (!id) throw new Error("id erforderlich");
+      const patch = source.patch && typeof source.patch === "object" ? source.patch : source;
+      const item = repo.updateRestarbeitItem(id, patch);
+      return { ok: true, item };
+    } catch (error) {
+      return { ok: false, error: error?.message || "Restarbeit konnte nicht gespeichert werden." };
+    }
+  });
 }
 
 module.exports = { registerRestarbeitenIpc };

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -242,6 +242,8 @@ contextBridge.exposeInMainWorld("bbmDb", {
   // ============================================================
   restarbeitenListByProject: (data) => ipcRenderer.invoke("restarbeiten:listByProject", data),
   restarbeitenGetProjectSettings: (data) => ipcRenderer.invoke("restarbeiten:getProjectSettings", data),
+  restarbeitenCreateItem: (data) => ipcRenderer.invoke("restarbeiten:createItem", data),
+  restarbeitenUpdateItem: (data) => ipcRenderer.invoke("restarbeiten:updateItem", data),
 });
 
 contextBridge.exposeInMainWorld("bbmPrint", {

--- a/src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js
+++ b/src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js
@@ -22,6 +22,20 @@ async function callAndNormalize(callFn, payload, entityName) {
   return response;
 }
 
+function buildCreatePayload(projectId, payload = {}) {
+  const pid = extractProjectId(projectId);
+  const out = { ...payload, projectId: pid };
+  delete out.project_id;
+  delete out.id;
+  return out;
+}
+
+function buildUpdatePayload(id, patch = {}) {
+  const rid = String(id ?? "").trim();
+  if (!rid) throw new Error("Restarbeiten-Datenzugriff: id fehlt.");
+  return { id: rid, patch: { ...patch } };
+}
+
 export async function listRestarbeitenByProject(projectId) {
   const bbmDb = requireBbmDb();
   if (typeof bbmDb.restarbeitenListByProject !== "function") {
@@ -40,4 +54,26 @@ export async function getRestarbeitenProjectSettings(projectId) {
   const pid = extractProjectId(projectId);
   const response = await callAndNormalize(bbmDb.restarbeitenGetProjectSettings, { projectId: pid }, "settings");
   return response.settings && typeof response.settings === "object" ? response.settings : {};
+}
+
+export async function createRestarbeitItem(projectId, payload = {}) {
+  const bbmDb = requireBbmDb();
+  if (typeof bbmDb.restarbeitenCreateItem !== "function") {
+    throw new Error("Restarbeiten-Datenzugriff nicht verfuegbar: restarbeitenCreateItem fehlt.");
+  }
+  const response = await callAndNormalize(
+    bbmDb.restarbeitenCreateItem,
+    buildCreatePayload(projectId, payload),
+    "create"
+  );
+  return response.item && typeof response.item === "object" ? response.item : null;
+}
+
+export async function updateRestarbeitItem(id, patch = {}) {
+  const bbmDb = requireBbmDb();
+  if (typeof bbmDb.restarbeitenUpdateItem !== "function") {
+    throw new Error("Restarbeiten-Datenzugriff nicht verfuegbar: restarbeitenUpdateItem fehlt.");
+  }
+  const response = await callAndNormalize(bbmDb.restarbeitenUpdateItem, buildUpdatePayload(id, patch), "update");
+  return response.item && typeof response.item === "object" ? response.item : null;
 }

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -1,0 +1,214 @@
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+function createField(doc, labelText, control) {
+  const wrap = doc.createElement("label");
+  wrap.style.display = "grid";
+  wrap.style.gap = "6px";
+
+  const label = doc.createElement("div");
+  label.textContent = labelText;
+  label.style.fontSize = "12px";
+  label.style.fontWeight = "700";
+
+  wrap.append(label, control);
+  return wrap;
+}
+
+function createSelect(doc, options) {
+  const select = doc.createElement("select");
+  select.style.minHeight = "34px";
+  select.style.padding = "6px 8px";
+  select.style.borderRadius = "8px";
+  select.style.border = "1px solid var(--card-border, #cfcfcf)";
+  select.style.background = "var(--card-bg, #fff)";
+
+  for (const option of options) {
+    const opt = doc.createElement("option");
+    opt.value = String(option.value ?? "");
+    opt.textContent = String(option.label ?? "");
+    select.appendChild(opt);
+  }
+
+  return select;
+}
+
+function createInput(doc, type = "text") {
+  const input = doc.createElement(type === "textarea" ? "textarea" : "input");
+  if (type !== "textarea") input.type = type;
+  input.style.minHeight = "34px";
+  input.style.padding = "6px 8px";
+  input.style.borderRadius = "8px";
+  input.style.border = "1px solid var(--card-border, #cfcfcf)";
+  input.style.background = "var(--card-bg, #fff)";
+  return input;
+}
+
+export default class RestarbeitenEditbox {
+  constructor({ documentRef = globalThis.document, onSave = null } = {}) {
+    this.document = documentRef || globalThis.document;
+    this.onSave = typeof onSave === "function" ? onSave : null;
+    this.root = null;
+    this.form = null;
+    this.saveBtn = null;
+    this.statusEl = null;
+    this.currentItem = null;
+    this.fields = {};
+  }
+
+  render() {
+    const doc = this.document;
+    const root = doc.createElement("section");
+    root.style.display = "grid";
+    root.style.gap = "10px";
+    root.style.padding = "12px";
+    root.style.border = "1px solid var(--card-border, #cfcfcf)";
+    root.style.borderRadius = "12px";
+    root.style.background = "var(--card-bg, #fff)";
+
+    const title = doc.createElement("h3");
+    title.textContent = "Editbox";
+    title.style.margin = "0";
+
+    const subtitle = doc.createElement("div");
+    subtitle.textContent = "Restarbeit bearbeiten";
+    subtitle.style.fontSize = "13px";
+    subtitle.style.opacity = "0.8";
+
+    const form = doc.createElement("form");
+    form.style.display = "grid";
+    form.style.gap = "10px";
+
+    const itemClass = createSelect(doc, [
+      { value: "rest", label: "Rest" },
+      { value: "mangel", label: "Mangel" },
+    ]);
+
+    const status = createSelect(doc, [
+      { value: "offen", label: "offen" },
+      { value: "in_arbeit", label: "in Arbeit" },
+      { value: "erledigt_gemeldet", label: "erledigt gemeldet" },
+      { value: "geprueft_erledigt", label: "geprueft erledigt" },
+      { value: "zurueckgewiesen", label: "zurueckgewiesen" },
+    ]);
+
+    const level1 = createInput(doc, "text");
+    const level2 = createInput(doc, "text");
+    const level3 = createInput(doc, "text");
+    const level4 = createInput(doc, "text");
+    const shortText = createInput(doc, "text");
+    const longText = createInput(doc, "textarea");
+    longText.rows = 4;
+    const dueDate = createInput(doc, "date");
+    const responsibleLabel = createInput(doc, "text");
+
+    form.append(
+      createField(doc, "item_class", itemClass),
+      createField(doc, "status", status),
+      createField(doc, "location_level_1", level1),
+      createField(doc, "location_level_2", level2),
+      createField(doc, "location_level_3", level3),
+      createField(doc, "location_level_4", level4),
+      createField(doc, "short_text", shortText),
+      createField(doc, "long_text", longText),
+      createField(doc, "due_date", dueDate),
+      createField(doc, "responsible_label", responsibleLabel)
+    );
+
+    const footer = doc.createElement("div");
+    footer.style.display = "flex";
+    footer.style.alignItems = "center";
+    footer.style.gap = "10px";
+
+    const saveBtn = doc.createElement("button");
+    saveBtn.type = "submit";
+    saveBtn.textContent = "Speichern";
+    saveBtn.style.minHeight = "36px";
+    saveBtn.style.padding = "8px 14px";
+    saveBtn.style.borderRadius = "8px";
+    saveBtn.style.border = "1px solid var(--card-border, #cfcfcf)";
+    saveBtn.style.fontWeight = "700";
+
+    const statusEl = doc.createElement("div");
+    statusEl.style.fontSize = "12px";
+    statusEl.style.opacity = "0.8";
+
+    footer.append(saveBtn, statusEl);
+    form.append(footer);
+    root.append(title, subtitle, form);
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (this.onSave) {
+        await this.onSave(this.getDraft());
+      }
+    });
+
+    this.root = root;
+    this.form = form;
+    this.saveBtn = saveBtn;
+    this.statusEl = statusEl;
+    this.fields = {
+      item_class: itemClass,
+      status,
+      location_level_1: level1,
+      location_level_2: level2,
+      location_level_3: level3,
+      location_level_4: level4,
+      short_text: shortText,
+      long_text: longText,
+      due_date: dueDate,
+      responsible_label: responsibleLabel,
+    };
+
+    this.setItem(null);
+    return root;
+  }
+
+  setStatus(text) {
+    if (!this.statusEl) return;
+    this.statusEl.textContent = String(text || "");
+  }
+
+  setSaving(isSaving) {
+    if (!this.saveBtn) return;
+    this.saveBtn.disabled = !!isSaving;
+  }
+
+  setItem(item) {
+    this.currentItem = item || null;
+    const source = this.currentItem || {};
+    const fields = this.fields || {};
+
+    if (fields.item_class) fields.item_class.value = normalizeText(source.item_class) || "rest";
+    if (fields.status) fields.status.value = normalizeText(source.status) || "offen";
+    if (fields.location_level_1) fields.location_level_1.value = normalizeText(source.location_level_1);
+    if (fields.location_level_2) fields.location_level_2.value = normalizeText(source.location_level_2);
+    if (fields.location_level_3) fields.location_level_3.value = normalizeText(source.location_level_3);
+    if (fields.location_level_4) fields.location_level_4.value = normalizeText(source.location_level_4);
+    if (fields.short_text) fields.short_text.value = normalizeText(source.short_text);
+    if (fields.long_text) fields.long_text.value = normalizeText(source.long_text);
+    if (fields.due_date) fields.due_date.value = normalizeText(source.due_date);
+    if (fields.responsible_label) fields.responsible_label.value = normalizeText(source.responsible_label);
+    if (this.root) {
+      this.root.dataset.hasItem = this.currentItem ? "1" : "0";
+    }
+  }
+
+  getDraft() {
+    const fields = this.fields || {};
+    return {
+      item_class: normalizeText(fields.item_class?.value) || "rest",
+      status: normalizeText(fields.status?.value) || "offen",
+      location_level_1: normalizeText(fields.location_level_1?.value),
+      location_level_2: normalizeText(fields.location_level_2?.value),
+      location_level_3: normalizeText(fields.location_level_3?.value),
+      location_level_4: normalizeText(fields.location_level_4?.value),
+      short_text: normalizeText(fields.short_text?.value),
+      long_text: normalizeText(fields.long_text?.value),
+      due_date: normalizeText(fields.due_date?.value),
+      responsible_label: normalizeText(fields.responsible_label?.value),
+    };
+  }
+}

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -110,15 +110,18 @@ export default class RestarbeitenScreen {
 
   _setSelectedItemId(itemId) {
     this.selectedItemId = normalizeText(itemId);
-    if (this.editbox) {
-      this.editbox.setItem(this._getSelectedItem());
-    }
+    if (this.editbox) this.editbox.setItem(this._getSelectedItem());
   }
 
   _renderList() {
     if (!this.listHost) return;
 
     const doc = this.listHost.ownerDocument || globalThis.document;
+    if (!this.effectiveProjectId) {
+      this.listHost.replaceChildren(createMessage(doc, "Kein Projektkontext für Restarbeiten vorhanden."));
+      return;
+    }
+
     if (!this.items.length) {
       this.listHost.replaceChildren(
         createMessage(doc, "Für dieses Projekt sind noch keine Restarbeiten vorhanden.")
@@ -138,6 +141,13 @@ export default class RestarbeitenScreen {
   _renderEditbox() {
     if (!this.editHost) return;
     const doc = this.editHost.ownerDocument || globalThis.document;
+
+    if (!this.effectiveProjectId) {
+      if (this.editbox) this.editbox.setItem(null);
+      this.editHost.replaceChildren();
+      return;
+    }
+
     const selectedItem = this._getSelectedItem();
 
     if (!selectedItem) {
@@ -226,8 +236,15 @@ export default class RestarbeitenScreen {
     this.editHost = document.createElement("div");
 
     this._renderHeader();
-    this._renderList();
-    this._renderEditbox();
+    if (this.effectiveProjectId) {
+      this._renderList();
+      this._renderEditbox();
+    } else {
+      this.listHost.replaceChildren(
+        createMessage(this.listHost.ownerDocument || globalThis.document, "Kein Projektkontext für Restarbeiten vorhanden.")
+      );
+      this.editHost.replaceChildren();
+    }
 
     root.append(this.headerHost, this.listHost, this.editHost);
     this.host = root;
@@ -238,7 +255,9 @@ export default class RestarbeitenScreen {
     if (!this.effectiveProjectId || !this.host) return;
 
     this.isLoading = true;
-    this.listHost?.replaceChildren(createMessage(this.listHost.ownerDocument || globalThis.document, "Restarbeiten werden geladen…"));
+    this.listHost?.replaceChildren(
+      createMessage(this.listHost.ownerDocument || globalThis.document, "Restarbeiten werden geladen…")
+    );
     if (this.editbox) this.editbox.setStatus("Lade...");
 
     try {

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -1,26 +1,30 @@
 import {
+  createRestarbeitItem,
   getRestarbeitenProjectSettings,
   listRestarbeitenByProject,
+  updateRestarbeitItem,
 } from "../data/restarbeitenDataSource.js";
 import { toRestarbeitenListItems } from "../viewModel/restarbeitenListItems.js";
+import RestarbeitenEditbox from "./RestarbeitenEditbox.js";
+import { applyPopupButtonStyle } from "../../../ui/popupButtonStyles.js";
 
 function normalizeText(value) {
   return String(value || "").trim();
 }
 
-function createLineCell(line1, line2, line3) {
-  const td = document.createElement("td");
+function createLineCell(doc, line1, line2, line3) {
+  const td = doc.createElement("td");
 
-  const line1Div = document.createElement("div");
+  const line1Div = doc.createElement("div");
   line1Div.textContent = line1;
   td.append(line1Div);
 
-  const line2Div = document.createElement("div");
+  const line2Div = doc.createElement("div");
   line2Div.textContent = line2;
   td.append(line2Div);
 
   if (typeof line3 === "string") {
-    const line3Div = document.createElement("div");
+    const line3Div = doc.createElement("div");
     line3Div.textContent = line3;
     td.append(line3Div);
   }
@@ -28,39 +32,58 @@ function createLineCell(line1, line2, line3) {
   return td;
 }
 
-function createHeaderCell(text) {
-  const th = document.createElement("th");
+function createHeaderCell(doc, text) {
+  const th = doc.createElement("th");
   th.textContent = text;
   return th;
 }
 
-function buildListTable(items) {
-  const table = document.createElement("table");
-  const thead = document.createElement("thead");
-  const headRow = document.createElement("tr");
+function buildListTable(doc, items, selectedId, onSelect) {
+  const table = doc.createElement("table");
+  table.style.width = "100%";
+  table.style.borderCollapse = "collapse";
+
+  const thead = doc.createElement("thead");
+  const headRow = doc.createElement("tr");
   headRow.append(
-    createHeaderCell("Nr. / Datum"),
-    createHeaderCell("Verortung"),
-    createHeaderCell("Restarbeit"),
-    createHeaderCell("Status")
+    createHeaderCell(doc, "Nr. / Datum"),
+    createHeaderCell(doc, "Verortung"),
+    createHeaderCell(doc, "Restarbeit"),
+    createHeaderCell(doc, "Status")
   );
   thead.append(headRow);
   table.append(thead);
 
-  const tbody = document.createElement("tbody");
+  const tbody = doc.createElement("tbody");
   for (const item of items) {
-    const row = document.createElement("tr");
+    const row = doc.createElement("tr");
+    row.dataset.restarbeitId = item.id;
+    row.style.cursor = "pointer";
+    row.style.borderBottom = "1px solid var(--card-border, #d6d6d6)";
+    row.style.verticalAlign = "top";
+    if (String(item.id) === String(selectedId)) {
+      row.style.background = "rgba(0, 0, 0, 0.05)";
+      row.dataset.selected = "1";
+    }
+    row.addEventListener("click", () => onSelect(item.id));
     row.append(
-      createLineCell(item.numberLine, item.dateLine),
-      createLineCell(item.locationLine1, item.locationLine2),
-      createLineCell(item.workLine1, item.workLine2),
-      createLineCell(item.statusLine1, item.statusLine2, item.statusLine3)
+      createLineCell(doc, item.numberLine, item.dateLine),
+      createLineCell(doc, item.locationLine1, item.locationLine2),
+      createLineCell(doc, item.workLine1, item.workLine2),
+      createLineCell(doc, item.statusLine1, item.statusLine2, item.statusLine3)
     );
     tbody.append(row);
   }
 
   table.append(tbody);
   return table;
+}
+
+function createMessage(doc, text) {
+  const el = doc.createElement("p");
+  el.textContent = text;
+  el.style.margin = "0";
+  return el;
 }
 
 export default class RestarbeitenScreen {
@@ -71,63 +94,183 @@ export default class RestarbeitenScreen {
     this.moduleId = moduleId || "restarbeiten";
     this.effectiveProjectId = "";
     this.host = null;
+    this.headerHost = null;
+    this.listHost = null;
+    this.editHost = null;
+    this.rows = [];
+    this.items = [];
+    this.selectedItemId = "";
+    this.isLoading = false;
+    this.editbox = null;
+  }
+
+  _getSelectedItem() {
+    return this.rows.find((item) => String(item.id) === String(this.selectedItemId)) || null;
+  }
+
+  _setSelectedItemId(itemId) {
+    this.selectedItemId = normalizeText(itemId);
+    if (this.editbox) {
+      this.editbox.setItem(this._getSelectedItem());
+    }
+  }
+
+  _renderList() {
+    if (!this.listHost) return;
+
+    const doc = this.listHost.ownerDocument || globalThis.document;
+    if (!this.items.length) {
+      this.listHost.replaceChildren(
+        createMessage(doc, "Für dieses Projekt sind noch keine Restarbeiten vorhanden.")
+      );
+      return;
+    }
+
+    this.listHost.replaceChildren(
+      buildListTable(doc, this.items, this.selectedItemId, (itemId) => {
+        this._setSelectedItemId(itemId);
+        this._renderList();
+        this._renderEditbox();
+      })
+    );
+  }
+
+  _renderEditbox() {
+    if (!this.editHost) return;
+    const doc = this.editHost.ownerDocument || globalThis.document;
+    const selectedItem = this._getSelectedItem();
+
+    if (!selectedItem) {
+      if (this.editbox) this.editbox.setItem(null);
+      this.editHost.replaceChildren(
+        createMessage(doc, "Eine Restarbeit auswaehlen oder ueber + Restarbeit neu anlegen.")
+      );
+      return;
+    }
+
+    if (!this.editbox) {
+      this.editbox = new RestarbeitenEditbox({
+        documentRef: doc,
+        onSave: async (draft) => {
+          if (!this.selectedItemId) return;
+          this.editbox?.setSaving(true);
+          try {
+            await updateRestarbeitItem(this.selectedItemId, draft);
+            await this.load({ selectItemId: this.selectedItemId });
+          } finally {
+            this.editbox?.setSaving(false);
+          }
+        },
+      });
+      this.editHost.replaceChildren(this.editbox.render());
+    }
+
+    this.editbox.setItem(selectedItem);
+    this.editbox.setStatus(selectedItem ? `Ausgewählt: #${selectedItem.running_number || selectedItem.id}` : "");
+  }
+
+  async _createRestarbeit() {
+    if (!this.effectiveProjectId) return;
+    this.editbox?.setStatus("Restarbeit wird angelegt...");
+    try {
+      const item = await createRestarbeitItem(this.effectiveProjectId, {});
+      const selectedId = item?.id ? String(item.id) : "";
+      await this.load({ selectItemId: selectedId });
+    } catch (error) {
+      if (this.editbox) this.editbox.setStatus(error?.message || "Restarbeit konnte nicht angelegt werden.");
+    }
+  }
+
+  _renderHeader() {
+    if (!this.headerHost) return;
+    const doc = this.headerHost.ownerDocument || globalThis.document;
+    const row = doc.createElement("div");
+    row.style.display = "flex";
+    row.style.alignItems = "center";
+    row.style.gap = "10px";
+
+    const title = doc.createElement("h2");
+    title.textContent = "Restarbeiten";
+    title.style.margin = "0";
+
+    const actionBtn = doc.createElement("button");
+    actionBtn.type = "button";
+    actionBtn.textContent = "+ Restarbeit";
+    applyPopupButtonStyle(actionBtn, { variant: "primary" });
+    actionBtn.disabled = !this.effectiveProjectId;
+    actionBtn.onclick = async () => {
+      await this._createRestarbeit();
+    };
+
+    const context = doc.createElement("div");
+    context.textContent = this.effectiveProjectId
+      ? `Projektkontext: #${this.effectiveProjectId}`
+      : "Projektkontext: nicht gesetzt";
+    context.style.marginLeft = "auto";
+    context.style.fontSize = "12px";
+    context.style.opacity = "0.85";
+
+    row.append(title, actionBtn, context);
+    this.headerHost.replaceChildren(row);
   }
 
   render() {
     const root = document.createElement("div");
     root.style.display = "grid";
-    root.style.gap = "8px";
-
-    const title = document.createElement("h2");
-    title.textContent = "Restarbeiten";
-    title.style.margin = "0";
-    root.append(title);
+    root.style.gap = "12px";
 
     this.effectiveProjectId = normalizeText(this.projectId || this.project?.id || "");
 
-    const context = document.createElement("div");
-    context.textContent = this.effectiveProjectId
-      ? `Projektkontext: #${this.effectiveProjectId}`
-      : "Projektkontext: nicht gesetzt";
-    root.append(context);
+    this.headerHost = document.createElement("div");
+    this.listHost = document.createElement("div");
+    this.editHost = document.createElement("div");
 
-    this.host = document.createElement("div");
-    root.append(this.host);
+    this._renderHeader();
+    this._renderList();
+    this._renderEditbox();
 
-    if (!this.effectiveProjectId) {
-      const missing = document.createElement("p");
-      missing.textContent = "Kein Projektkontext für Restarbeiten vorhanden.";
-      this.host.replaceChildren(missing);
-      return root;
-    }
-
-    const loading = document.createElement("p");
-    loading.textContent = "Restarbeiten werden geladen…";
-    this.host.replaceChildren(loading);
-
+    root.append(this.headerHost, this.listHost, this.editHost);
+    this.host = root;
     return root;
   }
 
-  async load() {
+  async load({ selectItemId = null } = {}) {
     if (!this.effectiveProjectId || !this.host) return;
+
+    this.isLoading = true;
+    this.listHost?.replaceChildren(createMessage(this.listHost.ownerDocument || globalThis.document, "Restarbeiten werden geladen…"));
+    if (this.editbox) this.editbox.setStatus("Lade...");
 
     try {
       await getRestarbeitenProjectSettings(this.effectiveProjectId);
       const rows = await listRestarbeitenByProject(this.effectiveProjectId);
-      const items = toRestarbeitenListItems(rows);
-
-      if (!items.length) {
-        const empty = document.createElement("p");
-        empty.textContent = "Für dieses Projekt sind noch keine Restarbeiten vorhanden.";
-        this.host.replaceChildren(empty);
-        return;
+      this.rows = Array.isArray(rows) ? rows : [];
+      this.items = toRestarbeitenListItems(this.rows);
+      const wantedId = normalizeText(selectItemId);
+      if (wantedId && this.items.some((item) => String(item.id) === wantedId)) {
+        this.selectedItemId = wantedId;
+      } else if (this.selectedItemId && !this.items.some((item) => String(item.id) === String(this.selectedItemId))) {
+        this.selectedItemId = this.items[0]?.id ? String(this.items[0].id) : "";
+      } else if (!this.selectedItemId && this.items[0]) {
+        this.selectedItemId = String(this.items[0].id);
       }
 
-      this.host.replaceChildren(buildListTable(items));
+      this._renderList();
+      this._renderEditbox();
     } catch (error) {
-      const err = document.createElement("p");
-      err.textContent = `Restarbeiten konnten nicht geladen werden: ${error?.message || "Unbekannter Fehler"}`;
-      this.host.replaceChildren(err);
+      this.rows = [];
+      this.items = [];
+      if (this.listHost) {
+        this.listHost.replaceChildren(
+          createMessage(
+            this.listHost.ownerDocument || globalThis.document,
+            `Restarbeiten konnten nicht geladen werden: ${error?.message || "Unbekannter Fehler"}`
+          )
+        );
+      }
+      if (this.editbox) this.editbox.setStatus("");
+    } finally {
+      this.isLoading = false;
     }
   }
 }

--- a/src/renderer/modules/restarbeiten/screens/index.js
+++ b/src/renderer/modules/restarbeiten/screens/index.js
@@ -1,3 +1,4 @@
 export { default as RestarbeitenScreen } from "./RestarbeitenScreen.js";
+export { default as RestarbeitenEditbox } from "./RestarbeitenEditbox.js";
 
 export const RESTARBEITEN_WORK_SCREEN_ID = "restarbeitenWork";


### PR DESCRIPTION
Implementiert Restarbeiten create/update, die Editbox-Grundform und die zugehoerigen Tests. Keine Foto-/Diktat-/Druck-/Mail-/Loesch-/Archivpfade. Tests: npm test