### PR TITLE
M7: Load & display Restarbeiten attachments and toggle primary photo

### DIFF
--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -263,3 +263,7 @@ Dabei gilt:
 - Beim Speichern werden `responsible_project_firm_id` und `responsible_label` gemeinsam gesetzt; bestehende Label-Fallbacks bleiben erhalten.
 - Liste zeigt weiterhin `responsible_label` in der Status-Metaspalte.
 - Fotos, Diktat, Druck, Mail, Filter und Smartphone-Import bleiben fuer spaetere Schritte offen.
+
+### M7 Restarbeiten-Attachments anzeigen und Hauptfoto markieren (neu)
+- Restarbeiten-Attachments koennen geladen, in der Editbox angezeigt und als Hauptfoto markiert werden.
+- Dateiimport, Projektordner-Kopie, Bildzuschnitt und Thumbnail-Erzeugung folgen in spaeteren Schritten.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -311,6 +311,70 @@ async function runRestarbeitenModuleTests(run) {
     }
   });
 
+
+  await run("M7 IPC/Preload: Attachment-Endpunkte vorhanden ohne Upload/Delete", () => {
+    const ipc = fs.readFileSync(path.join(__dirname, "../../src/main/ipc/restarbeitenIpc.js"), "utf8");
+    const preload = fs.readFileSync(path.join(__dirname, "../../src/main/preload.js"), "utf8");
+    assert.match(ipc, /restarbeiten:listAttachments/);
+    assert.match(ipc, /restarbeiten:setPrimaryAttachment/);
+    assert.match(preload, /restarbeitenListAttachments/);
+    assert.match(preload, /restarbeitenSetPrimaryAttachment/);
+    assert.doesNotMatch(ipc, /restarbeiten:deleteAttachment|restarbeiten:uploadAttachment|image/i);
+  });
+
+  await run("M7 DataSource: Attachments-Liste/Primary und Bridge-Fehler", async () => {
+    const repo = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js")
+    );
+    const prevWindow = globalThis.window;
+    const calls = [];
+    globalThis.window = {
+      bbmDb: {
+        restarbeitenListAttachments: async (payload) => {
+          calls.push({ type: "list", payload });
+          return { ok: true, attachments: [{ id: "a-1" }] };
+        },
+        restarbeitenSetPrimaryAttachment: async (payload) => {
+          calls.push({ type: "primary", payload });
+          return { ok: true };
+        },
+      },
+    };
+    try {
+      const list = await repo.listRestarbeitAttachments("r-1");
+      assert.equal(Array.isArray(list), true);
+      await repo.setPrimaryRestarbeitAttachment("r-1", "a-1");
+      assert.equal(calls[0].payload.restarbeitId, "r-1");
+      assert.equal(calls[1].payload.attachmentId, "a-1");
+    } finally {
+      globalThis.window = prevWindow;
+    }
+
+    globalThis.window = { bbmDb: {} };
+    try {
+      await assert.rejects(() => repo.listRestarbeitAttachments("r-1"), /restarbeitenListAttachments fehlt/);
+    } finally {
+      globalThis.window = prevWindow;
+    }
+  });
+
+
+  await run("M7 View/Editbox/Screen: Attachment-Anzeige verdrahtet", () => {
+    const view = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js"), "utf8");
+    const editbox = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js"), "utf8");
+    const screen = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"), "utf8");
+
+    assert.match(view, /Noch keine Fotos vorhanden\./);
+    assert.match(view, /slice\(0, 3\)/);
+    assert.match(view, /Hauptfoto/);
+    assert.match(editbox, /setAttachments\(attachments\)/);
+    assert.match(editbox, /onSetPrimaryAttachment/);
+    assert.match(screen, /listRestarbeitAttachments/);
+    assert.match(screen, /setPrimaryRestarbeitAttachment/);
+    assert.doesNotMatch(screen, /innerHTML\s*=/);
+    assert.doesNotMatch(editbox + view + screen, /Foto-Hinzufuegen|Loeschen|Diktat|Druck|Mail/);
+  });
+
   await run("M5 Screen: fehlender Projektkontext zeigt nur den Kontext-Hinweis", async () => {
     const prevWindow = globalThis.window;
     const prevDocument = globalThis.document;

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -172,7 +172,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(content, /Restarbeit/);
     assert.match(content, /Status/);
     assert.doesNotMatch(content, /tr\.innerHTML|innerHTML\s*=\s*\[/);
-    assert.doesNotMatch(content, /Diktat|Foto|Druck|Mail|Loeschen|Archivieren/);
+    assert.doesNotMatch(content, /Diktat|Druck|Mail|Loeschen|Archivieren/);
   });
 
   await run("M5 Repo/IPC/Preload/DataSource: Create und Update sind verdrahtet", async () => {
@@ -544,7 +544,7 @@ async function runRestarbeitenModuleTests(run) {
         path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js"),
         "utf8"
       );
-      assert.doesNotMatch(editboxSource, /Foto|Diktat|Druck|Mail/);
+      assert.doesNotMatch(editboxSource, /Diktat|Druck|Mail/);
     } finally {
       globalThis.document = prevDocument;
     }

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -262,6 +262,8 @@ async function runRestarbeitenModuleTests(run) {
           if (target) Object.assign(target, payload.patch || {});
           return { ok: true, item: { id: payload.id, ...payload.patch } };
         },
+        restarbeitenListAttachments: async () => ({ ok: true, attachments: [] }),
+        restarbeitenSetPrimaryAttachment: async () => ({ ok: true }),
         projectFirmsListByProject: async () => ({
           ok: true,
           list: [
@@ -358,6 +360,46 @@ async function runRestarbeitenModuleTests(run) {
     }
   });
 
+
+
+
+  await run("M7 Screen: Attachment-Ladefehler bricht Screen nicht hart ab", async () => {
+    const prevWindow = globalThis.window;
+    const prevDocument = globalThis.document;
+    globalThis.window = {
+      bbmDb: {
+        restarbeitenGetProjectSettings: async () => ({ ok: true, settings: {} }),
+        restarbeitenListByProject: async () => ({
+          ok: true,
+          items: [{ id: "r-1", running_number: 1, created_at: "2026-05-16", status: "offen", short_text: "A" }],
+        }),
+        projectFirmsListByProject: async () => ({ ok: true, list: [] }),
+        restarbeitenListAttachments: async () => ({ ok: false, error: "kaputt" }),
+        restarbeitenSetPrimaryAttachment: async () => ({ ok: true }),
+      },
+    };
+    globalThis.document = createFakeDocument();
+
+    try {
+      const Screen = (
+        await importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"))
+      ).default;
+      const screen = new Screen({ projectId: "p-1" });
+      screen.render();
+      await screen.load();
+
+      const row = screen.listHost.children[0].children[1].children[0];
+      row.dispatchEvent({ type: "click" });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      assert.equal(screen.selectedItemId, "r-1");
+      assert.equal(screen.listHost.children[0].tagName, "TABLE");
+      assert.equal(screen.editbox?.statusEl?.textContent, "Fotos konnten nicht geladen werden.");
+    } finally {
+      globalThis.window = prevWindow;
+      globalThis.document = prevDocument;
+    }
+  });
 
   await run("M7 View/Editbox/Screen: Attachment-Anzeige verdrahtet", () => {
     const view = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js"), "utf8");
@@ -520,6 +562,8 @@ async function runRestarbeitenModuleTests(run) {
       bbmDb: {
         restarbeitenGetProjectSettings: async () => ({ ok: true, settings: {} }),
         restarbeitenListByProject: async () => ({ ok: true, items: items.map((i) => ({ ...i })) }),
+        restarbeitenListAttachments: async () => ({ ok: true, attachments: [] }),
+        restarbeitenSetPrimaryAttachment: async () => ({ ok: true }),
         projectFirmsListByProject: async () => ({ ok: true, list: [{ id: "f1", name: "Firma A" }] }),
         restarbeitenCreateItem: async () => ({ ok: true, item: { id: "r-2" } }),
         restarbeitenUpdateItem: async (payload) => {

--- a/src/main/ipc/restarbeitenIpc.js
+++ b/src/main/ipc/restarbeitenIpc.js
@@ -8,6 +8,24 @@ function normalizeProjectId(payload) {
   return String(payload ?? "").trim();
 }
 
+
+
+function normalizeRestarbeitId(payload) {
+  if (payload && typeof payload === "object") {
+    const candidate = payload.restarbeitId ?? payload.restarbeit_id ?? payload.id;
+    return String(candidate ?? "").trim();
+  }
+  return String(payload ?? "").trim();
+}
+
+function normalizeAttachmentId(payload) {
+  if (payload && typeof payload === "object") {
+    const candidate = payload.attachmentId ?? payload.attachment_id ?? payload.id;
+    return String(candidate ?? "").trim();
+  }
+  return String(payload ?? "").trim();
+}
+
 function toBool(value, fallback = false) {
   if (value == null) return fallback;
   if (typeof value === "boolean") return value;
@@ -69,6 +87,32 @@ function registerRestarbeitenIpc({ ipcMain }) {
       return { ok: false, error: error?.message || "Restarbeit konnte nicht gespeichert werden." };
     }
   });
+
+  ipcMain.handle("restarbeiten:listAttachments", async (_event, payload) => {
+    try {
+      const restarbeitId = normalizeRestarbeitId(payload);
+      if (!restarbeitId) throw new Error("restarbeitId erforderlich");
+      const attachments = repo.listRestarbeitAttachments(restarbeitId);
+      return { ok: true, attachments: Array.isArray(attachments) ? attachments : [] };
+    } catch (error) {
+      return { ok: false, error: error?.message || "Attachments konnten nicht geladen werden." };
+    }
+  });
+
+  ipcMain.handle("restarbeiten:setPrimaryAttachment", async (_event, payload) => {
+    try {
+      const source = payload && typeof payload === "object" ? payload : {};
+      const restarbeitId = normalizeRestarbeitId(source);
+      const attachmentId = normalizeAttachmentId(source);
+      if (!restarbeitId) throw new Error("restarbeitId erforderlich");
+      if (!attachmentId) throw new Error("attachmentId erforderlich");
+      repo.setPrimaryRestarbeitAttachment(restarbeitId, attachmentId);
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: error?.message || "Hauptfoto konnte nicht gesetzt werden." };
+    }
+  });
+
 }
 
 module.exports = { registerRestarbeitenIpc };

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -244,6 +244,8 @@ contextBridge.exposeInMainWorld("bbmDb", {
   restarbeitenGetProjectSettings: (data) => ipcRenderer.invoke("restarbeiten:getProjectSettings", data),
   restarbeitenCreateItem: (data) => ipcRenderer.invoke("restarbeiten:createItem", data),
   restarbeitenUpdateItem: (data) => ipcRenderer.invoke("restarbeiten:updateItem", data),
+  restarbeitenListAttachments: (data) => ipcRenderer.invoke("restarbeiten:listAttachments", data),
+  restarbeitenSetPrimaryAttachment: (data) => ipcRenderer.invoke("restarbeiten:setPrimaryAttachment", data),
 });
 
 contextBridge.exposeInMainWorld("bbmPrint", {

--- a/src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js
+++ b/src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js
@@ -88,3 +88,42 @@ export async function updateRestarbeitItem(id, patch = {}) {
   const response = await callAndNormalize(bbmDb.restarbeitenUpdateItem, buildUpdatePayload(id, patch), "update");
   return response.item && typeof response.item === "object" ? response.item : null;
 }
+
+
+function extractRestarbeitId(restarbeitId) {
+  const normalized = String(restarbeitId ?? "").trim();
+  if (!normalized) throw new Error("Restarbeiten-Datenzugriff: restarbeitId fehlt.");
+  return normalized;
+}
+
+function extractAttachmentId(attachmentId) {
+  const normalized = String(attachmentId ?? "").trim();
+  if (!normalized) throw new Error("Restarbeiten-Datenzugriff: attachmentId fehlt.");
+  return normalized;
+}
+
+
+export async function listRestarbeitAttachments(restarbeitId) {
+  const bbmDb = requireBbmDb();
+  if (typeof bbmDb.restarbeitenListAttachments !== "function") {
+    throw new Error("Restarbeiten-Datenzugriff nicht verfuegbar: restarbeitenListAttachments fehlt.");
+  }
+  const rid = extractRestarbeitId(restarbeitId);
+  const response = await callAndNormalize(bbmDb.restarbeitenListAttachments, { restarbeitId: rid }, "attachments-liste");
+  return Array.isArray(response.attachments) ? response.attachments : [];
+}
+
+export async function setPrimaryRestarbeitAttachment(restarbeitId, attachmentId) {
+  const bbmDb = requireBbmDb();
+  if (typeof bbmDb.restarbeitenSetPrimaryAttachment !== "function") {
+    throw new Error("Restarbeiten-Datenzugriff nicht verfuegbar: restarbeitenSetPrimaryAttachment fehlt.");
+  }
+  const rid = extractRestarbeitId(restarbeitId);
+  const aid = extractAttachmentId(attachmentId);
+  await callAndNormalize(
+    bbmDb.restarbeitenSetPrimaryAttachment,
+    { restarbeitId: rid, attachmentId: aid },
+    "attachments-hauptfoto"
+  );
+  return true;
+}

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js
@@ -1,0 +1,105 @@
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+function getDisplayLabel(attachment) {
+  return normalizeText(attachment?.caption) || normalizeText(attachment?.file_name) || "Ohne Bezeichnung";
+}
+
+export default class RestarbeitenAttachmentsView {
+  constructor({ documentRef = globalThis.document, onSetPrimary = null } = {}) {
+    this.document = documentRef || globalThis.document;
+    this.onSetPrimary = typeof onSetPrimary === "function" ? onSetPrimary : null;
+    this.root = null;
+    this.attachments = [];
+  }
+
+  render() {
+    const root = this.document.createElement("section");
+    root.style.display = "grid";
+    root.style.gap = "8px";
+    this.root = root;
+    this._renderContent();
+    return root;
+  }
+
+  setAttachments(attachments) {
+    this.attachments = Array.isArray(attachments) ? attachments.slice(0, 3) : [];
+    this._renderContent();
+  }
+
+  _renderContent() {
+    if (!this.root) return;
+    const doc = this.document;
+    if (!this.attachments.length) {
+      const empty = doc.createElement("div");
+      empty.textContent = "Noch keine Fotos vorhanden.";
+      this.root.replaceChildren(empty);
+      return;
+    }
+
+    const wrapper = doc.createElement("div");
+    wrapper.style.display = "grid";
+    wrapper.style.gridTemplateColumns = "2fr 1fr";
+    wrapper.style.gap = "10px";
+
+    const primary = this.attachments.find((a) => Number(a?.is_primary) === 1 || a?.is_primary === true) || this.attachments[0];
+    const others = this.attachments.filter((a) => a !== primary);
+
+    wrapper.append(this._buildCard(primary, true));
+
+    const rightCol = doc.createElement("div");
+    rightCol.style.display = "grid";
+    rightCol.style.gap = "8px";
+    for (const attachment of others) rightCol.append(this._buildCard(attachment, false));
+    wrapper.append(rightCol);
+
+    this.root.replaceChildren(wrapper);
+  }
+
+  _buildCard(attachment, isPrimary) {
+    const doc = this.document;
+    const card = doc.createElement("article");
+    card.style.border = isPrimary ? "2px solid #3b82f6" : "1px solid var(--card-border, #cfcfcf)";
+    card.style.borderRadius = "10px";
+    card.style.padding = "8px";
+    card.style.display = "grid";
+    card.style.gap = "6px";
+
+    const path = normalizeText(attachment?.file_path);
+    if (path) {
+      const img = doc.createElement("img");
+      img.src = path;
+      img.alt = getDisplayLabel(attachment);
+      img.style.width = "100%";
+      img.style.height = isPrimary ? "140px" : "90px";
+      img.style.objectFit = "cover";
+      card.append(img);
+    } else {
+      const placeholder = doc.createElement("div");
+      placeholder.textContent = "Kein Bildpfad vorhanden.";
+      card.append(placeholder);
+    }
+
+    const label = doc.createElement("div");
+    label.textContent = getDisplayLabel(attachment);
+
+    const radioWrap = doc.createElement("label");
+    const radio = doc.createElement("input");
+    radio.type = "radio";
+    radio.name = "restarbeiten-primary-attachment";
+    radio.value = normalizeText(attachment?.id);
+    radio.checked = !!isPrimary;
+    radio.disabled = !radio.value;
+    radio.addEventListener("change", () => {
+      if (!radio.checked || !this.onSetPrimary) return;
+      this.onSetPrimary(radio.value);
+    });
+    const caption = doc.createElement("span");
+    caption.textContent = " Hauptfoto";
+    radioWrap.append(radio, caption);
+
+    card.append(label, radioWrap);
+    return card;
+  }
+}

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -1,3 +1,5 @@
+import RestarbeitenAttachmentsView from "./RestarbeitenAttachmentsView.js";
+
 function normalizeText(value) {
   return String(value ?? "").trim();
 }
@@ -57,7 +59,7 @@ function normalizeFirmEntries(list) {
 }
 
 export default class RestarbeitenEditbox {
-  constructor({ documentRef = globalThis.document, onSave = null } = {}) {
+  constructor({ documentRef = globalThis.document, onSave = null, onSetPrimaryAttachment = null } = {}) {
     this.document = documentRef || globalThis.document;
     this.onSave = typeof onSave === "function" ? onSave : null;
     this.root = null;
@@ -67,6 +69,9 @@ export default class RestarbeitenEditbox {
     this.currentItem = null;
     this.projectFirms = [];
     this.fields = {};
+    this.attachments = [];
+    this.attachmentsView = null;
+    this.onSetPrimaryAttachment = typeof onSetPrimaryAttachment === "function" ? onSetPrimaryAttachment : null;
   }
 
   render() {
@@ -128,6 +133,25 @@ export default class RestarbeitenEditbox {
       createField(doc, "responsible_project_firm_id", responsibleProjectFirmId)
     );
 
+
+    const attachmentsHost = doc.createElement("div");
+    attachmentsHost.style.display = "grid";
+    attachmentsHost.style.gap = "8px";
+
+    const attachmentsTitle = doc.createElement("div");
+    attachmentsTitle.textContent = "Fotos";
+    attachmentsTitle.style.fontSize = "12px";
+    attachmentsTitle.style.fontWeight = "700";
+
+    this.attachmentsView = new RestarbeitenAttachmentsView({
+      documentRef: doc,
+      onSetPrimary: (attachmentId) => {
+        if (this.onSetPrimaryAttachment) this.onSetPrimaryAttachment(attachmentId);
+      },
+    });
+
+    attachmentsHost.append(attachmentsTitle, this.attachmentsView.render());
+
     const footer = doc.createElement("div");
     footer.style.display = "flex";
     footer.style.alignItems = "center";
@@ -147,7 +171,7 @@ export default class RestarbeitenEditbox {
     statusEl.style.opacity = "0.8";
 
     footer.append(saveBtn, statusEl);
-    form.append(footer);
+    form.append(attachmentsHost, footer);
     root.append(title, subtitle, form);
 
     form.addEventListener("submit", async (event) => {
@@ -174,6 +198,7 @@ export default class RestarbeitenEditbox {
       responsible_project_firm_id: responsibleProjectFirmId,
     };
 
+    this.setAttachments([]);
     this.setItem(null);
     return root;
   }
@@ -203,6 +228,11 @@ export default class RestarbeitenEditbox {
       select.appendChild(legacy);
       select.value = targetId;
     }
+  }
+
+  setAttachments(attachments) {
+    this.attachments = Array.isArray(attachments) ? attachments : [];
+    if (this.attachmentsView) this.attachmentsView.setAttachments(this.attachments);
   }
 
   setStatus(text) {

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -3,6 +3,8 @@ import {
   getRestarbeitenProjectSettings,
   listRestarbeitenByProject,
   listResponsibleProjectFirms,
+  listRestarbeitAttachments,
+  setPrimaryRestarbeitAttachment,
   updateRestarbeitItem,
 } from "../data/restarbeitenDataSource.js";
 import { toRestarbeitenListItems } from "../viewModel/restarbeitenListItems.js";
@@ -104,6 +106,7 @@ export default class RestarbeitenScreen {
     this.isLoading = false;
     this.editbox = null;
     this.projectFirms = [];
+    this.attachmentsByItemId = new Map();
   }
 
   _getSelectedItem() {
@@ -136,6 +139,7 @@ export default class RestarbeitenScreen {
         this._setSelectedItemId(itemId);
         this._renderList();
         this._renderEditbox();
+        this._loadSelectedAttachments();
       })
     );
   }
@@ -173,13 +177,30 @@ export default class RestarbeitenScreen {
             this.editbox?.setSaving(false);
           }
         },
+        onSetPrimaryAttachment: async (attachmentId) => {
+          const selectedItem = this._getSelectedItem();
+          if (!selectedItem?.id) return;
+          await setPrimaryRestarbeitAttachment(selectedItem.id, attachmentId);
+          await this._loadSelectedAttachments();
+          this._renderEditbox();
+        },
       });
       this.editHost.replaceChildren(this.editbox.render());
     }
 
     this.editbox.setProjectFirms(this.projectFirms);
     this.editbox.setItem(selectedItem);
+    this.editbox.setAttachments(this.attachmentsByItemId.get(String(selectedItem.id)) || []);
     this.editbox.setStatus(selectedItem ? `Ausgewählt: #${selectedItem.running_number || selectedItem.id}` : "");
+  }
+
+  async _loadSelectedAttachments() {
+    const selectedItem = this._getSelectedItem();
+    if (!selectedItem?.id || !this.editbox) return;
+    const itemId = String(selectedItem.id);
+    const attachments = await listRestarbeitAttachments(itemId);
+    this.attachmentsByItemId.set(itemId, Array.isArray(attachments) ? attachments : []);
+    this.editbox.setAttachments(this.attachmentsByItemId.get(itemId) || []);
   }
 
   async _createRestarbeit() {
@@ -270,6 +291,7 @@ export default class RestarbeitenScreen {
         listResponsibleProjectFirms(this.effectiveProjectId),
       ]);
       this.rows = Array.isArray(rows) ? rows : [];
+      this.attachmentsByItemId = new Map();
       this.projectFirms = Array.isArray(firms) ? firms : [];
       this.items = toRestarbeitenListItems(this.rows);
       const wantedId = normalizeText(selectItemId);
@@ -287,6 +309,7 @@ export default class RestarbeitenScreen {
       this.rows = [];
       this.items = [];
       this.projectFirms = [];
+    this.attachmentsByItemId = new Map();
       if (this.listHost) {
         this.listHost.replaceChildren(
           createMessage(

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -139,7 +139,7 @@ export default class RestarbeitenScreen {
         this._setSelectedItemId(itemId);
         this._renderList();
         this._renderEditbox();
-        this._loadSelectedAttachments();
+        this._loadSelectedAttachments().catch(() => {});
       })
     );
   }
@@ -198,9 +198,16 @@ export default class RestarbeitenScreen {
     const selectedItem = this._getSelectedItem();
     if (!selectedItem?.id || !this.editbox) return;
     const itemId = String(selectedItem.id);
-    const attachments = await listRestarbeitAttachments(itemId);
-    this.attachmentsByItemId.set(itemId, Array.isArray(attachments) ? attachments : []);
-    this.editbox.setAttachments(this.attachmentsByItemId.get(itemId) || []);
+    try {
+      const attachments = await listRestarbeitAttachments(itemId);
+      this.attachmentsByItemId.set(itemId, Array.isArray(attachments) ? attachments : []);
+      this.editbox.setAttachments(this.attachmentsByItemId.get(itemId) || []);
+    } catch (_error) {
+      this.attachmentsByItemId.set(itemId, []);
+      this.editbox.setAttachments([]);
+      this.editbox.setStatus("Fotos konnten nicht geladen werden.");
+      throw _error;
+    }
   }
 
   async _createRestarbeit() {
@@ -309,7 +316,7 @@ export default class RestarbeitenScreen {
       this.rows = [];
       this.items = [];
       this.projectFirms = [];
-    this.attachmentsByItemId = new Map();
+      this.attachmentsByItemId = new Map();
       if (this.listHost) {
         this.listHost.replaceChildren(
           createMessage(


### PR DESCRIPTION
### Motivation
- Enable M7: load existing attachments for a Restarbeit, show them in the Editbox (max 3) and allow marking one as the primary photo without adding upload/processing features.
- Keep the change small and module-local: no file import, no image processing, no DB schema or packaging changes.

### Description
- Added IPC handlers in `src/main/ipc/restarbeitenIpc.js`: `restarbeiten:listAttachments` and `restarbeiten:setPrimaryAttachment` with defensive ID normalization and `{ ok: true/false }` responses.
- Exposed preload bridge methods `restarbeitenListAttachments` and `restarbeitenSetPrimaryAttachment` on `window.bbmDb` in `src/main/preload.js`.
- Implemented renderer DataSource functions `listRestarbeitAttachments` and `setPrimaryRestarbeitAttachment` in `src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js` with bridge checks, defensive normalization and array-normalized return values.
- Added a module-local view `src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js` that shows up to 3 attachments, displays a left larger primary photo, fallbacks when `file_path` missing, and a radio to toggle primary.
- Extended `RestarbeitenEditbox` (`src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js`) to include an attachments area, `setAttachments(attachments)` and an `onSetPrimaryAttachment` callback wired into the attachments view.
- Updated `RestarbeitenScreen` (`src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`) to load attachments when a Restarbeit is selected, pass them into the Editbox, call `setPrimaryRestarbeitAttachment(...)` on change and reload attachments afterward while keeping `render()` synchronous and `load()` as the data-loading entry point.
- Updated tests and docs: added M7 tests to `scripts/tests/restarbeitenModule.test.cjs` and a short M7 note in `docs/MODULARISIERUNGSPLAN.md`.

### Testing
- Ran the module tests with `node scripts/tests/restarbeitenModule.test.cjs`, which passed in this environment (tests covering IPC/preload, DataSource, view/editbox/screen wiring).
- Attempted `npm test` but it cannot run in this container due to missing system library for Electron (`libatk-1.0.so.0`), so full `npm test` was not executable here.
- The changes include only renderer/data/preload/ipc/view updates and no DB schema or packaging changes, keeping scope limited to the M7 goal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08718286288322aeb9be0a5697fbcb)