### PR TITLE
M9: Stabilize M8 photo import to include project_id in attachments

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1995,3 +1995,5 @@ Wichtig:
   - Speichern laedt die Liste erneut und haelt die Auswahl konsistent
   - Foto-/Diktat-/Druck-/Mail-/Loesch- und Archivpfade bleiben ausserhalb dieses Pakets
   - `npm test` laeuft gruen
+
+- M9 ist abgeschlossen: Der M8-Fotoimport speichert Attachments jetzt IPC-seitig DB-konform mit `project_id` ueber `addRestarbeitAttachment(...)`; der zugehoerige M8-Test erzwingt den Repo-Vertrag (`restarbeit_id`, `project_id`, `file_path`) und prueft die erwarteten Attachment-Felder.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -271,3 +271,7 @@ Dabei gilt:
 ### M8 Restarbeiten-Fotos importieren und als Attachments speichern (neu)
 - Restarbeiten-Fotos koennen per Dateiauswahl importiert, in den Projektordner kopiert und als Attachments gespeichert werden.
 - Bildzuschnitt, Thumbnail-Erzeugung, Smartphone-Import und Foto-Loeschen folgen spaeter.
+
+### M9 M8-Fotoimport gegen Repo-Vertrag stabilisiert (neu)
+- Der M8-Fotoimport wurde gegen den echten Attachment-Repo-Vertrag stabilisiert.
+- Beim Speichern von Attachments wird `project_id` jetzt aus dem normalisierten `projectId` mitgegeben.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -479,6 +479,9 @@ async function runRestarbeitenModuleTests(run) {
         setPrimaryRestarbeitAttachment: () => true,
         listRestarbeitAttachments: () => repoState.attachments,
         addRestarbeitAttachment: (payload) => {
+          if (!payload?.restarbeit_id) throw new Error("restarbeit_id required");
+          if (!payload?.project_id) throw new Error("project_id required");
+          if (!payload?.file_path) throw new Error("file_path required");
           repoState.added.push(payload);
           repoState.attachments = [...repoState.attachments, { id: String(repoState.attachments.length + 1), ...payload }];
           return repoState.attachments[repoState.attachments.length - 1];
@@ -505,7 +508,11 @@ async function runRestarbeitenModuleTests(run) {
         assert.equal(result.ok, true, result.error || JSON.stringify(result));
         assert.equal(result.canceled, false, JSON.stringify(result));
         assert.equal(repoState.added.length, 3, JSON.stringify(repoState.added));
+        assert.equal(repoState.added[0]?.restarbeit_id, "r1", JSON.stringify(repoState.added[0] || {}));
+        assert.equal(repoState.added[0]?.project_id, "p1", JSON.stringify(repoState.added[0] || {}));
         assert.match(String(repoState.added[0]?.file_path || ""), /Restarbeiten[\/]Fotos/, JSON.stringify(repoState.added[0] || {}));
+        assert.equal(Boolean(repoState.added[0]?.original_file_name), true, JSON.stringify(repoState.added[0] || {}));
+        assert.match(String(repoState.added[0]?.mime_type || ""), /^image\/(jpeg|png|webp)$/i, JSON.stringify(repoState.added[0] || {}));
 
         repoState.attachments = [{ id: "1" }, { id: "2" }];
         repoState.added = [];

--- a/src/main/ipc/restarbeitenIpc.js
+++ b/src/main/ipc/restarbeitenIpc.js
@@ -186,8 +186,10 @@ function registerRestarbeitenIpc({ ipcMain }) {
 
         repo.addRestarbeitAttachment({
           restarbeit_id: restarbeitId,
+          project_id: projectId,
           file_path: destPath,
           file_name: path.basename(destPath),
+          original_file_name: path.basename(src),
           mime_type: detectMimeType(destPath),
           file_size: Number(stats?.size || 0),
         });


### PR DESCRIPTION
### Motivation
- Fix a runtime error where the IPC handler saved attachments without the required `project_id`, because the repo contract for `addRestarbeitAttachment(...)` expects `restarbeit_id`, `project_id` and `file_path` and the previous test-stub was too permissive.

### Description
- Include `project_id: projectId` and `original_file_name: path.basename(src)` when calling `repo.addRestarbeitAttachment(...)` in `src/main/ipc/restarbeitenIpc.js` so the saved attachment is DB-/repo-conformant.
- Harden the M8 test stub in `scripts/tests/restarbeitenModule.test.cjs` so `addRestarbeitAttachment(payload)` now throws if `restarbeit_id`, `project_id` or `file_path` are missing, and add assertions that check `restarbeit_id`, `project_id`, `original_file_name` and `mime_type` on the saved payloads.
- Document the change by adding a short M9 note to `docs/MODULARISIERUNGSPLAN.md` and update `STATUS.md` with the M9 completion line.

### Testing
- Executed the focused module test with `node scripts/tests/restarbeitenModule.test.cjs`, which passed after the changes.
- Attempted the full test run with `npm test`, but it is not fully runnable in this environment because Electron fails to start due to a missing system library (`libatk-1.0.so.0`), so the full suite could not be executed here.
- Changed files: `src/main/ipc/restarbeitenIpc.js`, `scripts/tests/restarbeitenModule.test.cjs`, `docs/MODULARISIERUNGSPLAN.md`, `STATUS.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087dacc2148322ac4f629514f23881)