### PR TITLE
M10: Restarbeiten-Attachments löschen (DB + Dateisystem)

### DIFF
--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -275,3 +275,9 @@ Dabei gilt:
 ### M9 M8-Fotoimport gegen Repo-Vertrag stabilisiert (neu)
 - Der M8-Fotoimport wurde gegen den echten Attachment-Repo-Vertrag stabilisiert.
 - Beim Speichern von Attachments wird `project_id` jetzt aus dem normalisierten `projectId` mitgegeben.
+
+### M10 Restarbeiten-Attachment loeschen (neu)
+- Restarbeiten-Attachments koennen entfernt werden; DB-Datensatz wird geloescht.
+- Datei und optionales Thumbnail werden nach DB-Delete bestmoeglich entfernt.
+- Nach Loeschen wird die Attachment-Liste neu geladen; bei geloeschtem Hauptfoto wird ein verbleibendes Foto wieder Hauptfoto.
+- Bildzuschnitt, Thumbnail-Erzeugung und Smartphone-Import folgen spaeter.

--- a/scripts/tests/restarbeitenDataModel.test.cjs
+++ b/scripts/tests/restarbeitenDataModel.test.cjs
@@ -168,6 +168,33 @@ async function runRestarbeitenDataModelTests(run) {
     assert.equal(list2[0].id, a2.id);
     assert.equal(list2.filter((x) => x.is_primary === 1).length, 1);
   }));
+
+  await run("Attachment-Delete entfernt Datensatz und liefert Pfade", async () => withTemp(({ db, repo }) => {
+    const conn = db.initDatabase();
+    conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p1", "P1");
+    const item = repo.createRestarbeitItem({ project_id: "p1", short_text: "R1" });
+    const a1 = repo.addRestarbeitAttachment({ restarbeit_id: item.id, project_id: "p1", file_path: "/a.jpg", thumbnail_path: "/a_t.jpg", is_primary: true });
+    repo.addRestarbeitAttachment({ restarbeit_id: item.id, project_id: "p1", file_path: "/b.jpg", sort_order: 2 });
+
+    const result = repo.deleteRestarbeitAttachment(item.id, a1.id);
+    assert.equal(result.deleted, true);
+    assert.equal(result.file_path, "/a.jpg");
+    assert.equal(result.thumbnail_path, "/a_t.jpg");
+    assert.equal(repo.listRestarbeitAttachments(item.id).length, 1);
+    assert.equal(repo.listRestarbeitAttachments(item.id)[0].is_primary, 1);
+  }));
+
+  await run("Attachment-Delete behaelt Primary bei Nicht-Primary-Loeschung", async () => withTemp(({ db, repo }) => {
+    const conn = db.initDatabase();
+    conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p1", "P1");
+    const item = repo.createRestarbeitItem({ project_id: "p1", short_text: "R1" });
+    const a1 = repo.addRestarbeitAttachment({ restarbeit_id: item.id, project_id: "p1", file_path: "/a.jpg", is_primary: true });
+    const a2 = repo.addRestarbeitAttachment({ restarbeit_id: item.id, project_id: "p1", file_path: "/b.jpg", sort_order: 2 });
+    repo.deleteRestarbeitAttachment(item.id, a2.id);
+    assert.equal(repo.listRestarbeitAttachments(item.id)[0].id, a1.id);
+    assert.throws(() => repo.deleteRestarbeitAttachment(item.id, "x"), /attachment not found/);
+  }));
+
 }
 
 module.exports = { runRestarbeitenDataModelTests };

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -566,7 +566,9 @@ async function runRestarbeitenModuleTests(run) {
     const preload = fs.readFileSync(path.join(__dirname, "../../src/main/preload.js"), "utf8");
     assert.match(ipc, /restarbeiten:importAttachments/);
     assert.match(preload, /restarbeitenImportAttachments/);
-    assert.doesNotMatch(ipc + preload, /thumbnail|imageProcessing|uploadAttachment/i);
+    assert.doesNotMatch(ipc + preload, /imageProcessing/i);
+    assert.doesNotMatch(ipc + preload, /uploadAttachment/i);
+    assert.doesNotMatch(ipc + preload, /createThumbnail|generateThumbnail|thumbnailer|thumbnailGenerator/i);
   });
 
   await run("M8 DataSource: importRestarbeitAttachments normalisiert Antwort", async () => {

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -321,7 +321,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(ipc, /restarbeiten:setPrimaryAttachment/);
     assert.match(preload, /restarbeitenListAttachments/);
     assert.match(preload, /restarbeitenSetPrimaryAttachment/);
-    assert.doesNotMatch(ipc, /restarbeiten:deleteAttachment|restarbeiten:uploadAttachment|deleteAttachment|uploadAttachment|thumbnail|imageProcessing/i);
+    assert.doesNotMatch(ipc, /restarbeiten:uploadAttachment|uploadAttachment|imageProcessing/i);
   });
 
   await run("M7 DataSource: Attachments-Liste/Primary und Bridge-Fehler", async () => {
@@ -414,8 +414,28 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(screen, /listRestarbeitAttachments/);
     assert.match(screen, /setPrimaryRestarbeitAttachment/);
     assert.doesNotMatch(screen, /innerHTML\s*=/);
-    assert.doesNotMatch(editbox + view + screen, /Foto-Hinzufuegen|Loeschen|Diktat|Druck|Mail/);
+    assert.doesNotMatch(editbox + view + screen, /Diktat|Druck|Mail|Bildbearbeitung/);
   });
+
+
+  await run("M10 IPC/Preload: deleteAttachment verdrahtet", () => {
+    const ipc = fs.readFileSync(path.join(__dirname, "../../src/main/ipc/restarbeitenIpc.js"), "utf8");
+    const preload = fs.readFileSync(path.join(__dirname, "../../src/main/preload.js"), "utf8");
+    assert.match(ipc, /restarbeiten:deleteAttachment/);
+    assert.match(preload, /restarbeitenDeleteAttachment/);
+  });
+
+  await run("M10 DataSource: deleteAttachment normalisiert Antwort", async () => {
+    const ds = await importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js"));
+    const prevWindow = globalThis.window;
+    globalThis.window = { bbmDb: { restarbeitenDeleteAttachment: async () => ({ ok: true, attachments: null, warning: "x" }) } };
+    try {
+      const out = await ds.deleteRestarbeitAttachment("r-1", "a-1");
+      assert.equal(Array.isArray(out.attachments), true);
+      assert.equal(out.warning, "x");
+    } finally { globalThis.window = prevWindow; }
+  });
+
 
   await run("M5 Screen: fehlender Projektkontext zeigt nur den Kontext-Hinweis", async () => {
     const prevWindow = globalThis.window;

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -154,7 +154,8 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(preload, /restarbeitenGetProjectSettings/);
     assert.match(preload, /restarbeitenCreateItem/);
     assert.match(preload, /restarbeitenUpdateItem/);
-    assert.doesNotMatch(ipc, /restarbeiten:delete|restarbeiten:archive|restarbeiten:attachment/);
+    assert.doesNotMatch(ipc, /restarbeiten:archive/);
+    assert.doesNotMatch(ipc, /restarbeiten:deleteItem/);
   });
 
   await run("M4 Screen-Grenzen: sync render, load-Methode, 4 Spalten, kein innerHTML-Datenbau", () => {
@@ -565,7 +566,7 @@ async function runRestarbeitenModuleTests(run) {
     const preload = fs.readFileSync(path.join(__dirname, "../../src/main/preload.js"), "utf8");
     assert.match(ipc, /restarbeiten:importAttachments/);
     assert.match(preload, /restarbeitenImportAttachments/);
-    assert.doesNotMatch(ipc + preload, /deleteAttachment|thumbnail|imageProcessing/i);
+    assert.doesNotMatch(ipc + preload, /thumbnail|imageProcessing|uploadAttachment/i);
   });
 
   await run("M8 DataSource: importRestarbeitAttachments normalisiert Antwort", async () => {

--- a/src/main/db/restarbeitenRepo.js
+++ b/src/main/db/restarbeitenRepo.js
@@ -244,6 +244,49 @@ function setPrimaryRestarbeitAttachment(restarbeitId, attachmentId) {
   tx();
 }
 
+
+function deleteRestarbeitAttachment(restarbeitId, attachmentId) {
+  const db = initDatabase();
+  const rid = reqText(restarbeitId, "restarbeitId");
+  const aid = reqText(attachmentId, "attachmentId");
+
+  const attachment = db.prepare(`
+    SELECT * FROM restarbeiten_attachments
+    WHERE id = ? AND restarbeit_id = ?
+  `).get(aid, rid);
+  if (!attachment) throw new Error("attachment not found");
+
+  const filePath = toText(attachment.file_path);
+  const thumbnailPath = toText(attachment.thumbnail_path);
+  const wasPrimary = Number(attachment.is_primary) === 1 || attachment.is_primary === true;
+  const now = new Date().toISOString();
+
+  const tx = db.transaction(() => {
+    db.prepare(`DELETE FROM restarbeiten_attachments WHERE id = ? AND restarbeit_id = ?`).run(aid, rid);
+
+    if (wasPrimary) {
+      const next = db.prepare(`
+        SELECT id FROM restarbeiten_attachments
+        WHERE restarbeit_id = ?
+        ORDER BY sort_order ASC, created_at ASC
+        LIMIT 1
+      `).get(rid);
+
+      if (next?.id) {
+        db.prepare(`UPDATE restarbeiten_attachments SET is_primary = 1, updated_at = ? WHERE id = ?`).run(now, next.id);
+      }
+    }
+  });
+
+  tx();
+
+  return {
+    deleted: true,
+    attachment,
+    file_path: filePath,
+    thumbnail_path: thumbnailPath,
+  };
+}
 function listRestarbeitAttachments(restarbeitId) {
   const db = initDatabase();
   const rid = reqText(restarbeitId, "restarbeitId");
@@ -263,4 +306,5 @@ module.exports = {
   addRestarbeitAttachment,
   setPrimaryRestarbeitAttachment,
   listRestarbeitAttachments,
+  deleteRestarbeitAttachment,
 };

--- a/src/main/ipc/restarbeitenIpc.js
+++ b/src/main/ipc/restarbeitenIpc.js
@@ -202,6 +202,39 @@ function registerRestarbeitenIpc({ ipcMain }) {
     }
   });
 
+  ipcMain.handle("restarbeiten:deleteAttachment", async (_event, payload) => {
+    try {
+      const source = payload && typeof payload === "object" ? payload : {};
+      const restarbeitId = normalizeRestarbeitId(source);
+      const attachmentId = normalizeAttachmentId(source);
+      if (!restarbeitId) throw new Error("restarbeitId erforderlich");
+      if (!attachmentId) throw new Error("attachmentId erforderlich");
+
+      const deleted = repo.deleteRestarbeitAttachment(restarbeitId, attachmentId);
+      const warnings = [];
+
+      for (const filePath of [deleted?.file_path, deleted?.thumbnail_path]) {
+        const normalized = String(filePath || "").trim();
+        if (!normalized) continue;
+        try {
+          fs.rmSync(normalized, { force: true });
+        } catch (error) {
+          warnings.push(`Datei konnte nicht entfernt werden (${normalized}): ${error?.message || "Unbekannter Fehler"}`);
+        }
+      }
+
+      const attachments = repo.listRestarbeitAttachments(restarbeitId);
+      return {
+        ok: true,
+        attachments: Array.isArray(attachments) ? attachments : [],
+        ...(warnings.length ? { warning: warnings.join(" | ") } : {}),
+      };
+    } catch (error) {
+      return { ok: false, error: error?.message || "Attachment konnte nicht entfernt werden." };
+    }
+  });
+
+
   ipcMain.handle("restarbeiten:setPrimaryAttachment", async (_event, payload) => {
     try {
       const source = payload && typeof payload === "object" ? payload : {};

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -247,6 +247,7 @@ contextBridge.exposeInMainWorld("bbmDb", {
   restarbeitenListAttachments: (data) => ipcRenderer.invoke("restarbeiten:listAttachments", data),
   restarbeitenSetPrimaryAttachment: (data) => ipcRenderer.invoke("restarbeiten:setPrimaryAttachment", data),
   restarbeitenImportAttachments: (data) => ipcRenderer.invoke("restarbeiten:importAttachments", data),
+  restarbeitenDeleteAttachment: (data) => ipcRenderer.invoke("restarbeiten:deleteAttachment", data),
 });
 
 contextBridge.exposeInMainWorld("bbmPrint", {

--- a/src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js
+++ b/src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js
@@ -144,3 +144,19 @@ export async function importRestarbeitAttachments(restarbeitId, projectId) {
     attachments: Array.isArray(response.attachments) ? response.attachments : [],
   };
 }
+
+export async function deleteRestarbeitAttachment(restarbeitId, attachmentId) {
+  const bbmDb = requireBbmDb();
+  if (typeof bbmDb.restarbeitenDeleteAttachment !== "function") {
+    throw new Error("Restarbeiten-Datenzugriff nicht verfuegbar: restarbeitenDeleteAttachment fehlt.");
+  }
+  const rid = extractRestarbeitId(restarbeitId);
+  const aid = extractAttachmentId(attachmentId);
+  const response = await bbmDb.restarbeitenDeleteAttachment({ restarbeitId: rid, attachmentId: aid });
+  if (!response || typeof response !== "object") throw new Error("Restarbeiten-attachments-delete: ungueltige IPC-Antwort.");
+  if (response.ok !== true) throw new Error(response.error || "Foto konnte nicht entfernt werden.");
+  return {
+    attachments: Array.isArray(response.attachments) ? response.attachments : [],
+    warning: typeof response.warning === "string" && response.warning.trim() ? response.warning.trim() : null,
+  };
+}

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js
@@ -7,12 +7,13 @@ function getDisplayLabel(attachment) {
 }
 
 export default class RestarbeitenAttachmentsView {
-  constructor({ documentRef = globalThis.document, onSetPrimary = null, onImportAttachments = null } = {}) {
+  constructor({ documentRef = globalThis.document, onSetPrimary = null, onImportAttachments = null, onDeleteAttachment = null } = {}) {
     this.document = documentRef || globalThis.document;
     this.onSetPrimary = typeof onSetPrimary === "function" ? onSetPrimary : null;
     this.root = null;
     this.attachments = [];
     this.onImportAttachments = typeof onImportAttachments === "function" ? onImportAttachments : null;
+    this.onDeleteAttachment = typeof onDeleteAttachment === "function" ? onDeleteAttachment : null;
   }
 
   render() {
@@ -115,7 +116,21 @@ export default class RestarbeitenAttachmentsView {
     caption.textContent = " Hauptfoto";
     radioWrap.append(radio, caption);
 
-    card.append(label, radioWrap);
+    const deleteBtn = doc.createElement("button");
+    deleteBtn.type = "button";
+    deleteBtn.textContent = "Foto entfernen";
+    deleteBtn.disabled = !normalizeText(attachment?.id) || !this.onDeleteAttachment;
+    deleteBtn.addEventListener("click", () => {
+      const id = normalizeText(attachment?.id);
+      if (!id || !this.onDeleteAttachment) return;
+      const confirmed = typeof window !== "undefined" && typeof window.confirm === "function"
+        ? window.confirm("Foto wirklich entfernen?")
+        : false;
+      if (!confirmed) return;
+      this.onDeleteAttachment(id);
+    });
+
+    card.append(label, radioWrap, deleteBtn);
     return card;
   }
 }

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -59,7 +59,7 @@ function normalizeFirmEntries(list) {
 }
 
 export default class RestarbeitenEditbox {
-  constructor({ documentRef = globalThis.document, onSave = null, onSetPrimaryAttachment = null, onImportAttachments = null } = {}) {
+  constructor({ documentRef = globalThis.document, onSave = null, onSetPrimaryAttachment = null, onImportAttachments = null, onDeleteAttachment = null } = {}) {
     this.document = documentRef || globalThis.document;
     this.onSave = typeof onSave === "function" ? onSave : null;
     this.root = null;
@@ -73,6 +73,7 @@ export default class RestarbeitenEditbox {
     this.attachmentsView = null;
     this.onSetPrimaryAttachment = typeof onSetPrimaryAttachment === "function" ? onSetPrimaryAttachment : null;
     this.onImportAttachments = typeof onImportAttachments === "function" ? onImportAttachments : null;
+    this.onDeleteAttachment = typeof onDeleteAttachment === "function" ? onDeleteAttachment : null;
   }
 
   render() {
@@ -151,6 +152,9 @@ export default class RestarbeitenEditbox {
       },
       onImportAttachments: () => {
         if (this.onImportAttachments) this.onImportAttachments();
+      },
+      onDeleteAttachment: (attachmentId) => {
+        if (this.onDeleteAttachment) this.onDeleteAttachment(attachmentId);
       },
     });
 

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -5,6 +5,8 @@ import {
   listResponsibleProjectFirms,
   listRestarbeitAttachments,
   setPrimaryRestarbeitAttachment,
+  importRestarbeitAttachments,
+  deleteRestarbeitAttachment,
   updateRestarbeitItem,
 } from "../data/restarbeitenDataSource.js";
 import { toRestarbeitenListItems } from "../viewModel/restarbeitenListItems.js";
@@ -195,6 +197,20 @@ export default class RestarbeitenScreen {
             this.editbox?.setStatus(result?.canceled ? "Fotoimport abgebrochen." : "Fotos importiert.");
           } catch (_error) {
             this.editbox?.setStatus("Fotos konnten nicht importiert werden.");
+          }
+        },
+        onDeleteAttachment: async (attachmentId) => {
+          const selectedItem = this._getSelectedItem();
+          if (!selectedItem?.id) return;
+          try {
+            const result = await deleteRestarbeitAttachment(selectedItem.id, attachmentId);
+            const attachments = Array.isArray(result?.attachments) ? result.attachments : [];
+            this.attachmentsByItemId.set(String(selectedItem.id), attachments);
+            this.editbox?.setAttachments(attachments);
+            this.editbox?.setItem(selectedItem);
+            this.editbox?.setStatus(result?.warning ? `Foto entfernt. Hinweis: ${result.warning}` : "Foto entfernt.");
+          } catch (_error) {
+            this.editbox?.setStatus("Foto konnte nicht entfernt werden.");
           }
         },
       });


### PR DESCRIPTION
### Motivation
- Ermöglichen, ein Attachment einer Restarbeit zu löschen und dabei DB-Datensatz und zugehörige Datei(en) sauber zu entfernen, ohne Bildverarbeitung oder Schemaänderungen zu bauen.
- Sicherstellen, dass nach dem Löschen die Attachment-Liste neu geladen wird und bei Entfernen des Hauptfotos ein verbleibendes Foto automatisch Hauptfoto wird.

### Description
- Ergänzt Repo-Funktion `deleteRestarbeitAttachment(restarbeitId, attachmentId)` in `src/main/db/restarbeitenRepo.js` mit Validierung, DB-Delete und Primary-Neusetzung (ORDER BY `sort_order ASC, created_at ASC`).
- Fügt Main-IPC-Handler `restarbeiten:deleteAttachment` in `src/main/ipc/restarbeitenIpc.js` hinzu, der `deleteRestarbeitAttachment` aufruft, danach `file_path` und `thumbnail_path` best-effort per `fs.rmSync(..., { force: true })` entfernt und die aktualisierte Attachment-Liste zurückgibt; Dateilöschfehler werden als `warning` weitergegeben.
- Erweitert Preload-Bridge in `src/main/preload.js` um `restarbeitenDeleteAttachment` und DataSource in `src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js` um `deleteRestarbeitAttachment(...)` mit Bridge-Check und normalisiertem Rückgabeformat (`attachments`, optional `warning`).
- UI: ergänzt in `src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js` pro Attachment einen Button `Foto entfernen` mit `window.confirm("Foto wirklich entfernen?")` und leitet Löschaufruf über Editbox/Screen (Änderungen in `RestarbeitenEditbox.js` und `RestarbeitenScreen.js`) weiter, wobei Attachments neu gesetzt und Statushinweise angezeigt werden.
- Tests/Doku: ergänzt/erweitert Tests in `scripts/tests/restarbeitenDataModel.test.cjs` und `scripts/tests/restarbeitenModule.test.cjs` für Repo-Delete und IPC/DataSource-Verdrahtung sowie Eintrag in `docs/MODULARISIERUNGSPLAN.md` (M10).

### Testing
- Neue/erweiterte JS-Tests wurden hinzugefügt: `scripts/tests/restarbeitenDataModel.test.cjs` und `scripts/tests/restarbeitenModule.test.cjs` (M10-bezogene Fälle ergänzt), aber die Test-Suite konnte in der Cloud-Sandbox nicht vollständig ausgeführt werden.
- `npm test` wurde in der Sandbox gestartet und schlug fehl aufgrund fehlender nativer Electron-Bibliothek (`libatk-1.0.so.0`), daher konnten die Node/Electron-Tests hier nicht beendet; keine Aussage über in-VM Testgrün möglich.
- Die Implementierung ist lokal durch statische Prüfungen und regressionssichere DB-Operationen so angelegt, dass DB-Delete führend ist und Dateisystemfehler nur als Warnung behandelt werden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0881242c6c8322ae879b6d664f8d25)