### PR TITLE
M11: Stabilisiere Restarbeiten‑Fotoanzeige auf festem 2‑Spalten Landscape‑Layout

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,12 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+
+- M11 Restarbeiten-Fotoanzeige ist stabilisiert:
+  - feste 2-Spalten-Ansicht mit Hauptfoto links und bis zu zwei Nebenfotos rechts
+  - alle Bildflaechen im festen Landscape-Format mit `object-fit: cover`
+  - keine Bilddateibearbeitung, nur Anzeigeformatierung
+- Naechster offener Schritt: fachliche Sichtpruefung der Restarbeiten-Fotoansicht im UI.
 - Das globale FachwÃ¶rterbuch V1 fuer das Diktat ist jetzt technisch angebunden:
   - globale `dictionary_entries`-Tabelle, Dictionary-Service und IPC-/Preload-Bruecken sind vorhanden
   - `term` und `correction` sind getrennt modelliert, Kategorie bleibt fest `Bau`

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -281,3 +281,8 @@ Dabei gilt:
 - Datei und optionales Thumbnail werden nach DB-Delete bestmoeglich entfernt.
 - Nach Loeschen wird die Attachment-Liste neu geladen; bei geloeschtem Hauptfoto wird ein verbleibendes Foto wieder Hauptfoto.
 - Bildzuschnitt, Thumbnail-Erzeugung und Smartphone-Import folgen spaeter.
+
+### M11 Restarbeiten-Fotoanzeige im festen Landscape-Layout (neu)
+- Restarbeiten-Fotoanzeige ist jetzt als stabiles 2-Spalten-Landscape-Layout umgesetzt.
+- Hauptfoto steht links groß, bis zu zwei Nebenfotos stehen rechts untereinander.
+- Die Bilddateien werden nicht bearbeitet; es bleibt reine Anzeigeformatierung mit `object-fit: cover`.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -590,6 +590,37 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(screen, /importRestarbeitAttachments\(/);
     assert.match(screen, /Fotos importiert\.|Fotoimport abgebrochen\.|Fotos konnten nicht importiert werden\./);
   });
+
+
+  await run("M11 View/CSS: Landscape-2-Spalten-Layout stabil und modulnah", () => {
+    const viewPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js");
+    const cssPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/restarbeitenAttachments.css");
+    const view = fs.readFileSync(viewPath, "utf8");
+    const css = fs.readFileSync(cssPath, "utf8");
+
+    assert.match(view, /restarbeiten-attachments__grid/);
+    assert.match(view, /restarbeiten-attachments__primary/);
+    assert.match(view, /restarbeiten-attachments__secondary/);
+    assert.match(view, /others\.slice\(0, 2\)/);
+    assert.match(view, /restarbeiten-attachments__image/);
+    assert.match(view, /Kein Bildpfad vorhanden\./);
+    assert.match(view, /Foto hinzufügen/);
+    assert.match(view, /Maximal 3 Fotos vorhanden\./);
+    assert.match(view, /Foto entfernen/);
+    assert.match(view, /Hauptfoto/);
+    assert.match(view, /caption\) \|\| normalizeText\(attachment\?\.file_name\) \|\| "Ohne Bezeichnung"/);
+
+    assert.match(css, /grid-template-columns:\s*minmax\(0, 2fr\)\s+minmax\(0, 1fr\)/);
+    assert.match(css, /aspect-ratio:\s*16 \/ 9/);
+    assert.match(css, /object-fit:\s*cover/);
+
+    assert.doesNotMatch(view + css, /gallery|lightbox/i);
+    assert.doesNotMatch(view + css, /thumbnail/i);
+    assert.doesNotMatch(view + css, /imageProcessing/i);
+    assert.doesNotMatch(view + css, /Diktat|Druck|Mail/);
+    assert.doesNotMatch(view, /modules\/protokoll\/styles|tops\/styles/i);
+  });
+
   await run("M6 DataSource: listResponsibleProjectFirms nutzt Bridge und normalisiert Antworten", async () => {
     const repo = await importEsmFromFile(
       path.join(__dirname, "../../src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js")

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -614,6 +614,8 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(styleCode, /aspect-ratio:\s*16 \/ 9/);
     assert.match(styleCode, /object-fit:\s*cover/);
     assert.match(styleCode, /data-bbm-restarbeiten-attachments-style/);
+    assert.match(styleCode, /typeof\s+doc\?\.querySelector\s*===\s*["']function["']/);
+    assert.match(styleCode, /function\s+hasInjectedStyle\s*\(/);
     assert.doesNotMatch(view, /import\s+["']\.\/restarbeitenAttachments\.css["']/);
 
     assert.doesNotMatch(view + styleCode, /gallery|lightbox/i);

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -594,9 +594,9 @@ async function runRestarbeitenModuleTests(run) {
 
   await run("M11 View/CSS: Landscape-2-Spalten-Layout stabil und modulnah", () => {
     const viewPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js");
-    const cssPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/restarbeitenAttachments.css");
+    const stylePath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/restarbeitenAttachmentsStyle.js");
     const view = fs.readFileSync(viewPath, "utf8");
-    const css = fs.readFileSync(cssPath, "utf8");
+    const styleCode = fs.readFileSync(stylePath, "utf8");
 
     assert.match(view, /restarbeiten-attachments__grid/);
     assert.match(view, /restarbeiten-attachments__primary/);
@@ -610,14 +610,16 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(view, /Hauptfoto/);
     assert.match(view, /caption\) \|\| normalizeText\(attachment\?\.file_name\) \|\| "Ohne Bezeichnung"/);
 
-    assert.match(css, /grid-template-columns:\s*minmax\(0, 2fr\)\s+minmax\(0, 1fr\)/);
-    assert.match(css, /aspect-ratio:\s*16 \/ 9/);
-    assert.match(css, /object-fit:\s*cover/);
+    assert.match(styleCode, /grid-template-columns:\s*minmax\(0, 2fr\)\s+minmax\(0, 1fr\)/);
+    assert.match(styleCode, /aspect-ratio:\s*16 \/ 9/);
+    assert.match(styleCode, /object-fit:\s*cover/);
+    assert.match(styleCode, /data-bbm-restarbeiten-attachments-style/);
+    assert.doesNotMatch(view, /import\s+["']\.\/restarbeitenAttachments\.css["']/);
 
-    assert.doesNotMatch(view + css, /gallery|lightbox/i);
-    assert.doesNotMatch(view + css, /thumbnail/i);
-    assert.doesNotMatch(view + css, /imageProcessing/i);
-    assert.doesNotMatch(view + css, /Diktat|Druck|Mail/);
+    assert.doesNotMatch(view + styleCode, /gallery|lightbox/i);
+    assert.doesNotMatch(view + styleCode, /thumbnail/i);
+    assert.doesNotMatch(view + styleCode, /imageProcessing/i);
+    assert.doesNotMatch(view + styleCode, /Diktat|Druck|Mail/);
     assert.doesNotMatch(view, /modules\/protokoll\/styles|tops\/styles/i);
   });
 

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js
@@ -6,6 +6,8 @@ function getDisplayLabel(attachment) {
   return normalizeText(attachment?.caption) || normalizeText(attachment?.file_name) || "Ohne Bezeichnung";
 }
 
+import "./restarbeitenAttachments.css";
+
 export default class RestarbeitenAttachmentsView {
   constructor({ documentRef = globalThis.document, onSetPrimary = null, onImportAttachments = null, onDeleteAttachment = null } = {}) {
     this.document = documentRef || globalThis.document;
@@ -18,8 +20,7 @@ export default class RestarbeitenAttachmentsView {
 
   render() {
     const root = this.document.createElement("section");
-    root.style.display = "grid";
-    root.style.gap = "8px";
+    root.className = "restarbeiten-attachments";
     this.root = root;
     this._renderContent();
     return root;
@@ -34,8 +35,7 @@ export default class RestarbeitenAttachmentsView {
     if (!this.root) return;
     const doc = this.document;
     const actions = doc.createElement("div");
-    actions.style.display = "grid";
-    actions.style.gap = "6px";
+    actions.className = "restarbeiten-attachments__actions";
     if (this.attachments.length < 3 && this.onImportAttachments) {
       const addBtn = doc.createElement("button");
       addBtn.type = "button";
@@ -56,19 +56,19 @@ export default class RestarbeitenAttachmentsView {
     }
 
     const wrapper = doc.createElement("div");
-    wrapper.style.display = "grid";
-    wrapper.style.gridTemplateColumns = "2fr 1fr";
-    wrapper.style.gap = "10px";
+    wrapper.className = "restarbeiten-attachments__grid";
 
     const primary = this.attachments.find((a) => Number(a?.is_primary) === 1 || a?.is_primary === true) || this.attachments[0];
     const others = this.attachments.filter((a) => a !== primary);
 
-    wrapper.append(this._buildCard(primary, true));
+    const primaryColumn = doc.createElement("div");
+    primaryColumn.className = "restarbeiten-attachments__primary";
+    primaryColumn.append(this._buildCard(primary, true));
+    wrapper.append(primaryColumn);
 
     const rightCol = doc.createElement("div");
-    rightCol.style.display = "grid";
-    rightCol.style.gap = "8px";
-    for (const attachment of others) rightCol.append(this._buildCard(attachment, false));
+    rightCol.className = "restarbeiten-attachments__secondary";
+    for (const attachment of others.slice(0, 2)) rightCol.append(this._buildCard(attachment, false));
     wrapper.append(rightCol);
 
     this.root.replaceChildren(actions, wrapper);
@@ -77,28 +77,30 @@ export default class RestarbeitenAttachmentsView {
   _buildCard(attachment, isPrimary) {
     const doc = this.document;
     const card = doc.createElement("article");
-    card.style.border = isPrimary ? "2px solid #3b82f6" : "1px solid var(--card-border, #cfcfcf)";
-    card.style.borderRadius = "10px";
-    card.style.padding = "8px";
-    card.style.display = "grid";
-    card.style.gap = "6px";
+    card.className = isPrimary
+      ? "restarbeiten-attachments__card restarbeiten-attachments__card--primary"
+      : "restarbeiten-attachments__card";
+
+    const imageFrame = doc.createElement("div");
+    imageFrame.className = "restarbeiten-attachments__imageFrame";
 
     const path = normalizeText(attachment?.file_path);
     if (path) {
       const img = doc.createElement("img");
       img.src = path;
       img.alt = getDisplayLabel(attachment);
-      img.style.width = "100%";
-      img.style.height = isPrimary ? "140px" : "90px";
-      img.style.objectFit = "cover";
-      card.append(img);
+      img.className = "restarbeiten-attachments__image";
+      imageFrame.append(img);
     } else {
       const placeholder = doc.createElement("div");
+      placeholder.className = "restarbeiten-attachments__imageFallback";
       placeholder.textContent = "Kein Bildpfad vorhanden.";
-      card.append(placeholder);
+      imageFrame.append(placeholder);
     }
+    card.append(imageFrame);
 
-    const label = doc.createElement("div");
+    const label = doc.createElement("p");
+    label.className = "restarbeiten-attachments__caption";
     label.textContent = getDisplayLabel(attachment);
 
     const radioWrap = doc.createElement("label");

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js
@@ -6,7 +6,7 @@ function getDisplayLabel(attachment) {
   return normalizeText(attachment?.caption) || normalizeText(attachment?.file_name) || "Ohne Bezeichnung";
 }
 
-import "./restarbeitenAttachments.css";
+import { ensureRestarbeitenAttachmentsStyle } from "./restarbeitenAttachmentsStyle.js";
 
 export default class RestarbeitenAttachmentsView {
   constructor({ documentRef = globalThis.document, onSetPrimary = null, onImportAttachments = null, onDeleteAttachment = null } = {}) {
@@ -19,6 +19,7 @@ export default class RestarbeitenAttachmentsView {
   }
 
   render() {
+    ensureRestarbeitenAttachmentsStyle(this.document);
     const root = this.document.createElement("section");
     root.className = "restarbeiten-attachments";
     this.root = root;

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenAttachments.css
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenAttachments.css
@@ -1,0 +1,69 @@
+.restarbeiten-attachments {
+  display: grid;
+  gap: 8px;
+}
+
+.restarbeiten-attachments__actions {
+  display: grid;
+  gap: 6px;
+}
+
+.restarbeiten-attachments__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 10px;
+  align-items: stretch;
+}
+
+.restarbeiten-attachments__primary,
+.restarbeiten-attachments__secondary {
+  min-width: 0;
+}
+
+.restarbeiten-attachments__secondary {
+  display: grid;
+  gap: 8px;
+  grid-auto-rows: 1fr;
+}
+
+.restarbeiten-attachments__card {
+  border: 1px solid var(--card-border, #cfcfcf);
+  border-radius: 10px;
+  padding: 8px;
+  display: grid;
+  gap: 6px;
+}
+
+.restarbeiten-attachments__card--primary {
+  border: 2px solid #3b82f6;
+}
+
+.restarbeiten-attachments__imageFrame {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 6px;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.restarbeiten-attachments__imageFallback {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 8px;
+}
+
+.restarbeiten-attachments__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.restarbeiten-attachments__caption,
+.restarbeiten-attachments__meta {
+  margin: 0;
+}

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenAttachmentsStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenAttachmentsStyle.js
@@ -72,13 +72,37 @@ const RESTARBEITEN_ATTACHMENTS_STYLE_TEXT = `
 }
 `;
 
+function hasInjectedStyle(doc) {
+  if (typeof doc?.querySelector === "function") {
+    return !!doc.querySelector(`style[${RESTARBEITEN_ATTACHMENTS_STYLE_ATTR}="true"]`);
+  }
+
+  const children = Array.from(doc?.head?.children || []);
+  return children.some((node) => {
+    if (!node) return false;
+    if (typeof node.getAttribute === "function") {
+      return node.getAttribute(RESTARBEITEN_ATTACHMENTS_STYLE_ATTR) === "true";
+    }
+    return node[RESTARBEITEN_ATTACHMENTS_STYLE_ATTR] === "true";
+  });
+}
+
 export function ensureRestarbeitenAttachmentsStyle(documentRef = globalThis.document) {
   const doc = documentRef || globalThis.document;
   if (!doc?.head || typeof doc.createElement !== "function") return;
-  if (doc.querySelector(`style[${RESTARBEITEN_ATTACHMENTS_STYLE_ATTR}="true"]`)) return;
+  if (hasInjectedStyle(doc)) return;
 
   const style = doc.createElement("style");
-  style.setAttribute(RESTARBEITEN_ATTACHMENTS_STYLE_ATTR, "true");
+  if (typeof style.setAttribute === "function") {
+    style.setAttribute(RESTARBEITEN_ATTACHMENTS_STYLE_ATTR, "true");
+  } else {
+    style[RESTARBEITEN_ATTACHMENTS_STYLE_ATTR] = "true";
+  }
   style.textContent = RESTARBEITEN_ATTACHMENTS_STYLE_TEXT;
-  doc.head.appendChild(style);
+
+  if (typeof doc.head.appendChild === "function") {
+    doc.head.appendChild(style);
+  } else if (typeof doc.head.append === "function") {
+    doc.head.append(style);
+  }
 }

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenAttachmentsStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenAttachmentsStyle.js
@@ -1,3 +1,6 @@
+const RESTARBEITEN_ATTACHMENTS_STYLE_ATTR = "data-bbm-restarbeiten-attachments-style";
+
+const RESTARBEITEN_ATTACHMENTS_STYLE_TEXT = `
 .restarbeiten-attachments {
   display: grid;
   gap: 8px;
@@ -66,4 +69,16 @@
 .restarbeiten-attachments__caption,
 .restarbeiten-attachments__meta {
   margin: 0;
+}
+`;
+
+export function ensureRestarbeitenAttachmentsStyle(documentRef = globalThis.document) {
+  const doc = documentRef || globalThis.document;
+  if (!doc?.head || typeof doc.createElement !== "function") return;
+  if (doc.querySelector(`style[${RESTARBEITEN_ATTACHMENTS_STYLE_ATTR}="true"]`)) return;
+
+  const style = doc.createElement("style");
+  style.setAttribute(RESTARBEITEN_ATTACHMENTS_STYLE_ATTR, "true");
+  style.textContent = RESTARBEITEN_ATTACHMENTS_STYLE_TEXT;
+  doc.head.appendChild(style);
 }


### PR DESCRIPTION
### Motivation
- Die bisher per Inline‑Styles aufgebaute Fotoansicht soll visuell stabil, modular und dauerhaft lesbar werden, ohne Funktionslogik oder Bildverarbeitung zu ändern.
- Ziel ist ein festes Landscape‑Format mit großem Hauptfoto links und bis zu zwei Nebenfotos rechts, bei maximal 3 Attachments insgesamt.

### Description
- Die Ansicht `RestarbeitenAttachmentsView` wurde von Inline‑Styles auf modulnahe CSS‑Klassen umgestellt und als 2‑Spalten‑Grid aufgebaut; Hauptfoto links, Sekundärfotos rechts (max. 2), Attachments auf 3 begrenzt and Primary‑Logik unverändert (is_primary / erstes Attachment). (`src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js`).
- Neue modulnahe CSS‑Datei `restarbeitenAttachments.css` eingefügt, die feste Landscape‑Flächen (`aspect-ratio: 16/9`) sowie `object-fit: cover` und Fallback‑Platzhalter realisiert. (`src/renderer/modules/restarbeiten/screens/restarbeitenAttachments.css`).
- Tests ergänzt: `scripts/tests/restarbeitenModule.test.cjs` erhält M11‑Assertions zur Präsenz der CSS‑Klassen, Layoutstruktur, Platzhaltertexten, Begrenzung auf 3 Fotos und Negativchecks (keine Gallery/Thumbnail/ImageProcessing/Print/Diktat/ Mail‑Begriffe).
- Doku aktualisiert: `docs/MODULARISIERUNGSPLAN.md` und `STATUS.md` um M11‑Eintrag und kurzen Status ergänzt.

### Testing
- Neue assertions wurden in `scripts/tests/restarbeitenModule.test.cjs` hinzugefügt to verify view CSS classes and strings; these are static file/content checks intended for the existing test runner.
- Ein Versuch, die Test‑Suite mit `npm test` auszuführen, wurde gemacht but the run could not complete in this environment because Electron failed to start due to a missing system library (`libatk-1.0.so.0`), so full automated verification did not finish.
- Empfehlung: run `npm test` in CI or a developer environment where Electron system dependencies are available to perform the complete automated check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08898f4d948322a64b14e6d10e44bc)