### PR TITLE
Hotfix: M8 Restarbeiten Fotoimport-Test Windows-kompatibel

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -531,7 +531,7 @@ async function runRestarbeitenModuleTests(run) {
         assert.equal(repoState.added.length, 3, JSON.stringify(repoState.added));
         assert.equal(repoState.added[0]?.restarbeit_id, "r1", JSON.stringify(repoState.added[0] || {}));
         assert.equal(repoState.added[0]?.project_id, "p1", JSON.stringify(repoState.added[0] || {}));
-        assert.match(String(repoState.added[0]?.file_path || ""), /Restarbeiten[\/]Fotos/, JSON.stringify(repoState.added[0] || {}));
+        assert.match(String(repoState.added[0]?.file_path || ""), /Restarbeiten[\\/]Fotos/, JSON.stringify(repoState.added[0] || {}));
         assert.equal(Boolean(repoState.added[0]?.original_file_name), true, JSON.stringify(repoState.added[0] || {}));
         assert.match(String(repoState.added[0]?.mime_type || ""), /^image\/(jpeg|png|webp)$/i, JSON.stringify(repoState.added[0] || {}));
 


### PR DESCRIPTION
### Motivation
- Der M8 Main-IPC-Test scheiterte lokal auf Windows, weil die Pfad-Assertion nur `/` erwartete; die Prüfung soll sowohl Windows- als auch Unix-Pfade akzeptieren, ohne Produktivcode zu ändern.

### Description
- In `scripts/tests/restarbeitenModule.test.cjs` die Pfad-Assertion im M8-Test angepasst: Regex von `/Restarbeiten[\/ ]Fotos/` auf das Windows-/Unix-kompatible `/Restarbeiten[\\/]Fotos/` gesetzt (einzeiliger Testfix, nur Testcode geändert). 

### Testing
- `npm test` ausgeführt, der Lauf konnte in dieser Umgebung nicht vollständig abgeschlossen werden, weil die Electron-Runtime-Abhängigkeit `libatk-1.0.so.0` fehlt; daher kein kompletter grüner Testlauf hier.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088e7e380c83228277d70d6c5e1583)