### PR TITLE
M12: Restarbeiten-Liste fachlich layouten

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2003,3 +2003,9 @@ Wichtig:
   - `npm test` laeuft gruen
 
 - M9 ist abgeschlossen: Der M8-Fotoimport speichert Attachments jetzt IPC-seitig DB-konform mit `project_id` ueber `addRestarbeitAttachment(...)`; der zugehoerige M8-Test erzwingt den Repo-Vertrag (`restarbeit_id`, `project_id`, `file_path`) und prueft die erwarteten Attachment-Felder.
+
+- M12 Restarbeiten-Liste fachlich layoutet:
+  - 4-spaltige Tabelle blieb erhalten; Verortung als 2-zeilige Metaspalte.
+  - Status-Metaspalte mit Klasse, Status, Fertig bis, Verantwortlich und Ampel (inkl. testbarem data-ampel).
+  - modulnahe Style-Injektion fuer Restarbeiten-Liste hinzugefuegt.
+- Naechster offener Schritt: fachliche Sichtpruefung der M12-Listenoptik im UI.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -286,3 +286,9 @@ Dabei gilt:
 - Restarbeiten-Fotoanzeige ist jetzt als stabiles 2-Spalten-Landscape-Layout umgesetzt.
 - Hauptfoto steht links groß, bis zu zwei Nebenfotos stehen rechts untereinander.
 - Die Bilddateien werden nicht bearbeitet; es bleibt reine Anzeigeformatierung mit `object-fit: cover`.
+
+### M12 Restarbeiten-Liste fachlich layoutet (neu)
+- Die Restarbeiten-Liste bleibt bei 4 Hauptspalten (Nr./Datum, Verortung, Restarbeit, Status).
+- Verortung wird als Metaspalte mit zwei Zeilen dargestellt (L1/L2 und L3/L4).
+- Die Status-Metaspalte zeigt Klasse, Status, Fertig bis, Verantwortlich und Ampel (rot/orange/gruen/neutral).
+- M12 umfasst keine Filter-, Druck-, Mail- oder Archivfunktion.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -779,39 +779,81 @@ async function runRestarbeitenModuleTests(run) {
       globalThis.document = prevDocument;
     }
   });
-  await run("M4 ViewModel: Mapping fuer Anzeigezeilen", async () => {
+  await run("M12 ViewModel: Mapping und Ampel-Logik fuer Listenlayout", async () => {
     const vm = await importEsmFromFile(
       path.join(__dirname, "../../src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js")
     );
 
-    const item = vm.toRestarbeitenListItem({
-      id: "x",
-      running_number: 1,
-      created_at: "2026-05-16",
-      location_level_1: "Haus A",
-      location_level_2: "EG",
-      short_text: "Fenster",
-      long_text: "nachstellen",
-      item_class: "mangel",
-      status: "geprueft_erledigt",
-      due_date: "2026-05-20",
-      responsible_label: "Firma Test",
-    });
+    const today = new Date("2026-05-16T00:00:00Z");
+    const item = vm.toRestarbeitenListItem(
+      {
+        id: "x",
+        running_number: 12,
+        created_at: "2026-05-16",
+        location_level_1: "Haus A",
+        location_level_2: "EG",
+        location_level_3: "Raum 01",
+        location_level_4: "Fenster 2",
+        short_text: "Fenster",
+        long_text: "nachstellen",
+        item_class: "mangel",
+        status: "offen",
+        due_date: "2026-05-20",
+        responsible_label: "Firma Test",
+      },
+      today
+    );
 
-    assert.equal(item.numberLine, "#1");
+    assert.equal(item.numberLine, "#12");
+    assert.equal(item.dateLine, "2026-05-16");
     assert.equal(item.locationLine1, "Haus A / EG");
+    assert.equal(item.locationLine2, "Raum 01 / Fenster 2");
+    assert.equal(item.workLine1, "Fenster");
     assert.equal(item.workLine2, "nachstellen");
-    assert.match(item.statusLine1, /Mangel/);
-    assert.match(item.statusLine1, /gepr[üu]ft erledigt/);
-    assert.equal(item.statusLine2, "2026-05-20");
-    assert.equal(item.statusLine3, "Firma Test");
+    assert.equal(item.itemClassLabel, "Mangel");
+    assert.equal(vm.toRestarbeitenListItem({ item_class: "rest" }, today).itemClassLabel, "Rest");
+    assert.equal(item.statusLabel, "offen");
+    assert.equal(item.dueDateLabel, "2026-05-20");
+    assert.equal(item.responsibleLabel, "Firma Test");
+    assert.equal(item.ampelState, "orange");
 
-    const fallback = vm.toRestarbeitenListItem({ item_class: "rest", status: "in_arbeit" });
-    assert.match(fallback.statusLine1, /Rest/);
-    assert.match(fallback.statusLine1, /in Arbeit/);
-    assert.equal(fallback.statusLine3, "—");
-    assert.equal(JSON.stringify(fallback).includes("undefined"), false);
+    assert.equal(vm.getRestarbeitenAmpelState({ due_date: "2026-05-15", status: "offen" }, today), "rot");
+    assert.equal(vm.getRestarbeitenAmpelState({ due_date: "2026-05-24", status: "offen" }, today), "orange");
+    assert.equal(vm.getRestarbeitenAmpelState({ due_date: "2026-05-30", status: "offen" }, today), "gruen");
+    assert.equal(vm.getRestarbeitenAmpelState({ status: "offen" }, today), "neutral");
+    assert.equal(vm.getRestarbeitenAmpelState({ due_date: "ungültig", status: "offen" }, today), "neutral");
+    assert.equal(vm.getRestarbeitenAmpelState({ due_date: "2026-06-20", status: "verzug" }, today), "rot");
+    assert.equal(
+      vm.getRestarbeitenAmpelState({ due_date: "2026-05-01", status: "geprueft_erledigt" }, today),
+      "gruen"
+    );
   });
+  await run("M12 Screen/List: Status-Metaspalte und Klassenstruktur vorhanden", async () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"),
+      "utf8"
+    );
+    const styleContent = fs.readFileSync(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js"),
+      "utf8"
+    );
+
+    assert.match(content, /data\.restarbeitId/);
+    assert.match(content, /data\.selected/);
+    assert.match(content, /data\.ampel/);
+    assert.match(content, /Klasse:/);
+    assert.match(content, /Status:/);
+    assert.match(content, /Fertig bis:/);
+    assert.match(content, /Verantwortlich:/);
+    assert.doesNotMatch(content, /innerHTML\s*=/);
+
+    assert.match(styleContent, /restarbeiten-list__ampel--rot/);
+    assert.match(styleContent, /restarbeiten-list__ampel--orange/);
+    assert.match(styleContent, /restarbeiten-list__ampel--gruen/);
+    assert.match(styleContent, /restarbeiten-list__ampel--neutral/);
+    assert.doesNotMatch(styleContent, /import\s+["'].*\.css["']/);
+  });
+
 }
 
 module.exports = { runRestarbeitenModuleTests };

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -838,9 +838,9 @@ async function runRestarbeitenModuleTests(run) {
       "utf8"
     );
 
-    assert.match(content, /data\.restarbeitId/);
-    assert.match(content, /data\.selected/);
-    assert.match(content, /data\.ampel/);
+    assert.match(content, /dataset\.restarbeitId/);
+    assert.match(content, /dataset\.selected/);
+    assert.match(content, /dataset\.ampel/);
     assert.match(content, /Klasse:/);
     assert.match(content, /Status:/);
     assert.match(content, /Fertig bis:/);

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -12,28 +12,62 @@ import {
 import { toRestarbeitenListItems } from "../viewModel/restarbeitenListItems.js";
 import RestarbeitenEditbox from "./RestarbeitenEditbox.js";
 import { applyPopupButtonStyle } from "../../../ui/popupButtonStyles.js";
+import { ensureRestarbeitenListStyle } from "./restarbeitenListStyle.js";
 
 function normalizeText(value) {
   return String(value || "").trim();
 }
 
-function createLineCell(doc, line1, line2, line3) {
+function createLineCell(doc, line1, line2, class1, class2) {
   const td = doc.createElement("td");
 
   const line1Div = doc.createElement("div");
+  if (class1) line1Div.className = class1;
   line1Div.textContent = line1;
   td.append(line1Div);
 
   const line2Div = doc.createElement("div");
+  if (class2) line2Div.className = class2;
   line2Div.textContent = line2;
   td.append(line2Div);
 
-  if (typeof line3 === "string") {
-    const line3Div = doc.createElement("div");
-    line3Div.textContent = line3;
-    td.append(line3Div);
-  }
+  return td;
+}
 
+function createStatusCell(doc, item) {
+  const td = doc.createElement("td");
+  td.dataset.ampel = item.ampelState;
+
+  const meta = doc.createElement("div");
+  meta.className = "restarbeiten-list__meta";
+
+  const classLine = doc.createElement("div");
+  classLine.className = "restarbeiten-list__class";
+  classLine.textContent = `Klasse: ${item.itemClassLabel}`;
+
+  const statusLine = doc.createElement("div");
+  statusLine.className = "restarbeiten-list__status";
+  statusLine.textContent = `Status: ${item.statusLabel}`;
+
+  const dueLine = doc.createElement("div");
+  dueLine.className = "restarbeiten-list__due";
+  dueLine.textContent = `Fertig bis: ${item.dueDateLabel}`;
+
+  const responsibleLine = doc.createElement("div");
+  responsibleLine.className = "restarbeiten-list__responsible";
+  responsibleLine.textContent = `Verantwortlich: ${item.responsibleLabel}`;
+
+  const ampelLine = doc.createElement("div");
+  const ampelDot = doc.createElement("span");
+  ampelDot.className = `restarbeiten-list__ampel restarbeiten-list__ampel--${item.ampelState}`;
+  ampelDot.dataset.ampel = item.ampelState;
+
+  const ampelText = doc.createElement("span");
+  ampelText.textContent = `Ampel: ${item.ampelLabel}`;
+  ampelLine.append(ampelDot, ampelText);
+
+  meta.append(classLine, statusLine, dueLine, responsibleLine, ampelLine);
+  td.append(meta);
   return td;
 }
 
@@ -45,8 +79,7 @@ function createHeaderCell(doc, text) {
 
 function buildListTable(doc, items, selectedId, onSelect) {
   const table = doc.createElement("table");
-  table.style.width = "100%";
-  table.style.borderCollapse = "collapse";
+  table.className = "restarbeiten-list__table";
 
   const thead = doc.createElement("thead");
   const headRow = doc.createElement("tr");
@@ -62,20 +95,19 @@ function buildListTable(doc, items, selectedId, onSelect) {
   const tbody = doc.createElement("tbody");
   for (const item of items) {
     const row = doc.createElement("tr");
+    row.className = "restarbeiten-list__row";
     row.dataset.restarbeitId = item.id;
-    row.style.cursor = "pointer";
-    row.style.borderBottom = "1px solid var(--card-border, #d6d6d6)";
-    row.style.verticalAlign = "top";
+    row.dataset.ampel = item.ampelState;
     if (String(item.id) === String(selectedId)) {
-      row.style.background = "rgba(0, 0, 0, 0.05)";
+      row.classList.add("restarbeiten-list__row--selected");
       row.dataset.selected = "1";
     }
     row.addEventListener("click", () => onSelect(item.id));
     row.append(
-      createLineCell(doc, item.numberLine, item.dateLine),
-      createLineCell(doc, item.locationLine1, item.locationLine2),
-      createLineCell(doc, item.workLine1, item.workLine2),
-      createLineCell(doc, item.statusLine1, item.statusLine2, item.statusLine3)
+      createLineCell(doc, item.numberLine, item.dateLine, "restarbeiten-list__number", "restarbeiten-list__date"),
+      createLineCell(doc, item.locationLine1, item.locationLine2, "restarbeiten-list__location", "restarbeiten-list__location"),
+      createLineCell(doc, item.workLine1, item.workLine2, "restarbeiten-list__shortText", "restarbeiten-list__longText"),
+      createStatusCell(doc, item)
     );
     tbody.append(row);
   }
@@ -285,7 +317,10 @@ export default class RestarbeitenScreen {
   }
 
   render() {
+    ensureRestarbeitenListStyle(document);
+
     const root = document.createElement("div");
+    root.className = "restarbeiten-list";
     root.style.display = "grid";
     root.style.gap = "12px";
 

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -1,0 +1,75 @@
+const STYLE_ID = "restarbeiten-list-style";
+
+const CSS_TEXT = `
+.restarbeiten-list {
+  display: block;
+}
+
+.restarbeiten-list__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.restarbeiten-list__table th,
+.restarbeiten-list__table td {
+  vertical-align: top;
+  text-align: left;
+  padding: 6px 8px;
+}
+
+.restarbeiten-list__row {
+  border-bottom: 1px solid var(--card-border, #d6d6d6);
+  cursor: pointer;
+}
+
+.restarbeiten-list__row--selected {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.restarbeiten-list__number,
+.restarbeiten-list__shortText,
+.restarbeiten-list__class,
+.restarbeiten-list__status {
+  font-weight: 600;
+}
+
+.restarbeiten-list__date,
+.restarbeiten-list__longText,
+.restarbeiten-list__due,
+.restarbeiten-list__responsible,
+.restarbeiten-list__location {
+  opacity: 0.85;
+  font-size: 12px;
+}
+
+.restarbeiten-list__meta {
+  display: grid;
+  gap: 2px;
+}
+
+.restarbeiten-list__ampel {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+.restarbeiten-list__ampel--rot { background: #d33; }
+.restarbeiten-list__ampel--orange { background: #f0a000; }
+.restarbeiten-list__ampel--gruen { background: #1b8a3a; }
+.restarbeiten-list__ampel--neutral { background: #8a8a8a; }
+`;
+
+export function ensureRestarbeitenListStyle(documentRef = globalThis.document) {
+  const doc = documentRef;
+  if (!doc?.createElement || !doc?.head) return;
+  if (typeof doc.getElementById === "function" && doc.getElementById(STYLE_ID)) return;
+
+  const style = doc.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = CSS_TEXT;
+  doc.head.append(style);
+}

--- a/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
+++ b/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
@@ -15,8 +15,9 @@ function mapStatus(value) {
     offen: "offen",
     in_arbeit: "in Arbeit",
     erledigt_gemeldet: "erledigt gemeldet",
-    geprueft_erledigt: "gepr\u00fcft erledigt",
-    zurueckgewiesen: "zur\u00fcckgewiesen",
+    geprueft_erledigt: "geprüft erledigt",
+    zurueckgewiesen: "zurückgewiesen",
+    verzug: "Verzug",
   };
   return map[raw] || (raw || "offen");
 }
@@ -28,22 +29,93 @@ function joinSlash(a, b) {
   return left || right || "";
 }
 
-export function toRestarbeitenListItem(row = {}) {
+function parseDateOnly(value) {
+  const text = toText(value);
+  if (!text) return null;
+  const match = text.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (match) {
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    if (
+      parsed.getUTCFullYear() === year &&
+      parsed.getUTCMonth() === month - 1 &&
+      parsed.getUTCDate() === day
+    ) {
+      return parsed;
+    }
+    return null;
+  }
+  const parsed = new Date(text);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return new Date(Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate()));
+}
+
+function toDayStartUtc(dateLike = new Date()) {
+  const date = dateLike instanceof Date ? dateLike : new Date(dateLike);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+export function getRestarbeitenAmpelState(row = {}, today = new Date()) {
+  const status = toText(row.status).toLowerCase();
+  if (status === "verzug") return "rot";
+  if (status === "erledigt_gemeldet" || status === "geprueft_erledigt" || status === "geprüft erledigt") {
+    return "gruen";
+  }
+
+  const dueDate = parseDateOnly(row.due_date);
+  const todayStart = toDayStartUtc(today);
+  if (!dueDate || !todayStart) return "neutral";
+
+  const dueTime = dueDate.getTime();
+  const todayTime = todayStart.getTime();
+  if (dueTime < todayTime) return "rot";
+
+  const tenDaysAhead = new Date(todayStart);
+  tenDaysAhead.setUTCDate(tenDaysAhead.getUTCDate() + 10);
+  if (dueTime <= tenDaysAhead.getTime()) return "orange";
+
+  return "gruen";
+}
+
+function mapAmpelLabel(state) {
+  if (state === "rot") return "Rot";
+  if (state === "orange") return "Orange";
+  if (state === "gruen") return "Grün";
+  return "—";
+}
+
+export function toRestarbeitenListItem(row = {}, today = new Date()) {
+  const itemClassLabel = mapItemClass(row.item_class);
+  const statusLabel = mapStatus(row.status);
+  const dueDateLabel = toText(row.due_date, "—");
+  const responsibleLabel = toText(row.responsible_label, "—");
+  const ampelState = getRestarbeitenAmpelState(row, today);
+  const ampelLabel = mapAmpelLabel(ampelState);
+
   return {
     id: toText(row.id, ""),
+    itemClassLabel,
+    statusLabel,
+    dueDateLabel,
+    responsibleLabel,
+    ampelState,
+    ampelLabel,
     numberLine: toText(row.running_number) ? `#${toText(row.running_number)}` : "—",
     dateLine: toText(row.created_at, "—"),
     locationLine1: joinSlash(row.location_level_1, row.location_level_2) || "—",
     locationLine2: joinSlash(row.location_level_3, row.location_level_4) || "—",
     workLine1: toText(row.short_text, "—"),
     workLine2: toText(row.long_text, "—"),
-    statusLine1: `${mapItemClass(row.item_class)} · ${mapStatus(row.status)} · Ampel: —`,
-    statusLine2: toText(row.due_date, "—"),
-    statusLine3: toText(row.responsible_label, "—"),
+    statusLine1: `${itemClassLabel} · ${statusLabel} · Ampel: ${ampelLabel}`,
+    statusLine2: dueDateLabel,
+    statusLine3: responsibleLabel,
   };
 }
 
-export function toRestarbeitenListItems(rows = []) {
+export function toRestarbeitenListItems(rows = [], today = new Date()) {
   if (!Array.isArray(rows)) return [];
-  return rows.map((row) => toRestarbeitenListItem(row));
+  return rows.map((row) => toRestarbeitenListItem(row, today));
 }


### PR DESCRIPTION
### Motivation
- Die Restarbeiten-Liste soll fachlich lesbar werden ohne Backend-/Schema-Änderungen und ohne Screen-Architektur umzubauen.
- Ziel war eine kompakte 4‑Spalten-Tabelle mit einer zweizeiligen Verortung und einer Status‑Metaspalte inklusive testbarer Ampel‑Logik.

### Description
- ViewModel erweitert: `toRestarbeitenListItem(...)` liefert nun `itemClassLabel`, `statusLabel`, `dueDateLabel`, `responsibleLabel`, `ampelState`, `ampelLabel`, `locationLine1`, `locationLine2`, `workLine1`, `workLine2`, `numberLine`, `dateLine` und bleibt kompatibel zu bestehenden Feldern (file: `src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js`).
- Ampel-Logik gekapselt und exportiert als `getRestarbeitenAmpelState(row, today)` mit Regeln für `verzug`, erledigte Status, fehlendes/ungültiges Datum und 0..10‑Tage‑Fenster; `toRestarbeitenListItem` nutzt die Funktion und liefert testbare `ampelState`/`ampelLabel`.
- Screen-Rendering strukturiert: `RestarbeitenScreen` baut die 4 Spalten per `createElement` weiter auf, Verortung bleibt als Metaspalte (2 Zeilen), Status wird als Metaspalte mit Klasse/Status/Fertig‑bis/Verantwortlich/Ampel dargestellt; `data-restarbeit-id` und `data-selected` bleiben erhalten und `data-ampel` wurde ergänzt (file: `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`).
- Modulnahe Styles ergänzt via defensiver Style-Injektion (`ensureRestarbeitenListStyle`) statt globaler CSS-Imports (file: `src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js`).
- Tests und Doku: `scripts/tests/restarbeitenModule.test.cjs` erweitert um ViewModel-/Ampel-Assertions und Screen/Style-Prüfungen; `docs/MODULARISIERUNGSPLAN.md` und `STATUS.md` um M12 ergänzt.

### Testing
- Neue/aktualisierte Tests wurden hinzugefügt in `scripts/tests/restarbeitenModule.test.cjs` (ViewModel/Ampel-Logik und Screen/Style-Struktur).
- `npm test` wurde ausgeführt, lief in dieser Container-Umgebung jedoch nicht grün: die Testausführung scheiterte an einer fehlenden native Systembibliothek für Electron (`libatk-1.0.so.0`), weshalb die M12-Logik nicht vollständig in diesem CI-Container verifiziert werden konnte.
- Die Testdatei-Änderungen sind vorhanden und zielen darauf ab, die Ampel-Regeln und die neue Status‑Metaspalte automatisiert zu prüfen; in einer Zielumgebung mit vollständigen Electron‑Abhängigkeiten sollten die Tests ausführbar sein.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0890d88a9483229932e38d4ff54c58)