### PR TITLE
Hotfix M13.1: Show and start Restarbeiten from project tile

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2014,3 +2014,5 @@ Wichtig:
   - Projekt-Arbeitsbereich zeigt jetzt auch `Restarbeiten`, wenn das Modul freigeschaltet ist
   - der Button startet ueber den vorhandenen Projektmodulpfad (`openProjectModule`)
   - Protokoll- und Projektfirmen-Einstieg bleiben unveraendert
+
+- Hotfix M13.1: Restarbeiten-Button ist jetzt auch direkt auf der Projektkachel sichtbar und startet über openProjectModule.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -298,3 +298,7 @@ Dabei gilt:
 - Restarbeiten ist im Projekt-Arbeitsbereich als sichtbarer Modulstart enthalten, wenn das Modul im aktiven Modulumfang freigegeben ist.
 - Der Start erfolgt wie bei anderen Projektmodulen ueber `openProjectModule(projectId, "restarbeiten", { project })`.
 - Projektfirmen- und Protokoll-Einstiege bleiben unveraendert.
+
+### M13.1 Restarbeiten-Button auf Projektkachel (Hotfix)
+- Restarbeiten ist sowohl im Projekt-Arbeitsbereich als auch direkt auf der Projektkachel startbar.
+- Der Projektkachel-Start nutzt den bestehenden Projektmodulpfad `openProjectModule(projectId, "restarbeiten", { project })`.

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -653,8 +653,9 @@ async function runProjektverwaltungModuleTests(run) {
       await restarbeitenButton.click();
       assert.deepEqual(calls, [
         {
-          type: "protocol",
+          type: "module",
           projectId: "17",
+          moduleId: "protokoll",
           options: {
             project: {
               id: "17",
@@ -682,8 +683,9 @@ async function runProjektverwaltungModuleTests(run) {
       await editButton.click();
       assert.deepEqual(calls, [
         {
-          type: "protocol",
+          type: "module",
           projectId: "17",
+          moduleId: "protokoll",
           options: {
             project: {
               id: "17",
@@ -712,8 +714,9 @@ async function runProjektverwaltungModuleTests(run) {
       await projectCard.click();
       assert.deepEqual(calls, [
         {
-          type: "protocol",
+          type: "module",
           projectId: "17",
+          moduleId: "protokoll",
           options: {
             project: {
               id: "17",

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -160,6 +160,19 @@ function findNode(root, predicate) {
   return null;
 }
 
+function findNodes(root, predicate) {
+  const matches = [];
+  const stack = [root];
+  while (stack.length) {
+    const node = stack.shift();
+    if (predicate(node)) matches.push(node);
+    for (const child of node?.children || []) {
+      stack.push(child);
+    }
+  }
+  return matches;
+}
+
 async function runProjektverwaltungModuleTests(run) {
   const [
     {
@@ -565,10 +578,24 @@ async function runProjektverwaltungModuleTests(run) {
               label: "Protokoll",
               description: "Protokoll im aktuellen Projekt öffnen.",
             },
+            {
+              moduleId: "restarbeiten",
+              label: "Restarbeiten",
+              description: "Restarbeiten im aktuellen Projekt öffnen.",
+            },
+            {
+              moduleId: "projectFirms",
+              label: "Firmen im Projekt",
+              description: "Projektfirmen anzeigen.",
+            },
           ];
         },
         async openProjectProtocol(projectId, options) {
           calls.push({ type: "protocol", projectId, options });
+        },
+        async openProjectModule(projectId, moduleId, options) {
+          calls.push({ type: "module", projectId, moduleId, options });
+          return { ok: true };
         },
       },
     });
@@ -599,6 +626,14 @@ async function runProjektverwaltungModuleTests(run) {
         root,
         (node) => node?.dataset?.projectAction === "module" && node?.dataset?.moduleId === "protokoll"
       );
+      const restarbeitenButton = findNode(
+        root,
+        (node) => node?.dataset?.projectAction === "module" && node?.dataset?.moduleId === "restarbeiten"
+      );
+      const allRestarbeitenButtons = findNodes(
+        root,
+        (node) => node?.dataset?.projectAction === "module" && node?.dataset?.moduleId === "restarbeiten"
+      );
       const projectFirmsButton = findNode(
         root,
         (node) => node?.dataset?.projectAction === "module" && node?.dataset?.moduleId === "projectFirms"
@@ -608,15 +643,31 @@ async function runProjektverwaltungModuleTests(run) {
       assert.equal(!!projectCard, true);
       assert.equal(!!actionRail, true);
       assert.equal(!!moduleButton, true);
+      assert.equal(!!restarbeitenButton, true);
+      assert.equal(allRestarbeitenButtons.length, 1);
       assert.equal(!!projectFirmsButton, false);
       assert.equal(!!editButton, true);
-      assert.equal(actionRail.children.length >= 1, true);
+      assert.equal(actionRail.children.length >= 2, true);
 
       await moduleButton.click();
+      await restarbeitenButton.click();
       assert.deepEqual(calls, [
         {
           type: "protocol",
           projectId: "17",
+          options: {
+            project: {
+              id: "17",
+              short: "Projekt A",
+              name: "Projekt A",
+              project_number: "17",
+            },
+          },
+        },
+        {
+          type: "module",
+          projectId: "17",
+          moduleId: "restarbeiten",
           options: {
             project: {
               id: "17",
@@ -642,6 +693,19 @@ async function runProjektverwaltungModuleTests(run) {
             },
           },
         },
+        {
+          type: "module",
+          projectId: "17",
+          moduleId: "restarbeiten",
+          options: {
+            project: {
+              id: "17",
+              short: "Projekt A",
+              name: "Projekt A",
+              project_number: "17",
+            },
+          },
+        },
         { type: "edit", projectId: "17" },
       ]);
 
@@ -650,6 +714,19 @@ async function runProjektverwaltungModuleTests(run) {
         {
           type: "protocol",
           projectId: "17",
+          options: {
+            project: {
+              id: "17",
+              short: "Projekt A",
+              name: "Projekt A",
+              project_number: "17",
+            },
+          },
+        },
+        {
+          type: "module",
+          projectId: "17",
+          moduleId: "restarbeiten",
           options: {
             project: {
               id: "17",

--- a/src/renderer/modules/projektverwaltung/screens/ProjectsScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectsScreen.js
@@ -196,6 +196,19 @@ export default class ProjectsScreen {
       return false;
     }
 
+    if (typeof this.router?.openProjectModule === "function") {
+      const result = await this.router.openProjectModule(effectiveProjectId, normalizedModuleId, {
+        project: project || null,
+      });
+      if (typeof result === "object") {
+        if (result?.blocked) {
+          this._flashMsg(`${normalizedModuleId} ist fuer diese Lizenz nicht freigeschaltet.`, 9000);
+        }
+        return !!result?.ok;
+      }
+      return result !== false;
+    }
+
     return false;
   }
 


### PR DESCRIPTION
### Motivation
- Users need the `Restarbeiten` module to be visible and startable directly from the project tile next to `Protokoll` and `Edit` so they can open Restarbeiten for a specific project without additional navigation. 

### Description
- Added a generic fallback in `ProjectsScreen._openProjectModuleFromTile` that calls `this.router.openProjectModule(projectId, moduleId, { project })` after the existing `protokoll` and `projectFirms` special cases, and evaluates `{ ok, blocked }` responses the same way as `protokoll`.
- Ensured `_getProjectTileModuleActions` continues to use `this.router._getProjectWorkspaceModules()` and keeps `projectFirms` excluded while allowing `restarbeiten` to surface as a module action on the tile.
- Updated tests in `scripts/tests/projektverwaltungModule.test.cjs` to assert that the project tile shows `Protokoll`, `Restarbeiten`, and `Edit`, that `Restarbeiten` appears only once, and that clicking it calls `openProjectModule(..., 'restarbeiten', { project })` (no direct import of `RestarbeitenScreen`).
- Small documentation updates: `STATUS.md` and `docs/MODULARISIERUNGSPLAN.md` include the M13.1 hotfix note.

### Testing
- Ran the focused project-management test: `node scripts/tests/projektverwaltungModule.test.cjs` and the modified project-tile assertions passed locally (green).
- Attempted full test run with `npm test`, but the environment failed to start Electron due to missing system library `libatk-1.0.so.0`, so full `npm test` could not complete in this container (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0898aff66c83229773209e7580aec4)