### PR TITLE
Hotfix M14.1: Make Restarbeiten tests robust to dynamic location classes and header changes

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -38,6 +38,13 @@ function findNodes(node, predicate, acc = []) {
   return acc;
 }
 
+function findButtonByText(root, text) {
+  return findNodes(
+    root,
+    (node) => node?.tagName === "BUTTON" && String(node?.textContent || "").trim() === String(text)
+  )[0] || null;
+}
+
 function createFakeDocument() {
   const createNode = (tag, doc) => {
     const node = {
@@ -260,10 +267,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(content, /Restarbeit/);
     assert.match(content, /Status/);
     assert.match(content, /restarbeiten-sheet/);
-    assert.match(content, /restarbeiten-list__locationLevel--1/);
-    assert.match(content, /restarbeiten-list__locationLevel--2/);
-    assert.match(content, /restarbeiten-list__locationLevel--3/);
-    assert.match(content, /restarbeiten-list__locationLevel--4/);
+    assert.match(content, /restarbeiten-list__locationLevel--\$\{idx \+ 1\}/);
     assert.match(content, /restarbeiten-list__attachmentsRow/);
     assert.match(content, /restarbeiten-list__photosToggle/);
     assert.match(content, /dataset\.expanded/);
@@ -299,6 +303,23 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(allText.includes("+ Restarbeit"), true);
       assert.equal(allText.includes("Verortung"), true);
       assert.equal(allText.includes("Metaspalten"), true);
+
+      const locationCell = findNodes(
+        root,
+        (node) => node?.className === "restarbeiten-list__locationCell"
+      )[0];
+      if (locationCell) {
+        const locationLevelClasses = findNodes(
+          locationCell,
+          (node) =>
+            typeof node?.className === "string" &&
+            node.className.includes("restarbeiten-list__locationLevel--")
+        ).map((node) => node.className);
+        assert.equal(locationLevelClasses.some((name) => name.includes("--1")), true);
+        assert.equal(locationLevelClasses.some((name) => name.includes("--2")), true);
+        assert.equal(locationLevelClasses.some((name) => name.includes("--3")), true);
+        assert.equal(locationLevelClasses.some((name) => name.includes("--4")), true);
+      }
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;
@@ -591,7 +612,12 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(root.children.length >= 3, true);
       assert.match(screen.listHost.children[0].textContent, /Kein Projektkontext/);
       assert.equal(screen.editHost.children.length, 0);
-      assert.equal(screen.headerHost.children[0].children[1].disabled, true);
+      const addButton = findButtonByText(screen.headerHost, "+ Restarbeit");
+      assert.equal(Boolean(addButton), true);
+      assert.equal(addButton.disabled, true);
+      assert.equal(Boolean(findButtonByText(screen.headerHost, "Schließen")), true);
+      assert.equal(Boolean(findButtonByText(screen.headerHost, "Verortung")), true);
+      assert.equal(Boolean(findButtonByText(screen.headerHost, "Metaspalten")), true);
 
       await screen.load();
       assert.match(screen.listHost.children[0].textContent, /Kein Projektkontext/);


### PR DESCRIPTION
### Motivation
- After M14 merge two Restarbeiten tests became brittle: one asserted static class strings for dynamically generated location-level classes, and another relied on header child indices that shifted when a new button was added.
- The intent is to repair tests only so `npm test` (and the direct test runner) are not failing due to fragile assertions, without changing production code or behavior.

### Description
- Adjusted `scripts/tests/restarbeitenModule.test.cjs` to detect the `+ Restarbeit` button by its `textContent` instead of a fixed `children[index]` path and assert that this specific button is `disabled` when no project context exists. 
- Replaced static source assertions for `restarbeiten-list__locationLevel--1..4` with a check that accepts the dynamic class formation used in the code (`restarbeiten-list__locationLevel--${idx + 1}`) and, when a rendered location cell is present, inspects the actual rendered nodes for `--1..--4` suffixes. 
- Added helper `findButtonByText(...)` used by the tests and added the more robust location-class checks to the M14 smoke test. 
- No production/source files were modified; changes are limited to the test file `scripts/tests/restarbeitenModule.test.cjs`.

### Testing
- Ran the module tests directly with `node scripts/tests/restarbeitenModule.test.cjs`, which completed successfully. 
- Attempted `npm test`, but it failed in the Codex Cloud environment due to missing native Electron system library (`libatk-1.0.so.0`), which is an environment issue and not related to the code changes.
- Only automated tests listed above were executed; the patch contains no runtime behavior changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d048e40c8322b29383304dbf6126)