### PR TITLE
Hotfix: activate all modules in dev runtime

### DIFF
--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -572,6 +572,39 @@ async function runProjektverwaltungModuleTests(run) {
     assert.equal(moduleIds.filter((moduleId) => moduleId === "restarbeiten").length, 1);
   });
 
+  await run("Projektverwaltung: DEV-Version schaltet Modulfreigabe auf alle aktiven Module frei", async () => {
+    const moduleAccessState = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/app/modules/moduleAccessState.js")
+    );
+
+    const previousWindow = global.window;
+    global.window = {
+      bbmDb: {
+        async appIsPackaged() {
+          return { ok: true, isPackaged: false };
+        },
+        async licenseGetStatus() {
+          return {
+            ok: true,
+            valid: true,
+            modules: ["protokoll"],
+            features: [],
+          };
+        },
+      },
+    };
+
+    try {
+      await moduleAccessState.refreshCachedActiveModuleAccess({ force: true });
+      assert.equal(moduleAccessState.getCachedActiveModuleSource(), "dev");
+      assert.equal(moduleAccessState.isModuleActive("protokoll"), true);
+      assert.equal(moduleAccessState.isModuleActive("restarbeiten"), true);
+    } finally {
+      global.window = previousWindow;
+      await moduleAccessState.refreshCachedActiveModuleAccess({ force: true });
+    }
+  });
+
   await run("Projektverwaltung: Projektkarte rendert rechte Modul-Aktionsleiste und stoppt Bubble", async () => {
     const previousDocument = global.document;
     const fakeDocument = createFakeDocumentWithBubbling();

--- a/src/renderer/app/modules/moduleAccessState.js
+++ b/src/renderer/app/modules/moduleAccessState.js
@@ -30,6 +30,23 @@ function setCachedActiveModuleIds(moduleIds, source = "license") {
   return cachedActiveModuleIds;
 }
 
+async function isPackagedRuntime() {
+  const root = typeof window !== "undefined" ? window : globalThis;
+  const api = root?.bbmDb || {};
+
+  if (typeof api.appIsPackaged !== "function") {
+    return null;
+  }
+
+  try {
+    const res = await api.appIsPackaged();
+    if (!res?.ok) return null;
+    return !!res?.isPackaged;
+  } catch (_err) {
+    return null;
+  }
+}
+
 export function getCachedActiveModuleIds() {
   return cachedActiveModuleIds;
 }
@@ -51,6 +68,11 @@ export function isModuleActive(moduleId) {
 export async function refreshCachedActiveModuleAccess({ force = false } = {}) {
   if (!force && cachedActiveModulePromise) {
     return await cachedActiveModulePromise;
+  }
+
+  const packagedRuntime = await isPackagedRuntime();
+  if (packagedRuntime === false) {
+    return setCachedActiveModuleIds(DEFAULT_ACTIVE_MODULE_IDS, "dev");
   }
 
   const root = typeof window !== "undefined" ? window : globalThis;


### PR DESCRIPTION
Aktiviert in der lokalen Entwicklungsumgebung automatisch alle DEFAULT_ACTIVE_MODULE_IDS, damit Restarbeiten im Dev-Betrieb sichtbar/testbar ist. In packaged Builds bleibt die Lizenzlogik maßgeblich. Ergänzt einen Test für die DEV-Modulfreigabe.