### PR TITLE
M16.3: Fix restarbeiten tests and Editbox legacy-firm handling

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,13 @@ Sie ergÃ¤nzt:
 ## Aktueller Gesamtstand
 
 
+- M16.3 Restarbeiten-Tests und Editbox-Legacy-Firma nach M16-Merge repariert:
+  - M7/M8-Tests auf M16-Fachentscheidung angepasst (Fotos nicht in der Editbox, Fotoanzeige listenseitig).
+  - `setProjectFirms(...)` in der Editbox robust auf explizite Optionenpruefung fuer Legacy-Firmen umgestellt.
+  - geprueft mit `node scripts/tests/restarbeitenModule.test.cjs`; `npm test` scheitert in Codex Cloud weiter an fehlendem `libatk-1.0.so.0`.
+  - Naechster offener Schritt: CI/Host mit GUI-Libs fuer vollstaendigen `npm test`-Lauf verwenden.
+
+
 - M15 Restarbeiten-UI wurde strukturell auf TopsScreen-Shell umgestellt:
   - Header mit vier Verortungsfiltern (projektbezogene Labels + Fallback Ebene 1-4)
   - Sheet/Canvas/Paper + Edit-Canvas als feste Screen-Bereiche per data-Attributen

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -537,13 +537,19 @@ async function runRestarbeitenModuleTests(run) {
     const view = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js"), "utf8");
     const editbox = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js"), "utf8");
     const screen = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"), "utf8");
+    const dataSource = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js"), "utf8");
 
     assert.match(view, /Noch keine Fotos vorhanden\./);
     assert.match(view, /slice\(0, 3\)/);
     assert.match(view, /Hauptfoto/);
     assert.match(editbox, /setAttachments\(attachments\)/);
+    assert.doesNotMatch(editbox, /Fotos/);
     assert.match(screen, /listRestarbeitAttachments/);
-    assert.match(screen, /setPrimaryRestarbeitAttachment/);
+    assert.match(screen, /_renderAttachmentsPreview|restarbeiten-list__photosToggle/);
+    assert.match(screen, /listRestarbeitAttachments/);
+    assert.match(dataSource, /setPrimaryRestarbeitAttachment\(/);
+    assert.match(dataSource, /importRestarbeitAttachments\(/);
+    assert.match(dataSource, /deleteRestarbeitAttachment\(/);
     assert.doesNotMatch(screen, /innerHTML\s*=/);
     assert.doesNotMatch(editbox + view + screen, /Diktat|Druck|Mail|Bildbearbeitung/);
   });

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -533,7 +533,7 @@ async function runRestarbeitenModuleTests(run) {
     }
   });
 
-  await run("M7 View/Editbox/Screen: Attachment-Anzeige verdrahtet", () => {
+  await run("M7 View/Editbox/Screen: Editbox ohne Fotos, Foto-Logik bleibt erhalten", () => {
     const view = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js"), "utf8");
     const editbox = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js"), "utf8");
     const screen = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"), "utf8");
@@ -542,7 +542,6 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(view, /slice\(0, 3\)/);
     assert.match(view, /Hauptfoto/);
     assert.match(editbox, /setAttachments\(attachments\)/);
-    assert.match(editbox, /onSetPrimaryAttachment/);
     assert.match(screen, /listRestarbeitAttachments/);
     assert.match(screen, /setPrimaryRestarbeitAttachment/);
     assert.doesNotMatch(screen, /innerHTML\s*=/);
@@ -719,13 +718,18 @@ async function runRestarbeitenModuleTests(run) {
     } finally { globalThis.window = prevWindow; }
   });
 
-  await run("M8 View/Screen: Foto-hinzufuegen und Max-3-Hinweis verdrahtet", () => {
+  await run("M8 View/Screen: Fotoanzeige bleibt listenseitig, Import-UI nicht in Editbox", () => {
     const view = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenAttachmentsView.js"), "utf8");
     const screen = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"), "utf8");
+    const ds = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js"), "utf8");
     assert.match(view, /Foto hinzufügen/);
     assert.match(view, /Maximal 3 Fotos vorhanden\./);
-    assert.match(screen, /importRestarbeitAttachments\(/);
-    assert.match(screen, /Fotos importiert\.|Fotoimport abgebrochen\.|Fotos konnten nicht importiert werden\./);
+    assert.match(ds, /importRestarbeitAttachments\(/);
+    assert.match(screen, /listRestarbeitAttachments/);
+    assert.match(screen, /restarbeiten-list__photosToggle|_renderAttachmentsPreview/);
+    assert.doesNotMatch(screen, /importRestarbeitAttachments\(/);
+    const editbox = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js"), "utf8");
+    assert.doesNotMatch(editbox, /Fotos/);
   });
 
 
@@ -1028,8 +1032,11 @@ async function runRestarbeitenModuleTests(run) {
     legacyEditbox.setProjectFirms([{ id: "f1", name: "Firma A" }]);
     const legacySelect = legacyEditbox.fields.responsible_project_firm_id;
     assert.equal(legacySelect.value, "alt-1");
-    const legacyTexts = (legacySelect.children || []).map((option) => String(option?.textContent || ""));
-    assert.equal(legacyTexts.includes("Alte Firma") || legacyTexts.includes("(nicht mehr vorhanden)"), true);
+    const legacyOptions = legacySelect.children || [];
+    const legacyOption = legacyOptions.find((option) => String(option?.value || "") === "alt-1");
+    assert.equal(Boolean(legacyOption), true);
+    assert.equal(legacySelect.value, "alt-1");
+    assert.equal(["Alte Firma", "(nicht mehr vorhanden)"].includes(String(legacyOption?.textContent || "")), true);
     const markerButtons = findNodes(root, (node) => node?.tagName === "BUTTON" && (node?.textContent === "Rest" || node?.textContent === "Mangel"));
     markerButtons.find((b) => b.textContent === "Mangel").click();
     editbox.fields.status.value = "in_arbeit";

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -207,15 +207,17 @@ export default class RestarbeitenEditbox {
 
     const fallbackId = normalizeText(this.currentItem?.responsible_project_firm_id);
     const targetId = fallbackId || selectedBefore;
-    select.value = targetId;
+    const selectOptions = Array.from(select.children || []);
+    const hasTargetOption = !!targetId && selectOptions.some((option) => normalizeText(option?.value) === targetId);
 
-    if (targetId && select.value !== targetId) {
+    if (targetId && !hasTargetOption) {
       const legacy = this.document.createElement("option");
       legacy.value = targetId;
       legacy.textContent = normalizeText(this.currentItem?.responsible_label) || "(nicht mehr vorhanden)";
       select.appendChild(legacy);
-      select.value = targetId;
     }
+
+    select.value = targetId;
   }
 
   setAttachments(attachments) {


### PR DESCRIPTION
### Motivation
- After the M16 merge some restarbeiten tests broke because photos were removed from the Editbox and legacy responsible-company behavior was brittle in tests; the goal is to adapt tests to the M16 decision and make the Editbox robust for legacy firm IDs.
- Keep the M16 fachliche constraints: do not reintroduce photo UI in the Editbox and do not remove photo data logic or list-side photo handling.

### Description
- Adjusted test expectations in `scripts/tests/restarbeitenModule.test.cjs`: renamed and updated M7 and M8 checks so they no longer expect Attachments UI inside the Editbox and instead assert that photo UI remains list-side and that import logic lives in the DataSource/IPC layer.
- Strengthened the M16 legacy-firm assertions in the tests to explicitly check that a legacy option with the expected `value` exists and contains the legacy label or a fallback text.
- Made `setProjectFirms(...)` in `src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js` robust by normalizing firms, rebuilding the select options, explicitly checking existing option values (`Array.from(select.children).some(...)`) and only adding a legacy option when the target id is missing, then setting `select.value = targetId`.
- Updated `STATUS.md` to record the M16.3 mini-patch and current test status.
- Branch/PR: changes committed on branch `work` and a Pull Request was created targeting `main` (the PR tooling did not return a URL in the environment). Files changed: `scripts/tests/restarbeitenModule.test.cjs`, `src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js`, `STATUS.md`.

### Testing
- Ran `node scripts/tests/restarbeitenModule.test.cjs` and the restarbeiten module tests passed after the changes (green).
- Ran `npm test` but the full test run failed in this Codex-Cloud environment due to a missing system library required by Electron: `libatk-1.0.so.0` (environment issue), so full `npm test` could not be completed here.
- Conclusion: module-level test suite is fixed; a CI or host with the GUI libraries is needed to verify the complete `npm test` run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ec7b25b48322aaacc95b5218b65b)