### PR TITLE
M16.5: Add dataset.expanded for Restarbeiten photo toggle/preview

### DIFF
--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -343,6 +343,8 @@ export default class RestarbeitenScreen {
     toggle.type = "button";
     toggle.className = "restarbeiten-list__photosToggle";
     toggle.textContent = photosOpen ? "▾ Fotos" : "▸ Fotos";
+    toggle.dataset.expanded = photosOpen ? "1" : "0";
+    toggle.setAttribute("aria-expanded", photosOpen ? "true" : "false");
     toggle.addEventListener("click", (event) => {
       event.preventDefault();
       event.stopPropagation();
@@ -413,6 +415,7 @@ export default class RestarbeitenScreen {
 
     const wrap = doc.createElement("div");
     wrap.className = "restarbeiten-list__attachmentsWrap";
+    wrap.dataset.expanded = photosOpen ? "1" : "0";
     wrap.hidden = !photosOpen;
 
     if (!attachments.length) {


### PR DESCRIPTION
### Motivation
- Fix the M14 UI test expecting `dataset.expanded` for the list-side photo toggle/preview while preserving the M16 decisions (photos remain list-side, `expandedPhotoRows` stays authoritative). 

### Description
- Set `data-expanded` and `aria-expanded` on the photo toggle (`toggle.dataset.expanded` and `toggle.setAttribute("aria-expanded", ...)`) and set `data-expanded` on the attachments wrap (`wrap.dataset.expanded`) in `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`, without changing the existing `expandedPhotoRows` logic or visibility handling. 

### Testing
- Ran `node scripts/tests/restarbeitenModule.test.cjs` which exited successfully (test passed). 
- Ran `npm test` which could not complete in this environment due to Electron failing to start with missing system library `libatk-1.0.so.0`, so full `npm test` is blocked in the current Cloud environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09711235fc83229f6bf554fb2cb3d5)