### PR TITLE
M16.6: Add .restarbeiten-sheet__list CSS rule

### DIFF
--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -22,6 +22,7 @@ textarea.restarbeiten-editbox__control{min-height:84px;resize:vertical}
 .restarbeiten-header__filter{display:grid;gap:2px;font-size:11px}
 .restarbeiten-header__actions{display:flex;gap:6px}
 [data-bbm-restarbeiten-screen-area="sheet"]{flex:1;min-height:0;overflow:auto;padding:12px 22px 14px}
+.restarbeiten-sheet__list{min-height:0}
 [data-bbm-restarbeiten-screen-sheet-canvas="true"],[data-bbm-restarbeiten-screen-edit-canvas="true"]{width:100%;max-width:940px;margin:0 auto}
 [data-bbm-restarbeiten-screen-sheet-paper="true"]{background:#fff;border:1px solid #dce6f2;border-radius:12px;box-shadow:0 10px 24px rgba(15,23,42,.08);padding:8px 12px 12px}
 [data-bbm-restarbeiten-screen-area="edit"]{border-top:1px solid #d9e2ec;background:linear-gradient(180deg,#f8f4ec,#f1ebdf);padding:6px 10px 8px}


### PR DESCRIPTION
### Motivation
- Fix the single failing M14 expectation by adding the missing module-local CSS class to ensure the Restarbeiten sheet list is covered by the module style without changing UI structure.

### Description
- Inserted `.restarbeiten-sheet__list { min-height: 0; }` into `src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js` and prepared a local branch `codex/m16-6-restarbeiten-sheet-list`, but a Push/PR could not be created here because the remote `origin` is not available in this environment (STOPP: remote not configured).

### Testing
- Executed `node scripts/tests/restarbeitenModule.test.cjs` which passed, and attempted `npm test` which failed in this environment due to a missing system library (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0972d587c48322bede154384ce472e)