### PR TITLE
M17: Restarbeiten — Listendarstellung bereinigen (Nummer, Datum, Metaspalte, Ampel, Kurztext)

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -951,8 +951,8 @@ async function runRestarbeitenModuleTests(run) {
       today
     );
 
-    assert.equal(item.numberLine, "#12");
-    assert.equal(item.dateLine, "2026-05-16");
+    assert.equal(item.numberLine, "12");
+    assert.equal(item.dateLine, "16.05.2026");
     assert.equal(item.locationLine1, "Haus A / EG");
     assert.equal(item.locationLine2, "Raum 01 / Fenster 2");
     assert.equal(item.workLine1, "Fenster");
@@ -960,7 +960,8 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(item.itemClassLabel, "Mangel");
     assert.equal(vm.toRestarbeitenListItem({ item_class: "rest" }, today).itemClassLabel, "Rest");
     assert.equal(item.statusLabel, "offen");
-    assert.equal(item.dueDateLabel, "2026-05-20");
+    assert.equal(item.dueDateLabel, "20.05.2026");
+    assert.equal(vm.toRestarbeitenListItem({ created_at: "2026-05-17T19:08:44.076Z" }, today).dateLine, "17.05.2026");
     assert.equal(item.responsibleLabel, "Firma Test");
     assert.equal(item.ampelState, "orange");
 
@@ -988,16 +989,22 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(content, /dataset\.restarbeitId/);
     assert.match(content, /dataset\.selected/);
     assert.match(content, /dataset\.ampel/);
-    assert.match(content, /Klasse:/);
-    assert.match(content, /Status:/);
-    assert.match(content, /Fertig bis:/);
-    assert.match(content, /Verantwortlich:/);
+    assert.doesNotMatch(content, /Klasse:/);
+    assert.doesNotMatch(content, /Status:/);
+    assert.doesNotMatch(content, /Fertig bis:/);
+    assert.doesNotMatch(content, /Verantwortlich:/);
+    assert.doesNotMatch(content, /Ampel:/);
+    assert.match(content, /item\.itemClassLabel/);
+    assert.match(content, /item\.statusLabel/);
+    assert.match(content, /item\.dueDateLabel/);
+    assert.match(content, /item\.responsibleLabel/);
     assert.doesNotMatch(content, /innerHTML\s*=/);
 
     assert.match(styleContent, /restarbeiten-list__ampel--rot/);
     assert.match(styleContent, /restarbeiten-list__ampel--orange/);
     assert.match(styleContent, /restarbeiten-list__ampel--gruen/);
     assert.match(styleContent, /restarbeiten-list__ampel--neutral/);
+    assert.match(styleContent, /restarbeiten-list__date,.restarbeiten-list__shortText,.restarbeiten-list__longText,.restarbeiten-list__locationCompact\{font-size:12px/);
     assert.doesNotMatch(styleContent, /import\s+["'].*\.css["']/);
   });
 

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -380,10 +380,10 @@ export default class RestarbeitenScreen {
     col.className = "restarbeiten-list__metaCol";
 
     const lines = [
-      `Klasse: ${item.itemClassLabel}`,
-      `Status: ${item.statusLabel}`,
-      `Fertig bis: ${item.dueDateLabel}`,
-      `Verantwortlich: ${item.responsibleLabel}`,
+      item.itemClassLabel,
+      item.statusLabel,
+      item.dueDateLabel,
+      item.responsibleLabel,
     ];
 
     for (const text of lines) {
@@ -399,10 +399,7 @@ export default class RestarbeitenScreen {
     ampelDot.className = `restarbeiten-list__ampel restarbeiten-list__ampel--${item.ampelState}`;
     ampelDot.dataset.ampel = String(item.ampelState || "neutral");
 
-    const ampelText = doc.createElement("span");
-    ampelText.textContent = `Ampel: ${item.ampelLabel}`;
-
-    ampelLine.append(ampelDot, ampelText);
+    ampelLine.append(ampelDot);
     col.append(ampelLine);
 
     return col;

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -30,8 +30,8 @@ textarea.restarbeiten-editbox__control{min-height:84px;resize:vertical}
 .restarbeiten-list__row{border:1px solid #dae2ee;border-radius:8px;padding:6px;cursor:pointer}
 .restarbeiten-list__row[data-selected="1"]{background:#eef6ff;border-color:#95b8e8}
 .restarbeiten-list__rowGrid{display:grid;grid-template-columns:72px minmax(0,1fr) 180px;gap:8px}
-.restarbeiten-list__number,.restarbeiten-list__shortText{font-weight:700}
-.restarbeiten-list__date,.restarbeiten-list__longText,.restarbeiten-list__locationCompact{font-size:12px;opacity:.88}
+.restarbeiten-list__number{font-weight:700}
+.restarbeiten-list__date,.restarbeiten-list__shortText,.restarbeiten-list__longText,.restarbeiten-list__locationCompact{font-size:12px;opacity:.88}
 .restarbeiten-list__metaCol{font-size:12px;display:grid;gap:2px}
 .restarbeiten-list__ampelLine{display:inline-flex;align-items:center;gap:6px}
 .restarbeiten-list__ampel{display:inline-block;width:10px;height:10px;border-radius:50%;border:1px solid rgba(0,0,0,.2)}

--- a/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
+++ b/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
@@ -29,6 +29,16 @@ function joinSlash(a, b) {
   return left || right || "";
 }
 
+
+function formatDateDisplay(value, fallback = "—") {
+  const text = toText(value);
+  if (!text) return fallback;
+  const match = text.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return text;
+  const [, year, month, day] = match;
+  return `${day}.${month}.${year}`;
+}
+
 function parseDateOnly(value) {
   const text = toText(value);
   if (!text) return null;
@@ -90,7 +100,7 @@ function mapAmpelLabel(state) {
 export function toRestarbeitenListItem(row = {}, today = new Date()) {
   const itemClassLabel = mapItemClass(row.item_class);
   const statusLabel = mapStatus(row.status);
-  const dueDateLabel = toText(row.due_date, "—");
+  const dueDateLabel = formatDateDisplay(row.due_date, "—");
   const responsibleLabel = toText(row.responsible_label, "—");
   const ampelState = getRestarbeitenAmpelState(row, today);
   const ampelLabel = mapAmpelLabel(ampelState);
@@ -103,8 +113,8 @@ export function toRestarbeitenListItem(row = {}, today = new Date()) {
     responsibleLabel,
     ampelState,
     ampelLabel,
-    numberLine: toText(row.running_number) ? `#${toText(row.running_number)}` : "—",
-    dateLine: toText(row.created_at, "—"),
+    numberLine: toText(row.running_number) || "—",
+    dateLine: formatDateDisplay(row.created_at, "—"),
     locationLine1: joinSlash(row.location_level_1, row.location_level_2) || "—",
     locationLine2: joinSlash(row.location_level_3, row.location_level_4) || "—",
     locationLevel1: toText(row.location_level_1, ""),


### PR DESCRIPTION
### Motivation
- Sichtbare Listendarstellung im Modul `Restarbeiten` gemäß M17-Anforderung optisch vereinfachen: Nummern ohne `#`, Datumsanzeige `dd.mm.yyyy`, Metaspalte ohne Bezeichnungswörter, Ampel nur als Symbol und Kurztext in der gleichen Schriftgröße wie Langtext.

### Description
- Formatiere sichtbare Datums- und DatumTime-Werte mit einer robusten Hilfsfunktion `formatDateDisplay` und wende sie in `toRestarbeitenListItem` an, sodass `created_at` und `due_date` als `dd.mm.yyyy` angezeigt werden (`src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js`).
- Entferne das führende `#` in der sichtbaren Nummerndarstellung und lasse die technische `running_number` unverändert (`src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js`).
- Passe die Listendarstellung an, indem die Metaspalte nur noch die Werte (ohne „Klasse:“, „Status:“, „Fertig bis:“, „Verantwortlich:“) rendert und die Ampelzeile nur das Symbol anzeigt (weiterhin mit `dataset.ampel` und den vorhandenen CSS-Klassen) (`src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`).
- Gleiche die Kurztext-Schriftgröße an die Langtext-Schriftgröße an, indem CSS-Regeln in `restarbeitenListStyle.js` angepasst werden (`src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js`).
- Aktualisiere die Modul-Tests in `scripts/tests/restarbeitenModule.test.cjs` auf die neue Darstellung (Nummer ohne `#`, Datum im `dd.mm.yyyy`-Format, Metaspalte-Label-Entfall, Ampel-Text entfällt) (`scripts/tests/restarbeitenModule.test.cjs`).

### Testing
- Ausgeführt: `node scripts/tests/restarbeitenModule.test.cjs`, die Restarbeiten-Modultests liefen erfolgreich (grün) und die aktualisierten Assertions bestanden.
- Ausgeführt: `npm test` wurde versucht, schlägt jedoch in der Cloud-Umgebung fehl wegen fehlender native Systembibliothek `libatk-1.0.so.0`, daher ist das volle `npm test` in dieser Umgebung nicht grün ausführbar.
- Tests angepasst: Assertions in `toRestarbeitenListItem`- und Screen-/Style-Checks wurden auf die neue Anzeige (Nummer ohne `#`, `dd.mm.yyyy`, Metaspalte ohne Labels, Ampel ohne Text, Kurztext-Größe) aktualisiert and verified by the direct module test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a098cf394748322b4d78eeafcb86520)