### PR TITLE
M18: Remove Metaspalten and move '+ Restarbeit' into Editbox

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -257,8 +257,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(content, /render\s*\(/);
     assert.match(content, /async\s+load\s*\(/);
     assert.match(content, /Schließen/);
-    assert.match(content, /\+ Restarbeit/);
-    assert.match(content, /Metaspalten/);
+    assert.doesNotMatch(content, /Metaspalten/);
     assert.match(content, /location_level_1/);
     assert.match(content, /location_level_4/);
     assert.match(content, /Keine Restarbeiten für die aktuellen Filter/);
@@ -296,9 +295,9 @@ async function runRestarbeitenModuleTests(run) {
 
       const allText = collectText(root);
       assert.equal(allText.includes("Schließen"), true);
-      assert.equal(allText.includes("+ Restarbeit"), true);
+      assert.equal(Boolean(findButtonByText(screen.headerHost, "+ Restarbeit")), false);
       assert.equal(allText.includes("Ebene 1") || allText.includes("Haus"), true);
-      assert.equal(allText.includes("Metaspalten"), true);
+      assert.equal(Boolean(findButtonByText(screen.headerHost, "Metaspalten")), false);
 
       assert.equal(allText.includes("Alle"), true);
     } finally {
@@ -599,12 +598,11 @@ async function runRestarbeitenModuleTests(run) {
       assert.match(screen.listHost.children[0].textContent, /Kein Projektkontext/);
       assert.equal(screen.editHost.children.length, 0);
       const addButton = findButtonByText(screen.headerHost, "+ Restarbeit");
-      assert.equal(Boolean(addButton), true);
-      assert.equal(addButton.disabled, true);
+      assert.equal(Boolean(addButton), false);
       assert.equal(Boolean(findButtonByText(screen.headerHost, "Schließen")), true);
       const allText = collectText(root);
       assert.equal(allText.includes("Alle"), true);
-      assert.equal(Boolean(findButtonByText(screen.headerHost, "Metaspalten")), true);
+      assert.equal(Boolean(findButtonByText(screen.headerHost, "Metaspalten")), false);
 
       await screen.load();
       assert.match(screen.listHost.children[0].textContent, /Kein Projektkontext/);
@@ -1014,7 +1012,12 @@ async function runRestarbeitenModuleTests(run) {
     );
     const doc = createFakeDocument();
     const saveCalls = [];
-    const editbox = new mod.default({ documentRef: doc, onSave: async (draft) => saveCalls.push(draft) });
+    const createCalls = [];
+    const editbox = new mod.default({
+      documentRef: doc,
+      onSave: async (draft) => saveCalls.push(draft),
+      onCreate: async () => createCalls.push("create"),
+    });
     const root = editbox.render();
 
     assert.equal(String(root.className || "").includes("restarbeiten-editbox"), true);
@@ -1052,6 +1055,11 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(["Alte Firma", "(nicht mehr vorhanden)"].includes(String(legacyOption?.textContent || "")), true);
     const markerButtons = findNodes(root, (node) => node?.tagName === "BUTTON" && (node?.textContent === "Rest" || node?.textContent === "Mangel"));
     markerButtons.find((b) => b.textContent === "Mangel").click();
+    const createBtn = findButtonByText(root, "+ Restarbeit");
+    assert.equal(Boolean(createBtn), true);
+    assert.equal(String(createBtn?.className || "").includes("restarbeiten-editbox__create"), true);
+    createBtn.click();
+    assert.equal(createCalls.length, 1);
     editbox.fields.status.value = "in_arbeit";
     editbox.fields.responsible_project_firm_id.value = "f1";
     const draft = editbox.getDraft();

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -46,9 +46,10 @@ function normalizeFirmEntries(list) {
 }
 
 export default class RestarbeitenEditbox {
-  constructor({ documentRef = globalThis.document, onSave = null } = {}) {
+  constructor({ documentRef = globalThis.document, onSave = null, onCreate = null } = {}) {
     this.document = documentRef || globalThis.document;
     this.onSave = typeof onSave === "function" ? onSave : null;
+    this.onCreate = typeof onCreate === "function" ? onCreate : null;
     this.root = null;
     this.form = null;
     this.saveBtn = null;
@@ -143,6 +144,15 @@ export default class RestarbeitenEditbox {
     saveBtn.type = "submit";
     saveBtn.textContent = "Speichern";
     saveBtn.className = "restarbeiten-editbox__save";
+    const createBtn = this.onCreate ? doc.createElement("button") : null;
+    if (createBtn) {
+      createBtn.type = "button";
+      createBtn.textContent = "+ Restarbeit";
+      createBtn.className = "restarbeiten-editbox__create";
+      createBtn.addEventListener("click", async () => {
+        await this.onCreate?.();
+      });
+    }
     const statusEl = doc.createElement("div");
     statusEl.className = "restarbeiten-editbox__status";
 
@@ -151,6 +161,7 @@ export default class RestarbeitenEditbox {
       createField(doc, "Status", status),
       createField(doc, "Fertig bis", dueDate),
       createField(doc, "Verantwortlich", responsibleProjectFirmId),
+      ...(createBtn ? [createBtn] : []),
       saveBtn,
       statusEl
     );

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -8,7 +8,6 @@ import {
 } from "../data/restarbeitenDataSource.js";
 import { toRestarbeitenListItems } from "../viewModel/restarbeitenListItems.js";
 import RestarbeitenEditbox from "./RestarbeitenEditbox.js";
-import { applyPopupButtonStyle } from "../../../ui/popupButtonStyles.js";
 import { ensureRestarbeitenListStyle } from "./restarbeitenListStyle.js";
 
 const LOCATION_KEYS = ["location_level_1", "location_level_2", "location_level_3", "location_level_4"];
@@ -61,7 +60,6 @@ export default class RestarbeitenScreen {
     this.host = null;
     this.headerHost = null;
     this.headerFiltersHost = null;
-    this.btnCreate = null;
     this.listHost = null;
     this.editHost = null;
   }
@@ -104,23 +102,11 @@ export default class RestarbeitenScreen {
     btnClose.textContent = "Schließen";
     btnClose.onclick = () => this.router?.showProjectWorkspace?.();
 
-    const btnCreate = doc.createElement("button");
-    btnCreate.type = "button";
-    btnCreate.textContent = "+ Restarbeit";
-    btnCreate.disabled = true;
-    btnCreate.onclick = () => this._createRestarbeit();
-
-    const btnMeta = doc.createElement("button");
-    btnMeta.type = "button";
-    btnMeta.textContent = "Metaspalten";
-    applyPopupButtonStyle(btnMeta);
-
-    actions.append(btnClose, btnCreate, btnMeta);
+    actions.append(btnClose);
     header.append(title, filters, actions);
 
     this.headerHost = header;
     this.headerFiltersHost = filters;
-    this.btnCreate = btnCreate;
   }
 
   _buildSheetArea(doc) {
@@ -205,7 +191,6 @@ export default class RestarbeitenScreen {
     const controls = LOCATION_KEYS.map((key, idx) => this._buildSingleFilter(doc, key, idx + 1));
 
     this.headerFiltersHost.replaceChildren(...controls);
-    this._syncCreateButtonState();
   }
 
   _buildSingleFilter(doc, key, levelIndex) {
@@ -252,22 +237,16 @@ export default class RestarbeitenScreen {
     return normalizeText(this.projectSettings?.[`level_${levelIndex}_label`]) || LOCATION_LABEL_FALLBACKS[levelIndex - 1];
   }
 
-  _syncCreateButtonState() {
-    if (this.btnCreate) this.btnCreate.disabled = !this.effectiveProjectId;
-  }
-
   _renderList() {
     if (!this.listHost) return;
     const doc = this.listHost.ownerDocument || globalThis.document;
 
     if (!this.effectiveProjectId) {
       this.listHost.replaceChildren(createMessage(doc, "Kein Projektkontext für Restarbeiten vorhanden."));
-      this._syncCreateButtonState();
       return;
     }
 
     this.filteredItems = this._getFilteredItems();
-    this._syncCreateButtonState();
 
     if (!this.filteredItems.length) {
       this.listHost.replaceChildren(createMessage(doc, "Keine Restarbeiten für die aktuellen Filter."));
@@ -461,6 +440,7 @@ export default class RestarbeitenScreen {
     if (!this.editbox) {
       this.editbox = new RestarbeitenEditbox({
         documentRef: doc,
+        onCreate: this.effectiveProjectId ? async () => this._createRestarbeit() : null,
         onSave: async (draft) => {
           if (!this.selectedItemId) return;
           this.editbox?.setSaving(true);

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -13,6 +13,7 @@ textarea.restarbeiten-editbox__control{min-height:84px;resize:vertical}
 .restarbeiten-editbox__marker button{min-height:30px;border:1px solid #cfcfcf;border-radius:8px;background:#f7f7f7}
 .restarbeiten-editbox__marker button[data-active="1"]{background:#dfeaea;border-color:#87a5a5;font-weight:700}
 .restarbeiten-editbox__save{min-height:34px;border:1px solid #cfcfcf;border-radius:8px;background:#f5f5f5;font-weight:700}
+.restarbeiten-editbox__create{min-height:30px;padding:4px 8px;justify-self:start;border:1px solid #cfcfcf;border-radius:8px;background:#f5f5f5;font-size:12px;font-weight:700}
 .restarbeiten-editbox__status{font-size:11px;opacity:.8}
 @media (max-width:900px){.restarbeiten-editbox__layout{grid-template-columns:1fr}.restarbeiten-editbox__locationGrid{grid-template-columns:repeat(2,minmax(0,1fr))}}
 


### PR DESCRIPTION
### Motivation
- Simplify the `Restarbeiten` header per M18 by keeping only the module title, the four location filters and the close button, and move the `+ Restarbeit` action into the editbox to reduce header clutter.
- Keep the existing create logic owned by the screen while exposing a safe callback to the editbox for triggering creation without touching DB/IPC or global table engines.

### Description
- Removed the visible `Metaspalten` and `+ Restarbeit` buttons from the header in `RestarbeitenScreen` and cleaned up the related local header UI wiring.
- Kept `_createRestarbeit()` and the create logic in `RestarbeitenScreen` and passed it as an `onCreate` callback to `RestarbeitenEditbox` (via `onCreate: () => this._createRestarbeit()`), so the editbox can render a compact create button that invokes the screen create flow.
- Added a compact editbox create button and CSS class `.restarbeiten-editbox__create` and made the editbox render this button only when an `onCreate` callback is provided.
- Updated tests to reflect the new decision and removed header expectations for `Metaspalten` and header `+ Restarbeit`, and added assertions that the editbox renders the compact create button and calls the provided callback; modified files: `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`, `src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js`, `src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js`, and `scripts/tests/restarbeitenModule.test.cjs`.

### Testing
- Ran the module test `node scripts/tests/restarbeitenModule.test.cjs` and it passed (adjusted assertions for header and editbox placement of `+ Restarbeit`).
- Attempted `npm test` but it failed in this environment due to a missing system library required by Electron (`libatk-1.0.so.0`), which is an environment issue and not a code regression.
- Confirmed working behavior by inspecting the modified files and running the module smoke checks in the unit test harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a90f9eec83229a4643bd4afda988)