### PR TITLE
M19: Restarbeiten-Editbox flacher gestalten und Segment-Umschalter

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1022,6 +1022,8 @@ async function runRestarbeitenModuleTests(run) {
 
     assert.equal(String(root.className || "").includes("restarbeiten-editbox"), true);
     assert.equal(String(root.className || "").includes("restarbeiten-editbox--compact"), true);
+    assert.equal(Boolean(findNodes(root, (node) => String(node?.className || "").includes("restarbeiten-editbox__main"))[0]), true);
+    assert.equal(Boolean(findNodes(root, (node) => String(node?.className || "").includes("restarbeiten-editbox__meta"))[0]), true);
     assert.equal(collectText(root).includes("Fotos"), false);
     assert.equal(collectText(root).includes("RestarbeitenAttachmentsView"), false);
     assert.equal(typeof editbox.setAttachments, "function");
@@ -1053,7 +1055,17 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(Boolean(legacyOption), true);
     assert.equal(legacySelect.value, "alt-1");
     assert.equal(["Alte Firma", "(nicht mehr vorhanden)"].includes(String(legacyOption?.textContent || "")), true);
+    const toggleWrap = findNodes(root, (node) => String(node?.className || "").includes("restarbeiten-editbox__classToggle"))[0];
+    assert.equal(Boolean(toggleWrap), true);
     const markerButtons = findNodes(root, (node) => node?.tagName === "BUTTON" && (node?.textContent === "Rest" || node?.textContent === "Mangel"));
+    assert.equal(markerButtons.length, 2);
+    assert.equal(String(markerButtons.find((b) => b.textContent === "Rest")?.dataset?.active || ""), "1");
+    markerButtons.find((b) => b.textContent === "Mangel").click();
+    assert.equal(String(markerButtons.find((b) => b.textContent === "Mangel")?.dataset?.active || ""), "1");
+    assert.equal(String(markerButtons.find((b) => b.textContent === "Rest")?.dataset?.active || ""), "0");
+    markerButtons.find((b) => b.textContent === "Rest").click();
+    assert.equal(String(markerButtons.find((b) => b.textContent === "Rest")?.dataset?.active || ""), "1");
+    assert.equal(String(markerButtons.find((b) => b.textContent === "Mangel")?.dataset?.active || ""), "0");
     markerButtons.find((b) => b.textContent === "Mangel").click();
     const createBtn = findButtonByText(root, "+ Restarbeit");
     assert.equal(Boolean(createBtn), true);
@@ -1092,6 +1104,45 @@ async function runRestarbeitenModuleTests(run) {
     const combinedContent = `${editboxContent}\n${screenContent}`;
     assert.doesNotMatch(combinedContent, /execSync\(\s*["']git status/);
     assert.doesNotMatch(combinedContent, /node:child_process/);
+  });
+
+  await run("M19 Guardrails: Editbox CSS verdichtet und Segment-Umschalter vorhanden", () => {
+    const editboxContent = fs.readFileSync(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js"),
+      "utf8"
+    );
+    const styleContent = fs.readFileSync(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js"),
+      "utf8"
+    );
+    const screenContent = fs.readFileSync(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"),
+      "utf8"
+    );
+
+    assert.match(editboxContent, /restarbeiten-editbox__classToggle/);
+    assert.match(editboxContent, /restarbeiten-editbox__classToggleButton/);
+    assert.match(editboxContent, /restarbeiten-editbox__control--short/);
+    assert.match(editboxContent, /restarbeiten-editbox__control--long/);
+    assert.doesNotMatch(editboxContent, /style\s*=\s*["']/);
+
+    assert.match(styleContent, /\.restarbeiten-editbox__save\{/);
+    assert.match(styleContent, /\.restarbeiten-editbox__create\{/);
+    assert.match(styleContent, /\.restarbeiten-editbox__classToggle\{/);
+    assert.match(styleContent, /\.restarbeiten-editbox__classToggleButton\{/);
+    assert.match(styleContent, /\.restarbeiten-editbox__control\{/);
+    assert.match(styleContent, /\.restarbeiten-editbox__control--short\{/);
+    assert.match(styleContent, /textarea\.restarbeiten-editbox__control--long\{/);
+
+    assert.match(editboxContent, /short_text/);
+    assert.match(editboxContent, /long_text/);
+    assert.match(editboxContent, /responsible_project_firm_id/);
+    assert.match(editboxContent, /location_level_1/);
+    assert.match(editboxContent, /location_level_4/);
+
+    assert.match(editboxContent, /itemClass\.value = value === "mangel" \? "mangel" : "rest"/);
+    assert.match(screenContent, /restarbeiten-list/);
+    assert.doesNotMatch(screenContent, /<table|createElement\("table"\)/);
   });
 
 }

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -32,6 +32,8 @@ function createSelect(doc, options) {
 function createInput(doc, type = "text") {
   const input = doc.createElement(type === "textarea" ? "textarea" : "input");
   input.className = "restarbeiten-editbox__control";
+  if (type === "text") input.className += " restarbeiten-editbox__control--short";
+  if (type === "textarea") input.className += " restarbeiten-editbox__control--long";
   if (type !== "textarea") input.type = type;
   return input;
 }
@@ -114,13 +116,17 @@ export default class RestarbeitenEditbox {
     itemClass.value = "rest";
 
     const marker = doc.createElement("div");
-    marker.className = "restarbeiten-editbox__marker";
+    marker.className = "restarbeiten-editbox__classToggle";
+    marker.setAttribute("role", "group");
+    marker.setAttribute("aria-label", "Rest oder Mangel");
     const restBtn = doc.createElement("button");
     restBtn.type = "button";
     restBtn.textContent = "Rest";
+    restBtn.className = "restarbeiten-editbox__classToggleButton";
     const mangelBtn = doc.createElement("button");
     mangelBtn.type = "button";
     mangelBtn.textContent = "Mangel";
+    mangelBtn.className = "restarbeiten-editbox__classToggleButton";
     marker.append(restBtn, mangelBtn);
 
     const setItemClass = (value) => {

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -1,19 +1,21 @@
 const STYLE_ID = "restarbeiten-list-style";
 
 const CSS_TEXT = `
-.restarbeiten-editbox{max-width:940px;margin:0 auto;padding:10px;border:1px solid #bfd2d2;border-radius:10px;background:#fff;box-sizing:border-box}
-.restarbeiten-editbox__layout{display:grid;grid-template-columns:minmax(0,1fr) 260px;gap:10px;align-items:start}
-.restarbeiten-editbox__main,.restarbeiten-editbox__meta{display:grid;gap:8px}
-.restarbeiten-editbox__field{display:grid;gap:4px}
-.restarbeiten-editbox__label{font-size:11px;font-weight:700}
-.restarbeiten-editbox__control{min-height:32px;padding:6px 8px;border-radius:8px;border:1px solid #cfcfcf}
-textarea.restarbeiten-editbox__control{min-height:84px;resize:vertical}
+.restarbeiten-editbox{max-width:940px;margin:0 auto;padding:8px;border:1px solid #bfd2d2;border-radius:10px;background:#fff;box-sizing:border-box}
+.restarbeiten-editbox__layout{display:grid;grid-template-columns:minmax(0,1fr) 250px;gap:8px;align-items:start}
+.restarbeiten-editbox__main,.restarbeiten-editbox__meta{display:grid;gap:6px}
+.restarbeiten-editbox__field{display:grid;gap:3px}
+.restarbeiten-editbox__label{font-size:10px;font-weight:700}
+.restarbeiten-editbox__control{min-height:28px;padding:4px 7px;border-radius:6px;border:1px solid #cfcfcf;font-size:12px}
+.restarbeiten-editbox__control--short{min-height:26px;padding-top:3px;padding-bottom:3px}
+textarea.restarbeiten-editbox__control{min-height:74px;resize:vertical}
+textarea.restarbeiten-editbox__control--long{min-height:74px}
 .restarbeiten-editbox__locationGrid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:6px}
-.restarbeiten-editbox__marker{display:grid;grid-template-columns:1fr 1fr;gap:6px}
-.restarbeiten-editbox__marker button{min-height:30px;border:1px solid #cfcfcf;border-radius:8px;background:#f7f7f7}
-.restarbeiten-editbox__marker button[data-active="1"]{background:#dfeaea;border-color:#87a5a5;font-weight:700}
-.restarbeiten-editbox__save{min-height:34px;border:1px solid #cfcfcf;border-radius:8px;background:#f5f5f5;font-weight:700}
-.restarbeiten-editbox__create{min-height:30px;padding:4px 8px;justify-self:start;border:1px solid #cfcfcf;border-radius:8px;background:#f5f5f5;font-size:12px;font-weight:700}
+.restarbeiten-editbox__classToggle{display:grid;grid-template-columns:1fr 1fr;gap:4px;padding:2px;border:1px solid #cfd8d8;border-radius:999px;background:#f6f8f8}
+.restarbeiten-editbox__classToggleButton{min-height:26px;padding:3px 6px;border:1px solid transparent;border-radius:999px;background:transparent;font-size:12px;font-weight:600}
+.restarbeiten-editbox__classToggleButton[data-active="1"]{background:#dfeaea;border-color:#87a5a5;font-weight:700}
+.restarbeiten-editbox__save{min-height:28px;padding:4px 8px;border:1px solid #cfcfcf;border-radius:6px;background:#f5f5f5;font-size:12px;font-weight:700}
+.restarbeiten-editbox__create{min-height:26px;padding:3px 8px;justify-self:start;border:1px solid #cfcfcf;border-radius:6px;background:#f5f5f5;font-size:12px;font-weight:700}
 .restarbeiten-editbox__status{font-size:11px;opacity:.8}
 @media (max-width:900px){.restarbeiten-editbox__layout{grid-template-columns:1fr}.restarbeiten-editbox__locationGrid{grid-template-columns:repeat(2,minmax(0,1fr))}}
 


### PR DESCRIPTION
### Motivation
- Das UI der Restarbeiten-Editbox soll optisch flacher und kompakter wirken, Kurztext weniger dominant sein und der Rest/Mangel-Wechsel als klarer Segment-Umschalter angeboten werden, ohne Logik- oder Header-Änderungen.

### Description
- Reduziert Padding/Gaps und Höhen der Editbox-Controls in `src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js` und macht Buttons/Selects flacher und kompakter.
- Kennzeichnet Kurztext und Langtext separat mit `restarbeiten-editbox__control--short` bzw. `restarbeiten-editbox__control--long` und setzt die Klasse auf Inputs/Textarea in `src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js`.
- Ersetzt die bisherige Marker-Optik durch einen Segment-/Toggle-Wrapper `restarbeiten-editbox__classToggle` mit `restarbeiten-editbox__classToggleButton` für „Rest“/„Mangel“, wobei `item_class` unverändert `rest`/`mangel` bleibt.
- Ergänzt/aktualisiert Test-Assertions in `scripts/tests/restarbeitenModule.test.cjs` zur 2-Spalten-Struktur, Toggle-Verhalten und CSS-Guardrails.

### Testing
- `node scripts/tests/restarbeitenModule.test.cjs` wurde ausgeführt und lief erfolgreich (Modultests für Restarbeiten grünen durch). 
- `npm test` wurde gestartet und schlägt in der Cloud-Umgebung fehl wegen fehlender Systembibliothek `libatk-1.0.so.0` in der Electron-Umgebung, was eine Umgebungseinschränkung ist. 
- Ergebnis-Branch ist `work` und die PR-Erstellung wurde via internes Tool ausgelöst (Ziel: `main`), das Tool hat jedoch keine URL zurückgegeben.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09aaf90ad08322bbc1feb1c651f536)