### PR TITLE
M20: Restarbeiten Editbox — location inputs with datalist + compact field styling

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,15 @@ Sie ergÃ¤nzt:
 ## Aktueller Gesamtstand
 
 
+
+- M20 Restarbeiten-Editbox Verortungsvorschlaege + kompaktere Feldoptik umgesetzt:
+  - Verortungsfelder `location_level_1..4` sind als freie `input`-Felder mit `datalist`-Vorschlaegen verdrahtet (Auswahl + freie Eingabe).
+  - RestarbeitenScreen leitet eindeutige, sortierte Vorschlagswerte aus geladenen Rows ab und uebergibt sie an die Editbox.
+  - Verortungs- und Verantwortlich-Feldoptik ist sichtbar kompakter (kleinere Labels/Controls, weniger Padding).
+  - geprueft mit `node scripts/tests/restarbeitenModule.test.cjs`; `npm test` scheitert in Codex Cloud weiter an fehlendem `libatk-1.0.so.0`.
+  - Naechster offener Schritt: UI-Sichtpruefung der neuen Verortungs-Datalist im laufenden Client.
+
+
 - M16.3 Restarbeiten-Tests und Editbox-Legacy-Firma nach M16-Merge repariert:
   - M7/M8-Tests auf M16-Fachentscheidung angepasst (Fotos nicht in der Editbox, Fotoanzeige listenseitig).
   - `setProjectFirms(...)` in der Editbox robust auf explizite Optionenpruefung fuer Legacy-Firmen umgestellt.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1145,6 +1145,63 @@ async function runRestarbeitenModuleTests(run) {
     assert.doesNotMatch(screenContent, /<table|createElement\("table"\)/);
   });
 
+
+  await run("M20 Verortung: input+datalist, Options-Uebergabe und kompakte Klassen", async () => {
+    const editboxPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js");
+    const screenPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js");
+    const stylePath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js");
+
+    const editboxContent = fs.readFileSync(editboxPath, "utf8");
+    const screenContent = fs.readFileSync(screenPath, "utf8");
+    const styleContent = fs.readFileSync(stylePath, "utf8");
+
+    assert.match(editboxContent, /setLocationOptions\s*\(/);
+    assert.match(editboxContent, /createElement\("datalist"\)/);
+    assert.match(editboxContent, /input\.setAttribute\("list",\s*datalist\.id\)/);
+    assert.doesNotMatch(editboxContent, /innerHTML\s*=/);
+    assert.match(editboxContent, /location_level_1/);
+    assert.match(editboxContent, /location_level_4/);
+
+    assert.match(screenContent, /_collectLocationOptionsFromRows\s*\(/);
+    assert.match(screenContent, /this\.editbox\.setLocationOptions\(this\.locationOptions\)/);
+    assert.doesNotMatch(editboxContent, /from\s+["'][^"']*restarbeitenDataSource\.js["']/);
+
+    assert.match(styleContent, /\.restarbeiten-editbox__locationControl\{/);
+    assert.match(styleContent, /\.restarbeiten-editbox__metaControl\{/);
+    assert.match(styleContent, /\.restarbeiten-editbox__locationLabel\{/);
+
+    const mod = await importEsmFromFile(editboxPath);
+    const Editbox = mod.default;
+    const prevDocument = globalThis.document;
+    globalThis.document = createFakeDocument();
+
+    try {
+      const editbox = new Editbox({ documentRef: globalThis.document });
+      editbox.render();
+      editbox.setLocationOptions({
+        location_level_1: ["Haus 2", "Haus 1", "Haus 1"],
+        location_level_2: ["OG", "EG"],
+        location_level_3: ["WE 01"],
+        location_level_4: ["Bad"],
+      });
+
+      const listId = String(editbox.fields.location_level_1.list || "");
+      assert.equal(Boolean(listId), true);
+      const datalist = (editbox.fields.location_level_1.parentElement?.children || []).find((n) => n?.tagName === "DATALIST");
+      assert.equal(Boolean(datalist), true);
+      const optionValues = (datalist.children || []).map((n) => n.value);
+      assert.deepEqual(optionValues, ["Haus 1", "Haus 2"]);
+
+      editbox.fields.location_level_1.value = "Neues Haus";
+      assert.equal(editbox.getDraft().location_level_1, "Neues Haus");
+
+      assert.equal(String(editbox.fields.location_level_1.className).includes("restarbeiten-editbox__locationControl"), true);
+      assert.equal(String(editbox.fields.responsible_project_firm_id.className).includes("restarbeiten-editbox__metaControl"), true);
+    } finally {
+      globalThis.document = prevDocument;
+    }
+  });
+
 }
 
 module.exports = { runRestarbeitenModuleTests };

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1200,6 +1200,39 @@ async function runRestarbeitenModuleTests(run) {
     } finally {
       globalThis.document = prevDocument;
     }
+
+    const screenMod = await importEsmFromFile(screenPath);
+    const RestarbeitenScreen = screenMod.default;
+    const prevDocument2 = globalThis.document;
+    globalThis.document = createFakeDocument();
+    try {
+      const screen = new RestarbeitenScreen({ projectId: "p-1" });
+      const options = screen._collectLocationOptionsFromRows([
+        { location_level_1: "Haus 2", location_level_2: "OG", location_level_3: "WE 10", location_level_4: "Wohnen" },
+        { location_level_1: "Haus 1", location_level_2: "EG", location_level_3: "WE 01", location_level_4: "Bad" },
+        { location_level_1: "Haus 1", location_level_2: "EG", location_level_3: "WE 01", location_level_4: "" },
+      ]);
+      assert.deepEqual(options.location_level_1, ["Haus 1", "Haus 2"]);
+      assert.deepEqual(options.location_level_2, ["EG", "OG"]);
+
+      let forwardedOptions = null;
+      screen.editHost = globalThis.document.createElement("div");
+      screen.effectiveProjectId = "p-1";
+      screen.locationOptions = options;
+      screen.rows = [{ id: "r-1", location_level_1: "Haus 1" }];
+      screen.selectedItemId = "r-1";
+      screen.editbox = {
+        setLocationLabels() {},
+        setLocationOptions(value) { forwardedOptions = value; },
+        setItem() {},
+        setProjectFirms() {},
+        setAttachments() {},
+      };
+      screen._renderEditbox();
+      assert.deepEqual(forwardedOptions, options);
+    } finally {
+      globalThis.document = prevDocument2;
+    }
   });
 
 }

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -29,9 +29,10 @@ function createSelect(doc, options) {
   return select;
 }
 
-function createInput(doc, type = "text") {
+function createInput(doc, type = "text", className = "") {
   const input = doc.createElement(type === "textarea" ? "textarea" : "input");
   input.className = "restarbeiten-editbox__control";
+  if (className) input.className += ` ${className}`;
   if (type === "text") input.className += " restarbeiten-editbox__control--short";
   if (type === "textarea") input.className += " restarbeiten-editbox__control--long";
   if (type !== "textarea") input.type = type;
@@ -59,6 +60,8 @@ export default class RestarbeitenEditbox {
     this.currentItem = null;
     this.projectFirms = [];
     this.locationLabels = {};
+    this.locationOptions = {};
+    this.locationOptionLists = {};
     this.fields = {};
     this.attachments = [];
   }
@@ -93,10 +96,10 @@ export default class RestarbeitenEditbox {
     const shortText = createInput(doc, "text");
     const longText = createInput(doc, "textarea");
     longText.rows = 4;
-    const level1 = createInput(doc, "text");
-    const level2 = createInput(doc, "text");
-    const level3 = createInput(doc, "text");
-    const level4 = createInput(doc, "text");
+    const level1 = createInput(doc, "text", "restarbeiten-editbox__locationControl");
+    const level2 = createInput(doc, "text", "restarbeiten-editbox__locationControl");
+    const level3 = createInput(doc, "text", "restarbeiten-editbox__locationControl");
+    const level4 = createInput(doc, "text", "restarbeiten-editbox__locationControl");
 
     const locationGrid = doc.createElement("div");
     locationGrid.className = "restarbeiten-editbox__locationGrid";
@@ -104,6 +107,10 @@ export default class RestarbeitenEditbox {
     const loc2Field = createField(doc, this._getLocationLabel(2), level2, "restarbeiten-editbox__locationField");
     const loc3Field = createField(doc, this._getLocationLabel(3), level3, "restarbeiten-editbox__locationField");
     const loc4Field = createField(doc, this._getLocationLabel(4), level4, "restarbeiten-editbox__locationField");
+    [loc1Field, loc2Field, loc3Field, loc4Field].forEach((field) => {
+      const label = field.querySelector?.(".restarbeiten-editbox__label") || field.children[0];
+      if (label) label.className = `${label.className} restarbeiten-editbox__locationLabel`.trim();
+    });
     locationGrid.append(loc1Field, loc2Field, loc3Field, loc4Field);
 
     mainCol.append(
@@ -146,6 +153,7 @@ export default class RestarbeitenEditbox {
     ]);
     const dueDate = createInput(doc, "date");
     const responsibleProjectFirmId = createSelect(doc, [{ value: "", label: "— keine Auswahl —" }]);
+    responsibleProjectFirmId.className += " restarbeiten-editbox__metaControl";
     const saveBtn = doc.createElement("button");
     saveBtn.type = "submit";
     saveBtn.textContent = "Speichern";
@@ -202,10 +210,51 @@ export default class RestarbeitenEditbox {
     };
 
     this._setItemClass = setItemClass;
+    this._wireLocationDatalists();
     this.setItem(null);
     return root;
   }
 
+
+  _normalizeLocationOptions(options = {}) {
+    const normalized = {};
+    for (const key of LOCATION_KEYS) {
+      const values = Array.isArray(options?.[key]) ? options[key] : [];
+      const unique = [...new Set(values.map((value) => normalizeText(value)).filter(Boolean))];
+      normalized[key] = unique.sort((a, b) => a.localeCompare(b, "de"));
+    }
+    return normalized;
+  }
+
+  setLocationOptions(options) {
+    this.locationOptions = this._normalizeLocationOptions(options);
+    this._wireLocationDatalists();
+  }
+
+  _wireLocationDatalists() {
+    const doc = this.document;
+    for (const key of LOCATION_KEYS) {
+      const input = this.fields?.[key];
+      if (!input || !doc?.createElement) continue;
+      let datalist = this.locationOptionLists[key];
+      if (!datalist) {
+        datalist = doc.createElement("datalist");
+        datalist.id = `restarbeiten-editbox-${key}-options`;
+        this.locationOptionLists[key] = datalist;
+      }
+      datalist.replaceChildren();
+      for (const value of this.locationOptions?.[key] || []) {
+        const opt = doc.createElement("option");
+        opt.value = value;
+        datalist.append(opt);
+      }
+      const parent = input.parentElement;
+      if (parent && !parent.children.includes?.(datalist) && !Array.from(parent.children || []).includes(datalist)) {
+        parent.append(datalist);
+      }
+      input.setAttribute("list", datalist.id);
+    }
+  }
   setProjectFirms(firms) {
     this.projectFirms = normalizeFirmEntries(firms);
     const select = this.fields?.responsible_project_firm_id;

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -474,6 +474,7 @@ export default class RestarbeitenScreen {
     }
 
     this.editbox.setLocationLabels(this.projectSettings || {});
+    this.editbox.setLocationOptions(this.locationOptions);
     this.editbox.setItem(selectedItem);
     this.editbox.setProjectFirms(this.projectFirms);
     this.editbox.setAttachments(this.attachmentsByItemId.get(String(selectedItem.id)) || []);

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -45,6 +45,7 @@ export default class RestarbeitenScreen {
     this.selectedItemId = "";
     this.projectFirms = [];
     this.projectSettings = null;
+    this.locationOptions = { location_level_1: [], location_level_2: [], location_level_3: [], location_level_4: [] };
     this.editbox = null;
 
     this.filterState = {
@@ -162,6 +163,7 @@ export default class RestarbeitenScreen {
     this.items = toRestarbeitenListItems(this.rows);
     this.projectFirms = Array.isArray(projectFirms) ? projectFirms : [];
     this.projectSettings = projectSettings || null;
+    this.locationOptions = this._collectLocationOptionsFromRows(this.rows);
 
     if (selectItemId) {
       this._setSelectedItemId(selectItemId);
@@ -173,6 +175,20 @@ export default class RestarbeitenScreen {
     this._renderHeaderFilters();
     this._renderList();
     this._renderEditbox();
+  }
+
+
+  _collectLocationOptionsFromRows(rows = []) {
+    const options = {};
+    for (const key of LOCATION_KEYS) {
+      const unique = new Set();
+      for (const row of Array.isArray(rows) ? rows : []) {
+        const value = normalizeText(row?.[key]);
+        if (value) unique.add(value);
+      }
+      options[key] = [...unique].sort((a, b) => a.localeCompare(b, "de"));
+    }
+    return options;
   }
 
   _setSelectedItemId(itemId) {

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -5,12 +5,15 @@ const CSS_TEXT = `
 .restarbeiten-editbox__layout{display:grid;grid-template-columns:minmax(0,1fr) 250px;gap:8px;align-items:start}
 .restarbeiten-editbox__main,.restarbeiten-editbox__meta{display:grid;gap:6px}
 .restarbeiten-editbox__field{display:grid;gap:3px}
-.restarbeiten-editbox__label{font-size:10px;font-weight:700}
-.restarbeiten-editbox__control{min-height:28px;padding:4px 7px;border-radius:6px;border:1px solid #cfcfcf;font-size:12px}
-.restarbeiten-editbox__control--short{min-height:26px;padding-top:3px;padding-bottom:3px}
+.restarbeiten-editbox__label{font-size:9px;font-weight:700;line-height:1.15}
+.restarbeiten-editbox__control{min-height:24px;padding:3px 6px;border-radius:6px;border:1px solid #cfcfcf;font-size:11px;line-height:1.2}
+.restarbeiten-editbox__control--short{min-height:23px;padding-top:2px;padding-bottom:2px}
 textarea.restarbeiten-editbox__control{min-height:74px;resize:vertical}
 textarea.restarbeiten-editbox__control--long{min-height:74px}
-.restarbeiten-editbox__locationGrid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:6px}
+.restarbeiten-editbox__locationGrid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:5px}
+.restarbeiten-editbox__locationLabel{font-size:8px;letter-spacing:.01em}
+.restarbeiten-editbox__locationControl{min-height:22px;padding:2px 5px;font-size:10px}
+.restarbeiten-editbox__metaControl{min-height:23px;padding:2px 5px;font-size:10px}
 .restarbeiten-editbox__classToggle{display:grid;grid-template-columns:1fr 1fr;gap:4px;padding:2px;border:1px solid #cfd8d8;border-radius:999px;background:#f6f8f8}
 .restarbeiten-editbox__classToggleButton{min-height:26px;padding:3px 6px;border:1px solid transparent;border-radius:999px;background:transparent;font-size:12px;font-weight:600}
 .restarbeiten-editbox__classToggleButton[data-active="1"]{background:#dfeaea;border-color:#87a5a5;font-weight:700}


### PR DESCRIPTION
### Motivation
- Make the location fields in the Restarbeiten editbox support free text input while offering suggestions derived from existing rows, and visibly reduce the visual footprint of location/responsible fields as part of M20.

### Description
- Added collection of unique, non-empty, `localeCompare("de")`-sorted suggestion lists in `RestarbeitenScreen` via `_collectLocationOptionsFromRows(...)` and stored in `this.locationOptions`.
- Pass location suggestions from `RestarbeitenScreen` into the editbox with `setLocationOptions(...)` after `load()` without importing any data source into the editbox.
- Updated `RestarbeitenEditbox` to render location fields as editable `input` elements wired to DOM-created `<datalist>` elements (no `innerHTML`), with `setLocationOptions(...)`, `_wireLocationDatalists()` and normalization logic; `getDraft()`/`setItem()` payload unchanged.
- Tightened CSS rules to make labels and controls smaller and less padded, and added module-local classes for location/meta controls (`restarbeiten-editbox__locationControl`, `...__locationLabel`, `...__metaControl`) in `restarbeitenListStyle.js`.
- Added automated test block for M20 in `scripts/tests/restarbeitenModule.test.cjs` verifying `setLocationOptions`, datalist wiring, free input behaviour and compact classes.
- Updated `STATUS.md` with M20 entry.
- Files changed: `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`, `src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js`, `src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js`, `scripts/tests/restarbeitenModule.test.cjs`, `STATUS.md`.

### Testing
- Ran `node scripts/tests/restarbeitenModule.test.cjs` and the test suite for the Restarbeiten module completed successfully (M20 test included) — ✅.
- Ran `npm test` in this environment and it failed due to missing system library required by Electron (`libatk-1.0.so.0`), which is an environment/CI blocker not caused by the changes — ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b64890d0832281360a4a3479d13e)