### PR TITLE
M21: Restarbeiten-Editbox — Autosave statt Speichern-Button

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1165,6 +1165,16 @@ async function runRestarbeitenModuleTests(run) {
     editbox.setItem({ id: "r1", short_text: "Alt", status: "offen" });
     assert.equal(saveCalls.length, 0);
 
+    const submitState = { prevented: false, stopped: false };
+    editbox.form.dispatchEvent({
+      type: "submit",
+      preventDefault() { submitState.prevented = true; },
+      stopPropagation() { submitState.stopped = true; },
+    });
+    assert.equal(submitState.prevented, true);
+    assert.equal(submitState.stopped, true);
+    assert.equal(saveCalls.length, 0);
+
     editbox.fields.short_text.value = "Neu";
     await editbox.flushAutosave();
     assert.equal(saveCalls.length, 1);

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1184,6 +1184,83 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(saveCalls.length, 3);
   });
 
+  await run("M21.1 Autosave: pending Draft bleibt trotz setItem waehrend Save erhalten", async () => {
+    const mod = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js")
+    );
+
+    let resolveFirstSave;
+    const calls = [];
+    let running = 0;
+    const editbox = new mod.default({
+      documentRef: createFakeDocument(),
+      onSave: async (draft) => {
+        calls.push(draft);
+        running += 1;
+        if (running === 1) {
+          await new Promise((resolve) => { resolveFirstSave = resolve; });
+        }
+        running -= 1;
+      },
+    });
+
+    editbox.render();
+    editbox.setItem({ id: "r1", short_text: "Alt", status: "offen" });
+
+    editbox.fields.short_text.value = "Neu 1";
+    const firstFlush = editbox.flushAutosave();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    editbox.fields.short_text.value = "Neu 2";
+    await editbox.flushAutosave();
+    editbox.setItem({ id: "r1", short_text: "Neu 1", status: "offen" });
+
+    resolveFirstSave();
+    await firstFlush;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].short_text, "Neu 1");
+    assert.equal(calls[1].short_text, "Neu 2");
+  });
+
+  await run("M21.1 Autosave: laufender Save plus neue Aenderung fuehrt zu zweitem Save", async () => {
+    const mod = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js")
+    );
+
+    let resolveFirstSave;
+    const calls = [];
+    const editbox = new mod.default({
+      documentRef: createFakeDocument(),
+      onSave: async (draft) => {
+        calls.push(draft);
+        if (calls.length === 1) {
+          await new Promise((resolve) => { resolveFirstSave = resolve; });
+        }
+      },
+    });
+
+    editbox.render();
+    editbox.setItem({ id: "r1", short_text: "Alt", status: "offen" });
+
+    editbox.fields.short_text.value = "A";
+    const firstFlush = editbox.flushAutosave();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    editbox.fields.short_text.value = "B";
+    await editbox.flushAutosave();
+
+    resolveFirstSave();
+    await firstFlush;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].short_text, "A");
+    assert.equal(calls[1].short_text, "B");
+  });
+
+
   await run("M20 Verortung: input+datalist, Options-Uebergabe und kompakte Klassen", async () => {
     const editboxPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js");
     const screenPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js");

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1080,8 +1080,9 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(draft.due_date, "2026-05-16");
     assert.equal(draft.responsible_project_firm_id, "f1");
 
-    editbox.form.dispatchEvent({ type: "submit", preventDefault() {} });
-    assert.equal(saveCalls.length, 1);
+    editbox.fields.short_text.value = "Kurz neu";
+    await editbox.flushAutosave();
+    assert.equal(saveCalls.length >= 1, true);
     assert.equal(typeof saveCalls[0].short_text, "string");
     assert.equal(typeof saveCalls[0].long_text, "string");
     assert.equal(Object.hasOwn(saveCalls[0], "location_level_1"), true);
@@ -1126,7 +1127,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(editboxContent, /restarbeiten-editbox__control--long/);
     assert.doesNotMatch(editboxContent, /style\s*=\s*["']/);
 
-    assert.match(styleContent, /\.restarbeiten-editbox__save\{/);
+    assert.doesNotMatch(styleContent, /\.restarbeiten-editbox__save\{/);
     assert.match(styleContent, /\.restarbeiten-editbox__create\{/);
     assert.match(styleContent, /\.restarbeiten-editbox__classToggle\{/);
     assert.match(styleContent, /\.restarbeiten-editbox__classToggleButton\{/);
@@ -1145,6 +1146,43 @@ async function runRestarbeitenModuleTests(run) {
     assert.doesNotMatch(screenContent, /<table|createElement\("table"\)/);
   });
 
+
+  
+
+  await run("M21 Autosave: setItem/setLocation/setProjectFirms bleiben autosave-sicher", async () => {
+    const mod = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js")
+    );
+    const saveCalls = [];
+    const editbox = new mod.default({
+      documentRef: createFakeDocument(),
+      onSave: async (draft) => saveCalls.push(draft),
+    });
+    editbox.render();
+    editbox.setLocationOptions({ location_level_1: ["Haus A"] });
+    editbox.setProjectFirms([{ id: "f1", name: "Firma A" }]);
+    editbox.setLocationLabels({ level_1_label: "Haus" });
+    editbox.setItem({ id: "r1", short_text: "Alt", status: "offen" });
+    assert.equal(saveCalls.length, 0);
+
+    editbox.fields.short_text.value = "Neu";
+    await editbox.flushAutosave();
+    assert.equal(saveCalls.length, 1);
+    assert.equal(saveCalls[0].short_text, "Neu");
+
+    await editbox.flushAutosave();
+    assert.equal(saveCalls.length, 1);
+
+    editbox.fields.status.value = "in_arbeit";
+    editbox.fields.status.dispatchEvent({ type: "change" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(saveCalls.length, 2);
+
+    editbox.fields.short_text.value = "Neu2";
+    editbox.fields.short_text.dispatchEvent({ type: "blur" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(saveCalls.length, 3);
+  });
 
   await run("M20 Verortung: input+datalist, Options-Uebergabe und kompakte Klassen", async () => {
     const editboxPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js");

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1261,6 +1261,45 @@ async function runRestarbeitenModuleTests(run) {
   });
 
 
+  await run("M21.2 Autosave: fehlgeschlagener Draft kann erneut gespeichert werden", async () => {
+    const mod = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js")
+    );
+
+    const saveCalls = [];
+    const editbox = new mod.default({
+      documentRef: createFakeDocument(),
+      onSave: async (draft) => {
+        saveCalls.push(draft);
+        if (saveCalls.length === 1) {
+          throw new Error("transient");
+        }
+      },
+    });
+
+    editbox.render();
+    editbox.setItem({ id: "r1", short_text: "Alt", status: "offen" });
+
+    editbox.fields.short_text.value = "Neu";
+    await editbox.flushAutosave();
+
+    assert.equal(saveCalls.length, 1);
+    assert.equal(saveCalls[0].short_text, "Neu");
+    assert.equal(
+      String(editbox.statusEl?.textContent || "").includes("fehlgeschlagen") || editbox.pendingDraftKey.length > 0,
+      true
+    );
+
+    await editbox.flushAutosave();
+
+    assert.equal(saveCalls.length, 2);
+    assert.equal(saveCalls[1].short_text, "Neu");
+    assert.equal(String(editbox.statusEl?.textContent || ""), "Gespeichert");
+    assert.equal(editbox.pendingDraftKey, "");
+    assert.equal(editbox.lastSavedDraftKey, editbox._draftKeyFor(saveCalls[1]));
+  });
+
+
   await run("M20 Verortung: input+datalist, Options-Uebergabe und kompakte Klassen", async () => {
     const editboxPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js");
     const screenPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js");

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -4,6 +4,7 @@ function normalizeText(value) {
 
 const LOCATION_KEYS = ["location_level_1", "location_level_2", "location_level_3", "location_level_4"];
 const LOCATION_LABEL_FALLBACKS = ["Ebene 1", "Ebene 2", "Ebene 3", "Ebene 4"];
+const AUTOSAVE_DELAY_MS = 650;
 
 function createField(doc, labelText, control, className = "") {
   const wrap = doc.createElement("label");
@@ -55,7 +56,6 @@ export default class RestarbeitenEditbox {
     this.onCreate = typeof onCreate === "function" ? onCreate : null;
     this.root = null;
     this.form = null;
-    this.saveBtn = null;
     this.statusEl = null;
     this.currentItem = null;
     this.projectFirms = [];
@@ -64,6 +64,12 @@ export default class RestarbeitenEditbox {
     this.locationOptionLists = {};
     this.fields = {};
     this.attachments = [];
+    this.isApplyingItem = false;
+    this.isSaving = false;
+    this.autosaveTimer = null;
+    this.pendingDraftKey = "";
+    this.lastSavedDraftKey = "";
+    this.lastRequestedDraftKey = "";
   }
 
   _getLocationLabel(index) {
@@ -83,13 +89,10 @@ export default class RestarbeitenEditbox {
     const doc = this.document;
     const root = doc.createElement("section");
     root.className = "restarbeiten-editbox restarbeiten-editbox--compact";
-
     const form = doc.createElement("form");
     form.className = "restarbeiten-editbox__layout";
-
     const mainCol = doc.createElement("div");
     mainCol.className = "restarbeiten-editbox__main";
-
     const metaCol = doc.createElement("aside");
     metaCol.className = "restarbeiten-editbox__meta";
 
@@ -113,19 +116,12 @@ export default class RestarbeitenEditbox {
     });
     locationGrid.append(loc1Field, loc2Field, loc3Field, loc4Field);
 
-    mainCol.append(
-      createField(doc, "Kurztext", shortText),
-      createField(doc, "Langtext", longText),
-      locationGrid
-    );
+    mainCol.append(createField(doc, "Kurztext", shortText), createField(doc, "Langtext", longText), locationGrid);
 
     const itemClass = createInput(doc, "hidden");
     itemClass.value = "rest";
-
     const marker = doc.createElement("div");
     marker.className = "restarbeiten-editbox__classToggle";
-    marker.setAttribute("role", "group");
-    marker.setAttribute("aria-label", "Rest oder Mangel");
     const restBtn = doc.createElement("button");
     restBtn.type = "button";
     restBtn.textContent = "Rest";
@@ -135,164 +131,134 @@ export default class RestarbeitenEditbox {
     mangelBtn.textContent = "Mangel";
     mangelBtn.className = "restarbeiten-editbox__classToggleButton";
     marker.append(restBtn, mangelBtn);
-
     const setItemClass = (value) => {
       itemClass.value = value === "mangel" ? "mangel" : "rest";
       restBtn.dataset.active = itemClass.value === "rest" ? "1" : "0";
       mangelBtn.dataset.active = itemClass.value === "mangel" ? "1" : "0";
     };
-    restBtn.addEventListener("click", () => setItemClass("rest"));
-    mangelBtn.addEventListener("click", () => setItemClass("mangel"));
+    restBtn.addEventListener("click", () => {
+      setItemClass("rest");
+      this._triggerAutosaveImmediate();
+    });
+    mangelBtn.addEventListener("click", () => {
+      setItemClass("mangel");
+      this._triggerAutosaveImmediate();
+    });
 
     const status = createSelect(doc, [
-      { value: "offen", label: "offen" },
-      { value: "in_arbeit", label: "in Arbeit" },
-      { value: "erledigt_gemeldet", label: "erledigt gemeldet" },
-      { value: "geprueft_erledigt", label: "geprueft erledigt" },
-      { value: "zurueckgewiesen", label: "zurueckgewiesen" },
+      { value: "offen", label: "offen" }, { value: "in_arbeit", label: "in Arbeit" }, { value: "erledigt_gemeldet", label: "erledigt gemeldet" },
+      { value: "geprueft_erledigt", label: "geprueft erledigt" }, { value: "zurueckgewiesen", label: "zurueckgewiesen" },
     ]);
     const dueDate = createInput(doc, "date");
     const responsibleProjectFirmId = createSelect(doc, [{ value: "", label: "— keine Auswahl —" }]);
     responsibleProjectFirmId.className += " restarbeiten-editbox__metaControl";
-    const saveBtn = doc.createElement("button");
-    saveBtn.type = "submit";
-    saveBtn.textContent = "Speichern";
-    saveBtn.className = "restarbeiten-editbox__save";
     const createBtn = this.onCreate ? doc.createElement("button") : null;
     if (createBtn) {
       createBtn.type = "button";
       createBtn.textContent = "+ Restarbeit";
       createBtn.className = "restarbeiten-editbox__create";
       createBtn.addEventListener("click", async () => {
+        await this.flushAutosave();
         await this.onCreate?.();
       });
     }
     const statusEl = doc.createElement("div");
     statusEl.className = "restarbeiten-editbox__status";
 
-    metaCol.append(
-      createField(doc, "Rest / Mangel", marker),
-      createField(doc, "Status", status),
-      createField(doc, "Fertig bis", dueDate),
-      createField(doc, "Verantwortlich", responsibleProjectFirmId),
-      ...(createBtn ? [createBtn] : []),
-      saveBtn,
-      statusEl
-    );
-
+    metaCol.append(createField(doc, "Rest / Mangel", marker), createField(doc, "Status", status), createField(doc, "Fertig bis", dueDate), createField(doc, "Verantwortlich", responsibleProjectFirmId), ...(createBtn ? [createBtn] : []), statusEl);
     form.append(mainCol, metaCol, itemClass);
     root.append(form);
 
-    form.addEventListener("submit", async (event) => {
-      event.preventDefault();
-      if (this.onSave) await this.onSave(this.getDraft());
-    });
-
     this.root = root;
     this.form = form;
-    this.saveBtn = saveBtn;
     this.statusEl = statusEl;
-    this.fields = {
-      item_class: itemClass,
-      status,
-      location_level_1: level1,
-      location_level_2: level2,
-      location_level_3: level3,
-      location_level_4: level4,
-      short_text: shortText,
-      long_text: longText,
-      due_date: dueDate,
-      responsible_project_firm_id: responsibleProjectFirmId,
+    this.fields = { item_class: itemClass, status, location_level_1: level1, location_level_2: level2, location_level_3: level3, location_level_4: level4, short_text: shortText, long_text: longText, due_date: dueDate, responsible_project_firm_id: responsibleProjectFirmId,
       location_level_1__label: loc1Field.querySelector?.(".restarbeiten-editbox__label") || loc1Field.children[0],
       location_level_2__label: loc2Field.querySelector?.(".restarbeiten-editbox__label") || loc2Field.children[0],
       location_level_3__label: loc3Field.querySelector?.(".restarbeiten-editbox__label") || loc3Field.children[0],
-      location_level_4__label: loc4Field.querySelector?.(".restarbeiten-editbox__label") || loc4Field.children[0],
-    };
-
+      location_level_4__label: loc4Field.querySelector?.(".restarbeiten-editbox__label") || loc4Field.children[0], };
     this._setItemClass = setItemClass;
     this._wireLocationDatalists();
+    this._bindAutosaveInputs();
     this.setItem(null);
     return root;
   }
 
-
-  _normalizeLocationOptions(options = {}) {
-    const normalized = {};
-    for (const key of LOCATION_KEYS) {
-      const values = Array.isArray(options?.[key]) ? options[key] : [];
-      const unique = [...new Set(values.map((value) => normalizeText(value)).filter(Boolean))];
-      normalized[key] = unique.sort((a, b) => a.localeCompare(b, "de"));
-    }
-    return normalized;
-  }
-
-  setLocationOptions(options) {
-    this.locationOptions = this._normalizeLocationOptions(options);
-    this._wireLocationDatalists();
-  }
-
-  _wireLocationDatalists() {
-    const doc = this.document;
-    for (const key of LOCATION_KEYS) {
+  _bindAutosaveInputs() {
+    const debouncedKeys = [...LOCATION_KEYS, "short_text", "long_text"];
+    debouncedKeys.forEach((key) => {
       const input = this.fields?.[key];
-      if (!input || !doc?.createElement) continue;
-      let datalist = this.locationOptionLists[key];
-      if (!datalist) {
-        datalist = doc.createElement("datalist");
-        datalist.id = `restarbeiten-editbox-${key}-options`;
-        this.locationOptionLists[key] = datalist;
-      }
-      datalist.replaceChildren();
-      for (const value of this.locationOptions?.[key] || []) {
-        const opt = doc.createElement("option");
-        opt.value = value;
-        datalist.append(opt);
-      }
-      const parent = input.parentElement;
-      if (parent && !parent.children.includes?.(datalist) && !Array.from(parent.children || []).includes(datalist)) {
-        parent.append(datalist);
-      }
-      input.setAttribute("list", datalist.id);
-    }
-  }
-  setProjectFirms(firms) {
-    this.projectFirms = normalizeFirmEntries(firms);
-    const select = this.fields?.responsible_project_firm_id;
-    if (!select) return;
-
-    const selectedBefore = normalizeText(select.value);
-    const options = [{ id: "", name: "— keine Auswahl —" }, ...this.projectFirms];
-    select.replaceChildren();
-
-    for (const option of options) {
-      const opt = this.document.createElement("option");
-      opt.value = option.id;
-      opt.textContent = option.name || "—";
-      select.appendChild(opt);
-    }
-
-    const fallbackId = normalizeText(this.currentItem?.responsible_project_firm_id);
-    const targetId = fallbackId || selectedBefore;
-    const selectOptions = Array.from(select.children || []);
-    const hasTargetOption = !!targetId && selectOptions.some((option) => normalizeText(option?.value) === targetId);
-
-    if (targetId && !hasTargetOption) {
-      const legacy = this.document.createElement("option");
-      legacy.value = targetId;
-      legacy.textContent = normalizeText(this.currentItem?.responsible_label) || "(nicht mehr vorhanden)";
-      select.appendChild(legacy);
-    }
-
-    select.value = targetId;
+      if (!input?.addEventListener) return;
+      input.addEventListener("input", () => this._queueAutosave());
+      input.addEventListener("blur", () => this.flushAutosave());
+    });
+    ["status", "due_date", "responsible_project_firm_id"].forEach((key) => {
+      const input = this.fields?.[key];
+      if (!input?.addEventListener) return;
+      input.addEventListener("change", () => this._triggerAutosaveImmediate());
+    });
   }
 
-  setAttachments(attachments) {
-    this.attachments = Array.isArray(attachments) ? attachments : [];
+  _draftKeyFor(draft) { return JSON.stringify(draft || {}); }
+  _canAutosave() { return !!this.onSave && !!normalizeText(this.currentItem?.id) && !this.isApplyingItem; }
+
+  _queueAutosave() {
+    if (!this._canAutosave()) return;
+    if (this.autosaveTimer) clearTimeout(this.autosaveTimer);
+    this.autosaveTimer = setTimeout(() => { this.autosaveTimer = null; this.flushAutosave(); }, AUTOSAVE_DELAY_MS);
   }
+
+  _triggerAutosaveImmediate() {
+    if (!this._canAutosave()) return;
+    if (this.autosaveTimer) {
+      clearTimeout(this.autosaveTimer);
+      this.autosaveTimer = null;
+    }
+    void this.flushAutosave();
+  }
+
+  async flushAutosave() {
+    if (!this._canAutosave()) return;
+    const draft = this.getDraft();
+    const draftKey = this._draftKeyFor(draft);
+    if (draftKey === this.lastSavedDraftKey || draftKey === this.lastRequestedDraftKey) return;
+    this.pendingDraftKey = draftKey;
+    if (this.isSaving) return;
+    await this._runSaveLoop();
+  }
+
+  async _runSaveLoop() {
+    while (this.pendingDraftKey && !this.isApplyingItem) {
+      const draftKey = this.pendingDraftKey;
+      this.pendingDraftKey = "";
+      this.lastRequestedDraftKey = draftKey;
+      this.isSaving = true;
+      this.setStatus("Änderungen werden gespeichert …");
+      try {
+        await this.onSave?.(JSON.parse(draftKey));
+        this.lastSavedDraftKey = draftKey;
+        this.setStatus("Gespeichert");
+      } catch {
+        this.pendingDraftKey = draftKey;
+        this.setStatus("Speichern fehlgeschlagen");
+        break;
+      } finally {
+        this.isSaving = false;
+      }
+    }
+  }
+
+  _normalizeLocationOptions(options = {}) { const normalized = {}; for (const key of LOCATION_KEYS) { const values = Array.isArray(options?.[key]) ? options[key] : []; const unique = [...new Set(values.map((value) => normalizeText(value)).filter(Boolean))]; normalized[key] = unique.sort((a, b) => a.localeCompare(b, "de")); } return normalized; }
+  setLocationOptions(options) { this.locationOptions = this._normalizeLocationOptions(options); this._wireLocationDatalists(); }
+  _wireLocationDatalists() { const doc = this.document; for (const key of LOCATION_KEYS) { const input = this.fields?.[key]; if (!input || !doc?.createElement) continue; let datalist = this.locationOptionLists[key]; if (!datalist) { datalist = doc.createElement("datalist"); datalist.id = `restarbeiten-editbox-${key}-options`; this.locationOptionLists[key] = datalist; } datalist.replaceChildren(); for (const value of this.locationOptions?.[key] || []) { const opt = doc.createElement("option"); opt.value = value; datalist.append(opt); } const parent = input.parentElement; if (parent && !Array.from(parent.children || []).includes(datalist)) parent.append(datalist); input.setAttribute("list", datalist.id); } }
+
+  setProjectFirms(firms) { this.projectFirms = normalizeFirmEntries(firms); const select = this.fields?.responsible_project_firm_id; if (!select) return; const selectedBefore = normalizeText(select.value); const options = [{ id: "", name: "— keine Auswahl —" }, ...this.projectFirms]; select.replaceChildren(); for (const option of options) { const opt = this.document.createElement("option"); opt.value = option.id; opt.textContent = option.name || "—"; select.appendChild(opt); } const fallbackId = normalizeText(this.currentItem?.responsible_project_firm_id); const targetId = fallbackId || selectedBefore; const selectOptions = Array.from(select.children || []); const hasTargetOption = !!targetId && selectOptions.some((option) => normalizeText(option?.value) === targetId); if (targetId && !hasTargetOption) { const legacy = this.document.createElement("option"); legacy.value = targetId; legacy.textContent = normalizeText(this.currentItem?.responsible_label) || "(nicht mehr vorhanden)"; select.appendChild(legacy); } select.value = targetId; }
+  setAttachments(attachments) { this.attachments = Array.isArray(attachments) ? attachments : []; }
   setStatus(text) { if (this.statusEl) this.statusEl.textContent = String(text || ""); }
-  setSaving(isSaving) { if (this.saveBtn) this.saveBtn.disabled = !!isSaving; }
+  setSaving() {}
 
   setItem(item) {
+    this.isApplyingItem = true;
     this.currentItem = item || null;
     const source = this.currentItem || {};
     const fields = this.fields || {};
@@ -303,6 +269,10 @@ export default class RestarbeitenEditbox {
     if (fields.long_text) fields.long_text.value = normalizeText(source.long_text);
     if (fields.due_date) fields.due_date.value = normalizeText(source.due_date);
     this.setProjectFirms(this.projectFirms);
+    this.lastSavedDraftKey = this._draftKeyFor(this.getDraft());
+    this.pendingDraftKey = "";
+    this.lastRequestedDraftKey = "";
+    this.isApplyingItem = false;
   }
 
   getDraft() {
@@ -312,22 +282,7 @@ export default class RestarbeitenEditbox {
     const oldLabel = normalizeText(this.currentItem?.responsible_label);
     let responsibleProjectFirmId = null;
     let responsibleLabel = oldLabel;
-    if (selectedFirmId && selectedFirm) {
-      responsibleProjectFirmId = selectedFirm.id;
-      responsibleLabel = selectedFirm.name;
-    }
-    return {
-      item_class: normalizeText(fields.item_class?.value) || "rest",
-      status: normalizeText(fields.status?.value) || "offen",
-      location_level_1: normalizeText(fields.location_level_1?.value),
-      location_level_2: normalizeText(fields.location_level_2?.value),
-      location_level_3: normalizeText(fields.location_level_3?.value),
-      location_level_4: normalizeText(fields.location_level_4?.value),
-      short_text: normalizeText(fields.short_text?.value),
-      long_text: normalizeText(fields.long_text?.value),
-      due_date: normalizeText(fields.due_date?.value),
-      responsible_project_firm_id: responsibleProjectFirmId,
-      responsible_label: responsibleLabel,
-    };
+    if (selectedFirmId && selectedFirm) { responsibleProjectFirmId = selectedFirm.id; responsibleLabel = selectedFirm.name; }
+    return { item_class: normalizeText(fields.item_class?.value) || "rest", status: normalizeText(fields.status?.value) || "offen", location_level_1: normalizeText(fields.location_level_1?.value), location_level_2: normalizeText(fields.location_level_2?.value), location_level_3: normalizeText(fields.location_level_3?.value), location_level_4: normalizeText(fields.location_level_4?.value), short_text: normalizeText(fields.short_text?.value), long_text: normalizeText(fields.long_text?.value), due_date: normalizeText(fields.due_date?.value), responsible_project_firm_id: responsibleProjectFirmId, responsible_label: responsibleLabel };
   }
 }

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -68,6 +68,7 @@ export default class RestarbeitenEditbox {
     this.isSaving = false;
     this.autosaveTimer = null;
     this.pendingDraftKey = "";
+    this.currentItemDraftKey = "";
     this.lastSavedDraftKey = "";
     this.lastRequestedDraftKey = "";
   }
@@ -221,7 +222,8 @@ export default class RestarbeitenEditbox {
     if (!this._canAutosave()) return;
     const draft = this.getDraft();
     const draftKey = this._draftKeyFor(draft);
-    if (draftKey === this.lastSavedDraftKey || draftKey === this.lastRequestedDraftKey) return;
+    if (draftKey === this.lastSavedDraftKey) return;
+    if (this.isSaving && draftKey === this.lastRequestedDraftKey) return;
     this.pendingDraftKey = draftKey;
     if (this.isSaving) return;
     await this._runSaveLoop();
@@ -248,9 +250,46 @@ export default class RestarbeitenEditbox {
     }
   }
 
-  _normalizeLocationOptions(options = {}) { const normalized = {}; for (const key of LOCATION_KEYS) { const values = Array.isArray(options?.[key]) ? options[key] : []; const unique = [...new Set(values.map((value) => normalizeText(value)).filter(Boolean))]; normalized[key] = unique.sort((a, b) => a.localeCompare(b, "de")); } return normalized; }
-  setLocationOptions(options) { this.locationOptions = this._normalizeLocationOptions(options); this._wireLocationDatalists(); }
-  _wireLocationDatalists() { const doc = this.document; for (const key of LOCATION_KEYS) { const input = this.fields?.[key]; if (!input || !doc?.createElement) continue; let datalist = this.locationOptionLists[key]; if (!datalist) { datalist = doc.createElement("datalist"); datalist.id = `restarbeiten-editbox-${key}-options`; this.locationOptionLists[key] = datalist; } datalist.replaceChildren(); for (const value of this.locationOptions?.[key] || []) { const opt = doc.createElement("option"); opt.value = value; datalist.append(opt); } const parent = input.parentElement; if (parent && !Array.from(parent.children || []).includes(datalist)) parent.append(datalist); input.setAttribute("list", datalist.id); } }
+  _normalizeLocationOptions(options = {}) {
+    const normalized = {};
+    for (const key of LOCATION_KEYS) {
+      const values = Array.isArray(options?.[key]) ? options[key] : [];
+      const unique = [...new Set(values.map((value) => normalizeText(value)).filter(Boolean))];
+      normalized[key] = unique.sort((a, b) => a.localeCompare(b, "de"));
+    }
+    return normalized;
+  }
+  setLocationOptions(options) {
+    this.locationOptions = this._normalizeLocationOptions(options);
+    this._wireLocationDatalists();
+  }
+  _wireLocationDatalists() {
+    const doc = this.document;
+    for (const key of LOCATION_KEYS) {
+      const input = this.fields?.[key];
+      if (!input || !doc?.createElement) continue;
+
+      let datalist = this.locationOptionLists[key];
+      if (!datalist) {
+        datalist = doc.createElement("datalist");
+        datalist.id = `restarbeiten-editbox-${key}-options`;
+        this.locationOptionLists[key] = datalist;
+      }
+
+      datalist.replaceChildren();
+      for (const value of this.locationOptions?.[key] || []) {
+        const opt = doc.createElement("option");
+        opt.value = value;
+        datalist.append(opt);
+      }
+
+      const parent = input.parentElement;
+      if (parent && !Array.from(parent.children || []).includes(datalist)) {
+        parent.append(datalist);
+      }
+      input.setAttribute("list", datalist.id);
+    }
+  }
 
   setProjectFirms(firms) { this.projectFirms = normalizeFirmEntries(firms); const select = this.fields?.responsible_project_firm_id; if (!select) return; const selectedBefore = normalizeText(select.value); const options = [{ id: "", name: "— keine Auswahl —" }, ...this.projectFirms]; select.replaceChildren(); for (const option of options) { const opt = this.document.createElement("option"); opt.value = option.id; opt.textContent = option.name || "—"; select.appendChild(opt); } const fallbackId = normalizeText(this.currentItem?.responsible_project_firm_id); const targetId = fallbackId || selectedBefore; const selectOptions = Array.from(select.children || []); const hasTargetOption = !!targetId && selectOptions.some((option) => normalizeText(option?.value) === targetId); if (targetId && !hasTargetOption) { const legacy = this.document.createElement("option"); legacy.value = targetId; legacy.textContent = normalizeText(this.currentItem?.responsible_label) || "(nicht mehr vorhanden)"; select.appendChild(legacy); } select.value = targetId; }
   setAttachments(attachments) { this.attachments = Array.isArray(attachments) ? attachments : []; }
@@ -262,16 +301,29 @@ export default class RestarbeitenEditbox {
     this.currentItem = item || null;
     const source = this.currentItem || {};
     const fields = this.fields || {};
+
     this._setItemClass?.(normalizeText(source.item_class) || "rest");
     if (fields.status) fields.status.value = normalizeText(source.status) || "offen";
-    LOCATION_KEYS.forEach((key) => { if (fields[key]) fields[key].value = normalizeText(source[key]); });
+    LOCATION_KEYS.forEach((key) => {
+      if (fields[key]) fields[key].value = normalizeText(source[key]);
+    });
     if (fields.short_text) fields.short_text.value = normalizeText(source.short_text);
     if (fields.long_text) fields.long_text.value = normalizeText(source.long_text);
     if (fields.due_date) fields.due_date.value = normalizeText(source.due_date);
     this.setProjectFirms(this.projectFirms);
-    this.lastSavedDraftKey = this._draftKeyFor(this.getDraft());
-    this.pendingDraftKey = "";
-    this.lastRequestedDraftKey = "";
+
+    const loadedDraftKey = this._draftKeyFor(this.getDraft());
+    this.currentItemDraftKey = loadedDraftKey;
+    this.lastSavedDraftKey = loadedDraftKey;
+
+    const hasPending = !!this.pendingDraftKey;
+    const visibleDraftKey = this._draftKeyFor(this.getDraft());
+    const hasUnsavedVisibleDraft = visibleDraftKey !== loadedDraftKey;
+    if (!this.isSaving && !hasPending && !hasUnsavedVisibleDraft) {
+      this.pendingDraftKey = "";
+      this.lastRequestedDraftKey = "";
+    }
+
     this.isApplyingItem = false;
   }
 
@@ -282,7 +334,23 @@ export default class RestarbeitenEditbox {
     const oldLabel = normalizeText(this.currentItem?.responsible_label);
     let responsibleProjectFirmId = null;
     let responsibleLabel = oldLabel;
-    if (selectedFirmId && selectedFirm) { responsibleProjectFirmId = selectedFirm.id; responsibleLabel = selectedFirm.name; }
-    return { item_class: normalizeText(fields.item_class?.value) || "rest", status: normalizeText(fields.status?.value) || "offen", location_level_1: normalizeText(fields.location_level_1?.value), location_level_2: normalizeText(fields.location_level_2?.value), location_level_3: normalizeText(fields.location_level_3?.value), location_level_4: normalizeText(fields.location_level_4?.value), short_text: normalizeText(fields.short_text?.value), long_text: normalizeText(fields.long_text?.value), due_date: normalizeText(fields.due_date?.value), responsible_project_firm_id: responsibleProjectFirmId, responsible_label: responsibleLabel };
+    if (selectedFirmId && selectedFirm) {
+      responsibleProjectFirmId = selectedFirm.id;
+      responsibleLabel = selectedFirm.name;
+    }
+
+    return {
+      item_class: normalizeText(fields.item_class?.value) || "rest",
+      status: normalizeText(fields.status?.value) || "offen",
+      location_level_1: normalizeText(fields.location_level_1?.value),
+      location_level_2: normalizeText(fields.location_level_2?.value),
+      location_level_3: normalizeText(fields.location_level_3?.value),
+      location_level_4: normalizeText(fields.location_level_4?.value),
+      short_text: normalizeText(fields.short_text?.value),
+      long_text: normalizeText(fields.long_text?.value),
+      due_date: normalizeText(fields.due_date?.value),
+      responsible_project_firm_id: responsibleProjectFirmId,
+      responsible_label: responsibleLabel,
+    };
   }
 }

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -186,6 +186,12 @@ export default class RestarbeitenEditbox {
     form.append(mainCol, metaCol, itemClass);
     root.append(form);
 
+
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      event.stopPropagation?.();
+    });
+
     this.root = root;
     this.form = form;
     this.statusEl = statusEl;
@@ -389,8 +395,6 @@ export default class RestarbeitenEditbox {
     const loadedDraftKey = this._draftKeyFor(this.getDraft());
     this.currentItemDraftKey = loadedDraftKey;
     this.lastSavedDraftKey = loadedDraftKey;
-    this.lastSaveFailed = false;
-    this.failedDraftKey = "";
 
     const hasPending = !!this.pendingDraftKey;
     const visibleDraftKey = this._draftKeyFor(this.getDraft());
@@ -398,8 +402,8 @@ export default class RestarbeitenEditbox {
     if (!this.isSaving && !hasPending && !hasUnsavedVisibleDraft) {
       this.pendingDraftKey = "";
       this.lastRequestedDraftKey = "";
-    this.lastSaveFailed = false;
-    this.failedDraftKey = "";
+      this.lastSaveFailed = false;
+      this.failedDraftKey = "";
     }
 
     this.isApplyingItem = false;

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -71,6 +71,8 @@ export default class RestarbeitenEditbox {
     this.currentItemDraftKey = "";
     this.lastSavedDraftKey = "";
     this.lastRequestedDraftKey = "";
+    this.lastSaveFailed = false;
+    this.failedDraftKey = "";
   }
 
   _getLocationLabel(index) {
@@ -117,7 +119,11 @@ export default class RestarbeitenEditbox {
     });
     locationGrid.append(loc1Field, loc2Field, loc3Field, loc4Field);
 
-    mainCol.append(createField(doc, "Kurztext", shortText), createField(doc, "Langtext", longText), locationGrid);
+    mainCol.append(
+      createField(doc, "Kurztext", shortText),
+      createField(doc, "Langtext", longText),
+      locationGrid
+    );
 
     const itemClass = createInput(doc, "hidden");
     itemClass.value = "rest";
@@ -147,8 +153,11 @@ export default class RestarbeitenEditbox {
     });
 
     const status = createSelect(doc, [
-      { value: "offen", label: "offen" }, { value: "in_arbeit", label: "in Arbeit" }, { value: "erledigt_gemeldet", label: "erledigt gemeldet" },
-      { value: "geprueft_erledigt", label: "geprueft erledigt" }, { value: "zurueckgewiesen", label: "zurueckgewiesen" },
+      { value: "offen", label: "offen" },
+      { value: "in_arbeit", label: "in Arbeit" },
+      { value: "erledigt_gemeldet", label: "erledigt gemeldet" },
+      { value: "geprueft_erledigt", label: "geprueft erledigt" },
+      { value: "zurueckgewiesen", label: "zurueckgewiesen" },
     ]);
     const dueDate = createInput(doc, "date");
     const responsibleProjectFirmId = createSelect(doc, [{ value: "", label: "— keine Auswahl —" }]);
@@ -166,18 +175,36 @@ export default class RestarbeitenEditbox {
     const statusEl = doc.createElement("div");
     statusEl.className = "restarbeiten-editbox__status";
 
-    metaCol.append(createField(doc, "Rest / Mangel", marker), createField(doc, "Status", status), createField(doc, "Fertig bis", dueDate), createField(doc, "Verantwortlich", responsibleProjectFirmId), ...(createBtn ? [createBtn] : []), statusEl);
+    metaCol.append(
+      createField(doc, "Rest / Mangel", marker),
+      createField(doc, "Status", status),
+      createField(doc, "Fertig bis", dueDate),
+      createField(doc, "Verantwortlich", responsibleProjectFirmId),
+      ...(createBtn ? [createBtn] : []),
+      statusEl
+    );
     form.append(mainCol, metaCol, itemClass);
     root.append(form);
 
     this.root = root;
     this.form = form;
     this.statusEl = statusEl;
-    this.fields = { item_class: itemClass, status, location_level_1: level1, location_level_2: level2, location_level_3: level3, location_level_4: level4, short_text: shortText, long_text: longText, due_date: dueDate, responsible_project_firm_id: responsibleProjectFirmId,
+    this.fields = {
+      item_class: itemClass,
+      status,
+      location_level_1: level1,
+      location_level_2: level2,
+      location_level_3: level3,
+      location_level_4: level4,
+      short_text: shortText,
+      long_text: longText,
+      due_date: dueDate,
+      responsible_project_firm_id: responsibleProjectFirmId,
       location_level_1__label: loc1Field.querySelector?.(".restarbeiten-editbox__label") || loc1Field.children[0],
       location_level_2__label: loc2Field.querySelector?.(".restarbeiten-editbox__label") || loc2Field.children[0],
       location_level_3__label: loc3Field.querySelector?.(".restarbeiten-editbox__label") || loc3Field.children[0],
-      location_level_4__label: loc4Field.querySelector?.(".restarbeiten-editbox__label") || loc4Field.children[0], };
+      location_level_4__label: loc4Field.querySelector?.(".restarbeiten-editbox__label") || loc4Field.children[0],
+    };
     this._setItemClass = setItemClass;
     this._wireLocationDatalists();
     this._bindAutosaveInputs();
@@ -200,8 +227,13 @@ export default class RestarbeitenEditbox {
     });
   }
 
-  _draftKeyFor(draft) { return JSON.stringify(draft || {}); }
-  _canAutosave() { return !!this.onSave && !!normalizeText(this.currentItem?.id) && !this.isApplyingItem; }
+  _draftKeyFor(draft) {
+    return JSON.stringify(draft || {});
+  }
+
+  _canAutosave() {
+    return !!this.onSave && !!normalizeText(this.currentItem?.id) && !this.isApplyingItem;
+  }
 
   _queueAutosave() {
     if (!this._canAutosave()) return;
@@ -223,7 +255,9 @@ export default class RestarbeitenEditbox {
     const draft = this.getDraft();
     const draftKey = this._draftKeyFor(draft);
     if (draftKey === this.lastSavedDraftKey) return;
-    if (this.isSaving && draftKey === this.lastRequestedDraftKey) return;
+
+    const isFailedDraft = this.lastSaveFailed && draftKey === this.failedDraftKey;
+    if (this.isSaving && draftKey === this.lastRequestedDraftKey && !isFailedDraft) return;
     this.pendingDraftKey = draftKey;
     if (this.isSaving) return;
     await this._runSaveLoop();
@@ -239,8 +273,12 @@ export default class RestarbeitenEditbox {
       try {
         await this.onSave?.(JSON.parse(draftKey));
         this.lastSavedDraftKey = draftKey;
+        this.lastSaveFailed = false;
+        this.failedDraftKey = "";
         this.setStatus("Gespeichert");
       } catch {
+        this.lastSaveFailed = true;
+        this.failedDraftKey = draftKey;
         this.pendingDraftKey = draftKey;
         this.setStatus("Speichern fehlgeschlagen");
         break;
@@ -291,9 +329,45 @@ export default class RestarbeitenEditbox {
     }
   }
 
-  setProjectFirms(firms) { this.projectFirms = normalizeFirmEntries(firms); const select = this.fields?.responsible_project_firm_id; if (!select) return; const selectedBefore = normalizeText(select.value); const options = [{ id: "", name: "— keine Auswahl —" }, ...this.projectFirms]; select.replaceChildren(); for (const option of options) { const opt = this.document.createElement("option"); opt.value = option.id; opt.textContent = option.name || "—"; select.appendChild(opt); } const fallbackId = normalizeText(this.currentItem?.responsible_project_firm_id); const targetId = fallbackId || selectedBefore; const selectOptions = Array.from(select.children || []); const hasTargetOption = !!targetId && selectOptions.some((option) => normalizeText(option?.value) === targetId); if (targetId && !hasTargetOption) { const legacy = this.document.createElement("option"); legacy.value = targetId; legacy.textContent = normalizeText(this.currentItem?.responsible_label) || "(nicht mehr vorhanden)"; select.appendChild(legacy); } select.value = targetId; }
-  setAttachments(attachments) { this.attachments = Array.isArray(attachments) ? attachments : []; }
-  setStatus(text) { if (this.statusEl) this.statusEl.textContent = String(text || ""); }
+  setProjectFirms(firms) {
+    this.projectFirms = normalizeFirmEntries(firms);
+    const select = this.fields?.responsible_project_firm_id;
+    if (!select) return;
+
+    const selectedBefore = normalizeText(select.value);
+    const options = [{ id: "", name: "— keine Auswahl —" }, ...this.projectFirms];
+    select.replaceChildren();
+
+    for (const option of options) {
+      const opt = this.document.createElement("option");
+      opt.value = option.id;
+      opt.textContent = option.name || "—";
+      select.appendChild(opt);
+    }
+
+    const fallbackId = normalizeText(this.currentItem?.responsible_project_firm_id);
+    const targetId = fallbackId || selectedBefore;
+    const selectOptions = Array.from(select.children || []);
+    const hasTargetOption = !!targetId && selectOptions.some((option) => normalizeText(option?.value) === targetId);
+
+    if (targetId && !hasTargetOption) {
+      const legacy = this.document.createElement("option");
+      legacy.value = targetId;
+      legacy.textContent = normalizeText(this.currentItem?.responsible_label) || "(nicht mehr vorhanden)";
+      select.appendChild(legacy);
+    }
+
+    select.value = targetId;
+  }
+
+  setAttachments(attachments) {
+    this.attachments = Array.isArray(attachments) ? attachments : [];
+  }
+
+  setStatus(text) {
+    if (this.statusEl) this.statusEl.textContent = String(text || "");
+  }
+
   setSaving() {}
 
   setItem(item) {
@@ -315,6 +389,8 @@ export default class RestarbeitenEditbox {
     const loadedDraftKey = this._draftKeyFor(this.getDraft());
     this.currentItemDraftKey = loadedDraftKey;
     this.lastSavedDraftKey = loadedDraftKey;
+    this.lastSaveFailed = false;
+    this.failedDraftKey = "";
 
     const hasPending = !!this.pendingDraftKey;
     const visibleDraftKey = this._draftKeyFor(this.getDraft());
@@ -322,6 +398,8 @@ export default class RestarbeitenEditbox {
     if (!this.isSaving && !hasPending && !hasUnsavedVisibleDraft) {
       this.pendingDraftKey = "";
       this.lastRequestedDraftKey = "";
+    this.lastSaveFailed = false;
+    this.failedDraftKey = "";
     }
 
     this.isApplyingItem = false;


### PR DESCRIPTION
### Motivation
- Ersetze den manuellen `Speichern`-Button in der Restarbeiten-Editbox durch ein verlässliches Autosave-Verhalten, damit Änderungen sofort in der Liste sichtbar sind und das Verhalten an die bestehende `Protokoll`-Workbench angeglichen wird.
- Ziel ist ein kleines, risikobegrenztes Paket: UI-Verhalten ändern, Speichervorgang bleibt im Screen, keine Datenbank- oder Architekturänderungen.

### Description
- Entfernt den sichtbaren Save-Button aus `src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js` und behält das `onSave`-Callback als Autosave-Eingang bei.
- Implementiert Autosave in `RestarbeitenEditbox`: Debounce (≈650ms) für Text- und Verortungsfelder, Flush bei `blur`, sofortiges Save/kurzer Flush bei `change` für `status`, `due_date`, `responsible_project_firm_id` und beim Rest/Mangel-Umschalter; interne Guards `isApplyingItem`, `isSaving`, `pendingDraftKey`, `lastSavedDraftKey` verhindern Saves während `setItem`, doppelte Saves und Endlosschleifen.
- Vor dem Erstellen via `+ Restarbeit` werden offene Änderungen geflusht; `+ Restarbeit` bleibt in der Editbox erhalten.
- Keine Änderungen an DB-Payloads, Datenquellen oder der Screen-Save-Logik vorgenommen — der `RestarbeitenScreen` bleibt Besitzer von `updateRestarbeitItem`/Reload; die Editbox ruft lediglich automatisch `onSave(draft)` auf.
- Tests angepasst/ergänzt in `scripts/tests/restarbeitenModule.test.cjs` um die neue Autosave-Erwartung und Guardrails (entfernte `.restarbeiten-editbox__save`-Regel, neue `M21 Autosave`-Tests).

### Testing
- Ausgeführt: `node scripts/tests/restarbeitenModule.test.cjs`; Ergebnis: bestanden (direkte Restarbeiten-Tests grün).
- Ausgeführt: `npm test`; Ergebnis: fehlgeschlagen in Cloud-Umgebung wegen fehlender Systembibliothek (`libatk-1.0.so.0`) für Electron (Umgebungsproblem, nicht Code-Fehler).
- Geänderte Dateien: `src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js`, `scripts/tests/restarbeitenModule.test.cjs`.
- Pull Request: Branch `work` gegen `main` wurde erstellt in der Cloud-Umgebung (Commit `db3295a`); Werkzeugergebnis lieferte keine öffentliche PR-URL in dieser Umgebung.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09baf7b4f083229dc37d36422a38c3)