### PR TITLE
M22: Restarbeiten-Modul ohne Sidebar anzeigen

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -131,6 +131,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(entry.moduleLabel, "Restarbeiten");
     assert.equal(entry.workScreenId, "restarbeitenWork");
     assert.equal(entry.navigation.project[0].key, "restarbeiten");
+    assert.equal(entry.shell.hideSidebar, true);
   });
 
   await run("Restarbeiten: Workscreen ist ueber Resolver aufloesbar", () => {
@@ -139,6 +140,18 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(typeof resolved, "function");
   });
 
+
+  await run("Restarbeiten: Router wertet hideSidebar nur modulbezogen aus", () => {
+    const routerPath = path.join(__dirname, "../../src/renderer/app/Router.js");
+    const coreShellPath = path.join(__dirname, "../../src/renderer/app/CoreShell.js");
+    const routerSource = fs.readFileSync(routerPath, "utf8");
+    const coreShellSource = fs.readFileSync(coreShellPath, "utf8");
+
+    assert.equal(routerSource.includes("moduleEntry?.shell?.hideSidebar === true"), true);
+    assert.equal(routerSource.includes("this._setSidebarVisibility(!hideSidebar);"), true);
+    assert.equal(routerSource.includes("hideSidebar: false"), true);
+    assert.equal(coreShellSource.includes("router.shellLayout = { sidebar, bodyRow };"), true);
+  });
   await run("ProjectWorkspaceScreen: Restarbeiten wird als Modul geoeffnet", async () => {
     const calls = [];
     const screen = new workspaceModule.default({

--- a/src/renderer/app/CoreShell.js
+++ b/src/renderer/app/CoreShell.js
@@ -46,9 +46,10 @@ export default class CoreShell {
     });
     const headerEl = header.render();
 
-    const { contentRoot: content, topBox, bottomBox } = createCoreShellLayout({ headerEl });
+    const { contentRoot: content, topBox, bottomBox, sidebar, bodyRow } = createCoreShellLayout({ headerEl });
 
     router.contentRoot = content;
+    router.shellLayout = { sidebar, bodyRow };
 
     const applyThemeFromRouterContext = () => {
       applyThemeForSettings(router?.context?.settings || {});

--- a/src/renderer/app/Router.js
+++ b/src/renderer/app/Router.js
@@ -1,6 +1,7 @@
 // src/renderer/app/Router.js
 
 import {
+  findActiveModuleEntry,
   getActiveProjectModuleNavigation,
   PROTOKOLL_MODULE_ID,
   resolveActiveModuleScreen,
@@ -447,7 +448,7 @@ export default class Router {
   }
 
   // App-Kern: einheitlicher View-Host. Fachspezifische Pfade landen derzeit noch hier.
-  async show(v, { section, isTopsView = false, pageTitle = null } = {}) {
+  async show(v, { section, isTopsView = false, pageTitle = null, hideSidebar = false } = {}) {
     const prevView = this.currentView;
     if (prevView && prevView !== v) {
       try {
@@ -485,6 +486,8 @@ export default class Router {
 
     this._setActiveSection(section);
 
+    this._setSidebarVisibility(!hideSidebar);
+
     await this.ensureAppSettingsLoaded({ force: false });
     await this._syncProjectContextUi();
 
@@ -499,13 +502,24 @@ export default class Router {
     this._emitContextChange();
   }
 
+  _setSidebarVisibility(visible) {
+    const shellLayout = this.shellLayout || null;
+    const sidebar = shellLayout?.sidebar || null;
+    const bodyRow = shellLayout?.bodyRow || null;
+    if (!sidebar) return;
+
+    const isVisible = visible !== false;
+    sidebar.style.display = isVisible ? "flex" : "none";
+    if (bodyRow?.dataset) bodyRow.dataset.sidebarHidden = isVisible ? "0" : "1";
+  }
+
   // Kern-Routing / UI-Rahmenlogik: allgemeine Screen-Wechsel bleiben im Router gebuendelt.
   async showProjects() {
     await this.ensureActiveModuleAccess({ force: true });
     const mod = await import("../modules/projektverwaltung/index.js");
     const V = mod.ProjectsScreen;
     this.currentMeetingId = null;
-    await this.show(new V({ router: this }), { section: "projects", isTopsView: false });
+    await this.show(new V({ router: this }), { section: "projects", isTopsView: false, hideSidebar: false });
   }
 
   async showProjectWorkspace(projectId, options = {}) {
@@ -533,6 +547,7 @@ export default class Router {
         isTopsView: false,
         pageTitle: null,
         activeModuleLabel: this._getProjectWorkspaceModules()?.[0]?.label || "Protokoll",
+        hideSidebar: false,
       }
     );
   }
@@ -561,6 +576,11 @@ export default class Router {
     const pageTitle = String(options?.pageTitle || navEntry?.label || "").trim() || null;
     const activeModuleLabel =
       String(options?.activeModuleLabel || navEntry?.label || "").trim() || null;
+    const moduleEntry = findActiveModuleEntry(normalizedModuleId);
+    const hideSidebar =
+      options?.hideSidebar === true ||
+      navEntry?.hideSidebar === true ||
+      moduleEntry?.shell?.hideSidebar === true;
 
     this._setProjectRuntimeContext({ projectId: effectiveProjectId, meetingId: null });
     await this.show(
@@ -575,6 +595,7 @@ export default class Router {
         isTopsView: false,
         pageTitle,
         activeModuleLabel,
+        hideSidebar,
       }
     );
 

--- a/src/renderer/app/coreShellLayout.js
+++ b/src/renderer/app/coreShellLayout.js
@@ -85,6 +85,8 @@ export function createCoreShellLayout({ headerEl } = {}) {
     content,
     topBox,
     bottomBox,
+    sidebar,
+    bodyRow,
     sidebarWidth: CORE_SHELL_LAYOUT_SIDEBAR_WIDTH,
     padding: CORE_SHELL_LAYOUT_PADDING,
   };

--- a/src/renderer/modules/restarbeiten/index.js
+++ b/src/renderer/modules/restarbeiten/index.js
@@ -32,6 +32,9 @@ export function getRestarbeitenModuleEntry() {
     workScreenId: RESTARBEITEN_WORK_SCREEN_ID,
     screens: buildRestarbeitenModuleScreens(),
     navigation: buildRestarbeitenModuleNavigation(),
+    shell: Object.freeze({
+      hideSidebar: true,
+    }),
   });
 }
 


### PR DESCRIPTION
### Motivation
- Restarbeiten soll beim Öffnen die Sidebar ausblenden, ohne globale Shell- oder Protokoll-Änderungen einzuführen.
- Umsetzung soll minimal in App-Kern und Modul-Entry bleiben und die bestehende Shell-Mechanik wiederverwenden.

### Description
- Ergänzt das Restarbeiten-Modul-Entry um ein Shell-Metadatum `shell.hideSidebar: true` in `src/renderer/modules/restarbeiten/index.js`.
- Router erweitert: `show(...)` akzeptiert `hideSidebar` und wertet modulseitiges `hideSidebar` beim `openProjectModule(...)` aus; hinzugefügte Helper-Methode `_setSidebarVisibility` schaltet die Sidebar über die Shell-Layout-Referenzen (Änderung in `src/renderer/app/Router.js`).
- CoreShell und CoreShell-Layout liefern Sidebar-/Body-Referenzen an den Router (`router.shellLayout`) damit die Sichtbarkeit kontrolliert werden kann (Änderungen in `src/renderer/app/CoreShell.js` und `src/renderer/app/coreShellLayout.js`).
- Tests ergänzt/aktualisiert: `scripts/tests/restarbeitenModule.test.cjs` prüft `entry.shell.hideSidebar` und die Router/CoreShell-Verdrahtung; bestehende Protokoll-Router-Tests bleiben unverändert.

### Testing
- Ausgeführt: `node scripts/tests/restarbeitenModule.test.cjs` — bestanden.
- Ausgeführt: `node scripts/tests/protokollRouterFallback.test.cjs` — bestanden.
- Ausgeführt: `npm test` — nicht vollständig ausführbar in Codex-Cloud (Electron-Laufzeit fehlt: `libatk-1.0.so.0`), Test-Runner schlug fehl aus System-Bibliotheksgründen; die relevanten Paket-Tests sind jedoch grün.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c0d2b1408322887910c447fbe051)