### PR TITLE
M23: Restarbeiten UI‑Nachschärfung – Header, R/M‑Kürzel, Ampel, Typografie & Editbox‑Meta

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -319,6 +319,52 @@ async function runRestarbeitenModuleTests(run) {
     }
   });
 
+
+  await run("M23 UI-Nachschaerfung: Header, R/M, Ampel, Typografie und Editbox-Meta", () => {
+    const screenPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js");
+    const stylePath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js");
+    const vmPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js");
+    const editboxPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js");
+
+    const screen = fs.readFileSync(screenPath, "utf8");
+    const style = fs.readFileSync(stylePath, "utf8");
+    const vm = fs.readFileSync(vmPath, "utf8");
+    const editbox = fs.readFileSync(editboxPath, "utf8");
+
+    assert.match(screen, /title\.textContent\s*=\s*"Restarbeiten"/);
+    assert.doesNotMatch(screen, /restarbeiten-sheet__title|Arbeitsblatttitel/);
+    assert.match(screen, /restarbeiten-header__filters/);
+    assert.match(screen, /Schließen/);
+
+    assert.match(vm, /itemClassToken/);
+    assert.match(vm, /return "M"/);
+    assert.match(vm, /return "R"/);
+    assert.doesNotMatch(screen, /item\.itemClassLabel/);
+    assert.doesNotMatch(screen, /Mangel|Restarbeit/);
+
+    assert.match(screen, /statusLine\.className\s*=\s*"restarbeiten-list__ampelLine"/);
+    assert.match(screen, /statusLine\.textContent\s*=\s*item\.statusLabel/);
+    assert.match(screen, /ampelDot\.dataset\.ampel/);
+    assert.match(screen, /restarbeiten-list__ampel--\$\{item\.ampelState\}/);
+
+    assert.match(style, /restarbeiten-list__metaCol\{font-size:8pt/);
+    assert.match(style, /restarbeiten-list__date\{font-size:8pt/);
+    assert.match(style, /restarbeiten-list__shortText\{font-weight:500/);
+
+    assert.match(editbox, /restarbeiten-editbox__metaRow--triple/);
+    assert.match(editbox, /createField\(doc, "Status", status\)/);
+    assert.match(editbox, /createField\(doc, "Fertig bis", dueDate\)/);
+    assert.match(editbox, /createField\(doc, "Ampel", ampelPreview\)/);
+    assert.match(editbox, /createField\(doc, "Verantwortlich", responsibleProjectFirmId\)/);
+    assert.match(editbox, /restarbeiten-editbox__classToggle--compact/);
+    assert.match(editbox, /classActions\.append\(createField\(doc, "", marker\)\)/);
+    assert.match(editbox, /\+ Restarbeit/);
+    assert.doesNotMatch(editbox, /Speichern/);
+
+    assert.match(editbox, /form\.addEventListener\("submit",/);
+    assert.match(editbox, /event\.preventDefault\(\)/);
+    assert.match(editbox, /input\.setAttribute\("list", datalist\.id\)/);
+  });
   await run("M5 Repo/IPC/Preload/DataSource: Create und Update sind verdrahtet", async () => {
     const repo = await importEsmFromFile(
       path.join(__dirname, "../../src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js")

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -337,8 +337,11 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(screen, /Schließen/);
 
     assert.match(vm, /itemClassToken/);
+    assert.match(vm, /itemClassLabel/);
     assert.match(vm, /return "M"/);
     assert.match(vm, /return "R"/);
+    assert.match(vm, /return "Mangel"/);
+    assert.match(vm, /return "Rest"/);
     assert.doesNotMatch(screen, /item\.itemClassLabel/);
     assert.match(screen, /number\.textContent\s*=\s*`\$\{item\.itemClassToken\} \$\{item\.numberLine\}`/);
 

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -340,7 +340,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(vm, /return "M"/);
     assert.match(vm, /return "R"/);
     assert.doesNotMatch(screen, /item\.itemClassLabel/);
-    assert.doesNotMatch(screen, /Mangel|Restarbeit/);
+    assert.match(screen, /number\.textContent\s*=\s*`\$\{item\.itemClassToken\} \$\{item\.numberLine\}`/);
 
     assert.match(screen, /statusLine\.className\s*=\s*"restarbeiten-list__ampelLine"/);
     assert.match(screen, /statusLine\.textContent\s*=\s*item\.statusLabel/);
@@ -359,7 +359,11 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(editbox, /restarbeiten-editbox__classToggle--compact/);
     assert.match(editbox, /classActions\.append\(createField\(doc, "", marker\)\)/);
     assert.match(editbox, /\+ Restarbeit/);
-    assert.doesNotMatch(editbox, /Speichern/);
+    assert.doesNotMatch(editbox, /textContent\s*=\s*"Speichern"/);
+    assert.doesNotMatch(editbox, /restarbeiten-editbox__save/);
+    assert.doesNotMatch(editbox, /saveBtn/);
+    assert.match(editbox, /setStatus\("Änderungen werden gespeichert …"\)/);
+    assert.match(editbox, /setStatus\("Speichern fehlgeschlagen"\)/);
 
     assert.match(editbox, /form\.addEventListener\("submit",/);
     assert.match(editbox, /event\.preventDefault\(\)/);

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -1,3 +1,4 @@
+import { getRestarbeitenAmpelState } from "../viewModel/restarbeitenListItems.js";
 function normalizeText(value) {
   return String(value ?? "").trim();
 }
@@ -57,6 +58,7 @@ export default class RestarbeitenEditbox {
     this.root = null;
     this.form = null;
     this.statusEl = null;
+    this.ampelPreviewEl = null;
     this.currentItem = null;
     this.projectFirms = [];
     this.locationLabels = {};
@@ -65,6 +67,7 @@ export default class RestarbeitenEditbox {
     this.fields = {};
     this.attachments = [];
     this.isApplyingItem = false;
+    this._updateAmpelPreview();
     this.isSaving = false;
     this.autosaveTimer = null;
     this.pendingDraftKey = "";
@@ -162,6 +165,8 @@ export default class RestarbeitenEditbox {
     const dueDate = createInput(doc, "date");
     const responsibleProjectFirmId = createSelect(doc, [{ value: "", label: "— keine Auswahl —" }]);
     responsibleProjectFirmId.className += " restarbeiten-editbox__metaControl";
+    const ampelPreview = doc.createElement("span");
+    ampelPreview.className = "restarbeiten-editbox__ampelPreview";
     const createBtn = this.onCreate ? doc.createElement("button") : null;
     if (createBtn) {
       createBtn.type = "button";
@@ -175,12 +180,25 @@ export default class RestarbeitenEditbox {
     const statusEl = doc.createElement("div");
     statusEl.className = "restarbeiten-editbox__status";
 
-    metaCol.append(
-      createField(doc, "Rest / Mangel", marker),
+    marker.className += " restarbeiten-editbox__classToggle--compact";
+
+    const statusRow = doc.createElement("div");
+    statusRow.className = "restarbeiten-editbox__metaRow restarbeiten-editbox__metaRow--triple";
+    statusRow.append(
       createField(doc, "Status", status),
       createField(doc, "Fertig bis", dueDate),
+      createField(doc, "Ampel", ampelPreview)
+    );
+
+    const classActions = doc.createElement("div");
+    classActions.className = "restarbeiten-editbox__classActions";
+    classActions.append(createField(doc, "", marker));
+    if (createBtn) classActions.append(createBtn);
+
+    metaCol.append(
+      statusRow,
       createField(doc, "Verantwortlich", responsibleProjectFirmId),
-      ...(createBtn ? [createBtn] : []),
+      classActions,
       statusEl
     );
     form.append(mainCol, metaCol, itemClass);
@@ -195,6 +213,7 @@ export default class RestarbeitenEditbox {
     this.root = root;
     this.form = form;
     this.statusEl = statusEl;
+    this.ampelPreviewEl = ampelPreview;
     this.fields = {
       item_class: itemClass,
       status,
@@ -229,7 +248,7 @@ export default class RestarbeitenEditbox {
     ["status", "due_date", "responsible_project_firm_id"].forEach((key) => {
       const input = this.fields?.[key];
       if (!input?.addEventListener) return;
-      input.addEventListener("change", () => this._triggerAutosaveImmediate());
+      input.addEventListener("change", () => { this._updateAmpelPreview(); this._triggerAutosaveImmediate(); });
     });
   }
 
@@ -376,6 +395,17 @@ export default class RestarbeitenEditbox {
 
   setSaving() {}
 
+  _updateAmpelPreview() {
+    if (!this.ampelPreviewEl) return;
+    const state = getRestarbeitenAmpelState({
+      status: normalizeText(this.fields?.status?.value) || "offen",
+      due_date: normalizeText(this.fields?.due_date?.value),
+    });
+    this.ampelPreviewEl.className = `restarbeiten-editbox__ampelPreview restarbeiten-list__ampel restarbeiten-list__ampel--${state}`;
+    this.ampelPreviewEl.dataset.ampel = state;
+    this.ampelPreviewEl.textContent = "";
+  }
+
   setItem(item) {
     this.isApplyingItem = true;
     this.currentItem = item || null;
@@ -407,6 +437,7 @@ export default class RestarbeitenEditbox {
     }
 
     this.isApplyingItem = false;
+    this._updateAmpelPreview();
   }
 
   getDraft() {

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -318,7 +318,7 @@ export default class RestarbeitenScreen {
 
     const number = doc.createElement("div");
     number.className = "restarbeiten-list__number";
-    number.textContent = item.numberLine;
+    number.textContent = `${item.itemClassToken} ${item.numberLine}`;
 
     const date = doc.createElement("div");
     date.className = "restarbeiten-list__date";
@@ -374,28 +374,22 @@ export default class RestarbeitenScreen {
     const col = doc.createElement("div");
     col.className = "restarbeiten-list__metaCol";
 
-    const lines = [
-      item.itemClassLabel,
-      item.statusLabel,
-      item.dueDateLabel,
-      item.responsibleLabel,
-    ];
-
-    for (const text of lines) {
-      const line = doc.createElement("div");
-      line.textContent = text;
-      col.append(line);
-    }
-
-    const ampelLine = doc.createElement("div");
-    ampelLine.className = "restarbeiten-list__ampelLine";
+    const statusLine = doc.createElement("div");
+    statusLine.className = "restarbeiten-list__ampelLine";
+    statusLine.textContent = item.statusLabel;
 
     const ampelDot = doc.createElement("span");
     ampelDot.className = `restarbeiten-list__ampel restarbeiten-list__ampel--${item.ampelState}`;
     ampelDot.dataset.ampel = String(item.ampelState || "neutral");
+    statusLine.append(ampelDot);
 
-    ampelLine.append(ampelDot);
-    col.append(ampelLine);
+    const dueDateLine = doc.createElement("div");
+    dueDateLine.textContent = item.dueDateLabel;
+
+    const responsibleLine = doc.createElement("div");
+    responsibleLine.textContent = item.responsibleLabel;
+
+    col.append(statusLine, dueDateLine, responsibleLine);
 
     return col;
   }

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -14,6 +14,12 @@ textarea.restarbeiten-editbox__control--long{min-height:74px}
 .restarbeiten-editbox__locationLabel{font-size:8px;letter-spacing:.01em}
 .restarbeiten-editbox__locationControl{min-height:22px;padding:2px 5px;font-size:10px}
 .restarbeiten-editbox__metaControl{min-height:23px;padding:2px 5px;font-size:10px}
+.restarbeiten-editbox__metaRow{display:grid;gap:6px}
+.restarbeiten-editbox__metaRow--triple{grid-template-columns:minmax(0,1fr) minmax(0,1fr) auto;align-items:end}
+.restarbeiten-editbox__ampelPreview{display:inline-flex;align-items:center;justify-content:center;min-height:23px;padding:0 8px;border:1px solid #cfcfcf;border-radius:6px;background:#f8fafb}
+.restarbeiten-editbox__classActions{display:flex;align-items:center;gap:6px}
+.restarbeiten-editbox__classToggle--compact{width:max-content;min-width:90px;padding:1px 3px;gap:2px}
+.restarbeiten-editbox__classToggle--compact .restarbeiten-editbox__classToggleButton{min-height:20px;padding:1px 6px;font-size:10px}
 .restarbeiten-editbox__classToggle{display:grid;grid-template-columns:1fr 1fr;gap:4px;padding:2px;border:1px solid #cfd8d8;border-radius:999px;background:#f6f8f8}
 .restarbeiten-editbox__classToggleButton{min-height:26px;padding:3px 6px;border:1px solid transparent;border-radius:999px;background:transparent;font-size:12px;font-weight:600}
 .restarbeiten-editbox__classToggleButton[data-active="1"]{background:#dfeaea;border-color:#87a5a5;font-weight:700}
@@ -37,8 +43,10 @@ textarea.restarbeiten-editbox__control--long{min-height:74px}
 .restarbeiten-list__row[data-selected="1"]{background:#eef6ff;border-color:#95b8e8}
 .restarbeiten-list__rowGrid{display:grid;grid-template-columns:72px minmax(0,1fr) 180px;gap:8px}
 .restarbeiten-list__number{font-weight:700}
-.restarbeiten-list__date,.restarbeiten-list__shortText,.restarbeiten-list__longText,.restarbeiten-list__locationCompact{font-size:12px;opacity:.88}
-.restarbeiten-list__metaCol{font-size:12px;display:grid;gap:2px}
+.restarbeiten-list__date{font-size:8pt}
+.restarbeiten-list__shortText,.restarbeiten-list__longText,.restarbeiten-list__locationCompact{font-size:12px;opacity:.88}
+.restarbeiten-list__shortText{font-weight:500}
+.restarbeiten-list__metaCol{font-size:8pt;display:grid;gap:2px}
 .restarbeiten-list__ampelLine{display:inline-flex;align-items:center;gap:6px}
 .restarbeiten-list__ampel{display:inline-block;width:10px;height:10px;border-radius:50%;border:1px solid rgba(0,0,0,.2)}
 .restarbeiten-list__ampel--rot{background:#d33}

--- a/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
+++ b/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
@@ -3,10 +3,10 @@ function toText(value, fallback = "") {
   return text || fallback;
 }
 
-function mapItemClass(value) {
+function mapItemClassToken(value) {
   const raw = toText(value).toLowerCase();
-  if (raw === "mangel") return "Mangel";
-  return "Rest";
+  if (raw === "mangel") return "M";
+  return "R";
 }
 
 function mapStatus(value) {
@@ -90,29 +90,20 @@ export function getRestarbeitenAmpelState(row = {}, today = new Date()) {
   return "gruen";
 }
 
-function mapAmpelLabel(state) {
-  if (state === "rot") return "Rot";
-  if (state === "orange") return "Orange";
-  if (state === "gruen") return "Grün";
-  return "—";
-}
-
 export function toRestarbeitenListItem(row = {}, today = new Date()) {
-  const itemClassLabel = mapItemClass(row.item_class);
+  const itemClassToken = mapItemClassToken(row.item_class);
   const statusLabel = mapStatus(row.status);
   const dueDateLabel = formatDateDisplay(row.due_date, "—");
   const responsibleLabel = toText(row.responsible_label, "—");
   const ampelState = getRestarbeitenAmpelState(row, today);
-  const ampelLabel = mapAmpelLabel(ampelState);
 
   return {
     id: toText(row.id, ""),
-    itemClassLabel,
+    itemClassToken,
     statusLabel,
     dueDateLabel,
     responsibleLabel,
     ampelState,
-    ampelLabel,
     numberLine: toText(row.running_number) || "—",
     dateLine: formatDateDisplay(row.created_at, "—"),
     locationLine1: joinSlash(row.location_level_1, row.location_level_2) || "—",
@@ -123,9 +114,6 @@ export function toRestarbeitenListItem(row = {}, today = new Date()) {
     locationLevel4: toText(row.location_level_4, ""),
     workLine1: toText(row.short_text, "—"),
     workLine2: toText(row.long_text, "—"),
-    statusLine1: `${itemClassLabel} · ${statusLabel} · Ampel: ${ampelLabel}`,
-    statusLine2: dueDateLabel,
-    statusLine3: responsibleLabel,
   };
 }
 

--- a/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
+++ b/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
@@ -9,6 +9,12 @@ function mapItemClassToken(value) {
   return "R";
 }
 
+function mapItemClassLabel(value) {
+  const raw = toText(value).toLowerCase();
+  if (raw === "mangel") return "Mangel";
+  return "Rest";
+}
+
 function mapStatus(value) {
   const raw = toText(value).toLowerCase();
   const map = {
@@ -92,6 +98,7 @@ export function getRestarbeitenAmpelState(row = {}, today = new Date()) {
 
 export function toRestarbeitenListItem(row = {}, today = new Date()) {
   const itemClassToken = mapItemClassToken(row.item_class);
+  const itemClassLabel = mapItemClassLabel(row.item_class);
   const statusLabel = mapStatus(row.status);
   const dueDateLabel = formatDateDisplay(row.due_date, "—");
   const responsibleLabel = toText(row.responsible_label, "—");
@@ -100,6 +107,7 @@ export function toRestarbeitenListItem(row = {}, today = new Date()) {
   return {
     id: toText(row.id, ""),
     itemClassToken,
+    itemClassLabel,
     statusLabel,
     dueDateLabel,
     responsibleLabel,


### PR DESCRIPTION
### Motivation
- Optische Feinheiten im Modul `Restarbeiten` anpassen, damit Titel, R/M‑Kennzeichnung, Ampelplatzierung und Schriftbilder dem UI‑Spezbrief M23 entsprechen.
- Editbox‑Metabereich kompakter und auf drei logische Zeilen ordnen, ohne Daten- oder Speicherlogik zu ändern.

### Description
- Verschiebt die Anzeige des Titels in den Header und entfernt den Blatt‑Titel in der Liste; Header‑Filter und der `Schließen`‑Button bleiben erhalten (Änderung in `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`).
- R/M‑Kürzel: ViewModel liefert nun Token `R`/`M` statt ausgeschriebener Wörter und die Liste zeigt das Kürzel neben der laufenden Nummer (`src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js` und Anpassung in `RestarbeitenScreen.js`).
- Ampel/Status: Ampel‑Symbol wird neben der Statuszeile gerendert (keine Farbworte mehr), `dataset.ampel` und bestehende Ampel‑CSS‑Klassen bleiben erhalten (`RestarbeitenScreen.js` + `viewModel`).
- Typografie / CSS: Kurztext in der Liste auf `font-weight: 500`, rechte Metaspalte und Datum unter der Nummer auf `8pt`; zusätzliche Styles für kompakte Editbox‑Meta wurden in `src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js` ergänzt.
- Editbox‑Meta‑Anordnung: rechte Spalte neu angeordnet in drei Zeilen (Status / Fertig bis / Ampel‑Preview; Verantwortlich; kompakter Rest/Mangel‑Toggle + `+ Restarbeit`), Ampel‑Preview ableitbar über die vorhandene Ampel‑Logik (`getRestarbeitenAmpelState`) und wird bei Feldänderungen aktualisiert (`src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js`).
- Tests: Ergänzende Assertions für M23 wurden zu `scripts/tests/restarbeitenModule.test.cjs` hinzugefügt, die die neuen Strukturen und CSS‑Marker prüfen.

### Testing
- Ausgeführte Modultests: `node scripts/tests/restarbeitenModule.test.cjs` — bestanden (prüft Header/Titel, R/M‑Kürzel, Ampel‑Platzierung, Typografie‑Regeln und Editbox‑Meta‑Markers).
- Gesamttest: `npm test` wurde versucht, scheitert in dieser Umgebung wegen fehlender native Electron‑Library (`libatk-1.0.so.0`), daher die volle Test‑Suite hier nicht grün nachweisbar.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c7216994832287fc1ee9f8a181f4)