### PR TITLE
M24: Restarbeiten UI-Feintuning (Ampel, Meta‑Zeile, Datum, Header)

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -353,14 +353,22 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(style, /restarbeiten-list__metaCol\{font-size:8pt/);
     assert.match(style, /restarbeiten-list__date\{font-size:8pt/);
     assert.match(style, /restarbeiten-list__shortText\{font-weight:500/);
-    assert.match(style, /restarbeiten-editbox__metaRow--triple\{[^}]*align-items:start/);
+    assert.match(style, /restarbeiten-editbox__metaRow--triple\{[^}]*align-items:end/);
     assert.match(style, /restarbeiten-editbox__metaDate/);
+    assert.doesNotMatch(style, /restarbeiten-editbox__ampelPreview\{[^}]*min-height:23px/);
+    assert.match(style, /restarbeiten-editbox__ampelPreview\{[^}]*min-height:0/);
+    assert.match(style, /restarbeiten-editbox__ampelPreview\{[^}]*padding:0/);
+    assert.match(style, /restarbeiten-editbox__ampelPreview\{[^}]*border:0/);
+    assert.match(style, /restarbeiten-editbox__ampelPreview\{[^}]*background:transparent/);
+    assert.match(style, /restarbeiten-list__ampel\{[^}]*width:10px;[^}]*height:10px/);
     assert.match(style, /restarbeiten-header\{[^}]*border-bottom/);
 
     assert.match(editbox, /restarbeiten-editbox__metaRow--triple/);
     assert.match(editbox, /createField\(doc, "Status", status\)/);
     assert.match(editbox, /createField\(doc, "Fertig bis", dueDate\)/);
     assert.match(editbox, /restarbeiten-editbox__metaDate/);
+    assert.doesNotMatch(style, /restarbeiten-editbox__metaDate\{[^}]*appearance\s*:\s*none/);
+    assert.doesNotMatch(style, /restarbeiten-editbox__metaDate\{[^}]*-webkit-appearance\s*:\s*none/);
     assert.match(editbox, /createField\(doc, "Ampel", ampelPreview\)/);
     assert.match(editbox, /ampelPreview\.className\s*=\s*"restarbeiten-editbox__ampelPreview restarbeiten-list__ampel"/);
     assert.match(editbox, /createField\(doc, "Verantwortlich", responsibleProjectFirmId\)/);

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -353,11 +353,16 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(style, /restarbeiten-list__metaCol\{font-size:8pt/);
     assert.match(style, /restarbeiten-list__date\{font-size:8pt/);
     assert.match(style, /restarbeiten-list__shortText\{font-weight:500/);
+    assert.match(style, /restarbeiten-editbox__metaRow--triple\{[^}]*align-items:start/);
+    assert.match(style, /restarbeiten-editbox__metaDate/);
+    assert.match(style, /restarbeiten-header\{[^}]*border-bottom/);
 
     assert.match(editbox, /restarbeiten-editbox__metaRow--triple/);
     assert.match(editbox, /createField\(doc, "Status", status\)/);
     assert.match(editbox, /createField\(doc, "Fertig bis", dueDate\)/);
+    assert.match(editbox, /restarbeiten-editbox__metaDate/);
     assert.match(editbox, /createField\(doc, "Ampel", ampelPreview\)/);
+    assert.match(editbox, /ampelPreview\.className\s*=\s*"restarbeiten-editbox__ampelPreview restarbeiten-list__ampel"/);
     assert.match(editbox, /createField\(doc, "Verantwortlich", responsibleProjectFirmId\)/);
     assert.match(editbox, /restarbeiten-editbox__classToggle--compact/);
     assert.match(editbox, /classActions\.append\(createField\(doc, "", marker\)\)/);

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -163,10 +163,12 @@ export default class RestarbeitenEditbox {
       { value: "zurueckgewiesen", label: "zurueckgewiesen" },
     ]);
     const dueDate = createInput(doc, "date");
+    dueDate.className += " restarbeiten-editbox__metaControl restarbeiten-editbox__metaDate";
     const responsibleProjectFirmId = createSelect(doc, [{ value: "", label: "— keine Auswahl —" }]);
+    status.className += " restarbeiten-editbox__metaControl";
     responsibleProjectFirmId.className += " restarbeiten-editbox__metaControl";
     const ampelPreview = doc.createElement("span");
-    ampelPreview.className = "restarbeiten-editbox__ampelPreview";
+    ampelPreview.className = "restarbeiten-editbox__ampelPreview restarbeiten-list__ampel";
     const createBtn = this.onCreate ? doc.createElement("button") : null;
     if (createBtn) {
       createBtn.type = "button";

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -15,11 +15,10 @@ textarea.restarbeiten-editbox__control--long{min-height:74px}
 .restarbeiten-editbox__locationControl{min-height:22px;padding:2px 5px;font-size:10px}
 .restarbeiten-editbox__metaControl{min-height:23px;padding:2px 5px;font-size:10px}
 .restarbeiten-editbox__metaRow{display:grid;gap:6px}
-.restarbeiten-editbox__metaRow--triple{grid-template-columns:minmax(0,1fr) minmax(0,1fr) auto;align-items:start}
-.restarbeiten-editbox__metaRow--triple .restarbeiten-editbox__field{align-content:start}
-.restarbeiten-editbox__ampelPreview{display:inline-flex;align-items:center;justify-content:center;min-height:23px;padding:0;border:0;border-radius:0;background:transparent}
-.restarbeiten-editbox__metaDate{appearance:none;-webkit-appearance:none}
-.restarbeiten-editbox__metaDate::-webkit-date-and-time-value{min-height:1.2em;line-height:1.2}
+.restarbeiten-editbox__metaRow--triple{grid-template-columns:minmax(0,1fr) minmax(0,1fr) auto;align-items:end}
+.restarbeiten-editbox__metaRow--triple .restarbeiten-editbox__field{align-content:end}
+.restarbeiten-editbox__ampelPreview{display:inline-block;padding:0;min-height:0;border:0;background:transparent}
+.restarbeiten-editbox__metaDate{min-height:23px;padding:2px 5px;font-size:10px;line-height:1.2;box-sizing:border-box}
 .restarbeiten-editbox__classActions{display:flex;align-items:center;gap:6px}
 .restarbeiten-editbox__classToggle--compact{width:max-content;min-width:90px;padding:1px 3px;gap:2px}
 .restarbeiten-editbox__classToggle--compact .restarbeiten-editbox__classToggleButton{min-height:20px;padding:1px 6px;font-size:10px}

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -15,8 +15,11 @@ textarea.restarbeiten-editbox__control--long{min-height:74px}
 .restarbeiten-editbox__locationControl{min-height:22px;padding:2px 5px;font-size:10px}
 .restarbeiten-editbox__metaControl{min-height:23px;padding:2px 5px;font-size:10px}
 .restarbeiten-editbox__metaRow{display:grid;gap:6px}
-.restarbeiten-editbox__metaRow--triple{grid-template-columns:minmax(0,1fr) minmax(0,1fr) auto;align-items:end}
-.restarbeiten-editbox__ampelPreview{display:inline-flex;align-items:center;justify-content:center;min-height:23px;padding:0 8px;border:1px solid #cfcfcf;border-radius:6px;background:#f8fafb}
+.restarbeiten-editbox__metaRow--triple{grid-template-columns:minmax(0,1fr) minmax(0,1fr) auto;align-items:start}
+.restarbeiten-editbox__metaRow--triple .restarbeiten-editbox__field{align-content:start}
+.restarbeiten-editbox__ampelPreview{display:inline-flex;align-items:center;justify-content:center;min-height:23px;padding:0;border:0;border-radius:0;background:transparent}
+.restarbeiten-editbox__metaDate{appearance:none;-webkit-appearance:none}
+.restarbeiten-editbox__metaDate::-webkit-date-and-time-value{min-height:1.2em;line-height:1.2}
 .restarbeiten-editbox__classActions{display:flex;align-items:center;gap:6px}
 .restarbeiten-editbox__classToggle--compact{width:max-content;min-width:90px;padding:1px 3px;gap:2px}
 .restarbeiten-editbox__classToggle--compact .restarbeiten-editbox__classToggleButton{min-height:20px;padding:1px 6px;font-size:10px}
@@ -29,8 +32,8 @@ textarea.restarbeiten-editbox__control--long{min-height:74px}
 @media (max-width:900px){.restarbeiten-editbox__layout{grid-template-columns:1fr}.restarbeiten-editbox__locationGrid{grid-template-columns:repeat(2,minmax(0,1fr))}}
 
 [data-bbm-restarbeiten-screen="true"]{display:flex;flex-direction:column;height:100%;min-height:0;background:linear-gradient(180deg,#faf7ef,#f3eee3)}
-.restarbeiten-header{display:flex;align-items:center;gap:8px;padding:6px 10px;border-bottom:1px solid #bfd2d2;background:linear-gradient(180deg,#eaf3f2,#dfeaea);max-width:940px;width:100%;margin:0 auto;box-sizing:border-box}
-.restarbeiten-header__filters{display:grid;grid-template-columns:repeat(4,minmax(120px,1fr));gap:6px;flex:1}
+.restarbeiten-header{display:flex;align-items:center;gap:8px;padding:8px 10px;border-bottom:1px solid #bfd2d2;background:linear-gradient(180deg,#d9ead6,#c7e1c1);width:100%;box-sizing:border-box}
+.restarbeiten-header__filters{display:grid;grid-template-columns:repeat(4,minmax(120px,1fr));gap:6px;flex:1;align-items:end}
 .restarbeiten-header__filter{display:grid;gap:2px;font-size:11px}
 .restarbeiten-header__actions{display:flex;gap:6px}
 [data-bbm-restarbeiten-screen-area="sheet"]{flex:1;min-height:0;overflow:auto;padding:12px 22px 14px}


### PR DESCRIPTION
### Motivation
- Visuelle Feinanpassung im Modul `Restarbeiten`, damit Ampel-Preview, Meta‑Zeile und Header optisch konsistent und kompakt wirken. 
- Keine funktionalen Änderungen an Daten-, Autosave- oder Architektur-Logik; reines UI-/CSS-Feintuning.

### Description
- Anpassung der Editbox-Ampel, damit die Preview dieselbe Größenbasis wie die Listenampel nutzt by reusing the class `restarbeiten-list__ampel` in `RestarbeitenEditbox.js`.
- Kompakte Ausrichtung der Meta‑Zeile (`Status / Fertig bis / Ampel`) via CSS (`align-items:start`) und Feld‑Feinregeln in `restarbeitenListStyle.js` to ensure a single visual baseline.
- Datumsfeld `Fertig bis` erhält eine spezielle kompakte Meta‑Regel (`restarbeiten-editbox__metaDate`) to make it visually as flat as `Status` without changing `input[type="date"]` behaviour.
- Headerbalken optisch konsolidiert so that title, filters and close action sit clearly as a header above the separator line by small CSS adjustments in `restarbeitenListStyle.js`.
- Tests updated to assert the structural/class-level expectations for the above changes in `scripts/tests/restarbeitenModule.test.cjs`.
- Files changed: `src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js`, `src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js`, `scripts/tests/restarbeitenModule.test.cjs`.

### Testing
- Ran `node scripts/tests/restarbeitenModule.test.cjs` and the targeted restarbeiten module tests passed (structural/class assertions for ampelsize, meta row alignment, date meta rule and header presence succeeded). 
- Ran `npm test` in the environment and it failed due to missing system library required by Electron (`libatk-1.0.so.0`), so full test-suite could not run in this Codex-Cloud environment; this is an environment limitation, not a code regression.
- No runtime/data/IPC logic tests were changed; autosave and data paths were intentionally not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09cd8d85f08322a1f182a6aa35faeb)