### PR TITLE
M25: Use app:getVersion for header and remove Restarbeiten title from filter bar

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -331,7 +331,7 @@ async function runRestarbeitenModuleTests(run) {
     const vm = fs.readFileSync(vmPath, "utf8");
     const editbox = fs.readFileSync(editboxPath, "utf8");
 
-    assert.match(screen, /title\.textContent\s*=\s*"Restarbeiten"/);
+    assert.doesNotMatch(screen, /title\.textContent\s*=\s*"Restarbeiten"/);
     assert.doesNotMatch(screen, /restarbeiten-sheet__title|Arbeitsblatttitel/);
     assert.match(screen, /restarbeiten-header__filters/);
     assert.match(screen, /Schließen/);

--- a/src/renderer/app/CoreShell.js
+++ b/src/renderer/app/CoreShell.js
@@ -25,10 +25,18 @@ export default class CoreShell {
   constructor({ router, version } = {}) {
     this.router = router || null;
     this.version = version || "";
+    this.header = null;
   }
 
   start() {
     this._initShell();
+  }
+
+  setVersion(version) {
+    const normalizedVersion = String(version || "").trim();
+    if (!normalizedVersion) return;
+    this.version = normalizedVersion;
+    this.header?.setVersion?.(normalizedVersion);
   }
 
   _initShell() {
@@ -44,6 +52,7 @@ export default class CoreShell {
       sidebarWidth: CORE_SHELL_LAYOUT_SIDEBAR_WIDTH,
       padding: CORE_SHELL_LAYOUT_PADDING,
     });
+    this.header = header;
     const headerEl = header.render();
 
     const { contentRoot: content, topBox, bottomBox, sidebar, bodyRow } = createCoreShellLayout({ headerEl });

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -8,7 +8,6 @@ import { DEFAULT_THEME_SETTINGS, applyThemeForSettings } from "./theme/themes.js
 import { applyPopupButtonStyle, applyPopupCardStyle } from "./ui/popupButtonStyles.js";
 
 // App-Kern-Bootstrap: zentrale Startkonstanten und lokale Storage-/Settings-Keys.
-const APP_VERSION = "1.0";
 const PRINT_V2_PAD_LEFT_KEY = "print.v2.pagePadLeftMm";
 const PRINT_V2_PAD_RIGHT_KEY = "print.v2.pagePadRightMm";
 const PRINT_V2_PAD_TOP_KEY = "print.v2.pagePadTopMm";
@@ -159,8 +158,18 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   const coreShell = new CoreShell({
     router,
-    version: APP_VERSION,
+    version: "",
   });
 
   coreShell.start();
+
+  try {
+    const versionRes = await window.bbmDb?.appGetVersion?.();
+    const runtimeVersion = String(versionRes?.version || "").trim();
+    if (versionRes?.ok && runtimeVersion) {
+      coreShell.setVersion(runtimeVersion);
+    }
+  } catch (_e) {
+    // keep fallback header version
+  }
 });

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -89,9 +89,6 @@ export default class RestarbeitenScreen {
     const header = doc.createElement("header");
     header.className = "restarbeiten-header";
 
-    const title = doc.createElement("div");
-    title.textContent = "Restarbeiten";
-
     const filters = doc.createElement("div");
     filters.className = "restarbeiten-header__filters";
 
@@ -104,7 +101,7 @@ export default class RestarbeitenScreen {
     btnClose.onclick = () => this.router?.showProjectWorkspace?.();
 
     actions.append(btnClose);
-    header.append(title, filters, actions);
+    header.append(filters, actions);
 
     this.headerHost = header;
     this.headerFiltersHost = filters;

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -31,8 +31,8 @@ textarea.restarbeiten-editbox__control--long{min-height:74px}
 @media (max-width:900px){.restarbeiten-editbox__layout{grid-template-columns:1fr}.restarbeiten-editbox__locationGrid{grid-template-columns:repeat(2,minmax(0,1fr))}}
 
 [data-bbm-restarbeiten-screen="true"]{display:flex;flex-direction:column;height:100%;min-height:0;background:linear-gradient(180deg,#faf7ef,#f3eee3)}
-.restarbeiten-header{display:flex;align-items:center;gap:8px;padding:8px 10px;border-bottom:1px solid #bfd2d2;background:linear-gradient(180deg,#d9ead6,#c7e1c1);width:100%;box-sizing:border-box}
-.restarbeiten-header__filters{display:grid;grid-template-columns:repeat(4,minmax(120px,1fr));gap:6px;flex:1;align-items:end}
+.restarbeiten-header{display:flex;align-items:flex-end;gap:8px;padding:8px 10px;border-bottom:1px solid #bfd2d2;background:linear-gradient(180deg,#d9ead6,#c7e1c1);width:100%;box-sizing:border-box}
+.restarbeiten-header__filters{display:grid;grid-template-columns:repeat(4,minmax(120px,1fr));gap:6px;flex:1;align-items:end;justify-items:start}
 .restarbeiten-header__filter{display:grid;gap:2px;font-size:11px}
 .restarbeiten-header__actions{display:flex;gap:6px}
 [data-bbm-restarbeiten-screen-area="sheet"]{flex:1;min-height:0;overflow:auto;padding:12px 22px 14px}

--- a/src/renderer/ui/MainHeader.js
+++ b/src/renderer/ui/MainHeader.js
@@ -32,7 +32,7 @@ function getBlockedTransportMessage(payload = null) {
 }
 
 export default class MainHeader {
-  constructor({ router, version = "1.0", sidebarWidth = 220, padding = 12 } = {}) {
+  constructor({ router, version = "", sidebarWidth = 220, padding = 12 } = {}) {
     this.router = router;
     this.version = version;
     this.sidebarWidth = Number(sidebarWidth) || 220;
@@ -125,6 +125,11 @@ export default class MainHeader {
     this._buildChannelLoading = null;
     this._buildChannel = "";
     this._baseWindowTitle = String(document?.title || "BBM").trim() || "BBM";
+  }
+
+  setVersion(version) {
+    this.version = String(version || "").trim();
+    this._syncHeaderIdentity();
   }
 
   _readUiMode() {


### PR DESCRIPTION
### Motivation
- Replace the hard-coded renderer version with the real runtime app version from the existing IPC bridge so the global header shows the correct `BBM ${version}`.
- Ensure the Restarbeiten filter bar only contains filter controls and the close button, removing the duplicate module title to keep the global header as the single source of module identity.

### Description
- `src/renderer/main.js`: removed `APP_VERSION = "1.0"`, start `CoreShell` with an empty version and asynchronously call `window.bbmDb?.appGetVersion?.()` to update the shell via `coreShell.setVersion(...)` when a valid runtime version is returned.
- `src/renderer/app/CoreShell.js`: store the header instance on `this.header` and add `setVersion(version)` which normalizes the version and forwards it to the header via `this.header.setVersion(...)`.
- `src/renderer/ui/MainHeader.js`: remove the hard `"1.0"` default, add `setVersion(version)` to update the header identity without changing other header logic, and keep display format `BBM ${version}`.
- `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`: removed the injected `title.textContent = "Restarbeiten"` from the filter/header area so the filter bar only contains filters and the close button.
- `src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js`: small CSS adjustments to align filters to the left and keep the close action on the right after title removal.
- `scripts/tests/restarbeitenModule.test.cjs`: updated assertion to expect no `title.textContent = "Restarbeiten"` in the Restarbeiten screen source.

### Testing
- Ran `node scripts/tests/restarbeitenModule.test.cjs` and the test suite for the Restarbeiten module passed. 
- Ran `node scripts/tests/projektverwaltungModule.test.cjs` and the Projektverwaltung-related assertions passed. 
- Ran `npm test` in the Cloud environment and it failed due to the environment missing native Electron dependency `libatk-1.0.so.0`, so full `npm test` could not complete in this environment (environmental limitation, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09dbe227d8832283f20828617caa70)