### PR TITLE
M26: Globalen Header kompakter und feiner darstellen

### DIFF
--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -955,6 +955,9 @@ async function runProjektverwaltungModuleTests(run) {
     assert.equal(mainHeaderSource.includes("_syncHeaderIdentity"), true);
     assert.equal(mainHeaderSource.includes("_getHeaderModuleText"), true);
     assert.equal(mainHeaderSource.includes("_getHeaderProjectText"), true);
+    assert.equal(mainHeaderSource.includes("actionWrap.style.gridRow = \"2\""), true);
+    assert.equal(mainHeaderSource.includes("stickyNotice.style.gridRow = \"3\""), true);
+    assert.equal(mainHeaderSource.includes("actionWrap.style.gridRow = \"3\""), false);
   });
 
   await run("Projektverwaltung: MainHeader rendert Version, Aktiv-Kontext und Kundentext", async () => {

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -1005,7 +1005,12 @@ async function runProjektverwaltungModuleTests(run) {
       assert.equal(header.elActive.textContent, "aktiv: Protokoll | 04-2026 - UI-Polish für BBM");
       assert.equal(header.elRightInfo.textContent, "Planungsbüro Steffen Bandholt, 22880 Wedel");
       assert.equal(header.elRightInfo.style.position, "absolute");
-      assert.equal(header.elRightInfo.style.top, "12px");
+      assert.equal(header.elRightInfo.style.top, "10px");
+      assert.equal(header.root.style.gridTemplateRows, "auto auto auto");
+      assert.equal(header.root.style.rowGap, "4px");
+      assert.equal(header.root.style.padding, "10px 12px 7px");
+      assert.equal(header.elVersion.style.fontWeight, "700");
+      assert.equal(header.elActive.style.fontWeight, "500");
       assert.equal(!!findNode(header.root, (node) => node?.textContent === "DEV"), false);
       assert.equal(header.elActive.textContent.includes("bereit:"), false);
       assert.equal(header.elActive.textContent.includes("| -"), false);

--- a/src/renderer/ui/MainHeader.js
+++ b/src/renderer/ui/MainHeader.js
@@ -263,7 +263,7 @@ export default class MainHeader {
 
     const actionWrap = document.createElement("div");
     actionWrap.style.gridColumn = "1 / span 3";
-    actionWrap.style.gridRow = "3";
+    actionWrap.style.gridRow = "2";
     actionWrap.style.justifySelf = "center";
     actionWrap.style.alignSelf = "end";
     actionWrap.style.display = "inline-flex";

--- a/src/renderer/ui/MainHeader.js
+++ b/src/renderer/ui/MainHeader.js
@@ -145,7 +145,8 @@ export default class MainHeader {
     const root = document.createElement("div");
     root.style.boxSizing = "border-box";
     root.style.width = "100%";
-    root.style.padding = `${this.padding}px`;
+    const headerPadding = Math.max(8, this.padding - 2);
+    root.style.padding = `${headerPadding}px ${this.padding}px ${Math.max(6, headerPadding - 3)}px`;
     root.style.borderBottom = "1px solid var(--card-border)";
     root.style.background = "var(--header-bg)";
     root.style.color = "var(--header-text)";
@@ -161,9 +162,9 @@ export default class MainHeader {
     // fixed-ish layout, PDF-nah
     root.style.display = "grid";
     root.style.gridTemplateColumns = "1fr auto 1fr";
-    root.style.gridTemplateRows = "auto auto auto auto";
+    root.style.gridTemplateRows = "auto auto auto";
     root.style.columnGap = "12px";
-    root.style.rowGap = "6px";
+    root.style.rowGap = "4px";
     root.style.alignItems = "start";
 
     const logoGroup = document.createElement("div");
@@ -219,9 +220,9 @@ export default class MainHeader {
     leftIdentity.style.maxWidth = "100%";
 
     const elVersion = document.createElement("div");
-    elVersion.style.fontSize = "15px";
-    elVersion.style.lineHeight = "18px";
-    elVersion.style.fontWeight = "800";
+    elVersion.style.fontSize = "14px";
+    elVersion.style.lineHeight = "16px";
+    elVersion.style.fontWeight = "700";
     elVersion.style.whiteSpace = "nowrap";
     elVersion.style.overflow = "hidden";
     elVersion.style.textOverflow = "ellipsis";
@@ -231,8 +232,8 @@ export default class MainHeader {
     const elActive = document.createElement("div");
     elActive.style.display = "block";
     elActive.style.fontSize = "13px";
-    elActive.style.lineHeight = "16px";
-    elActive.style.fontWeight = "600";
+    elActive.style.lineHeight = "15px";
+    elActive.style.fontWeight = "500";
     elActive.style.whiteSpace = "nowrap";
     elActive.style.overflow = "hidden";
     elActive.style.textOverflow = "ellipsis";
@@ -244,15 +245,15 @@ export default class MainHeader {
     // Right info (license/customer line) bottom-right
     const rightInfo = document.createElement("div");
     rightInfo.style.position = "absolute";
-    rightInfo.style.top = `${this.padding}px`;
+    rightInfo.style.top = `${headerPadding}px`;
     rightInfo.style.right = `${this.padding}px`;
     rightInfo.style.display = "block";
     rightInfo.style.minWidth = "160px";
     rightInfo.style.maxWidth = "100%";
     rightInfo.style.textAlign = "right";
     rightInfo.style.fontSize = "12px";
-    rightInfo.style.lineHeight = "16px";
-    rightInfo.style.fontWeight = "600";
+    rightInfo.style.lineHeight = "15px";
+    rightInfo.style.fontWeight = "500";
     rightInfo.style.whiteSpace = "nowrap";
     rightInfo.style.overflow = "hidden";
     rightInfo.style.textOverflow = "ellipsis";
@@ -262,7 +263,7 @@ export default class MainHeader {
 
     const actionWrap = document.createElement("div");
     actionWrap.style.gridColumn = "1 / span 3";
-    actionWrap.style.gridRow = "2";
+    actionWrap.style.gridRow = "3";
     actionWrap.style.justifySelf = "center";
     actionWrap.style.alignSelf = "end";
     actionWrap.style.display = "inline-flex";
@@ -755,7 +756,7 @@ export default class MainHeader {
 
     const stickyNotice = document.createElement("div");
     stickyNotice.style.gridColumn = "1 / span 3";
-    stickyNotice.style.gridRow = "4";
+    stickyNotice.style.gridRow = "3";
     stickyNotice.style.display = "none";
     stickyNotice.style.alignItems = "center";
     stickyNotice.style.gap = "10px";
@@ -784,7 +785,7 @@ export default class MainHeader {
 
     if (this._isNewUi) {
       root.style.gridTemplateRows = "auto auto auto";
-      root.style.rowGap = "8px";
+      root.style.rowGap = "5px";
       elCenterTitle.style.fontSize = "20px";
       elCenterTitle.style.lineHeight = "24px";
       elCenterTitle.style.fontWeight = "700";


### PR DESCRIPTION
### Motivation
- Der globale App-Header wirkte zu hoch und verschwendete vertikalen Platz zwischen der „aktiv: …“-Zeile und der Trennlinie; Ziel ist eine elegantere, feinere und niedrigere Darstellung ohne Funktionsverlust.

### Description
- `src/renderer/ui/MainHeader.js` gezielt kompakter gemacht: Padding reduziert und dynamisch berechnet, `gridTemplateRows` von 4→3 gesetzt, `rowGap` verkleinert und einige Grid-Row-Zuordnungen angepasst, damit die Trennlinie näher an der Aktiv-Zeile liegt.
- Typografie leicht abgeschwächt: `elVersion`, `elActive` und die rechte Info haben kleinere `fontSize`/`lineHeight`/`fontWeight`-Werte, um eine ruhigere, weniger dominante Kopfzeile zu erzielen.
- `scripts/tests/projektverwaltungModule.test.cjs` ergänzt/angepasst, um die neuen Header-Stile (padding, rowGap, gridTemplateRows, fontWeight, rightInfo.top) abzusichern.
- Bestehende Header-Funktionen bleiben unangetastet (Versionsbezug via `appGetVersion`, Anzeige `aktiv: Modul | Projekt`, Sticky Notice, Print/Mail/Setup-Logik und Logo/Dev-Badge-Logik).

### Testing
- `node scripts/tests/restarbeitenModule.test.cjs` ausgeführt und erfolgreich (grün).
- `node scripts/tests/projektverwaltungModule.test.cjs` ausgeführt und erfolgreich (grün) inklusive neuer Assertions für kompakte Header-Styles.
- `npm test` wurde versucht, schlug in der Codex-Cloud-Umgebung fehl aufgrund fehlender Systembibliothek (`libatk-1.0.so.0`), weshalb der volle npm-Testlauf nicht abschließbar war.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e145a940832297233a83bfdce9ed)