### PR TITLE
M27: Align MainHeader left typography to rightInfo

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,14 @@ Sie ergÃ¤nzt:
 
 
 
+- M27 Globaler Header links typografisch an rechte Buerozeile angeglichen:
+  - `BBM ${version}` links auf 12px/15px reduziert und Font-Weight von 700 auf 600 abgesenkt.
+  - `aktiv: ...` links auf 12px/15px gehalten und bei Weight 500 belassen, damit die linke Seite nicht dominanter als `rightInfo` wirkt.
+  - Header-Zeilenstruktur bleibt unveraendert (`actionWrap` Zeile 2, `stickyNotice` Zeile 3); keine Zusatzzeile, keine Filterleisten-Aenderung.
+  - geprueft mit `node scripts/tests/projektverwaltungModule.test.cjs` und `node scripts/tests/restarbeitenModule.test.cjs`; `npm test` scheitert in Codex Cloud weiter an fehlendem `libatk-1.0.so.0`.
+  - Naechster offener Schritt: Volltestlauf (`npm test`) auf Host/CI mit installierten Electron-Systemlibs.
+
+
 - Hotfix M26.2 Testlauf repariert und Filterleiste-Begriff in Restarbeiten-Tests abgesichert:
   - MainHeader-Test akzeptiert den kompakten Header im alten und neuen UI-Modus deterministisch (rowGap 4px/5px), ohne Versions- oder Grid-Vertragsrueckbau.
   - Restarbeiten-M12/M16/M19-Tests auf aktuellen Zielstand angehoben (Token M/R, kein itemClassLabel in Metaspalte, kompakte Editbox ohne Speichern-Button).

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -1012,8 +1012,15 @@ async function runProjektverwaltungModuleTests(run) {
       assert.equal(header.root.style.gridTemplateRows, "auto auto auto");
       assert.equal(["4px", "5px"].includes(header.root.style.rowGap), true);
       assert.equal(header.root.style.padding, "10px 12px 7px");
-      assert.equal(header.elVersion.style.fontWeight, "700");
+      assert.equal(header.elVersion.style.fontSize, "12px");
+      assert.equal(header.elVersion.style.lineHeight, "15px");
+      assert.equal(["500", "600"].includes(header.elVersion.style.fontWeight), true);
+      assert.equal(header.elVersion.style.fontWeight === "700", false);
+      assert.equal(header.elVersion.style.fontWeight === "800", false);
+      assert.equal(header.elActive.style.fontSize, "12px");
+      assert.equal(header.elActive.style.lineHeight, "15px");
       assert.equal(header.elActive.style.fontWeight, "500");
+      assert.equal(header.elVersion.style.fontSize <= header.elRightInfo.style.fontSize, true);
       assert.equal(!!findNode(header.root, (node) => node?.textContent === "DEV"), false);
       assert.equal(header.elActive.textContent.includes("bereit:"), false);
       assert.equal(header.elActive.textContent.includes("| -"), false);

--- a/src/renderer/ui/MainHeader.js
+++ b/src/renderer/ui/MainHeader.js
@@ -220,9 +220,9 @@ export default class MainHeader {
     leftIdentity.style.maxWidth = "100%";
 
     const elVersion = document.createElement("div");
-    elVersion.style.fontSize = "14px";
-    elVersion.style.lineHeight = "16px";
-    elVersion.style.fontWeight = "700";
+    elVersion.style.fontSize = "12px";
+    elVersion.style.lineHeight = "15px";
+    elVersion.style.fontWeight = "600";
     elVersion.style.whiteSpace = "nowrap";
     elVersion.style.overflow = "hidden";
     elVersion.style.textOverflow = "ellipsis";
@@ -231,7 +231,7 @@ export default class MainHeader {
 
     const elActive = document.createElement("div");
     elActive.style.display = "block";
-    elActive.style.fontSize = "13px";
+    elActive.style.fontSize = "12px";
     elActive.style.lineHeight = "15px";
     elActive.style.fontWeight = "500";
     elActive.style.whiteSpace = "nowrap";


### PR DESCRIPTION
### Motivation
- The left header (version and active module/project) appeared visually dominant compared to the right office/customer line and should be typographically refined to match the right-side `rightInfo` tone. 
- Keep the compact header from M26 and avoid any layout or logic changes while making the left side calmer and more elegant.

### Description
- Adjusted left header styles in `src/renderer/ui/MainHeader.js`: set `elVersion` to `fontSize: 12px`, `lineHeight: 15px`, `fontWeight: 600` and `elActive` to `fontSize: 12px`, `lineHeight: 15px`, `fontWeight: 500`, leaving `rightInfo` unchanged as the visual reference. 
- Updated `scripts/tests/projektverwaltungModule.test.cjs` to assert the new `elVersion` and `elActive` typography and to keep the grid/row contract (`actionWrap` row 2, `stickyNotice` row 3) unchanged. 
- Added a short M27 entry to `STATUS.md` documenting the change and next steps. 
- No header logic, version source (`app:getVersion`), filter bar, restarbeiten lists, editbox, autosave, DB, printing, mail, dictation, router or architecture were modified.

### Testing
- Ran `node scripts/tests/projektverwaltungModule.test.cjs` and the focused header assertions passed. 
- Ran `node scripts/tests/restarbeitenModule.test.cjs` and relevant tests passed. 
- Attempted `npm test` but the full test run failed in the Codex Cloud environment due to a missing native GUI library (`libatk-1.0.so.0`); this is an environmental issue and should be validated on Host/CI with Electron system libs installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e7a3cc2083228b6423589bc6950f)