### PR TITLE
M28: Expand Restarbeiten filter bar — add class and meta filters

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1234,6 +1234,47 @@ async function runRestarbeitenModuleTests(run) {
 
   });
 
+  await run("M28 Filterleiste: links Klassenfilter, Mitte Verortung, rechts Metafilter (nicht globaler Header)", async () => {
+    const mod = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js")
+    );
+    const screen = new mod.default({ projectId: "p-1", router: { showProjectWorkspace() {} } });
+    const doc = createFakeDocument();
+    globalThis.document = doc;
+    screen.render();
+    screen.rows = [
+      { id: "1", item_class: "mangel", status: "offen", due_date: "2026-05-20", responsible_project_firm_id: "f1", location_level_1: "Haus A" },
+      { id: "2", item_class: "rest", status: "in_arbeit", due_date: "2026-05-21", responsible_project_firm_id: "f2", location_level_1: "Haus B" },
+    ];
+    screen.items = [
+      { id: "1", itemClassLabel: "Mangel", locationLevel1: "Haus A", locationLevel2: "", locationLevel3: "", locationLevel4: "" },
+      { id: "2", itemClassLabel: "Rest", locationLevel1: "Haus B", locationLevel2: "", locationLevel3: "", locationLevel4: "" },
+    ];
+    screen.projectFirms = [{ id: "f1", name: "Firma 1" }, { id: "f2", name: "Firma 2" }];
+    screen._renderHeaderFilters();
+
+    const source = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"), "utf8");
+    assert.match(source, /item_class/);
+    assert.match(source, /responsible_project_firm_id/);
+    assert.match(source, /due_date/);
+    assert.match(source, /restarbeiten-filterleiste__classFilter/);
+    assert.match(source, /Status/);
+    assert.match(source, /Fertig bis/);
+    assert.match(source, /Verantwortlich/);
+    assert.doesNotMatch(source, /title\.textContent\s*=\s*["']Restarbeiten["']/);
+
+    screen.filterState.item_class = "mangel";
+    assert.deepEqual(screen._getFilteredItems().map((item) => item.id), ["1"]);
+    screen.filterState.item_class = "rest";
+    assert.deepEqual(screen._getFilteredItems().map((item) => item.id), ["2"]);
+    screen.filterState.item_class = "";
+    screen.filterState.location_level_1 = "Haus A";
+    screen.filterState.status = "offen";
+    screen.filterState.due_date = "2026-05-20";
+    screen.filterState.responsible_project_firm_id = "f1";
+    assert.deepEqual(screen._getFilteredItems().map((item) => item.id), ["1"]);
+  });
+
 
   
 

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1247,7 +1247,7 @@ async function runRestarbeitenModuleTests(run) {
       { id: "2", item_class: "rest", status: "in_arbeit", due_date: "2026-05-21", responsible_project_firm_id: "f2", location_level_1: "Haus B" },
     ];
     screen.items = [
-      { id: "1", itemClassLabel: "Mangel", locationLevel1: "Haus A", locationLevel2: "", locationLevel3: "", locationLevel4: "" },
+      { id: "1", itemClassLabel: "", locationLevel1: "Haus A", locationLevel2: "", locationLevel3: "", locationLevel4: "" },
       { id: "2", itemClassLabel: "Rest", locationLevel1: "Haus B", locationLevel2: "", locationLevel3: "", locationLevel4: "" },
     ];
     screen.projectFirms = [{ id: "f1", name: "Firma 1" }, { id: "f2", name: "Firma 2" }];
@@ -1263,9 +1263,22 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(source, /Verantwortlich/);
     assert.doesNotMatch(source, /title\.textContent\s*=\s*["']Restarbeiten["']/);
 
+    const statusFilter = findNodes(
+      screen.headerFiltersHost,
+      (node) => node?.tagName === "SELECT" && node?.dataset?.filterKey === "status"
+    )[0];
+    const statusOptions = Array.isArray(statusFilter?.children) ? statusFilter.children : [];
+    const inArbeitOption = statusOptions.find((opt) => opt.value === "in_arbeit");
+    assert.equal(Boolean(inArbeitOption), true);
+    assert.equal(inArbeitOption.textContent, "in Arbeit");
+    assert.equal(statusOptions.some((opt) => opt.textContent === "in_arbeit"), false);
+
     screen.filterState.item_class = "mangel";
     assert.deepEqual(screen._getFilteredItems().map((item) => item.id), ["1"]);
     screen.filterState.item_class = "rest";
+    assert.deepEqual(screen._getFilteredItems().map((item) => item.id), ["2"]);
+    screen.filterState.item_class = "";
+    screen.filterState.status = "in_arbeit";
     assert.deepEqual(screen._getFilteredItems().map((item) => item.id), ["2"]);
     screen.filterState.item_class = "";
     screen.filterState.location_level_1 = "Haus A";

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1286,6 +1286,59 @@ async function runRestarbeitenModuleTests(run) {
     screen.filterState.due_date = "2026-05-20";
     screen.filterState.responsible_project_firm_id = "f1";
     assert.deepEqual(screen._getFilteredItems().map((item) => item.id), ["1"]);
+
+    const getMetaSelect = (filterKey) =>
+      findNodes(
+        screen.headerFiltersHost,
+        (node) => node?.tagName === "SELECT" && node?.dataset?.filterKey === filterKey
+      )[0];
+
+    // stale status value wird beim Rendern bereinigt
+    screen.filterState.status = "in_arbeit";
+    screen.filterState.due_date = "";
+    screen.filterState.responsible_project_firm_id = "";
+    screen.rows = [
+      { id: "3", item_class: "rest", status: "offen", due_date: "2026-05-20", responsible_project_firm_id: "f1", location_level_1: "Haus A" },
+    ];
+    screen.items = [
+      { id: "3", itemClassLabel: "Rest", locationLevel1: "Haus A", locationLevel2: "", locationLevel3: "", locationLevel4: "" },
+    ];
+    screen.projectFirms = [{ id: "f1", name: "Firma 1" }];
+    screen._renderHeaderFilters();
+    assert.equal(screen.filterState.status, "");
+    assert.equal(getMetaSelect("status")?.value, "");
+    assert.deepEqual(screen._getFilteredItems().map((item) => item.id), ["3"]);
+
+    // stale due_date value wird beim Rendern bereinigt
+    screen.filterState.due_date = "2026-05-21";
+    screen._renderHeaderFilters();
+    assert.equal(screen.filterState.due_date, "");
+    assert.equal(getMetaSelect("due_date")?.value, "");
+
+    // stale responsible value wird beim Rendern bereinigt
+    screen.filterState.responsible_project_firm_id = "f-alt";
+    screen._renderHeaderFilters();
+    assert.equal(screen.filterState.responsible_project_firm_id, "");
+    assert.equal(getMetaSelect("responsible_project_firm_id")?.value, "");
+
+    // row lookup bleibt funktional mit Map-basiertem Zugriff
+    screen.rows = [
+      { id: "4", item_class: "mangel", status: "offen", due_date: "2026-05-20", responsible_project_firm_id: "f1", location_level_1: "Haus A" },
+      { id: "5", item_class: "rest", status: "offen", due_date: "2026-05-20", responsible_project_firm_id: "f2", location_level_1: "Haus A" },
+    ];
+    screen.items = [
+      { id: "4", itemClassLabel: "", locationLevel1: "Haus A", locationLevel2: "", locationLevel3: "", locationLevel4: "" },
+      { id: "5", itemClassLabel: "", locationLevel1: "Haus A", locationLevel2: "", locationLevel3: "", locationLevel4: "" },
+    ];
+    screen.filterState.item_class = "mangel";
+    screen.filterState.status = "offen";
+    screen.filterState.responsible_project_firm_id = "f1";
+    assert.deepEqual(screen._getFilteredItems().map((item) => item.id), ["4"]);
+
+    const getFilteredItemsSource = source.match(/_getFilteredItems\(\)\s*\{[\s\S]*?\n  \}/)?.[0] || "";
+    assert.match(getFilteredItemsSource, /rowsById/);
+    assert.match(getFilteredItemsSource, /new Map\(/);
+    assert.doesNotMatch(getFilteredItemsSource, /this\.rows\.find\(/);
   });
 
 

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -6,12 +6,13 @@ import {
   listRestarbeitAttachments,
   updateRestarbeitItem,
 } from "../data/restarbeitenDataSource.js";
-import { toRestarbeitenListItems } from "../viewModel/restarbeitenListItems.js";
+import { mapRestarbeitenStatusLabel, toRestarbeitenListItems } from "../viewModel/restarbeitenListItems.js";
 import RestarbeitenEditbox from "./RestarbeitenEditbox.js";
 import { ensureRestarbeitenListStyle } from "./restarbeitenListStyle.js";
 
 const LOCATION_KEYS = ["location_level_1", "location_level_2", "location_level_3", "location_level_4"];
 const LOCATION_LABEL_FALLBACKS = ["Ebene 1", "Ebene 2", "Ebene 3", "Ebene 4"];
+const STATUS_FILTER_ORDER = ["offen", "in_arbeit", "erledigt_gemeldet", "geprueft_erledigt", "zurueckgewiesen", "verzug"];
 
 function normalizeText(value) {
   return String(value || "").trim();
@@ -216,7 +217,7 @@ export default class RestarbeitenScreen {
       this._buildMetaFilter(doc, {
         key: "status",
         label: "Status",
-        values: this._collectUniqueRowsValues("status"),
+        values: this._collectStatusFilterValues(),
       }),
       this._buildMetaFilter(doc, {
         key: "due_date",
@@ -307,6 +308,24 @@ export default class RestarbeitenScreen {
     return [...unique].sort((a, b) => a.localeCompare(b, "de"));
   }
 
+  _collectStatusFilterValues() {
+    const unique = new Set();
+    for (const row of this.rows) {
+      const value = normalizeText(row?.status).toLowerCase();
+      if (value) unique.add(value);
+    }
+    const values = [...unique];
+    values.sort((a, b) => {
+      const indexA = STATUS_FILTER_ORDER.indexOf(a);
+      const indexB = STATUS_FILTER_ORDER.indexOf(b);
+      if (indexA >= 0 && indexB >= 0) return indexA - indexB;
+      if (indexA >= 0) return -1;
+      if (indexB >= 0) return 1;
+      return a.localeCompare(b, "de");
+    });
+    return values.map((value) => ({ value, label: mapRestarbeitenStatusLabel(value) }));
+  }
+
   _collectResponsibleValues() {
     const map = new Map();
     for (const firm of this.projectFirms) {
@@ -390,8 +409,11 @@ export default class RestarbeitenScreen {
 
   _getFilteredItems() {
     return this.items.filter((item) => {
+      const row = this.rows.find((entry) => String(entry.id) === String(item.id));
+      if (!row) return false;
+
       const classFilter = normalizeText(this.filterState.item_class).toLowerCase();
-      if (classFilter && normalizeText(item.itemClassLabel).toLowerCase() !== classFilter) return false;
+      if (classFilter && normalizeText(row.item_class).toLowerCase() !== classFilter) return false;
 
       const locationMatches = LOCATION_KEYS.every((key, idx) => {
         const selected = normalizeText(this.filterState[key]);
@@ -399,9 +421,6 @@ export default class RestarbeitenScreen {
         return normalizeText(item[`locationLevel${idx + 1}`]) === selected;
       });
       if (!locationMatches) return false;
-
-      const row = this.rows.find((entry) => String(entry.id) === String(item.id));
-      if (!row) return false;
 
       const statusFilter = normalizeText(this.filterState.status);
       if (statusFilter && normalizeText(row.status) !== statusFilter) return false;

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -359,16 +359,24 @@ export default class RestarbeitenScreen {
     allOption.value = "";
     allOption.textContent = "Alle";
     select.append(allOption);
+    const allowedValues = new Set([""]);
     for (const entry of values) {
       const rawValue = typeof entry === "object" ? normalizeText(entry.value) : normalizeText(entry);
       if (!rawValue) continue;
+      allowedValues.add(rawValue);
       const opt = doc.createElement("option");
       opt.value = rawValue;
       const display = typeof entry === "object" ? normalizeText(entry.label || entry.value) : rawValue;
       opt.textContent = formatDisplay ? formatDisplay(display) : display;
       select.append(opt);
     }
-    select.value = normalizeText(this.filterState[key]);
+    const currentValue = normalizeText(this.filterState[key]);
+    if (currentValue && !allowedValues.has(currentValue)) {
+      this.filterState[key] = "";
+      select.value = "";
+    } else {
+      select.value = currentValue;
+    }
     select.addEventListener("change", () => {
       this.filterState[key] = normalizeText(select.value);
       this._renderList();
@@ -408,8 +416,9 @@ export default class RestarbeitenScreen {
   }
 
   _getFilteredItems() {
+    const rowsById = new Map(this.rows.map((row) => [String(row?.id), row]));
     return this.items.filter((item) => {
-      const row = this.rows.find((entry) => String(entry.id) === String(item.id));
+      const row = rowsById.get(String(item.id));
       if (!row) return false;
 
       const classFilter = normalizeText(this.filterState.item_class).toLowerCase();

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -49,10 +49,14 @@ export default class RestarbeitenScreen {
     this.editbox = null;
 
     this.filterState = {
+      item_class: "",
       location_level_1: "",
       location_level_2: "",
       location_level_3: "",
       location_level_4: "",
+      status: "",
+      due_date: "",
+      responsible_project_firm_id: "",
     };
 
     this.attachmentsByItemId = new Map();
@@ -201,9 +205,57 @@ export default class RestarbeitenScreen {
     if (!this.headerFiltersHost) return;
 
     const doc = this.headerFiltersHost.ownerDocument || globalThis.document;
-    const controls = LOCATION_KEYS.map((key, idx) => this._buildSingleFilter(doc, key, idx + 1));
+    const classFilter = this._buildClassFilter(doc);
+    const locationWrap = doc.createElement("div");
+    locationWrap.className = "restarbeiten-filterleiste__locationFilters";
+    locationWrap.append(...LOCATION_KEYS.map((key, idx) => this._buildSingleFilter(doc, key, idx + 1)));
 
-    this.headerFiltersHost.replaceChildren(...controls);
+    const metaWrap = doc.createElement("div");
+    metaWrap.className = "restarbeiten-filterleiste__metaFilters";
+    metaWrap.append(
+      this._buildMetaFilter(doc, {
+        key: "status",
+        label: "Status",
+        values: this._collectUniqueRowsValues("status"),
+      }),
+      this._buildMetaFilter(doc, {
+        key: "due_date",
+        label: "Fertig bis",
+        values: this._collectUniqueRowsValues("due_date"),
+        formatDisplay: (value) => this._formatDateDisplay(value),
+      }),
+      this._buildMetaFilter(doc, {
+        key: "responsible_project_firm_id",
+        label: "Verantwortlich",
+        values: this._collectResponsibleValues(),
+      })
+    );
+
+    this.headerFiltersHost.replaceChildren(classFilter, locationWrap, metaWrap);
+  }
+
+  _buildClassFilter(doc) {
+    const wrap = doc.createElement("div");
+    wrap.className = "restarbeiten-filterleiste__classFilter";
+    const values = [
+      { value: "", label: "Alle" },
+      { value: "mangel", label: "Mangel" },
+      { value: "rest", label: "Rest" },
+    ];
+    for (const entry of values) {
+      const button = doc.createElement("button");
+      button.type = "button";
+      button.className = "restarbeiten-filterleiste__classFilterButton";
+      button.textContent = entry.label;
+      button.dataset.active = this.filterState.item_class === entry.value ? "1" : "0";
+      button.onclick = () => {
+        this.filterState.item_class = entry.value;
+        this._renderHeaderFilters();
+        this._renderList();
+      };
+      wrap.append(button);
+    }
+    return wrap;
   }
 
   _buildSingleFilter(doc, key, levelIndex) {
@@ -246,6 +298,66 @@ export default class RestarbeitenScreen {
     return [...new Set(values)].sort((a, b) => a.localeCompare(b, "de"));
   }
 
+  _collectUniqueRowsValues(key) {
+    const unique = new Set();
+    for (const row of this.rows) {
+      const value = normalizeText(row?.[key]);
+      if (value) unique.add(value);
+    }
+    return [...unique].sort((a, b) => a.localeCompare(b, "de"));
+  }
+
+  _collectResponsibleValues() {
+    const map = new Map();
+    for (const firm of this.projectFirms) {
+      const id = normalizeText(firm?.id);
+      const label = normalizeText(firm?.name || firm?.display_name || firm?.label);
+      if (id && label) map.set(id, label);
+    }
+    for (const row of this.rows) {
+      const id = normalizeText(row?.responsible_project_firm_id);
+      const label = normalizeText(row?.responsible_label);
+      if (id && !map.has(id)) map.set(id, label || id);
+    }
+    return [...map.entries()].map(([value, label]) => ({ value, label }));
+  }
+
+  _formatDateDisplay(value) {
+    const text = normalizeText(value);
+    const match = text.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (!match) return text || "—";
+    return `${match[3]}.${match[2]}.${match[1]}`;
+  }
+
+  _buildMetaFilter(doc, { key, label, values = [], formatDisplay = null } = {}) {
+    const wrap = doc.createElement("label");
+    wrap.className = "restarbeiten-header__filter restarbeiten-header__filter--meta";
+    const caption = doc.createElement("span");
+    caption.textContent = label;
+    const select = doc.createElement("select");
+    select.dataset.filterKey = key;
+    const allOption = doc.createElement("option");
+    allOption.value = "";
+    allOption.textContent = "Alle";
+    select.append(allOption);
+    for (const entry of values) {
+      const rawValue = typeof entry === "object" ? normalizeText(entry.value) : normalizeText(entry);
+      if (!rawValue) continue;
+      const opt = doc.createElement("option");
+      opt.value = rawValue;
+      const display = typeof entry === "object" ? normalizeText(entry.label || entry.value) : rawValue;
+      opt.textContent = formatDisplay ? formatDisplay(display) : display;
+      select.append(opt);
+    }
+    select.value = normalizeText(this.filterState[key]);
+    select.addEventListener("change", () => {
+      this.filterState[key] = normalizeText(select.value);
+      this._renderList();
+    });
+    wrap.append(caption, select);
+    return wrap;
+  }
+
   _getFilterLabel(levelIndex) {
     return normalizeText(this.projectSettings?.[`level_${levelIndex}_label`]) || LOCATION_LABEL_FALLBACKS[levelIndex - 1];
   }
@@ -278,11 +390,29 @@ export default class RestarbeitenScreen {
 
   _getFilteredItems() {
     return this.items.filter((item) => {
-      return LOCATION_KEYS.every((key, idx) => {
+      const classFilter = normalizeText(this.filterState.item_class).toLowerCase();
+      if (classFilter && normalizeText(item.itemClassLabel).toLowerCase() !== classFilter) return false;
+
+      const locationMatches = LOCATION_KEYS.every((key, idx) => {
         const selected = normalizeText(this.filterState[key]);
         if (!selected) return true;
         return normalizeText(item[`locationLevel${idx + 1}`]) === selected;
       });
+      if (!locationMatches) return false;
+
+      const row = this.rows.find((entry) => String(entry.id) === String(item.id));
+      if (!row) return false;
+
+      const statusFilter = normalizeText(this.filterState.status);
+      if (statusFilter && normalizeText(row.status) !== statusFilter) return false;
+
+      const dueDateFilter = normalizeText(this.filterState.due_date);
+      if (dueDateFilter && normalizeText(row.due_date) !== dueDateFilter) return false;
+
+      const responsibleFilter = normalizeText(this.filterState.responsible_project_firm_id);
+      if (responsibleFilter && normalizeText(row.responsible_project_firm_id) !== responsibleFilter) return false;
+
+      return true;
     });
   }
 

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -30,10 +30,16 @@ textarea.restarbeiten-editbox__control--long{min-height:74px}
 @media (max-width:900px){.restarbeiten-editbox__layout{grid-template-columns:1fr}.restarbeiten-editbox__locationGrid{grid-template-columns:repeat(2,minmax(0,1fr))}}
 
 [data-bbm-restarbeiten-screen="true"]{display:flex;flex-direction:column;height:100%;min-height:0;background:linear-gradient(180deg,#faf7ef,#f3eee3)}
-.restarbeiten-header{display:flex;align-items:flex-end;gap:8px;padding:8px 10px;border-bottom:1px solid #bfd2d2;background:linear-gradient(180deg,#d9ead6,#c7e1c1);width:100%;box-sizing:border-box}
-.restarbeiten-header__filters{display:grid;grid-template-columns:repeat(4,minmax(120px,1fr));gap:6px;flex:1;align-items:end;justify-items:start}
+.restarbeiten-header{display:flex;align-items:flex-end;gap:8px;padding:8px 10px;border-bottom:1px solid #bfd2d2;background:linear-gradient(180deg,#d9ead6,#c7e1c1);width:100%;box-sizing:border-box;flex-wrap:wrap}
+.restarbeiten-header__filters{display:flex;gap:8px;flex:1;align-items:flex-end;justify-content:space-between;flex-wrap:wrap}
 .restarbeiten-header__filter{display:grid;gap:2px;font-size:11px}
+.restarbeiten-filterleiste__classFilter{display:inline-grid;grid-template-columns:repeat(3,auto);gap:2px;padding:2px;border:1px solid #b6cdb4;border-radius:999px;background:#f2f8ef;align-self:end}
+.restarbeiten-filterleiste__classFilterButton{min-height:22px;padding:1px 8px;border:1px solid transparent;border-radius:999px;background:transparent;font-size:10px;font-weight:700;white-space:nowrap}
+.restarbeiten-filterleiste__classFilterButton[data-active="1"]{background:#dbead6;border-color:#86a786}
+.restarbeiten-filterleiste__locationFilters{display:grid;grid-template-columns:repeat(4,minmax(110px,1fr));gap:6px;flex:1;min-width:340px}
+.restarbeiten-filterleiste__metaFilters{display:grid;grid-template-columns:repeat(3,minmax(110px,150px));gap:6px;justify-content:end}
 .restarbeiten-header__actions{display:flex;gap:6px}
+@media (max-width:980px){.restarbeiten-filterleiste__locationFilters{grid-template-columns:repeat(2,minmax(120px,1fr));min-width:260px}.restarbeiten-filterleiste__metaFilters{grid-template-columns:repeat(3,minmax(100px,1fr));width:100%}}
 [data-bbm-restarbeiten-screen-area="sheet"]{flex:1;min-height:0;overflow:auto;padding:12px 22px 14px}
 .restarbeiten-sheet__list{min-height:0}
 [data-bbm-restarbeiten-screen-sheet-canvas="true"],[data-bbm-restarbeiten-screen-edit-canvas="true"]{width:100%;max-width:940px;margin:0 auto}

--- a/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
+++ b/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
@@ -15,7 +15,7 @@ function mapItemClassLabel(value) {
   return "Rest";
 }
 
-function mapStatus(value) {
+export function mapRestarbeitenStatusLabel(value) {
   const raw = toText(value).toLowerCase();
   const map = {
     offen: "offen",
@@ -99,7 +99,7 @@ export function getRestarbeitenAmpelState(row = {}, today = new Date()) {
 export function toRestarbeitenListItem(row = {}, today = new Date()) {
   const itemClassToken = mapItemClassToken(row.item_class);
   const itemClassLabel = mapItemClassLabel(row.item_class);
-  const statusLabel = mapStatus(row.status);
+  const statusLabel = mapRestarbeitenStatusLabel(row.status);
   const dueDateLabel = formatDateDisplay(row.due_date, "—");
   const responsibleLabel = toText(row.responsible_label, "—");
   const ampelState = getRestarbeitenAmpelState(row, today);


### PR DESCRIPTION
### Motivation
- Extend the green Restarbeiten filter bar to provide a compact left-side class selector (Alle/Mangel/Rest) and right-side meta filters (Status, Fertig bis, Verantwortlich) while preserving existing location filters and keeping the global header unchanged. 
- Ensure all active filters combine as AND when filtering the list and keep the change isolated to the filter bar and related list filtering logic. 
- This change builds on M27 (PR #110) which is present in the current `main` branch (merge commit for PR #110 found in the local history). 

### Description
- Added new filter state keys `item_class`, `status`, `due_date`, and `responsible_project_firm_id` to the screen state in `RestarbeitenScreen`. 
- Implemented a compact class selector (Alle / Mangel / Rest) and new meta selects for `Status`, `Fertig bis` and `Verantwortlich`, and kept the existing four location selects using the project-provided labels. 
- Extended `_getFilteredItems()` to apply all active filters as an AND chain (class -> location levels -> status -> due_date -> responsible_project_firm_id). 
- Adjusted CSS in the restarbeiten list style to layout the filter bar in three segments (class | location filters | meta filters) with compact/wrap behavior. 
- Files changed: `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`, `src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js`, `scripts/tests/restarbeitenModule.test.cjs`.

### Testing
- Ran `node scripts/tests/restarbeitenModule.test.cjs` and the suite covering the new M28 assertions passed. 
- Ran `node scripts/tests/projektverwaltungModule.test.cjs` and it passed. 
- Ran `npm test` but it failed in this Codex Cloud environment due to missing system library `libatk-1.0.so.0` in Electron, unrelated to the code changes (reported as environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09eb84ccf88322969cf3b40a98e35a)