### PR TITLE
M29: Restarbeiten-Filterleiste kompakt neu anordnen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,15 @@ Sie ergÃ¤nzt:
 ## Aktueller Gesamtstand
 
 
+- M29 Restarbeiten-Filterleiste neu gegliedert und kompakter angeordnet:
+  - Klassenfilter (Alle/Mangel/Rest) ist jetzt vertikal und kleiner, aktive Auswahl bleibt visuell markiert.
+  - Verortungsfilter sind als zwei Zweiergruppen aufgebaut (Level 1+2, Level 3+4) und die Label-Logik bleibt projektbezogen unverändert.
+  - Metafilter sind in obere Zeile (Status + Fertig bis) und untere Zeile (Verantwortlich) aufgeteilt; Feldlabels stehen neben den Selects.
+  - Schließen bleibt als eigener rechter Aktionsbereich in der Filterleiste.
+  - geprueft mit `node scripts/tests/restarbeitenModule.test.cjs` und `node scripts/tests/projektverwaltungModule.test.cjs`; `npm test` scheitert in Codex Cloud weiter an fehlendem `libatk-1.0.so.0`.
+  - Naechster offener Schritt: visueller UI-Check der kompakten Filterleiste auf realer Laufzeitbreite.
+
+
 
 - M27 Globaler Header links typografisch an rechte Buerozeile angeglichen:
   - `BBM ${version}` links auf 12px/15px reduziert und Font-Weight von 700 auf 600 abgesenkt.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1254,19 +1254,35 @@ async function runRestarbeitenModuleTests(run) {
     screen._renderHeaderFilters();
 
     const source = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"), "utf8");
+    const styleSource = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js"), "utf8");
     assert.match(source, /item_class/);
     assert.match(source, /responsible_project_firm_id/);
     assert.match(source, /due_date/);
     assert.match(source, /restarbeiten-filterleiste__classFilter/);
+    assert.match(source, /restarbeiten-filterleiste__locationGroupA/);
+    assert.match(source, /restarbeiten-filterleiste__locationGroupB/);
+    assert.match(source, /restarbeiten-filterleiste__metaTopRow/);
+    assert.match(source, /restarbeiten-filterleiste__metaResponsibleRow/);
+    assert.match(source, /restarbeiten-filterleiste__fieldLabel/);
     assert.match(source, /Status/);
     assert.match(source, /Fertig bis/);
     assert.match(source, /Verantwortlich/);
     assert.doesNotMatch(source, /title\.textContent\s*=\s*["']Restarbeiten["']/);
+    assert.doesNotMatch(source, /Haus\s*\/\s*Geschoss|Einheit\s*\/\s*Raum/);
+    assert.match(styleSource, /restarbeiten-filterleiste__classFilter\{display:grid;grid-template-columns:1fr/);
+    assert.match(styleSource, /restarbeiten-filterleiste__field\{display:inline-flex;align-items:center/);
+    assert.match(styleSource, /restarbeiten-filterleiste__locationFilters\{display:grid;grid-template-columns:repeat\(2/);
+    assert.match(styleSource, /restarbeiten-filterleiste__metaTopRow\{display:grid;grid-template-columns:repeat\(2/);
+    assert.match(styleSource, /restarbeiten-header__actions\{display:flex;gap:6px;margin-left:auto/);
 
     const statusFilter = findNodes(
       screen.headerFiltersHost,
       (node) => node?.tagName === "SELECT" && node?.dataset?.filterKey === "status"
     )[0];
+    const fieldNodes = findNodes(screen.headerFiltersHost, (node) =>
+      String(node?.className || "").includes("restarbeiten-filterleiste__field")
+    );
+    assert.equal(fieldNodes.length >= 7, true);
     const statusOptions = Array.isArray(statusFilter?.children) ? statusFilter.children : [];
     const inArbeitOption = statusOptions.find((opt) => opt.value === "in_arbeit");
     assert.equal(Boolean(inArbeitOption), true);

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -209,11 +209,19 @@ export default class RestarbeitenScreen {
     const classFilter = this._buildClassFilter(doc);
     const locationWrap = doc.createElement("div");
     locationWrap.className = "restarbeiten-filterleiste__locationFilters";
-    locationWrap.append(...LOCATION_KEYS.map((key, idx) => this._buildSingleFilter(doc, key, idx + 1)));
+    const locationGroupA = doc.createElement("div");
+    locationGroupA.className = "restarbeiten-filterleiste__locationGroupA";
+    locationGroupA.append(this._buildSingleFilter(doc, "location_level_1", 1), this._buildSingleFilter(doc, "location_level_2", 2));
+    const locationGroupB = doc.createElement("div");
+    locationGroupB.className = "restarbeiten-filterleiste__locationGroupB";
+    locationGroupB.append(this._buildSingleFilter(doc, "location_level_3", 3), this._buildSingleFilter(doc, "location_level_4", 4));
+    locationWrap.append(locationGroupA, locationGroupB);
 
     const metaWrap = doc.createElement("div");
     metaWrap.className = "restarbeiten-filterleiste__metaFilters";
-    metaWrap.append(
+    const metaTopRow = doc.createElement("div");
+    metaTopRow.className = "restarbeiten-filterleiste__metaTopRow";
+    metaTopRow.append(
       this._buildMetaFilter(doc, {
         key: "status",
         label: "Status",
@@ -224,13 +232,18 @@ export default class RestarbeitenScreen {
         label: "Fertig bis",
         values: this._collectUniqueRowsValues("due_date"),
         formatDisplay: (value) => this._formatDateDisplay(value),
-      }),
+      })
+    );
+    const metaResponsibleRow = doc.createElement("div");
+    metaResponsibleRow.className = "restarbeiten-filterleiste__metaResponsibleRow";
+    metaResponsibleRow.append(
       this._buildMetaFilter(doc, {
         key: "responsible_project_firm_id",
         label: "Verantwortlich",
         values: this._collectResponsibleValues(),
       })
     );
+    metaWrap.append(metaTopRow, metaResponsibleRow);
 
     this.headerFiltersHost.replaceChildren(classFilter, locationWrap, metaWrap);
   }
@@ -261,9 +274,10 @@ export default class RestarbeitenScreen {
 
   _buildSingleFilter(doc, key, levelIndex) {
     const wrap = doc.createElement("label");
-    wrap.className = "restarbeiten-header__filter";
+    wrap.className = "restarbeiten-filterleiste__field";
 
     const caption = doc.createElement("span");
+    caption.className = "restarbeiten-filterleiste__fieldLabel";
     caption.textContent = this._getFilterLabel(levelIndex);
 
     const select = doc.createElement("select");
@@ -350,8 +364,9 @@ export default class RestarbeitenScreen {
 
   _buildMetaFilter(doc, { key, label, values = [], formatDisplay = null } = {}) {
     const wrap = doc.createElement("label");
-    wrap.className = "restarbeiten-header__filter restarbeiten-header__filter--meta";
+    wrap.className = "restarbeiten-filterleiste__field";
     const caption = doc.createElement("span");
+    caption.className = "restarbeiten-filterleiste__fieldLabel";
     caption.textContent = label;
     const select = doc.createElement("select");
     select.dataset.filterKey = key;

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -30,16 +30,22 @@ textarea.restarbeiten-editbox__control--long{min-height:74px}
 @media (max-width:900px){.restarbeiten-editbox__layout{grid-template-columns:1fr}.restarbeiten-editbox__locationGrid{grid-template-columns:repeat(2,minmax(0,1fr))}}
 
 [data-bbm-restarbeiten-screen="true"]{display:flex;flex-direction:column;height:100%;min-height:0;background:linear-gradient(180deg,#faf7ef,#f3eee3)}
-.restarbeiten-header{display:flex;align-items:flex-end;gap:8px;padding:8px 10px;border-bottom:1px solid #bfd2d2;background:linear-gradient(180deg,#d9ead6,#c7e1c1);width:100%;box-sizing:border-box;flex-wrap:wrap}
-.restarbeiten-header__filters{display:flex;gap:8px;flex:1;align-items:flex-end;justify-content:space-between;flex-wrap:wrap}
-.restarbeiten-header__filter{display:grid;gap:2px;font-size:11px}
-.restarbeiten-filterleiste__classFilter{display:inline-grid;grid-template-columns:repeat(3,auto);gap:2px;padding:2px;border:1px solid #b6cdb4;border-radius:999px;background:#f2f8ef;align-self:end}
-.restarbeiten-filterleiste__classFilterButton{min-height:22px;padding:1px 8px;border:1px solid transparent;border-radius:999px;background:transparent;font-size:10px;font-weight:700;white-space:nowrap}
+.restarbeiten-header{display:flex;align-items:flex-start;gap:8px;padding:8px 10px;border-bottom:1px solid #bfd2d2;background:linear-gradient(180deg,#d9ead6,#c7e1c1);width:100%;box-sizing:border-box;flex-wrap:wrap}
+.restarbeiten-header__filters{display:flex;gap:8px;flex:1;align-items:flex-start;flex-wrap:wrap}
+.restarbeiten-filterleiste__field{display:inline-flex;align-items:center;gap:5px;font-size:10px;white-space:nowrap}
+.restarbeiten-filterleiste__fieldLabel{font-size:10px;font-weight:600}
+.restarbeiten-filterleiste__field select{min-height:22px;padding:1px 5px;font-size:10px;max-width:140px}
+.restarbeiten-filterleiste__classFilter{display:grid;grid-template-columns:1fr;gap:2px;padding:2px;border:1px solid #b6cdb4;border-radius:8px;background:#f2f8ef;align-self:flex-start}
+.restarbeiten-filterleiste__classFilterButton{min-height:18px;padding:1px 6px;border:1px solid transparent;border-radius:999px;background:transparent;font-size:10px;font-weight:700;white-space:nowrap;text-align:left}
 .restarbeiten-filterleiste__classFilterButton[data-active="1"]{background:#dbead6;border-color:#86a786}
-.restarbeiten-filterleiste__locationFilters{display:grid;grid-template-columns:repeat(4,minmax(110px,1fr));gap:6px;flex:1;min-width:340px}
-.restarbeiten-filterleiste__metaFilters{display:grid;grid-template-columns:repeat(3,minmax(110px,150px));gap:6px;justify-content:end}
-.restarbeiten-header__actions{display:flex;gap:6px}
-@media (max-width:980px){.restarbeiten-filterleiste__locationFilters{grid-template-columns:repeat(2,minmax(120px,1fr));min-width:260px}.restarbeiten-filterleiste__metaFilters{grid-template-columns:repeat(3,minmax(100px,1fr));width:100%}}
+.restarbeiten-filterleiste__locationFilters{display:grid;grid-template-columns:repeat(2,minmax(180px,1fr));gap:6px 10px;min-width:360px}
+.restarbeiten-filterleiste__locationGroupA,.restarbeiten-filterleiste__locationGroupB{display:grid;gap:4px}
+.restarbeiten-filterleiste__metaFilters{display:grid;gap:4px;min-width:320px}
+.restarbeiten-filterleiste__metaTopRow{display:grid;grid-template-columns:repeat(2,minmax(145px,1fr));gap:8px}
+.restarbeiten-filterleiste__metaResponsibleRow{display:grid;grid-template-columns:minmax(0,1fr)}
+.restarbeiten-filterleiste__metaResponsibleRow .restarbeiten-filterleiste__field select{max-width:220px;width:100%}
+.restarbeiten-header__actions{display:flex;gap:6px;margin-left:auto;align-self:flex-start}
+@media (max-width:980px){.restarbeiten-filterleiste__locationFilters{grid-template-columns:1fr;min-width:280px}.restarbeiten-filterleiste__metaFilters{min-width:280px}.restarbeiten-filterleiste__metaTopRow{grid-template-columns:1fr}.restarbeiten-header__actions{margin-left:0}}
 [data-bbm-restarbeiten-screen-area="sheet"]{flex:1;min-height:0;overflow:auto;padding:12px 22px 14px}
 .restarbeiten-sheet__list{min-height:0}
 [data-bbm-restarbeiten-screen-sheet-canvas="true"],[data-bbm-restarbeiten-screen-edit-canvas="true"]{width:100%;max-width:940px;margin:0 auto}


### PR DESCRIPTION
### Motivation
- Ziel ist, die grüne Filterleiste im Modul `restarbeiten` kompakter und logisch gegliedert anzuordnen, ohne Filterlogik oder globale Header/Editbox zu ändern. 

### Description
- Reorganisiert die Filter-Header-Struktur in `RestarbeitenScreen.js` und erstellt zwei Verortungsgruppen (`location_level_1+2` und `location_level_3+4`), eine vertikale, kompakte Klassenfilter-Gruppe und eine zweizeilige Meta-Filterstruktur (oben `Status` + `Fertig bis`, unten `Verantwortlich`).
- Labels der Filterfelder werden jetzt inline links neben den jeweiligen Auswahlfeldern gerendert und erhalten modulnahe CSS-Klassen wie `restarbeiten-filterleiste__field` und `restarbeiten-filterleiste__fieldLabel`.
- Anpassungen der Styles in `restarbeitenListStyle.js` zur kompakten Anordnung, Zeilen-/Grid-Layout und responsivem Wrap-Verhalten; Klassenfilter ist nun vertikal kompakt und die Meta-Top/Responsible-Rows sind getrennt.
- Tests in `scripts/tests/restarbeitenModule.test.cjs` wurden erweitert, um die neue Struktur (Location-Groups, Meta-Top/Responsible-Row, field labels) zu prüfen; `STATUS.md` wurde um einen M29-Eintrag ergänzt.
- Geänderte Dateien: `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`, `src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js`, `scripts/tests/restarbeitenModule.test.cjs`, `STATUS.md`.

### Testing
- `node scripts/tests/restarbeitenModule.test.cjs` ran and passed against the modified code. ✅
- `node scripts/tests/projektverwaltungModule.test.cjs` ran and passed. ✅
- `npm test` was attempted but failed in this cloud environment due to missing system library `libatk-1.0.so.0` (Electron cannot start), so full test-suite run is blocked here. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09f90002a8832290fb11aeefba9bb5)