### PR TITLE
Hotfix M29.1: adjust Restarbeiten tests for current typography and async create

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1083,7 +1083,8 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(styleContent, /restarbeiten-list__ampel--orange/);
     assert.match(styleContent, /restarbeiten-list__ampel--gruen/);
     assert.match(styleContent, /restarbeiten-list__ampel--neutral/);
-    assert.match(styleContent, /restarbeiten-list__date,.restarbeiten-list__shortText,.restarbeiten-list__longText,.restarbeiten-list__locationCompact\{font-size:12px/);
+    assert.match(styleContent, /restarbeiten-list__date\{font-size:8pt/);
+    assert.match(styleContent, /restarbeiten-list__shortText,.restarbeiten-list__longText,.restarbeiten-list__locationCompact\{font-size:12px/);
     assert.doesNotMatch(styleContent, /import\s+["'].*\.css["']/);
   });
 
@@ -1153,6 +1154,8 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(Boolean(createBtn), true);
     assert.equal(String(createBtn?.className || "").includes("restarbeiten-editbox__create"), true);
     createBtn.click();
+    await Promise.resolve();
+    await Promise.resolve();
     assert.equal(createCalls.length, 1);
     editbox.fields.status.value = "in_arbeit";
     editbox.fields.responsible_project_firm_id.value = "f1";


### PR DESCRIPTION
### Motivation
- Fix two failing local tests introduced after M29 by updating outdated Restarbeiten test expectations for typography and for the async `+ Restarbeit` handler.

### Description
- Updated `scripts/tests/restarbeitenModule.test.cjs` to assert `.restarbeiten-list__date{font-size:8pt}` and keep `.restarbeiten-list__shortText,.restarbeiten-list__longText,.restarbeiten-list__locationCompact{font-size:12px}` as a separate assertion.
- Made the `+ Restarbeit` test async-safe by adding `await Promise.resolve(); await Promise.resolve();` after `createBtn.click()` so the async click handler can complete before asserting `createCalls.length`.
- No production code was changed and autosave/UI/filter/database/architecture behavior was not modified.

### Testing
- Ran `node scripts/tests/restarbeitenModule.test.cjs` and the targeted Restarbeiten tests passed.
- Ran `node scripts/tests/projektverwaltungModule.test.cjs` and it passed.
- Attempted `npm test` but it failed in this environment due to a missing system library (`libatk-1.0.so.0`), so full suite confirmation must run in CI or a matching runtime.
- Verified that M29 / PR #112 is present in the current branch history before making the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09fc045bcc8322ae3500e9476af22c)