### PR TITLE
Hotfix M29.2: M16 Autosave-Test reparieren (Item-ID hinzufügen)

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1125,7 +1125,8 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(collectText(fallbackRoot).includes("Ebene 4"), true);
 
     editbox.setProjectFirms([{ id: "f1", name: "Firma A" }]);
-    editbox.setItem({ item_class: "rest", status: "offen", short_text: "Kurz", long_text: "Lang", due_date: "2026-05-16" });
+    // Autosave erwartet bewusst eine Item-ID (ohne ID kein Save-Call).
+    editbox.setItem({ id: "r1", item_class: "rest", status: "offen", short_text: "Kurz", long_text: "Lang", due_date: "2026-05-16" });
 
     const legacyEditbox = new mod.default({ documentRef: createFakeDocument() });
     legacyEditbox.render();


### PR DESCRIPTION
### Motivation
- Der M16-Test erwartete einen Autosave, lief jedoch gegen die fachliche Regel, weil das Test-Item keine `id` hatte; Autosave darf nur bei vorhandenem `currentItem.id` laufen.

### Description
- Korrigiert den Test in `scripts/tests/restarbeitenModule.test.cjs` indem das initiale Test-Item eine `id: "r1"` erhält und ein kurzer Kommentar ergänzt wurde, der klarstellt, dass Autosave bewusst eine Item-ID voraussetzt.
- Es wurden ausschließlich Testdateien angepasst; keine Produktions- oder Autosave-Logik geändert.

### Testing
- `node scripts/tests/restarbeitenModule.test.cjs` — erfolgreich (M16-Test jetzt grün).
- `node scripts/tests/projektverwaltungModule.test.cjs` — erfolgreich.
- `npm test` — fehlgeschlagen in dieser Cloud-Umgebung aufgrund fehlender Systembibliothek (`libatk-1.0.so.0`), daher kein vollständiger npm-Testlauf hier möglich.
- PR erstellt gegen `main` auf Branch `work` (PR-Tool lieferte Titel/Body in dieser Umgebung).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ffc4c2e483229bd2308e8f8ca728)