### PR TITLE
Hotfix M30.2: use ipcSource in restarbeitenModule test (ipc -> ipcSource)

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -398,7 +398,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(ipcSource, /restarbeiten:updateItem/);
     assert.match(preload, /restarbeitenCreateItem/);
     assert.match(preload, /restarbeitenUpdateItem/);
-    assert.match(ipc, /restarbeiten:softDeleteItem/);
+    assert.match(ipcSource, /restarbeiten:softDeleteItem/);
     assert.match(preload, /restarbeitenSoftDeleteItem/);
 
     const calls = [];


### PR DESCRIPTION
### Motivation
- Fix a failing test that threw `ReferenceError: ipc is not defined` in the M5 test by using the in-scope variable used to read the IPC source.

### Description
- In `scripts/tests/restarbeitenModule.test.cjs` the assertion `assert.match(ipc, /restarbeiten:softDeleteItem/);` was corrected to `assert.match(ipcSource, /restarbeiten:softDeleteItem/);`, and no other files or production logic were modified.

### Testing
- Executed `node scripts/tests/restarbeitenModule.test.cjs`, `node scripts/tests/restarbeitenDataModel.test.cjs`, and `node scripts/tests/projektverwaltungModule.test.cjs` and they passed; running `npm test` in this environment fails due to missing system library `libatk-1.0.so.0` (Electron cannot start).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5467a25c832290b9dcb62840cbad)