### PR TITLE
Restarbeiten-Editbox: Begriffe auf „Restpunkt“ vereinheitlicht (Arbeitsstand #117)

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -310,7 +310,7 @@ async function runRestarbeitenModuleTests(run) {
 
       const allText = collectText(root);
       assert.equal(allText.includes("Schließen"), true);
-      assert.equal(Boolean(findButtonByText(screen.headerHost, "+ Restarbeit")), false);
+      assert.equal(Boolean(findButtonByText(screen.headerHost, "+ Restpunkt")), false);
       assert.equal(allText.includes("Ebene 1") || allText.includes("Haus"), true);
       assert.equal(Boolean(findButtonByText(screen.headerHost, "Metaspalten")), false);
 
@@ -376,7 +376,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(editbox, /createField\(doc, "Verantwortlich", responsibleProjectFirmId\)/);
     assert.match(editbox, /restarbeiten-editbox__classToggle--compact/);
     assert.match(editbox, /classActions\.append\(createField\(doc, "", marker\)\)/);
-    assert.match(editbox, /\+ Restarbeit/);
+    assert.match(editbox, /\+ Restpunkt/);
     assert.doesNotMatch(editbox, /textContent\s*=\s*"Speichern"/);
     assert.doesNotMatch(editbox, /restarbeiten-editbox__save/);
     assert.doesNotMatch(editbox, /saveBtn/);
@@ -680,7 +680,7 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(root.children.length >= 3, true);
       assert.match(screen.listHost.children[0].textContent, /Kein Projektkontext/);
       assert.equal(screen.editHost.children.length, 0);
-      const addButton = findButtonByText(screen.headerHost, "+ Restarbeit");
+      const addButton = findButtonByText(screen.headerHost, "+ Restpunkt");
       assert.equal(Boolean(addButton), false);
       assert.equal(Boolean(findButtonByText(screen.headerHost, "Schließen")), true);
       const allText = collectText(root);
@@ -1155,7 +1155,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(String(markerButtons.find((b) => b.textContent === "Rest")?.dataset?.active || ""), "1");
     assert.equal(String(markerButtons.find((b) => b.textContent === "Mangel")?.dataset?.active || ""), "0");
     markerButtons.find((b) => b.textContent === "Mangel").click();
-    const createBtn = findButtonByText(root, "+ Restarbeit");
+    const createBtn = findButtonByText(root, "+ Restpunkt");
     assert.equal(Boolean(createBtn), true);
     assert.equal(String(createBtn?.className || "").includes("restarbeiten-editbox__create"), true);
     createBtn.click();

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -172,7 +172,7 @@ export default class RestarbeitenEditbox {
     const createBtn = this.onCreate ? doc.createElement("button") : null;
     if (createBtn) {
       createBtn.type = "button";
-      createBtn.textContent = "+ Restarbeit";
+      createBtn.textContent = "+ Restpunkt";
       createBtn.className = "restarbeiten-editbox__create";
       createBtn.addEventListener("click", async () => {
         await this.flushAutosave();

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -612,7 +612,7 @@ export default class RestarbeitenScreen {
     if (!selectedItem) {
       if (this.editbox) this.editbox.setItem(null);
       this.editHost.replaceChildren(
-        createMessage(doc, "Eine Restarbeit auswaehlen oder ueber + Restarbeit neu anlegen.")
+        createMessage(doc, "Einen Restpunkt auswaehlen oder ueber + Restpunkt neu anlegen.")
       );
       return;
     }


### PR DESCRIPTION
### Motivation
- Konsolidierung der UI-Beschriftungen in der laufenden Layoutarbeit für das Restarbeiten-Editbox-Paket, ohne neue Fachfunktion einzubauen.
- Begriffsgebrauch vereinheitlichen (RP = Restpunkt) zur besseren Konsistenz in UI und Tests während des laufenden Arbeits-PRs #117.

### Description
- Ändert die Aktionsbeschriftung in der Editbox von `+ Restarbeit` auf `+ Restpunkt` in `src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js`.
- Passt den Leerlauf-Hinweistext in `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js` auf `Einen Restpunkt auswaehlen oder ueber + Restpunkt neu anlegen.` an.
- Aktualisiert die betroffenen Unit-/Smoke-Tests in `scripts/tests/restarbeitenModule.test.cjs` auf die neuen Begriffe; es handelt sich ausschließlich um textuelle/prüfungsseitige Anpassungen.

### Testing
- Ausgeführt: `node scripts/tests/restarbeitenModule.test.cjs`; Ergebnis: bestanden.
- Ausgeführt: `node scripts/tests/projektverwaltungModule.test.cjs`; Ergebnis: bestanden.
- Ausgeführt: `node scripts/tests/restarbeitenDataModel.test.cjs`; Ergebnis: bestanden.
- Ergänzend: `npm test` wurde versucht, schlägt in dieser Cloud-Umgebung fehl wegen fehlender Systembibliothek (`libatk-1.0.so.0`), daher nicht vollständig ausführbar.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5bc7ee7c83228698c8dd0446a9c5)