### PR TITLE
M31: Restarbeiten-Editbox — „erledigt am“, Notiz-Popup und Statuslogik

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -384,6 +384,9 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(editbox, /restarbeiten-editbox__metaRow--status/);
     assert.match(editbox, /createField\(doc, "Status", status\)/);
     assert.match(editbox, /createField\(doc, "Fertig bis", dueDate\)/);
+    assert.match(editbox, /createField\(doc, "erledigt am", completedAt\)/);
+    assert.match(editbox, /Folgende Maßnahmen sind getroffen:/);
+    assert.match(editbox, /aria-label", "Notiz"/);
     assert.match(editbox, /restarbeiten-editbox__metaDate/);
     assert.doesNotMatch(style, /restarbeiten-editbox__metaDate\{[^}]*appearance\s*:\s*none/);
     assert.doesNotMatch(style, /restarbeiten-editbox__metaDate\{[^}]*-webkit-appearance\s*:\s*none/);
@@ -540,7 +543,7 @@ async function runRestarbeitenModuleTests(run) {
       screen.editbox.fields.short_text.value = "Neu";
       screen.editbox.fields.long_text.value = "Lang 2";
       screen.editbox.fields.item_class.value = "mangel";
-      screen.editbox.fields.status.value = "in_arbeit";
+      screen.editbox.fields.status.value = "in arbeit";
       await screen.editbox.onSave(screen.editbox.getDraft());
 
       assert.equal(calls.find((call) => call.type === "update")?.payload.id, "r-1");
@@ -1192,11 +1195,11 @@ async function runRestarbeitenModuleTests(run) {
     await Promise.resolve();
     await Promise.resolve();
     assert.equal(createCalls.length, 1);
-    editbox.fields.status.value = "in_arbeit";
+    editbox.fields.status.value = "in arbeit";
     editbox.fields.responsible_project_firm_id.value = "f1";
     const draft = editbox.getDraft();
     assert.equal(draft.item_class, "mangel");
-    assert.equal(draft.status, "in_arbeit");
+    assert.equal(draft.status, "in arbeit");
     assert.equal(draft.due_date, "2026-05-16");
     assert.equal(draft.responsible_project_firm_id, "f1");
 
@@ -1432,7 +1435,7 @@ async function runRestarbeitenModuleTests(run) {
     await editbox.flushAutosave();
     assert.equal(saveCalls.length, 1);
 
-    editbox.fields.status.value = "in_arbeit";
+    editbox.fields.status.value = "in arbeit";
     editbox.fields.status.dispatchEvent({ type: "change" });
     await new Promise((resolve) => setTimeout(resolve, 0));
     assert.equal(saveCalls.length, 2);

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1230,6 +1230,72 @@ async function runRestarbeitenModuleTests(run) {
     assert.doesNotMatch(combinedContent, /node:child_process/);
   });
 
+  await run("M31.1 Notiz/Status/Ampel: completion_note leer speicherbar und Legacy-Mapping stabil", async () => {
+    const mod = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js")
+    );
+    const vm = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js")
+    );
+    const saveCalls = [];
+    const editbox = new mod.default({
+      documentRef: createFakeDocument(),
+      onSave: async (draft) => saveCalls.push(draft),
+    });
+    const root = editbox.render();
+
+    editbox.setItem({ id: "r1", status: "offen", completion_note: "Alt", completed_at: "" });
+    const noteBtn = findNodes(root, (n) => n?.tagName === "BUTTON" && String(n?.getAttribute?.("aria-label") || "") === "Notiz")[0];
+    assert.equal(Boolean(noteBtn), true);
+    noteBtn.click();
+    const textareaA = findNodes(root, (n) => n?.tagName === "TEXTAREA")[0];
+    assert.equal(textareaA.value, "Alt");
+    textareaA.value = "";
+    findButtonByText(root, "Speichern").click();
+    await Promise.resolve();
+    await editbox.flushAutosave();
+    assert.equal(editbox.getDraft().completion_note, "");
+    assert.equal(saveCalls.some((x) => x.completion_note === ""), true);
+
+    editbox.setItem({ id: "r1", status: "offen", completion_note: "Alt" });
+    noteBtn.click();
+    const textareaB = findNodes(root, (n) => n?.tagName === "TEXTAREA")[0];
+    textareaB.value = "Neu";
+    findButtonByText(root, "Abbrechen").click();
+    assert.equal(editbox.getDraft().completion_note, "Alt");
+
+    editbox.setItem({ id: "r1", status: "in_arbeit" });
+    assert.equal(editbox.fields.status.value, "in arbeit");
+    editbox.setItem({ id: "r1", status: "erledigt_gemeldet" });
+    assert.equal(editbox.fields.status.value, "erledigt");
+    editbox.setItem({ id: "r1", status: "geprueft_erledigt" });
+    assert.equal(editbox.fields.status.value, "erledigt");
+    editbox.setItem({ id: "r1", status: "geprüft erledigt" });
+    assert.equal(editbox.fields.status.value, "erledigt");
+    editbox.setItem({ id: "r1", status: "x-unknown" });
+    assert.equal(editbox.fields.status.value, "offen");
+
+    const today = new Date(Date.UTC(2026, 4, 18));
+    assert.equal(vm.getRestarbeitenAmpelState({ status: "erledigt", due_date: "2026-05-01" }, today), "gruen");
+    assert.equal(vm.getRestarbeitenAmpelState({ status: "erledigt_gemeldet", due_date: "2026-05-01" }, today), "gruen");
+    assert.equal(vm.getRestarbeitenAmpelState({ status: "geprueft_erledigt", due_date: "2026-05-01" }, today), "gruen");
+
+    editbox.setItem({ id: "r1", status: "offen", completion_note: "Alt", completed_at: "" });
+    editbox.fields.status.value = "erledigt";
+    editbox.fields.status.dispatchEvent({ type: "change" });
+    assert.equal(Boolean(editbox.fields.completed_at.value), true);
+    assert.equal(Boolean(findNodes(root, (n) => String(n?.className || "").includes("restarbeiten-editbox__noteDialog"))[0]), true);
+    const keepDate = "2026-05-20";
+    editbox.setItem({ id: "r1", status: "offen", completion_note: "Alt", completed_at: keepDate });
+    editbox.fields.status.value = "erledigt";
+    editbox.fields.status.dispatchEvent({ type: "change" });
+    assert.equal(editbox.fields.completed_at.value, keepDate);
+    editbox.fields.status.value = "offen";
+    editbox.fields.status.dispatchEvent({ type: "change" });
+    assert.equal(editbox.getDraft().completed_at, keepDate);
+    assert.equal(editbox.getDraft().completion_note, "Alt");
+  });
+
   await run("M19 Guardrails: Editbox CSS verdichtet und Filterleiste fachlich geklärt", () => {
     const editboxContent = fs.readFileSync(
       path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js"),

--- a/src/main/db/restarbeitenRepo.js
+++ b/src/main/db/restarbeitenRepo.js
@@ -3,10 +3,8 @@ const { initDatabase } = require("./database");
 
 const ALLOWED_STATUS = new Set([
   "offen",
-  "in_arbeit",
-  "erledigt_gemeldet",
-  "geprueft_erledigt",
-  "zurueckgewiesen",
+  "in arbeit",
+  "erledigt",
 ]);
 const ALLOWED_ITEM_CLASSES = new Set(["rest", "mangel"]);
 
@@ -25,7 +23,10 @@ function reqText(value, name) {
 function normalizeStatus(value) {
   const clean = toText(value);
   if (!clean) return "offen";
-  return ALLOWED_STATUS.has(clean) ? clean : "offen";
+  if (ALLOWED_STATUS.has(clean)) return clean;
+  if (clean === "in_arbeit") return "in arbeit";
+  if (clean === "erledigt_gemeldet" || clean === "geprueft_erledigt") return "erledigt";
+  return "offen";
 }
 
 function normalizeRestarbeitItemClass(value) {

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -6,6 +6,11 @@ function normalizeText(value) {
 const LOCATION_KEYS = ["location_level_1", "location_level_2", "location_level_3", "location_level_4"];
 const LOCATION_LABEL_FALLBACKS = ["Ebene 1", "Ebene 2", "Ebene 3", "Ebene 4"];
 const AUTOSAVE_DELAY_MS = 650;
+const EDITBOX_STATUS_OPTIONS = [
+  { value: "offen", label: "offen" },
+  { value: "in arbeit", label: "in arbeit" },
+  { value: "erledigt", label: "erledigt" },
+];
 
 function createField(doc, labelText, control, className = "") {
   const wrap = doc.createElement("label");
@@ -77,6 +82,7 @@ export default class RestarbeitenEditbox {
     this.lastRequestedDraftKey = "";
     this.lastSaveFailed = false;
     this.failedDraftKey = "";
+    this.noteDraftValue = "";
   }
 
   _getLocationLabel(index) {
@@ -198,13 +204,7 @@ export default class RestarbeitenEditbox {
       this._triggerAutosaveImmediate();
     });
 
-    const status = createSelect(doc, [
-      { value: "offen", label: "offen" },
-      { value: "in_arbeit", label: "in Arbeit" },
-      { value: "erledigt_gemeldet", label: "erledigt gemeldet" },
-      { value: "geprueft_erledigt", label: "geprueft erledigt" },
-      { value: "zurueckgewiesen", label: "zurueckgewiesen" },
-    ]);
+    const status = createSelect(doc, EDITBOX_STATUS_OPTIONS);
     const dueDate = createInput(doc, "date");
     dueDate.className += " restarbeiten-editbox__metaControl restarbeiten-editbox__metaDate";
     const responsibleProjectFirmId = createSelect(doc, [{ value: "", label: "— keine Auswahl —" }]);
@@ -250,10 +250,25 @@ export default class RestarbeitenEditbox {
     }
     const responsibleField = createField(doc, "Verantwortlich", responsibleProjectFirmId);
     responsibleField.className += " restarbeiten-editbox__responsibleField";
+    const completedAt = createInput(doc, "date");
+    completedAt.className += " restarbeiten-editbox__metaControl restarbeiten-editbox__metaDate";
+    const completionNoteBtn = doc.createElement("button");
+    completionNoteBtn.type = "button";
+    completionNoteBtn.textContent = "✎";
+    completionNoteBtn.title = "Notiz";
+    completionNoteBtn.setAttribute("aria-label", "Notiz");
+    completionNoteBtn.className = "restarbeiten-editbox__noteBtn";
+    completionNoteBtn.addEventListener("click", () => this._openCompletionNoteDialog());
+    const completedAtRow = doc.createElement("div");
+    completedAtRow.className = "restarbeiten-editbox__metaRow restarbeiten-editbox__metaRow--completedAt";
+    const completedAtField = createField(doc, "erledigt am", completedAt);
+    const completionNoteField = createField(doc, "", completionNoteBtn);
+    completedAtRow.append(completedAtField, completionNoteField);
     metaCol.append(
       dueDateRow,
       statusFieldRow,
       responsibleField,
+      completedAtRow,
       statusEl
     );
     rightGroup.append(locationGrid, metaCol);
@@ -285,6 +300,7 @@ export default class RestarbeitenEditbox {
       short_text__counter: shortCounter,
       long_text__counter: longCounter,
       due_date: dueDate,
+      completed_at: completedAt,
       responsible_project_firm_id: responsibleProjectFirmId,
       location_level_1__label: loc1Field.querySelector?.(".restarbeiten-editbox__label") || loc1Field.children[0],
       location_level_2__label: loc2Field.querySelector?.(".restarbeiten-editbox__label") || loc2Field.children[0],
@@ -310,11 +326,58 @@ export default class RestarbeitenEditbox {
       });
       input.addEventListener("blur", () => this.flushAutosave());
     });
-    ["status", "due_date", "responsible_project_firm_id"].forEach((key) => {
+    ["status", "due_date", "completed_at", "responsible_project_firm_id"].forEach((key) => {
       const input = this.fields?.[key];
       if (!input?.addEventListener) return;
-      input.addEventListener("change", () => { this._updateAmpelPreview(); this._triggerAutosaveImmediate(); });
+      input.addEventListener("change", () => {
+        if (key === "status") this._handleStatusChange();
+        this._updateAmpelPreview();
+        this._triggerAutosaveImmediate();
+      });
     });
+  }
+
+  _todayIsoDate() {
+    const now = new Date();
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  }
+
+  _openCompletionNoteDialog() {
+    const doc = this.document;
+    const overlay = doc.createElement("div");
+    overlay.className = "restarbeiten-editbox__noteDialog";
+    const card = doc.createElement("div");
+    const prompt = doc.createElement("p");
+    prompt.textContent = "Folgende Maßnahmen sind getroffen:";
+    const textarea = createInput(doc, "textarea");
+    textarea.value = normalizeText(this.noteDraftValue || this.currentItem?.completion_note);
+    const actions = doc.createElement("div");
+    const saveBtn = doc.createElement("button");
+    saveBtn.type = "button";
+    saveBtn.textContent = "Speichern";
+    const cancelBtn = doc.createElement("button");
+    cancelBtn.type = "button";
+    cancelBtn.textContent = "Abbrechen";
+    cancelBtn.addEventListener("click", () => overlay.remove());
+    saveBtn.addEventListener("click", async () => {
+      this.noteDraftValue = normalizeText(textarea.value);
+      overlay.remove();
+      this._triggerAutosaveImmediate();
+      await this.flushAutosave();
+    });
+    actions.append(saveBtn, cancelBtn);
+    card.append(prompt, textarea, actions);
+    overlay.append(card);
+    this.root?.append(overlay);
+  }
+
+  _handleStatusChange() {
+    const status = normalizeText(this.fields?.status?.value);
+    if (status !== "erledigt") return;
+    if (!normalizeText(this.fields?.completed_at?.value) && this.fields?.completed_at) {
+      this.fields.completed_at.value = this._todayIsoDate();
+    }
+    this._openCompletionNoteDialog();
   }
 
   _draftKeyFor(draft) {
@@ -502,13 +565,19 @@ export default class RestarbeitenEditbox {
     const fields = this.fields || {};
 
     this._setItemClass?.(normalizeText(source.item_class) || "rest");
-    if (fields.status) fields.status.value = normalizeText(source.status) || "offen";
+    if (fields.status) {
+      const status = normalizeText(source.status) || "offen";
+      const allowed = EDITBOX_STATUS_OPTIONS.map((entry) => entry.value);
+      fields.status.value = allowed.includes(status) ? status : "offen";
+    }
     LOCATION_KEYS.forEach((key) => {
       if (fields[key]) fields[key].value = normalizeText(source[key]);
     });
     if (fields.short_text) fields.short_text.value = normalizeText(source.short_text);
     if (fields.long_text) fields.long_text.value = normalizeText(source.long_text);
     if (fields.due_date) fields.due_date.value = normalizeText(source.due_date);
+    if (fields.completed_at) fields.completed_at.value = normalizeText(source.completed_at);
+    this.noteDraftValue = normalizeText(source.completion_note);
     this.setProjectFirms(this.projectFirms);
     this._updateTextRailCounters();
     this._updateTitle();
@@ -553,6 +622,8 @@ export default class RestarbeitenEditbox {
       short_text: normalizeText(fields.short_text?.value),
       long_text: normalizeText(fields.long_text?.value),
       due_date: normalizeText(fields.due_date?.value),
+      completed_at: normalizeText(fields.completed_at?.value),
+      completion_note: normalizeText(this.noteDraftValue || this.currentItem?.completion_note),
       responsible_project_firm_id: responsibleProjectFirmId,
       responsible_label: responsibleLabel,
     };

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -55,6 +55,15 @@ function normalizeFirmEntries(list) {
   }).filter(Boolean);
 }
 
+function normalizeEditboxStatus(value) {
+  const raw = normalizeText(value).toLowerCase();
+  if (!raw) return "offen";
+  if (raw === "in arbeit" || raw === "erledigt" || raw === "offen") return raw;
+  if (raw === "in_arbeit") return "in arbeit";
+  if (raw === "erledigt_gemeldet" || raw === "geprueft_erledigt" || raw === "geprüft erledigt") return "erledigt";
+  return "offen";
+}
+
 export default class RestarbeitenEditbox {
   constructor({ documentRef = globalThis.document, onSave = null, onCreate = null } = {}) {
     this.document = documentRef || globalThis.document;
@@ -350,7 +359,7 @@ export default class RestarbeitenEditbox {
     const prompt = doc.createElement("p");
     prompt.textContent = "Folgende Maßnahmen sind getroffen:";
     const textarea = createInput(doc, "textarea");
-    textarea.value = normalizeText(this.noteDraftValue || this.currentItem?.completion_note);
+    textarea.value = normalizeText(this.noteDraftValue);
     const actions = doc.createElement("div");
     const saveBtn = doc.createElement("button");
     saveBtn.type = "button";
@@ -566,9 +575,7 @@ export default class RestarbeitenEditbox {
 
     this._setItemClass?.(normalizeText(source.item_class) || "rest");
     if (fields.status) {
-      const status = normalizeText(source.status) || "offen";
-      const allowed = EDITBOX_STATUS_OPTIONS.map((entry) => entry.value);
-      fields.status.value = allowed.includes(status) ? status : "offen";
+      fields.status.value = normalizeEditboxStatus(source.status);
     }
     LOCATION_KEYS.forEach((key) => {
       if (fields[key]) fields[key].value = normalizeText(source[key]);
@@ -623,7 +630,7 @@ export default class RestarbeitenEditbox {
       long_text: normalizeText(fields.long_text?.value),
       due_date: normalizeText(fields.due_date?.value),
       completed_at: normalizeText(fields.completed_at?.value),
-      completion_note: normalizeText(this.noteDraftValue || this.currentItem?.completion_note),
+      completion_note: normalizeText(this.noteDraftValue),
       responsible_project_firm_id: responsibleProjectFirmId,
       responsible_label: responsibleLabel,
     };

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -34,7 +34,9 @@ textarea.restarbeiten-editbox__control--long{min-height:74px}
 .restarbeiten-editbox__metaRow{display:grid;gap:4px;width:max-content;outline:1px solid rgba(251,191,36,.25)}
 .restarbeiten-editbox__metaRow--dueDate{grid-template-columns:max-content 14px;align-items:end;justify-items:start}
 .restarbeiten-editbox__metaRow--status{grid-template-columns:max-content;align-items:end;justify-items:start}
+.restarbeiten-editbox__metaRow--completedAt{grid-template-columns:max-content max-content;align-items:end;justify-items:start}
 .restarbeiten-editbox__metaRow--dueDate .restarbeiten-editbox__field,.restarbeiten-editbox__metaRow--status .restarbeiten-editbox__field{align-content:end}
+.restarbeiten-editbox__metaRow--completedAt .restarbeiten-editbox__field{align-content:end}
 .restarbeiten-editbox__statusField,.restarbeiten-editbox__dueDateField,.restarbeiten-editbox__responsibleField{justify-self:start}
 .restarbeiten-editbox__statusField,.restarbeiten-editbox__responsibleField{width:auto;max-width:none}
 .restarbeiten-editbox__dueDateField{width:auto;max-width:none}
@@ -54,6 +56,11 @@ textarea.restarbeiten-editbox__control--long{min-height:74px}
 .restarbeiten-editbox__create{min-height:18px;padding:0 6px;justify-self:start;border:1px solid #cfcfcf;border-radius:6px;background:#f5f5f5;font-size:8px;font-weight:700}
 .restarbeiten-editbox__create--right{justify-self:end}
 .restarbeiten-editbox__status{font-size:8px;opacity:.8}
+.restarbeiten-editbox__noteBtn{min-height:18px;padding:0 6px;border:1px solid #cfcfcf;border-radius:6px;background:#fff;font-size:10px;line-height:1}
+.restarbeiten-editbox__noteDialog{position:fixed;inset:0;display:grid;place-items:center;background:rgba(15,23,42,.24);z-index:9999}
+.restarbeiten-editbox__noteDialog>div{background:#fff;border:1px solid #cfcfcf;border-radius:8px;padding:10px;display:grid;gap:8px;min-width:280px;max-width:420px}
+.restarbeiten-editbox__noteDialog textarea{min-height:110px}
+.restarbeiten-editbox__noteDialog div:last-child{display:flex;justify-content:flex-end;gap:6px}
 @media (max-width:900px){.restarbeiten-editbox__body{display:grid;grid-template-columns:1fr}.restarbeiten-editbox__rightGroup{display:grid;grid-template-columns:1fr;width:100%}.restarbeiten-editbox__main{display:grid;grid-template-columns:1fr;max-width:none;width:100%}.restarbeiten-editbox__locationGrid{grid-template-columns:repeat(2,minmax(0,1fr));max-width:none;width:100%}}
 
 [data-bbm-restarbeiten-screen="true"]{display:flex;flex-direction:column;height:100%;min-height:0;background:linear-gradient(180deg,#faf7ef,#f3eee3)}

--- a/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
+++ b/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
@@ -19,7 +19,9 @@ export function mapRestarbeitenStatusLabel(value) {
   const raw = toText(value).toLowerCase();
   const map = {
     offen: "offen",
+    "in arbeit": "in arbeit",
     in_arbeit: "in Arbeit",
+    erledigt: "erledigt",
     erledigt_gemeldet: "erledigt gemeldet",
     geprueft_erledigt: "geprüft erledigt",
     zurueckgewiesen: "zurückgewiesen",
@@ -77,7 +79,7 @@ function toDayStartUtc(dateLike = new Date()) {
 export function getRestarbeitenAmpelState(row = {}, today = new Date()) {
   const status = toText(row.status).toLowerCase();
   if (status === "verzug") return "rot";
-  if (status === "erledigt_gemeldet" || status === "geprueft_erledigt" || status === "geprüft erledigt") {
+  if (status === "erledigt" || status === "erledigt_gemeldet" || status === "geprueft_erledigt" || status === "geprüft erledigt") {
     return "gruen";
   }
 


### PR DESCRIPTION
### Motivation
- Ergänzen der Restarbeiten-Editbox um die fachliche M31-Funktionen: sichtbares Feld „erledigt am“, Maßnahmen-Notiz und die Statusauswahl `offen` / `in arbeit` / `erledigt` mit zugehöriger Automatik beim Wechsel zu `erledigt`. 
- Die Änderung soll minimal, rückwärtsverträglich und ohne DB-Migration oder Layout-Großumbau umgesetzt werden. 

### Description
- UI: `completed_at` (Label „erledigt am“) wurde im rechten Metablock unter `Verantwortlich` ergänzt und ein Notiz-Button (✎) mit `title`/`aria-label` "Notiz" hinzugefügt, der ein Popup mit exakt dem Text "Folgende Maßnahmen sind getroffen:" öffnet. 
- Status: die Editbox bietet jetzt nur noch die drei sichtbaren Optionen `offen`, `in arbeit`, `erledigt` und lädt/zeigt unbekannte/legacy Werte defensiv. 
- Verhalten: beim Wechsel auf `erledigt` wird, falls leer, `completed_at` auf das lokale Tagesdatum (`yyyy-mm-dd`) gesetzt und das Notiz-Popup automatisch geöffnet; `completion_note` wird über den bestehenden Autosave-/Save-Pfad gespeichert und bei Rückwechsel nicht gelöscht. 
- Backend/Repo: minimale Normalisierung in `restarbeitenRepo.js`, die legacy-Werte (`in_arbeit`, `erledigt_gemeldet`, `geprueft_erledigt`) defensiv auf die neuen M31-Werte mapped. 
- Styling/Tests: nur ergänzende CSS-Regeln für die neue Meta-Row und das Notiz-Popup hinzugefügt und bestehende farbige Hilfsrahmen/Outlines unverändert belassen; relevante Tests in `scripts/tests/restarbeitenModule.test.cjs` wurden erweitert.

### Testing
- `node scripts/tests/restarbeitenModule.test.cjs` wurde ausgeführt und die angepassten Editbox-Assertions (Status-Optionen, `erledigt am`, Notiz-Button/Popup-Text) liefen erfolgreich. 
- `node scripts/tests/restarbeitenDataModel.test.cjs` und `node scripts/tests/projektverwaltungModule.test.cjs` wurden ausgeführt und liefen erfolgreich. 
- `npm test` wurde versucht und schlägt in dieser Cloud-Umgebung fehl wegen fehlender Systembibliothek `libatk-1.0.so.0` (erwarteter Umgebungsfehler, daher nicht aussagekräftig für UI/Electron-Integration). 
- Branch mit Änderungen: `work` (lokal committed); ein PR konnte in dieser Umgebung nicht veröffentlicht werden, daher STOPP: Branch muss in das Remote-Repository gepusht und ein Pull Request gegen `main` auf GitHub erstellt werden, bevor das Paket als geliefert gilt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b6f5212bc8322abe6e0ae1f1a4ac8)