### PR TITLE
Hotfix M31.2: Notiz-Popup ‚Übernehmen‘ und M31.1-Testfix

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1245,13 +1245,13 @@ async function runRestarbeitenModuleTests(run) {
     const root = editbox.render();
 
     editbox.setItem({ id: "r1", status: "offen", completion_note: "Alt", completed_at: "" });
-    const noteBtn = findNodes(root, (n) => n?.tagName === "BUTTON" && String(n?.getAttribute?.("aria-label") || "") === "Notiz")[0];
+    const noteBtn = findNodes(root, (n) => n?.tagName === "BUTTON" && String(n?.className || "").includes("restarbeiten-editbox__noteBtn"))[0];
     assert.equal(Boolean(noteBtn), true);
     noteBtn.click();
     const textareaA = findNodes(root, (n) => n?.tagName === "TEXTAREA")[0];
     assert.equal(textareaA.value, "Alt");
     textareaA.value = "";
-    findButtonByText(root, "Speichern").click();
+    findButtonByText(root, "Übernehmen").click();
     await Promise.resolve();
     await editbox.flushAutosave();
     assert.equal(editbox.getDraft().completion_note, "");

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -363,7 +363,7 @@ export default class RestarbeitenEditbox {
     const actions = doc.createElement("div");
     const saveBtn = doc.createElement("button");
     saveBtn.type = "button";
-    saveBtn.textContent = "Speichern";
+    saveBtn.textContent = "Übernehmen";
     const cancelBtn = doc.createElement("button");
     cancelBtn.type = "button";
     cancelBtn.textContent = "Abbrechen";
@@ -371,7 +371,6 @@ export default class RestarbeitenEditbox {
     saveBtn.addEventListener("click", async () => {
       this.noteDraftValue = normalizeText(textarea.value);
       overlay.remove();
-      this._triggerAutosaveImmediate();
       await this.flushAutosave();
     });
     actions.append(saveBtn, cancelBtn);


### PR DESCRIPTION
### Motivation
- Repair failing tests after M31 by removing the unwanted `textContent = "Speichern"` in the Notiz-Popup and ensure the completion-note save path is robust and race-free.

### Description
- Renamed the Notiz-Popup button from `"Speichern"` to `"Übernehmen"` and simplified the save path so that after `this.noteDraftValue = normalizeText(textarea.value)` the code executes `await this.flushAutosave()` deterministically, and updated the test to find the note button by class and click `"Übernehmen"` (`src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js`, `scripts/tests/restarbeitenModule.test.cjs`).

### Testing
- Ran `node scripts/tests/restarbeitenModule.test.cjs`, `node scripts/tests/restarbeitenDataModel.test.cjs`, and `node scripts/tests/projektverwaltungModule.test.cjs`, which passed locally; `npm test` could not complete in this environment due to missing system library (`libatk-1.0.so.0`) causing Electron to fail to start.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b75cfe1048322972f6ddeda17f29d)