### PR TITLE
M32 Restarbeiten: Soft-Delete-Button in Editbox

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -321,7 +321,6 @@ async function runRestarbeitenModuleTests(run) {
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;
-      globalThis.confirm = undefined;
     }
   });
 
@@ -410,6 +409,9 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(editbox, /\+ Restpunkt/);
     assert.match(editbox, /textContent = "Löschen"/);
     assert.match(editbox, /Diesen Restpunkt wirklich löschen\?/);
+    assert.match(editbox, /_openDeleteDialog\(/);
+    assert.match(editbox, /Abbrechen/);
+    assert.doesNotMatch(editbox, /globalThis\.confirm/);
     assert.match(editbox, /deleteBtn\.disabled = true/);
     assert.doesNotMatch(editbox, /textContent\s*=\s*"Speichern"/);
     assert.doesNotMatch(editbox, /restarbeiten-editbox__save/);
@@ -559,15 +561,24 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(calls.find((call) => call.type === "update")?.payload.id, "r-1");
       assert.equal(calls.find((call) => call.type === "update")?.payload.patch.short_text, "Neu");
 
-      globalThis.confirm = () => false;
       const deleteBtn = screen.editbox.fields.delete_button;
       assert.equal(Boolean(deleteBtn), true);
       assert.equal(deleteBtn.disabled, false);
       await deleteBtn.click();
+      const deleteDialog = screen.editbox.root.querySelector?.(".restarbeiten-editbox__deleteDialog");
+      assert.equal(Boolean(deleteDialog), true);
+      assert.match(deleteDialog.textContent, /Diesen Restpunkt wirklich löschen\?/);
+      const cancelBtn = findButtonByText(deleteDialog, "Abbrechen");
+      const confirmDeleteBtn = findButtonByText(deleteDialog, "Löschen");
+      assert.equal(Boolean(cancelBtn), true);
+      assert.equal(Boolean(confirmDeleteBtn), true);
+      await cancelBtn.click();
       assert.equal(calls.some((call) => call.type === "soft-delete"), false);
 
-      globalThis.confirm = () => true;
       await deleteBtn.click();
+      const deleteDialog2 = screen.editbox.root.querySelector?.(".restarbeiten-editbox__deleteDialog");
+      const confirmDeleteBtn2 = findButtonByText(deleteDialog2, "Löschen");
+      await confirmDeleteBtn2.click();
       assert.equal(calls.find((call) => call.type === "soft-delete")?.payload.id, "r-1");
       assert.equal(screen.selectedItemId, "");
       assert.match(screen.editHost.children[0].textContent, /Einen Restpunkt auswaehlen oder ueber \+ Restpunkt neu anlegen\./);
@@ -580,7 +591,6 @@ async function runRestarbeitenModuleTests(run) {
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;
-      globalThis.confirm = undefined;
     }
   });
 
@@ -675,7 +685,6 @@ async function runRestarbeitenModuleTests(run) {
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;
-      globalThis.confirm = undefined;
     }
   });
 
@@ -758,7 +767,6 @@ async function runRestarbeitenModuleTests(run) {
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;
-      globalThis.confirm = undefined;
     }
   });
 
@@ -1076,7 +1084,6 @@ async function runRestarbeitenModuleTests(run) {
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;
-      globalThis.confirm = undefined;
     }
   });
   await run("M12 ViewModel: Mapping und Ampel-Logik fuer Listenlayout", async () => {

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -321,6 +321,7 @@ async function runRestarbeitenModuleTests(run) {
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;
+      globalThis.confirm = undefined;
     }
   });
 
@@ -407,6 +408,9 @@ async function runRestarbeitenModuleTests(run) {
     assert.doesNotMatch(editbox, /textColumn\.append\(\s*classActions,/);
     assert.match(editbox, /const markerField = createField\(doc, "", marker\)/);
     assert.match(editbox, /\+ Restpunkt/);
+    assert.match(editbox, /textContent = "Löschen"/);
+    assert.match(editbox, /Diesen Restpunkt wirklich löschen\?/);
+    assert.match(editbox, /deleteBtn\.disabled = true/);
     assert.doesNotMatch(editbox, /textContent\s*=\s*"Speichern"/);
     assert.doesNotMatch(editbox, /restarbeiten-editbox__save/);
     assert.doesNotMatch(editbox, /saveBtn/);
@@ -508,6 +512,12 @@ async function runRestarbeitenModuleTests(run) {
         },
         restarbeitenListAttachments: async () => ({ ok: true, attachments: [] }),
         restarbeitenSetPrimaryAttachment: async () => ({ ok: true }),
+        restarbeitenSoftDeleteItem: async (payload) => {
+          calls.push({ type: "soft-delete", payload });
+          const idx = items.findIndex((item) => String(item.id) === String(payload.id));
+          if (idx >= 0) items[idx].deleted_at = "2026-05-18T12:00:00.000Z";
+          return { ok: true, item: idx >= 0 ? { ...items[idx] } : null };
+        },
         projectFirmsListByProject: async () => ({
           ok: true,
           list: [
@@ -549,6 +559,19 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(calls.find((call) => call.type === "update")?.payload.id, "r-1");
       assert.equal(calls.find((call) => call.type === "update")?.payload.patch.short_text, "Neu");
 
+      globalThis.confirm = () => false;
+      const deleteBtn = screen.editbox.fields.delete_button;
+      assert.equal(Boolean(deleteBtn), true);
+      assert.equal(deleteBtn.disabled, false);
+      await deleteBtn.click();
+      assert.equal(calls.some((call) => call.type === "soft-delete"), false);
+
+      globalThis.confirm = () => true;
+      await deleteBtn.click();
+      assert.equal(calls.find((call) => call.type === "soft-delete")?.payload.id, "r-1");
+      assert.equal(screen.selectedItemId, "");
+      assert.match(screen.editHost.children[0].textContent, /Einen Restpunkt auswaehlen oder ueber \+ Restpunkt neu anlegen\./);
+
       await screen._createRestarbeit();
       assert.equal(calls.find((call) => call.type === "create")?.payload.projectId, "p-1");
       assert.equal(screen.selectedItemId, "r-2");
@@ -557,6 +580,7 @@ async function runRestarbeitenModuleTests(run) {
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;
+      globalThis.confirm = undefined;
     }
   });
 
@@ -623,6 +647,12 @@ async function runRestarbeitenModuleTests(run) {
         projectFirmsListByProject: async () => ({ ok: true, list: [] }),
         restarbeitenListAttachments: async () => ({ ok: false, error: "kaputt" }),
         restarbeitenSetPrimaryAttachment: async () => ({ ok: true }),
+        restarbeitenSoftDeleteItem: async (payload) => {
+          calls.push({ type: "soft-delete", payload });
+          const idx = items.findIndex((item) => String(item.id) === String(payload.id));
+          if (idx >= 0) items[idx].deleted_at = "2026-05-18T12:00:00.000Z";
+          return { ok: true, item: idx >= 0 ? { ...items[idx] } : null };
+        },
       },
     };
     globalThis.document = createFakeDocument();
@@ -645,6 +675,7 @@ async function runRestarbeitenModuleTests(run) {
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;
+      globalThis.confirm = undefined;
     }
   });
 
@@ -727,6 +758,7 @@ async function runRestarbeitenModuleTests(run) {
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;
+      globalThis.confirm = undefined;
     }
   });
 
@@ -995,6 +1027,12 @@ async function runRestarbeitenModuleTests(run) {
         restarbeitenListByProject: async () => ({ ok: true, items: items.map((i) => ({ ...i })) }),
         restarbeitenListAttachments: async () => ({ ok: true, attachments: [] }),
         restarbeitenSetPrimaryAttachment: async () => ({ ok: true }),
+        restarbeitenSoftDeleteItem: async (payload) => {
+          calls.push({ type: "soft-delete", payload });
+          const idx = items.findIndex((item) => String(item.id) === String(payload.id));
+          if (idx >= 0) items[idx].deleted_at = "2026-05-18T12:00:00.000Z";
+          return { ok: true, item: idx >= 0 ? { ...items[idx] } : null };
+        },
         projectFirmsListByProject: async () => ({ ok: true, list: [{ id: "f1", name: "Firma A" }] }),
         restarbeitenCreateItem: async () => ({ ok: true, item: { id: "r-2" } }),
         restarbeitenUpdateItem: async (payload) => {
@@ -1038,6 +1076,7 @@ async function runRestarbeitenModuleTests(run) {
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;
+      globalThis.confirm = undefined;
     }
   });
   await run("M12 ViewModel: Mapping und Ampel-Logik fuer Listenlayout", async () => {

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -484,6 +484,16 @@ async function runRestarbeitenModuleTests(run) {
         item_class: "rest",
         status: "offen",
       },
+      {
+        id: "r-9",
+        running_number: 9,
+        created_at: "2026-05-16",
+        location_level_1: "Haus B",
+        short_text: "Zweit",
+        long_text: "Noch da",
+        item_class: "rest",
+        status: "offen",
+      },
     ];
     globalThis.window = {
       bbmDb: {
@@ -546,6 +556,7 @@ async function runRestarbeitenModuleTests(run) {
       await screen.load();
 
       assert.equal(screen.listHost.children[0].tagName, "UL");
+      assert.equal(screen.selectedItemId, "r-1");
       const row = screen.listHost.children[0].children[0];
       row.dispatchEvent({ type: "click" });
       assert.equal(screen.selectedItemId, "r-1");
@@ -581,6 +592,8 @@ async function runRestarbeitenModuleTests(run) {
       await confirmDeleteBtn2.click();
       assert.equal(calls.find((call) => call.type === "soft-delete")?.payload.id, "r-1");
       assert.equal(screen.selectedItemId, "");
+      assert.equal(screen.listHost.children[0].tagName, "UL");
+      assert.equal(screen.listHost.children[0].children.length >= 1, true);
       assert.match(screen.editHost.children[0].textContent, /Einen Restpunkt auswaehlen oder ueber \+ Restpunkt neu anlegen\./);
 
       await screen._createRestarbeit();

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -270,7 +270,7 @@ export default class RestarbeitenEditbox {
       deleteBtn.addEventListener("click", async () => {
         const selectedId = normalizeText(this.currentItem?.id);
         if (!selectedId || this.isDeleting) return;
-        const approve = globalThis.confirm?.("Diesen Restpunkt wirklich löschen?");
+        const approve = await this._openDeleteDialog();
         if (!approve) return;
         this.isDeleting = true;
         deleteBtn.disabled = true;
@@ -415,6 +415,38 @@ export default class RestarbeitenEditbox {
     card.append(prompt, textarea, actions);
     overlay.append(card);
     this.root?.append(overlay);
+  }
+
+
+  _openDeleteDialog() {
+    const doc = this.document;
+    return new Promise((resolve) => {
+      const overlay = doc.createElement("div");
+      overlay.className = "restarbeiten-editbox__deleteDialog";
+      const card = doc.createElement("div");
+      const prompt = doc.createElement("p");
+      prompt.textContent = "Diesen Restpunkt wirklich löschen?";
+      const actions = doc.createElement("div");
+      const deleteBtn = doc.createElement("button");
+      deleteBtn.type = "button";
+      deleteBtn.textContent = "Löschen";
+      const cancelBtn = doc.createElement("button");
+      cancelBtn.type = "button";
+      cancelBtn.textContent = "Abbrechen";
+      const close = (approved) => {
+        if (typeof overlay.remove === "function") overlay.remove();
+        else if (overlay.parentElement && Array.isArray(overlay.parentElement.children)) {
+          overlay.parentElement.children = overlay.parentElement.children.filter((child) => child !== overlay);
+        }
+        resolve(approved === true);
+      };
+      cancelBtn.addEventListener("click", () => close(false));
+      deleteBtn.addEventListener("click", () => close(true));
+      actions.append(deleteBtn, cancelBtn);
+      card.append(prompt, actions);
+      overlay.append(card);
+      this.root?.append(overlay);
+    });
   }
 
   _handleStatusChange() {

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -65,10 +65,11 @@ function normalizeEditboxStatus(value) {
 }
 
 export default class RestarbeitenEditbox {
-  constructor({ documentRef = globalThis.document, onSave = null, onCreate = null } = {}) {
+  constructor({ documentRef = globalThis.document, onSave = null, onCreate = null, onDelete = null } = {}) {
     this.document = documentRef || globalThis.document;
     this.onSave = typeof onSave === "function" ? onSave : null;
     this.onCreate = typeof onCreate === "function" ? onCreate : null;
+    this.onDelete = typeof onDelete === "function" ? onDelete : null;
     this.root = null;
     this.form = null;
     this.titleEl = null;
@@ -92,6 +93,7 @@ export default class RestarbeitenEditbox {
     this.lastSaveFailed = false;
     this.failedDraftKey = "";
     this.noteDraftValue = "";
+    this.isDeleting = false;
   }
 
   _getLocationLabel(index) {
@@ -257,6 +259,31 @@ export default class RestarbeitenEditbox {
       createBtn.className += " restarbeiten-editbox__create--right";
       classActions.append(createBtn);
     }
+
+    const deleteBtn = this.onDelete ? doc.createElement("button") : null;
+    if (deleteBtn) {
+      deleteBtn.type = "button";
+      deleteBtn.textContent = "Löschen";
+      deleteBtn.title = "Löschen";
+      deleteBtn.className = "restarbeiten-editbox__delete";
+      deleteBtn.disabled = true;
+      deleteBtn.addEventListener("click", async () => {
+        const selectedId = normalizeText(this.currentItem?.id);
+        if (!selectedId || this.isDeleting) return;
+        const approve = globalThis.confirm?.("Diesen Restpunkt wirklich löschen?");
+        if (!approve) return;
+        this.isDeleting = true;
+        deleteBtn.disabled = true;
+        try {
+          await this.flushAutosave();
+          await this.onDelete?.(selectedId);
+        } finally {
+          this.isDeleting = false;
+          deleteBtn.disabled = !normalizeText(this.currentItem?.id);
+        }
+      });
+      classActions.append(deleteBtn);
+    }
     const responsibleField = createField(doc, "Verantwortlich", responsibleProjectFirmId);
     responsibleField.className += " restarbeiten-editbox__responsibleField";
     const completedAt = createInput(doc, "date");
@@ -315,6 +342,7 @@ export default class RestarbeitenEditbox {
       location_level_2__label: loc2Field.querySelector?.(".restarbeiten-editbox__label") || loc2Field.children[0],
       location_level_3__label: loc3Field.querySelector?.(".restarbeiten-editbox__label") || loc3Field.children[0],
       location_level_4__label: loc4Field.querySelector?.(".restarbeiten-editbox__label") || loc4Field.children[0],
+      delete_button: deleteBtn,
     };
     this._setItemClass = setItemClass;
     this._wireLocationDatalists();
@@ -597,6 +625,7 @@ export default class RestarbeitenEditbox {
     this.setProjectFirms(this.projectFirms);
     this._updateTextRailCounters();
     this._updateTitle();
+    if (fields.delete_button) fields.delete_button.disabled = !normalizeText(source.id) || this.isDeleting;
 
     const loadedDraftKey = this._draftKeyFor(this.getDraft());
     this.currentItemDraftKey = loadedDraftKey;

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -5,6 +5,7 @@ import {
   listResponsibleProjectFirms,
   listRestarbeitAttachments,
   updateRestarbeitItem,
+  softDeleteRestarbeitItem,
 } from "../data/restarbeitenDataSource.js";
 import { mapRestarbeitenStatusLabel, toRestarbeitenListItems } from "../viewModel/restarbeitenListItems.js";
 import RestarbeitenEditbox from "./RestarbeitenEditbox.js";
@@ -632,6 +633,13 @@ export default class RestarbeitenScreen {
           } finally {
             this.editbox?.setSaving(false);
           }
+        },
+        onDelete: async (itemId) => {
+          if (!normalizeText(itemId)) return;
+          await softDeleteRestarbeitItem(itemId);
+          this.selectedItemId = "";
+          this.attachmentsByItemId.delete(String(itemId));
+          await this.load({ selectItemId: "" });
         },
       });
 

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -145,7 +145,7 @@ export default class RestarbeitenScreen {
     this.editHost = editCanvas;
   }
 
-  async load({ selectItemId = "" } = {}) {
+  async load({ selectItemId = "", keepSelectionEmpty = false } = {}) {
     this.effectiveProjectId = normalizeText(this.projectId || this.project?.id || this.router?.currentProjectId);
 
     if (!this.effectiveProjectId) {
@@ -169,7 +169,9 @@ export default class RestarbeitenScreen {
     this.projectSettings = projectSettings || null;
     this.locationOptions = this._collectLocationOptionsFromRows(this.rows);
 
-    if (selectItemId) {
+    if (keepSelectionEmpty) {
+      this._setSelectedItemId("");
+    } else if (selectItemId) {
       this._setSelectedItemId(selectItemId);
     } else if (!this.selectedItemId && this.rows[0]?.id) {
       this._setSelectedItemId(this.rows[0].id);
@@ -639,7 +641,7 @@ export default class RestarbeitenScreen {
           await softDeleteRestarbeitItem(itemId);
           this.selectedItemId = "";
           this.attachmentsByItemId.delete(String(itemId));
-          await this.load({ selectItemId: "" });
+          await this.load({ selectItemId: "", keepSelectionEmpty: true });
         },
       });
 


### PR DESCRIPTION
### Motivation
- Zusatzbedarf: Ermöglichen, einen ausgewählten Restpunkt (RP) aus der Editbox per Soft Delete zu entfernen, ohne Hard-Delete oder running_number-Änderung.

### Description
- Editbox: `RestarbeitenEditbox` erweitert um `onDelete`-Hook und einen `Löschen`-Button in der Aktionsleiste, der nur bei vorhandener Auswahl aktiv ist; Button zeigt eine Sicherheitsabfrage `Diesen Restpunkt wirklich löschen?` und schützt vor Doppelaufrufen via `isDeleting`.
- Verhalten: Vor dem Löschvorgang werden offene Autosave-Änderungen per `flushAutosave()` abgearbeitet; anschließend wird die vorhandene Soft-Delete-Bridge verwendet (`restarbeitenSoftDeleteItem` / `softDeleteRestarbeitItem`); nach Erfolg wird Auswahl geleert und die Liste neu geladen (Editbox fällt in „keine Auswahl“-Zustand).
- Screen-Integration: `RestarbeitenScreen` verdrahtet `onDelete` und ruft `softDeleteRestarbeitItem` auf, löscht lokale Attachment-Cache-Einträge und lädt die Liste neu; keine DB-Migration oder Hard-Delete-Logik wurde eingefügt.
- Tests: `scripts/tests/restarbeitenModule.test.cjs` erweitert um Assertions für Button-Text, Confirm-Dialog und Soft-Delete-Aufruf; entsprechendes Mocking des IPC/Preload-Handlers wurde ergänzt.
- Geänderte Dateien: `src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js`, `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`, `scripts/tests/restarbeitenModule.test.cjs`.

### Testing
- Ausgeführte gezielte Tests: `node scripts/tests/restarbeitenModule.test.cjs` (grün), `node scripts/tests/restarbeitenDataModel.test.cjs` (grün), `node scripts/tests/projektverwaltungModule.test.cjs` (grün).
- `npm test` in der Codex-Cloud-Umgebung schlägt fehl aufgrund fehlender Systemlib `libatk-1.0.so.0` (Umgebungslimit), die gezielten Modul-Tests sind jedoch grün.
- Ergebnis: Geforderte Soft-Delete-Flows und UI-Guardrails sind durch Tests abgesichert; `npm test`-Problem ist eine CI/runtime-Umgebungsbeschränkung und kein Fehler der Implementierung.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b794978e48322bc55c736b8662fb9)