### PR TITLE
M33: Restarbeiten — gefilterte Liste per V2‑PDF drucken

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1791,6 +1791,89 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(source.includes("Restpunkte (RP)"), true);
   });
 
+  await run("M33.1 Restarbeiten-Druck: Button, Filter-Payload, deleted_at, keine Fotos, Leerfall", async () => {
+    const prevWindow = globalThis.window;
+    const prevDocument = globalThis.document;
+    const printCalls = [];
+    const statusCalls = [];
+    const items = [
+      {
+        id: "r-1", running_number: 1, item_class: "rest", short_text: "Rest A", long_text: "Lang A",
+        location_level_1: "Haus A", location_level_2: "EG", location_level_3: "WE 1", location_level_4: "Bad",
+        status: "offen", due_date: "2026-05-30", responsible_label: "Firma A", completed_at: "", completion_note: "",
+      },
+      {
+        id: "r-2", running_number: 2, item_class: "mangel", short_text: "Mangel A", long_text: "Lang M1",
+        location_level_1: "Haus B", location_level_2: "OG", location_level_3: "WE 2", location_level_4: "Küche",
+        status: "in_arbeit", due_date: "2026-05-20", responsible_label: "Firma B", completed_at: "", completion_note: "Note",
+      },
+      {
+        id: "r-3", running_number: 3, item_class: "mangel", short_text: "Mangel B", long_text: "Lang M2",
+        location_level_1: "Haus C", location_level_2: "DG", location_level_3: "WE 3", location_level_4: "Flur",
+        status: "offen", due_date: "2026-05-21", responsible_label: "Firma C", completed_at: "", completion_note: "",
+        deleted_at: "2026-05-19T10:00:00.000Z",
+      },
+    ];
+    globalThis.window = {
+      bbmPrint: { printPdf: async (payload) => { printCalls.push(payload); return { ok: true }; } },
+      bbmDb: {
+        restarbeitenGetProjectSettings: async () => ({ ok: true, settings: { level_1_label: "Gebäude", level_2_label: "Stock", level_3_label: "Bereich", level_4_label: "Zone" } }),
+        restarbeitenListByProject: async () => ({ ok: true, items: items.map((i) => ({ ...i })) }),
+        projectFirmsListByProject: async () => ({ ok: true, list: [] }),
+        restarbeitenListAttachments: async () => ({ ok: true, attachments: [] }),
+      },
+    };
+    globalThis.document = createFakeDocument();
+
+    try {
+      const RestarbeitenScreen = (await importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"))).default;
+      const screen = new RestarbeitenScreen({ projectId: "p-1" });
+      const root = screen.render();
+      await screen.load();
+      screen.editbox = { setStatus: (msg) => statusCalls.push(msg) };
+
+      const btnPrint = findButtonByText(root, "Drucken");
+      assert.ok(btnPrint);
+      assert.equal(findNodes(root, (n) => n?.tagName === "BUTTON" && String(n?.textContent || "").trim() === "+ Restpunkt").length >= 1, true);
+      assert.equal(findNodes(screen.editHost, (n) => n?.tagName === "BUTTON" && String(n?.textContent || "").trim() === "Drucken").length, 0);
+
+      screen.filterState.item_class = "mangel";
+      screen._renderList();
+      await btnPrint.onclick();
+
+      assert.equal(printCalls.length, 1);
+      assert.equal(printCalls[0].mode, "restarbeiten");
+      assert.equal(printCalls[0].projectId, "p-1");
+      assert.equal(Array.isArray(printCalls[0].restarbeitenRows), true);
+      assert.equal(printCalls[0].restarbeitenRows.length, 1);
+      assert.equal(printCalls[0].restarbeitenRows[0].running_number, 2);
+      assert.equal(printCalls[0].restarbeitenRows[0].item_class, "mangel");
+      assert.deepEqual(printCalls[0].restarbeitenLocationLabels, {
+        level_1_label: "Gebäude",
+        level_2_label: "Stock",
+        level_3_label: "Bereich",
+        level_4_label: "Zone",
+      });
+      const row = printCalls[0].restarbeitenRows[0];
+      for (const key of ["running_number","item_class","short_text","long_text","location_level_1","location_level_2","location_level_3","location_level_4","status","due_date","responsible_label","completed_at","completion_note"]) {
+        assert.equal(Object.prototype.hasOwnProperty.call(row, key), true);
+      }
+      for (const key of ["attachments", "photos", "file_path", "thumbnail_path"]) {
+        assert.equal(Object.prototype.hasOwnProperty.call(row, key), false);
+      }
+
+      screen.filterState.item_class = "mangel";
+      screen.filterState.location_level_1 = "Nicht vorhanden";
+      screen._renderList();
+      await btnPrint.onclick();
+      assert.equal(printCalls.length, 1);
+      assert.equal(statusCalls.includes("Keine Restpunkte für den Druck vorhanden."), true);
+    } finally {
+      globalThis.window = prevWindow;
+      globalThis.document = prevDocument;
+    }
+  });
+
 
   await run("M30.1 Guardrails: Create-Pfade bereinigen running_number/deleted_at", () => {
     const dsPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js");

--- a/src/main/ipc/printIpc.js
+++ b/src/main/ipc/printIpc.js
@@ -351,6 +351,7 @@ async function printToPdf(payload = {}) {
     settingsOverride: payload.settingsOverride || null,
     orientation,
     todoResponsibleFilter: payload.todoResponsibleFilter || null,
+    restarbeitenRows: payload.restarbeitenRows || null,
   });
   const projectNumber = data?.project?.project_number || data?.project?.projectNumber || null;
 
@@ -482,6 +483,7 @@ function registerPrintIpc() {
         settingsOverride: p.settingsOverride || null,
         orientation,
         todoResponsibleFilter: p.todoResponsibleFilter || null,
+        restarbeitenRows: p.restarbeitenRows || null,
       });
       // Version/Channel für PDF-Footer mitgeben
       data.appVersion = app.getVersion ? app.getVersion() : "";

--- a/src/main/ipc/printIpc.js
+++ b/src/main/ipc/printIpc.js
@@ -352,6 +352,7 @@ async function printToPdf(payload = {}) {
     orientation,
     todoResponsibleFilter: payload.todoResponsibleFilter || null,
     restarbeitenRows: payload.restarbeitenRows || null,
+    restarbeitenLocationLabels: payload.restarbeitenLocationLabels || null,
   });
   const projectNumber = data?.project?.project_number || data?.project?.projectNumber || null;
 
@@ -451,6 +452,8 @@ async function printToPdf(payload = {}) {
         mode,
         projectId,
         meetingId,
+        restarbeitenRows: payload.restarbeitenRows || null,
+        restarbeitenLocationLabels: payload.restarbeitenLocationLabels || null,
         settingsOverride: payload.settingsOverride || null,
         orientation,
         testOrientation: payload.testOrientation || null,
@@ -484,6 +487,7 @@ function registerPrintIpc() {
         orientation,
         todoResponsibleFilter: p.todoResponsibleFilter || null,
         restarbeitenRows: p.restarbeitenRows || null,
+        restarbeitenLocationLabels: p.restarbeitenLocationLabels || null,
       });
       // Version/Channel für PDF-Footer mitgeben
       data.appVersion = app.getVersion ? app.getVersion() : "";
@@ -512,6 +516,8 @@ function registerPrintIpc() {
           mode: p.mode || "topsAll",
           projectId: p.projectId || null,
           meetingId: p.meetingId || null,
+          restarbeitenRows: p.restarbeitenRows || null,
+          restarbeitenLocationLabels: p.restarbeitenLocationLabels || null,
           settingsOverride: p.settingsOverride || null,
           orientation,
           testOrientation: p.testOrientation || null,

--- a/src/main/print/printData.js
+++ b/src/main/print/printData.js
@@ -912,12 +912,14 @@ function _loadPrintDocumentContent({
   settings,
   todoResponsibleFilter,
   restarbeitenRows,
+  restarbeitenLocationLabels,
 } = {}) {
   let participants = [];
   let tops = [];
   let firms = [];
   let todoRows = [];
   let restarbeitenItems = [];
+  let restarbeitenLabels = null;
 
   if (mode === "preview" || mode === "protocol" || mode === "headerTest") {
     participants = _listMeetingParticipants(db, meetingId);
@@ -950,6 +952,7 @@ function _loadPrintDocumentContent({
     }
   } else if (mode === "restarbeiten") {
     restarbeitenItems = Array.isArray(restarbeitenRows) ? restarbeitenRows : [];
+    restarbeitenLabels = restarbeitenLocationLabels || null;
   }
 
   return {
@@ -958,6 +961,7 @@ function _loadPrintDocumentContent({
     firms,
     todoRows,
     restarbeitenItems,
+    restarbeitenLocationLabels: restarbeitenLabels,
   };
 }
 
@@ -969,6 +973,7 @@ async function getPrintData({
   orientation,
   todoResponsibleFilter,
   restarbeitenRows,
+  restarbeitenLocationLabels,
 } = {}) {
   const { resolvePrintMode } = await _loadPrintModesModule();
   const normalizedMode = resolvePrintMode(mode, { fallback: "protocol" });
@@ -998,6 +1003,7 @@ async function getPrintData({
     settings: runtimeContext.settings, 
     todoResponsibleFilter, 
     restarbeitenRows,
+    restarbeitenLocationLabels,
   }); 
  
   const status = getStatus({ fresh: false }); 

--- a/src/main/print/printData.js
+++ b/src/main/print/printData.js
@@ -49,6 +49,7 @@ function _docLabelForMode(mode) {
   if (m === "topsAll") return "TOP-Liste";
   if (m === "firms") return "Firmenliste";
   if (m === "todo") return "ToDo-Liste";
+  if (m === "restarbeiten") return "Restarbeitenliste";
   if (m === "headerTest") return "Kopf-Test";
   return "Dokument";
 }
@@ -91,7 +92,7 @@ function _resolvePrintProfile(mode) {
     };
   }
 
-  if (m === "firms" || m === "todo" || m === "topsAll") {
+  if (m === "firms" || m === "todo" || m === "topsAll" || m === "restarbeiten") {
     return {
       key: "list",
       parent: "base",
@@ -910,11 +911,13 @@ function _loadPrintDocumentContent({
   meeting,
   settings,
   todoResponsibleFilter,
+  restarbeitenRows,
 } = {}) {
   let participants = [];
   let tops = [];
   let firms = [];
   let todoRows = [];
+  let restarbeitenItems = [];
 
   if (mode === "preview" || mode === "protocol" || mode === "headerTest") {
     participants = _listMeetingParticipants(db, meetingId);
@@ -945,6 +948,8 @@ function _loadPrintDocumentContent({
         return key === filter.toLowerCase();
       });
     }
+  } else if (mode === "restarbeiten") {
+    restarbeitenItems = Array.isArray(restarbeitenRows) ? restarbeitenRows : [];
   }
 
   return {
@@ -952,6 +957,7 @@ function _loadPrintDocumentContent({
     tops,
     firms,
     todoRows,
+    restarbeitenItems,
   };
 }
 
@@ -962,6 +968,7 @@ async function getPrintData({
   settingsOverride,
   orientation,
   todoResponsibleFilter,
+  restarbeitenRows,
 } = {}) {
   const { resolvePrintMode } = await _loadPrintModesModule();
   const normalizedMode = resolvePrintMode(mode, { fallback: "protocol" });
@@ -990,6 +997,7 @@ async function getPrintData({
     meeting: runtimeContext.meeting, 
     settings: runtimeContext.settings, 
     todoResponsibleFilter, 
+    restarbeitenRows,
   }); 
  
   const status = getStatus({ fresh: false }); 

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -33,6 +33,15 @@ function buildCompactLocation(item = {}) {
   return values.length ? values.join(" · ") : "—";
 }
 
+function buildRestarbeitenLocationLabels(projectSettings = null) {
+  return {
+    level_1_label: normalizeText(projectSettings?.level_1_label) || "Haus",
+    level_2_label: normalizeText(projectSettings?.level_2_label) || "Geschoss",
+    level_3_label: normalizeText(projectSettings?.level_3_label) || "Einheit",
+    level_4_label: normalizeText(projectSettings?.level_4_label) || "Raum",
+  };
+}
+
 export default class RestarbeitenScreen {
   constructor({ router, projectId, project, moduleId } = {}) {
     this.router = router || null;
@@ -725,6 +734,7 @@ export default class RestarbeitenScreen {
       mode: "restarbeiten",
       projectId: this.effectiveProjectId,
       restarbeitenRows,
+      restarbeitenLocationLabels: buildRestarbeitenLocationLabels(this.projectSettings),
     });
   }
 }

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -107,7 +107,12 @@ export default class RestarbeitenScreen {
     btnClose.textContent = "Schließen";
     btnClose.onclick = () => this.router?.showProjectWorkspace?.();
 
-    actions.append(btnClose);
+    const btnPrint = doc.createElement("button");
+    btnPrint.type = "button";
+    btnPrint.textContent = "Drucken";
+    btnPrint.onclick = () => this._printFilteredList();
+
+    actions.append(btnPrint, btnClose);
     header.append(filters, actions);
 
     this.headerHost = header;
@@ -682,5 +687,44 @@ export default class RestarbeitenScreen {
     const target = Number(this.sheetArea.scrollHeight || 0) - Number(this.sheetArea.clientHeight || 0);
     this.sheetArea.scrollTop = target > 0 ? target : 0;
     this.createScrollPending = false;
+  }
+
+  async _printFilteredList() {
+    const visibleItems = Array.isArray(this.filteredItems) ? this.filteredItems : [];
+    if (!visibleItems.length) {
+      this.editbox?.setStatus("Keine Restpunkte für den Druck vorhanden.");
+      return;
+    }
+    const rowsById = new Map(this.rows.map((row) => [String(row?.id), row]));
+    const restarbeitenRows = visibleItems
+      .map((item) => {
+        const row = rowsById.get(String(item.id));
+        if (!row || row.deleted_at) return null;
+        return {
+          running_number: row.running_number || "",
+          item_class: row.item_class || "",
+          short_text: row.short_text || "",
+          long_text: row.long_text || "",
+          location_level_1: row.location_level_1 || "",
+          location_level_2: row.location_level_2 || "",
+          location_level_3: row.location_level_3 || "",
+          location_level_4: row.location_level_4 || "",
+          status: row.status || "",
+          due_date: row.due_date || "",
+          responsible_label: row.responsible_label || "",
+          completed_at: row.completed_at || "",
+          completion_note: row.completion_note || "",
+        };
+      })
+      .filter(Boolean);
+    if (!restarbeitenRows.length) {
+      this.editbox?.setStatus("Keine Restpunkte für den Druck vorhanden.");
+      return;
+    }
+    await globalThis.window?.bbmPrint?.printPdf?.({
+      mode: "restarbeiten",
+      projectId: this.effectiveProjectId,
+      restarbeitenRows,
+    });
   }
 }

--- a/src/renderer/print/layout/PrintShell.js
+++ b/src/renderer/print/layout/PrintShell.js
@@ -93,6 +93,8 @@ function _buildTableHead(type, topsLayout) {
     tr.innerHTML = `<th>Firma</th><th>Typ</th><th>Aktiv</th>`;
   } else if (type === "todo") {
     tr.innerHTML = `<th>TOP</th><th>Kurztext</th><th>Status</th><th>Fertig bis</th><th>Ampel</th>`;
+  } else if (type === "restarbeiten") {
+    tr.innerHTML = `<th>Nr.</th><th>Klasse</th><th>Kurztext</th><th>Langtext</th><th>Haus</th><th>Geschoss</th><th>Einheit</th><th>Raum</th><th>Status</th><th>Fertig bis</th><th>Verantwortlich</th><th>erledigt am</th><th>Notiz/Maßnahmen</th>`;
   }
 
   thead.appendChild(tr);
@@ -214,6 +216,13 @@ function _buildGenericRow(row) {
     const tdAmpel = _el("td", "todoAmpelCell");
     if (row.ampelColor) tdAmpel.appendChild(_el("span", `ampelDot ${row.ampelColor}`));
     tr.appendChild(tdAmpel);
+    return tr;
+  }
+  if (row?.kind === "restarbeitItem") {
+    const tr = document.createElement("tr");
+    tr.className = "restarbeitItemRow";
+    const cells = Array.isArray(row.cells) ? row.cells : [];
+    for (const cell of cells) tr.appendChild(_el("td", "", cell || ""));
     return tr;
   }
 
@@ -378,6 +387,7 @@ function _buildTable(page, data) {
   else if (type === "firms") table.className = "firmsTable";
   else if (type === "firmsCards") table.className = "firmsCardsTable";
   else if (type === "todo") table.className = "todoTable";
+  else if (type === "restarbeiten") table.className = "restarbeitenTable";
   _applyTopsTableLayout(table, topsLayout);
 
   const colgroup = _buildColGroup(type, topsLayout);
@@ -400,9 +410,11 @@ function _buildTable(page, data) {
           ? "Keine Firmen vorhanden."
           : type === "todo"
             ? "Keine offenen ToDos vorhanden."
+            : type === "restarbeiten"
+              ? "Keine Restpunkte für den Druck vorhanden."
             : "Keine Einträge vorhanden.";
     const td = _el("td", "", msg);
-    td.colSpan = type === "todo" ? 5 : type === "firms" ? 3 : 1;
+    td.colSpan = type === "todo" ? 5 : type === "firms" ? 3 : type === "restarbeiten" ? 13 : 1;
     tr.appendChild(td);
     tbody.appendChild(tr);
   }

--- a/src/renderer/print/layout/PrintShell.js
+++ b/src/renderer/print/layout/PrintShell.js
@@ -94,7 +94,12 @@ function _buildTableHead(type, topsLayout) {
   } else if (type === "todo") {
     tr.innerHTML = `<th>TOP</th><th>Kurztext</th><th>Status</th><th>Fertig bis</th><th>Ampel</th>`;
   } else if (type === "restarbeiten") {
-    tr.innerHTML = `<th>Nr.</th><th>Klasse</th><th>Kurztext</th><th>Langtext</th><th>Haus</th><th>Geschoss</th><th>Einheit</th><th>Raum</th><th>Status</th><th>Fertig bis</th><th>Verantwortlich</th><th>erledigt am</th><th>Notiz/Maßnahmen</th>`;
+    const labels = globalThis.__bbmRestarbeitenLocationLabels || {};
+    const level1 = String(labels.level_1_label || "").trim() || "Haus";
+    const level2 = String(labels.level_2_label || "").trim() || "Geschoss";
+    const level3 = String(labels.level_3_label || "").trim() || "Einheit";
+    const level4 = String(labels.level_4_label || "").trim() || "Raum";
+    tr.innerHTML = `<th>Nr.</th><th>Klasse</th><th>Kurztext</th><th>Langtext</th><th>${level1}</th><th>${level2}</th><th>${level3}</th><th>${level4}</th><th>Status</th><th>Fertig bis</th><th>Verantwortlich</th><th>erledigt am</th><th>Notiz/Maßnahmen</th>`;
   }
 
   thead.appendChild(tr);
@@ -584,6 +589,7 @@ export function renderPrint({ pages, data } = {}) {
     throw new Error(`Unbekannter Druckmodus: ${String(data?.mode || "").trim() || "-"}`);
   }
   const runtimeData = { ...(data || {}), mode: normalizedMode };
+  globalThis.__bbmRestarbeitenLocationLabels = runtimeData?.restarbeitenLocationLabels || null;
   const root = _el("div", "printRoot printV2Root");
   root.dataset.orientation = _normalizeOrientation(runtimeData?.orientation);
   root.dataset.tableLayout = _getTopLayout(runtimeData).tableKey || "protokoll_tops";

--- a/src/renderer/print/printApp.js
+++ b/src/renderer/print/printApp.js
@@ -57,6 +57,7 @@ function _docLabel(mode) {
   if (normalizedMode === "topsAll") return "TOP-Liste";
   if (normalizedMode === "firms") return "Firmenliste";
   if (normalizedMode === "todo") return "ToDo-Liste";
+  if (normalizedMode === "restarbeiten") return "Restarbeitenliste";
   if (normalizedMode === "headerTest") return "Kopf-Test";
   return "Dokument";
 }
@@ -1725,6 +1726,30 @@ function _buildPages(data) {
       });
     }
     return _paginateGeneric({ rows, type: "todo", projectLabel, docLabel, data });
+  }
+  if (mode === "restarbeiten") {
+    const rows = [];
+    for (const r of data.restarbeitenItems || []) {
+      rows.push({
+        kind: "restarbeitItem",
+        cells: [
+          r.running_number || "",
+          String(r.item_class || "").toLowerCase() === "mangel" ? "M" : "R",
+          r.short_text || "",
+          r.long_text || "",
+          r.location_level_1 || "",
+          r.location_level_2 || "",
+          r.location_level_3 || "",
+          r.location_level_4 || "",
+          r.status || "",
+          _formatDateIso(r.due_date),
+          r.responsible_label || "",
+          _formatDateIso(r.completed_at),
+          r.completion_note || "",
+        ],
+      });
+    }
+    return _paginateGeneric({ rows, type: "restarbeiten", projectLabel, docLabel, data });
   }
 
   return _paginateTops(data);

--- a/src/renderer/print/v2/header/headerUtils.js
+++ b/src/renderer/print/v2/header/headerUtils.js
@@ -35,6 +35,7 @@ function _docLabelFromMode(mode) {
   if (m === "topsAll") return "Liste aller Top´s im Projekt";
   if (m === "firms") return "Firmenliste";
   if (m === "todo") return "ToDo-Liste";
+  if (m === "restarbeiten") return "Restarbeitenliste";
   if (m === "headerTest") return "Kopf-Test";
   return "Dokument";
 }
@@ -154,7 +155,7 @@ function _resolveHeaderTitle({ data, settings, meeting, modeLabel } = {}) {
 
 function _listStandLine({ data, meeting } = {}) {
   const mode = String(data?.mode || "").trim();
-  if (!(mode === "firms" || mode === "todo" || mode === "topsAll" || mode === "protocol")) return "";
+  if (!(mode === "firms" || mode === "todo" || mode === "topsAll" || mode === "protocol" || mode === "restarbeiten")) return "";
   // In der v2-Vollkopfzeile sollen für Protokoll/Vorabzug keine Nummer-/Datumszeilen angezeigt werden.
   if (mode === "protocol" || mode === "preview") return "";
 

--- a/src/shared/print/printModes.mjs
+++ b/src/shared/print/printModes.mjs
@@ -26,6 +26,11 @@ const PRINT_MODE_DEFINITIONS = Object.freeze([
     dialogLabel: "ToDo-Liste",
   }),
   Object.freeze({
+    key: "restarbeiten",
+    label: "Restarbeitenliste",
+    dialogLabel: "Restarbeitenliste",
+  }),
+  Object.freeze({
     key: "topsAll",
     label: "TOP-Liste",
     dialogLabel: "TOP-Liste",


### PR DESCRIPTION
### Motivation
- Benutzer sollen die aktuell sichtbare/gefilterte Restarbeitenliste direkt über den vorhandenen V2‑PDF-Ausgabeweg drucken können. 
- Es soll keine neue PDF‑Architektur oder externe Bibliothek eingeführt werden, sondern der bestehende V2-Flow minimal erweitert werden. 
- Die Ausgabe muss nur sichtbare (nicht gelöschte) Einträge in der Reihenfolge der Listendarstellung enthalten und Guardrails (keine Fotos, kein Protokoll‑Umbau) wahren. 

### Description
- UI: In der Filter-/Listenaktionsleiste des Restarbeiten‑Screens wurde ein Button `Drucken` ergänzt, der die aktuell gefilterten sichtbaren Items sammelt und den Druck startet (`src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`).
- Print‑Mode: Ein neuer Print‑Mode `restarbeiten` wurde zu `src/shared/print/printModes.mjs` hinzugefügt und in den Print‑Data/IPC‑Pfad eingebunden, so dass `restarbeitenRows` als kleiner, spezifischer Payload durchgereicht wird (`src/main/ipc/printIpc.js`, `src/main/print/printData.js`).
- Renderer: Der V2‑Renderer erhält Darstellung/Tabellenkopf und Seitenpaginierung für die Restarbeitenliste, inklusive Zeilenaufbau und Empty‑State (`src/renderer/print/printApp.js`, `src/renderer/print/layout/PrintShell.js`) und Header‑Beschriftung in `src/renderer/print/v2/header/headerUtils.js`.
- Minimal und modulnah implementiert: Bestehender V2‑Printflow und IPC/API bleiben erhalten; es wurde nur die REST‑spezifische Payload/Render‑Integration ergänzt (keine Änderungen an Protokoll/TOP‑Logik). 

### Testing
- `node scripts/tests/restarbeitenModule.test.cjs` wurde ausgeführt und lieferte erfolgreiches Ergebnis. 
- `node scripts/tests/restarbeitenDataModel.test.cjs` und `node scripts/tests/projektverwaltungModule.test.cjs` wurden ausgeführt und lieferten erfolgreiche Ergebnisse. 
- `npm test` konnte in dieser Cloud‑Umgebung nicht vollständig ausgeführt werden, da Electron wegen fehlender Systembibliothek (`libatk-1.0.so.0`) nicht startet; die gezielten Restarbeiten‑Tests sind jedoch grün.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c0fb765288322834033ce560dfdeb)