### PR TITLE
Fix M33 restarbeiten test guardrails

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -285,7 +285,9 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(content, /restarbeiten-list__photosToggle/);
     assert.match(content, /dataset\.expanded/);
     assert.doesNotMatch(content, /tr\.innerHTML|innerHTML\s*=\s*\[/);
-    assert.doesNotMatch(content, /Diktat|Druck|Mail|Loeschen|Archivieren/);
+    assert.doesNotMatch(content, /Diktat|Mail|Archivieren/);
+    assert.match(content, /Drucken/);
+    assert.match(content, /_printFilteredList/);
     assert.match(styleContent, /restarbeiten-sheet__list/);
   });
 
@@ -576,7 +578,12 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(Boolean(deleteBtn), true);
       assert.equal(deleteBtn.disabled, false);
       await deleteBtn.click();
-      const deleteDialog = screen.editbox.root.querySelector?.(".restarbeiten-editbox__deleteDialog");
+      await Promise.resolve();
+      const deleteDialog =
+        screen.editbox.root.querySelector?.(".restarbeiten-editbox__deleteDialog") ||
+        findNodes(screen.editbox.root, (n) =>
+          String(n?.className || "").includes("restarbeiten-editbox__deleteDialog")
+        )[0];
       assert.equal(Boolean(deleteDialog), true);
       assert.match(deleteDialog.textContent, /Diesen Restpunkt wirklich löschen\?/);
       const cancelBtn = findButtonByText(deleteDialog, "Abbrechen");
@@ -587,7 +594,12 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(calls.some((call) => call.type === "soft-delete"), false);
 
       await deleteBtn.click();
-      const deleteDialog2 = screen.editbox.root.querySelector?.(".restarbeiten-editbox__deleteDialog");
+      await Promise.resolve();
+      const deleteDialog2 =
+        screen.editbox.root.querySelector?.(".restarbeiten-editbox__deleteDialog") ||
+        findNodes(screen.editbox.root, (n) =>
+          String(n?.className || "").includes("restarbeiten-editbox__deleteDialog")
+        )[0];
       const confirmDeleteBtn2 = findButtonByText(deleteDialog2, "Löschen");
       await confirmDeleteBtn2.click();
       assert.equal(calls.find((call) => call.type === "soft-delete")?.payload.id, "r-1");
@@ -719,7 +731,10 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(dataSource, /importRestarbeitAttachments\(/);
     assert.match(dataSource, /deleteRestarbeitAttachment\(/);
     assert.doesNotMatch(screen, /innerHTML\s*=/);
-    assert.doesNotMatch(editbox + view + screen, /Diktat|Druck|Mail|Bildbearbeitung/);
+    assert.doesNotMatch(editbox + view, /Diktat|Druck|Mail|Bildbearbeitung/);
+    assert.doesNotMatch(screen, /Diktat|Mail|Bildbearbeitung/);
+    assert.match(screen, /Drucken/);
+    assert.match(screen, /_printFilteredList/);
   });
 
 


### PR DESCRIPTION
### Motivation
- Nach M33 führen veraltete Test-Guardrails dazu, dass `npm test` für das Restarbeiten-Paket rot läuft, und der Delete-Dialog-Test ist im Fake‑DOM nicht stabil.
- Ziel ist, die Tests zu aktualisieren und nur die Tests robuster zu machen, ohne Produktionslogik oder Layout zu ändern.

### Description
- Aktualisiert `scripts/tests/restarbeitenModule.test.cjs` um die M14-Guardrails: `Druck/Drucken` und `_printFilteredList` sind im Screen jetzt erlaubt, weiterhin verboten bleiben `Diktat`, `Mail` und `Archivieren`.
- Trennung der M7-Prüfungen: `editbox + view` verbietet weiterhin `Diktat|Druck|Mail|Bildbearbeitung`, während `screen` nur noch `Diktat|Mail|Bildbearbeitung` verbietet und `Drucken`/_printFilteredList positiv absichert.
- Robustere M5-Delete-Dialog-Abfrage: nach `deleteBtn.click()` wird ein Microtask abgewartet (`await Promise.resolve()`), und der Dialog wird per `querySelector` mit `findNodes(...)`-Fallback gesucht (für beide Delete-Durchläufe).
- Nur eine Datei wurde geändert: `scripts/tests/restarbeitenModule.test.cjs`.

### Testing
- `npm test` wurde ausgeführt und schlug in dieser Umgebung fehl, weil native Electron‑Libraries fehlen (`libatk-1.0.so.0: cannot open shared object file`), daher konnten die Änderungen nicht vollständig in dieser Umgebung grün verifiziert werden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1cd47e4483229f5a044149b73ebb)