### PR TITLE
M33.4: Add Restarbeiten project folder and mode-based feature guard for printing

### DIFF
--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -99,6 +99,7 @@ async function main() {
     assert.equal(out.protocolsDir, path.join("C:\\Daten", "bbm", "12 - Test", "Protokolle"));
     assert.equal(out.previewDir, path.join("C:\\Daten", "bbm", "12 - Test", "Vorabzug"));
     assert.equal(out.listsDir, path.join("C:\\Daten", "bbm", "12 - Test", "Listen"));
+    assert.equal(out.restarbeitenDir, path.join("C:\\Daten", "bbm", "12 - Test", "Restarbeiten"));
   });
 
   await runTopsStoreTests(run);

--- a/scripts/tests/licenseFeatureGuards.test.cjs
+++ b/scripts/tests/licenseFeatureGuards.test.cjs
@@ -40,7 +40,27 @@ async function runLicenseFeatureGuardTests(run) {
   await run("License-Guard: PDF-IPC nutzt modebasierte Feature-Zuordnung", () => {
     assert.equal(printIpc.includes("function _featureForPrintMode(mode)"), true);
     assert.equal(printIpc.includes('if (m === "restarbeiten") return "restarbeiten";'), true);
+    assert.equal(printIpc.includes('ipcMain.handle("print:getData"'), true);
+    assert.equal(printIpc.includes('ipcMain.handle("print:openHtmlPreview"'), true);
+    assert.equal(printIpc.includes('ipcMain.handle("print:toPdf"'), true);
+    assert.equal(printIpc.includes('ipcMain.handle("print:htmlToPdf"'), true);
     assert.equal(printIpc.includes("_enforceFeature(_featureForPrintMode(p.mode));"), true);
+  });
+
+  await run("License-Guard: Protokoll-Listenendpunkte bleiben protokollgeschuetzt", () => {
+    assert.equal(printIpc.includes('ipcMain.handle("protocol:findStoredPdf"'), true);
+    assert.equal(printIpc.includes('_enforceFeature("protokoll");'), true);
+    assert.equal(printIpc.includes('ipcMain.handle("firms:listStoredPdfs"'), true);
+    assert.equal(printIpc.includes('_enforceFeature(_featureForStoredProjectKind(p.kind));'), true);
+    assert.equal(printIpc.includes('function _featureForStoredProjectKind(kind)'), true);
+  });
+
+
+  await run("License-Guard: protocol:findStoredPdf darf nicht modebasiert sein", () => {
+    const idx = printIpc.indexOf('ipcMain.handle("protocol:findStoredPdf"');
+    assert.equal(idx >= 0, true);
+    const slice = printIpc.slice(idx, idx + 320);
+    assert.equal(slice.includes('_featureForPrintMode(p.mode)'), false);
   });
 
   await run("License-Guard: Audio-IPC prüft Diktat-Feature", () => {

--- a/scripts/tests/licenseFeatureGuards.test.cjs
+++ b/scripts/tests/licenseFeatureGuards.test.cjs
@@ -37,8 +37,10 @@ async function runLicenseFeatureGuardTests(run) {
   const topsScreenSource = read("src/renderer/modules/protokoll/screens/TopsScreen.js");
   const dictationControllerSource = read("src/renderer/features/audio-dictation/DictationController.js");
 
-  await run("License-Guard: PDF-IPC prüft Protokoll-Modul", () => {
-    assert.equal(printIpc.includes('_enforceFeature("protokoll");'), true);
+  await run("License-Guard: PDF-IPC nutzt modebasierte Feature-Zuordnung", () => {
+    assert.equal(printIpc.includes("function _featureForPrintMode(mode)"), true);
+    assert.equal(printIpc.includes('if (m === "restarbeiten") return "restarbeiten";'), true);
+    assert.equal(printIpc.includes("_enforceFeature(_featureForPrintMode(p.mode));"), true);
   });
 
   await run("License-Guard: Audio-IPC prüft Diktat-Feature", () => {

--- a/src/main/ipc/printIpc.js
+++ b/src/main/ipc/printIpc.js
@@ -100,6 +100,7 @@ function _folderForMode(mode) {
   if (m === "protocol") return "Protokolle";
   if (m === "preview" || m === "vorabzug") return "Vorabzug";
   if (m === "todo" || m === "topsall" || m === "firms") return "Listen";
+  if (m === "restarbeiten") return "Restarbeiten";
   return "PDF";
 }
 
@@ -313,6 +314,12 @@ function _enforceFeature(feature) {
   enforceLicensedFeature(feature);
 }
 
+function _featureForPrintMode(mode) {
+  const m = String(mode || "").trim().toLowerCase();
+  if (m === "restarbeiten") return "restarbeiten";
+  return "protokoll";
+}
+
 function attachPrintDebugPipes(win, jobId) {
   win.webContents.on("console-message", (_event, level, message, line, sourceId) => {
     const lvl = ["LOG", "WARN", "ERROR", "DEBUG"][level] || String(level);
@@ -476,8 +483,8 @@ function registerPrintIpc() {
   // Stable technical service entry points for renderer callers.
   ipcMain.handle("print:getData", async (_evt, payload) =>
     _runIpcTask(async () => {
-      _enforceFeature("protokoll");
       const p = payload || {};
+      _enforceFeature(_featureForPrintMode(p.mode));
       const orientation = _resolveRequestedOrientation(p);
       const data = await getPrintData({
         mode: p.mode,
@@ -498,12 +505,12 @@ function registerPrintIpc() {
 
   ipcMain.handle("print:openHtmlPreview", async (_evt, payload) =>
     _runIpcTask(async () => {
-      _enforceFeature("protokoll");
+      const p = payload || {};
+      _enforceFeature(_featureForPrintMode(p.mode));
       if (app.isPackaged) {
         return { ok: false, error: "DEV-only." };
       }
 
-      const p = payload || {};
       const orientation = _resolveRequestedOrientation(p);
       const jobId = _randId();
       const win = createPrintWindow({ show: true, devTools: false });
@@ -542,13 +549,14 @@ function registerPrintIpc() {
 
   ipcMain.handle("print:toPdf", async (_evt, payload) =>
     _runIpcTask(async () => {
-      _enforceFeature("protokoll");
+      const p = payload || {};
+      _enforceFeature(_featureForPrintMode(p.mode));
       console.log(
         `[PRINT_ACTIVE] handler=print:toPdf payload.mode=${payload?.mode || ""} projectId=${
           payload?.projectId ?? ""
         } meetingId=${payload?.meetingId ?? ""}`
       );
-      const outPath = await printToPdf(payload || {});
+      const outPath = await printToPdf(p);
       return { ok: true, filePath: outPath };
     })
   );
@@ -556,8 +564,8 @@ function registerPrintIpc() {
 
   ipcMain.handle("protocol:findStoredPdf", async (_evt, payload) =>
     _runIpcTask(async () => {
-      _enforceFeature("protokoll");
       const p = payload || {};
+      _enforceFeature(_featureForPrintMode(p.mode));
       return findStoredProtocolPdf({
         baseDir: p.baseDir,
         project: p.project || null,
@@ -569,8 +577,8 @@ function registerPrintIpc() {
 
   ipcMain.handle("firms:listStoredPdfs", async (_evt, payload) =>
     _runIpcTask(async () => {
-      _enforceFeature("protokoll");
       const p = payload || {};
+      _enforceFeature(_featureForPrintMode(p.mode));
       return listStoredFirmsPdfs({
         baseDir: p.baseDir,
         project: p.project || null,
@@ -580,8 +588,8 @@ function registerPrintIpc() {
 
   ipcMain.handle("print:listStoredProjectPdfs", async (_evt, payload) =>
     _runIpcTask(async () => {
-      _enforceFeature("protokoll");
       const p = payload || {};
+      _enforceFeature(_featureForPrintMode(p.mode));
       return listStoredProjectPdfs({
         baseDir: p.baseDir,
         project: p.project || null,
@@ -592,13 +600,14 @@ function registerPrintIpc() {
 
   ipcMain.handle("print:htmlToPdf", async (_evt, payload) =>
     _runIpcTask(async () => {
-      _enforceFeature("protokoll");
+      const p = payload || {};
+      _enforceFeature(_featureForPrintMode(p.mode));
       console.log(
         `[PRINT_ACTIVE] handler=print:htmlToPdf payload.mode=${payload?.mode || ""} projectId=${
           payload?.projectId ?? ""
         } meetingId=${payload?.meetingId ?? ""}`
       );
-      const outPath = await printToPdf(payload || {});
+      const outPath = await printToPdf(p);
       return { ok: true, filePath: outPath };
     })
   );

--- a/src/main/ipc/printIpc.js
+++ b/src/main/ipc/printIpc.js
@@ -320,6 +320,12 @@ function _featureForPrintMode(mode) {
   return "protokoll";
 }
 
+function _featureForStoredProjectKind(kind) {
+  const k = String(kind || "").trim().toLowerCase();
+  if (k === "protocol") return "protokoll";
+  return "protokoll";
+}
+
 function attachPrintDebugPipes(win, jobId) {
   win.webContents.on("console-message", (_event, level, message, line, sourceId) => {
     const lvl = ["LOG", "WARN", "ERROR", "DEBUG"][level] || String(level);
@@ -565,7 +571,7 @@ function registerPrintIpc() {
   ipcMain.handle("protocol:findStoredPdf", async (_evt, payload) =>
     _runIpcTask(async () => {
       const p = payload || {};
-      _enforceFeature(_featureForPrintMode(p.mode));
+      _enforceFeature("protokoll");
       return findStoredProtocolPdf({
         baseDir: p.baseDir,
         project: p.project || null,
@@ -578,7 +584,7 @@ function registerPrintIpc() {
   ipcMain.handle("firms:listStoredPdfs", async (_evt, payload) =>
     _runIpcTask(async () => {
       const p = payload || {};
-      _enforceFeature(_featureForPrintMode(p.mode));
+      _enforceFeature("protokoll");
       return listStoredFirmsPdfs({
         baseDir: p.baseDir,
         project: p.project || null,
@@ -589,7 +595,7 @@ function registerPrintIpc() {
   ipcMain.handle("print:listStoredProjectPdfs", async (_evt, payload) =>
     _runIpcTask(async () => {
       const p = payload || {};
-      _enforceFeature(_featureForPrintMode(p.mode));
+      _enforceFeature(_featureForStoredProjectKind(p.kind));
       return listStoredProjectPdfs({
         baseDir: p.baseDir,
         project: p.project || null,

--- a/src/main/ipc/projectStoragePaths.js
+++ b/src/main/ipc/projectStoragePaths.js
@@ -33,6 +33,7 @@ function buildStoragePreviewPaths({ baseDir, project } = {}) {
     protocolsDir: path.join(projectBaseDir, "Protokolle"),
     previewDir: path.join(projectBaseDir, "Vorabzug"),
     listsDir: path.join(projectBaseDir, "Listen"),
+    restarbeitenDir: path.join(projectBaseDir, "Restarbeiten"),
   };
 }
 


### PR DESCRIPTION
### Motivation
- Ensure `Restarbeiten` prints are stored in their own project subfolder and not routed to the generic PDF fallback. 
- Make print/preview license checks mode-aware so `restarbeiten` is guarded by the `restarbeiten` feature instead of being implicitly tied to `protokoll`.

### Description
- Extended folder mapping in `printIpc.js` by adding `Restarbeiten` to `_folderForMode` and creating a new helper `function _featureForPrintMode(mode)` that returns `restarbeiten` for that mode and `protokoll` otherwise.
- Replaced hardcoded `_enforceFeature("protokoll")` calls in print/preview IPC handlers with `_enforceFeature(_featureForPrintMode(p.mode))` and normalized handler payload usage to `p` where needed in `src/main/ipc/printIpc.js`.
- Added `restarbeitenDir` to the preview/build paths in `src/main/ipc/projectStoragePaths.js` via `buildStoragePreviewPaths(...)` so `projects:storagePreview` now includes `restarbeitenDir` alongside existing fields.
- Adjusted tests to verify the new paths and feature-mapping: `scripts/test.cjs` asserts `restarbeitenDir` is returned and `scripts/tests/licenseFeatureGuards.test.cjs` checks for the `_featureForPrintMode` pattern and its enforcement usage.

### Testing
- Ran `node scripts/tests/restarbeitenModule.test.cjs` and it completed successfully (tests passed). 
- Ran `node scripts/tests/projektverwaltungModule.test.cjs` and it completed successfully (tests passed). 
- Ran full node test runner `node scripts/test.cjs` and the suite completed with all included checks passing (many `ok - ...` results printed). 
- Ran `npm test` but it failed in the Cloud runtime due to a missing system library (`libatk-1.0.so.0`), so the Electron-based test runner could not execute here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c3e89a3448322bc879e00921f98fa)