### PR TITLE
M33.5: Restarbeiten „Drucken“ öffnet V2-Vorschau statt Direkt-PDF

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2091,3 +2091,8 @@ Wichtig:
   - Standard-Listenpfad blendet soft-gelöschte RP aus; optionaler Include-Flag bleibt für Rohzugriffe möglich.
   - RP-Nummernlogik bleibt stabil ohne Wiederverwendung (Soft-Delete-Datensätze zählen weiterhin in `MAX(running_number)`).
   - keine sichtbare UI-Änderung.
+
+- M33.5 Restarbeiten:
+  - Drucken im Restarbeiten-Header öffnet jetzt den bestehenden V2-Vorschaupfad (`print:openHtmlPreview`) statt direktem PDF-Write.
+  - Payload bleibt modebasiert auf `mode: "restarbeiten"` inklusive gefilterter `restarbeitenRows` und `restarbeitenLocationLabels`.
+  - Restarbeiten-Ordner/`restarbeitenDir` und modebasierter Feature-Guard aus M33.4/M33.4.1 bleiben unverändert.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1819,9 +1819,10 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(source.includes("Restpunkte (RP)"), true);
   });
 
-  await run("M33.1 Restarbeiten-Druck: Button, Filter-Payload, deleted_at, keine Fotos, Leerfall", async () => {
+  await run("M33.5 Restarbeiten-Druck: Button, Preview-Payload, deleted_at, keine Fotos, Leerfall", async () => {
     const prevWindow = globalThis.window;
     const prevDocument = globalThis.document;
+    const previewCalls = [];
     const printCalls = [];
     const statusCalls = [];
     const items = [
@@ -1845,6 +1846,7 @@ async function runRestarbeitenModuleTests(run) {
     globalThis.window = {
       bbmPrint: { printPdf: async (payload) => { printCalls.push(payload); return { ok: true }; } },
       bbmDb: {
+        printOpenHtmlPreview: async (payload) => { previewCalls.push(payload); return { ok: true }; },
         restarbeitenGetProjectSettings: async () => ({ ok: true, settings: { level_1_label: "Gebäude", level_2_label: "Stock", level_3_label: "Bereich", level_4_label: "Zone" } }),
         restarbeitenListByProject: async () => ({ ok: true, items: items.map((i) => ({ ...i })) }),
         projectFirmsListByProject: async () => ({ ok: true, list: [] }),
@@ -1869,20 +1871,21 @@ async function runRestarbeitenModuleTests(run) {
       screen._renderList();
       await btnPrint.onclick();
 
-      assert.equal(printCalls.length, 1);
-      assert.equal(printCalls[0].mode, "restarbeiten");
-      assert.equal(printCalls[0].projectId, "p-1");
-      assert.equal(Array.isArray(printCalls[0].restarbeitenRows), true);
-      assert.equal(printCalls[0].restarbeitenRows.length, 1);
-      assert.equal(printCalls[0].restarbeitenRows[0].running_number, 2);
-      assert.equal(printCalls[0].restarbeitenRows[0].item_class, "mangel");
-      assert.deepEqual(printCalls[0].restarbeitenLocationLabels, {
+      assert.equal(previewCalls.length, 1);
+      assert.equal(printCalls.length, 0);
+      assert.equal(previewCalls[0].mode, "restarbeiten");
+      assert.equal(previewCalls[0].projectId, "p-1");
+      assert.equal(Array.isArray(previewCalls[0].restarbeitenRows), true);
+      assert.equal(previewCalls[0].restarbeitenRows.length, 1);
+      assert.equal(previewCalls[0].restarbeitenRows[0].running_number, 2);
+      assert.equal(previewCalls[0].restarbeitenRows[0].item_class, "mangel");
+      assert.deepEqual(previewCalls[0].restarbeitenLocationLabels, {
         level_1_label: "Gebäude",
         level_2_label: "Stock",
         level_3_label: "Bereich",
         level_4_label: "Zone",
       });
-      const row = printCalls[0].restarbeitenRows[0];
+      const row = previewCalls[0].restarbeitenRows[0];
       for (const key of ["running_number","item_class","short_text","long_text","location_level_1","location_level_2","location_level_3","location_level_4","status","due_date","responsible_label","completed_at","completion_note"]) {
         assert.equal(Object.prototype.hasOwnProperty.call(row, key), true);
       }
@@ -1894,12 +1897,19 @@ async function runRestarbeitenModuleTests(run) {
       screen.filterState.location_level_1 = "Nicht vorhanden";
       screen._renderList();
       await btnPrint.onclick();
-      assert.equal(printCalls.length, 1);
+      assert.equal(previewCalls.length, 1);
+      assert.equal(printCalls.length, 0);
       assert.equal(statusCalls.includes("Keine Restpunkte für den Druck vorhanden."), true);
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;
     }
+  });
+
+  await run("M33.5 Preload-Bridge: printOpenHtmlPreview -> print:openHtmlPreview", () => {
+    const preloadPath = path.join(__dirname, "../../src/main/preload.js");
+    const source = fs.readFileSync(preloadPath, "utf8");
+    assert.match(source, /printOpenHtmlPreview:\s*\(data\)\s*=>\s*ipcRenderer\.invoke\("print:openHtmlPreview",\s*data\)/);
   });
 
 

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -124,6 +124,7 @@ contextBridge.exposeInMainWorld("bbmDb", {
   // ============================================================
   // Druck (HTML -> PDF)
   // ============================================================
+  printOpenHtmlPreview: (data) => ipcRenderer.invoke("print:openHtmlPreview", data),
   printHtmlToPdf: (data) => ipcRenderer.invoke("print:htmlToPdf", data),
   printPdf: (data) => ipcRenderer.invoke("print:toPdf", data),
 

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -730,7 +730,7 @@ export default class RestarbeitenScreen {
       this.editbox?.setStatus("Keine Restpunkte für den Druck vorhanden.");
       return;
     }
-    await globalThis.window?.bbmPrint?.printPdf?.({
+    await globalThis.window?.bbmDb?.printOpenHtmlPreview?.({
       mode: "restarbeiten",
       projectId: this.effectiveProjectId,
       restarbeitenRows,


### PR DESCRIPTION
### Motivation
- Behebt das fachliche Verhalten, dass der Header-Button „Drucken“ in Restarbeiten still eine PDF schreibt statt die vorhandene V2-Vorschau zu öffnen.
- Ziel ist die Wiederverwendung des bestehenden V2-Preview-/Printwegs mit mode `restarbeiten` und Erhalt der M33.4-Guardrails und Ablage-Logik.

### Description
- Ändert die Restarbeiten-Header-Aktion so, dass sie `window.bbmDb.printOpenHtmlPreview({...})` aufruft und nicht mehr direkt `printPdf` verwendet; Payload enthält `mode: "restarbeiten"`, `projectId`, `restarbeitenRows` (gefiltert, ohne `deleted_at`) und `restarbeitenLocationLabels`.
- Ergänzt die Preload-Bridge minimal um `printOpenHtmlPreview: (data) => ipcRenderer.invoke("print:openHtmlPreview", data)` unter `bbmDb`.
- Passt die Modultests an: `scripts/tests/restarbeitenModule.test.cjs` prüft nun den Preview-Aufruf statt Direkt-PDF und fügt einen Preload-Bridge-Check hinzu.
- Aktualisiert `STATUS.md` um einen kurzen M33.5-Eintrag; keine Änderungen an Ordner-/Storage-Logik, Feature-Guard oder Druck-Engine vorgenommen.

### Testing
- `node scripts/tests/restarbeitenModule.test.cjs` — ausgeführt und bestanden (test prüft Preview-Aufruf, Payload-Inhalt und Leerfall-Verhalten).
- `node scripts/tests/projektverwaltungModule.test.cjs` — ausgeführt und bestanden.
- `node scripts/tests/licenseFeatureGuards.test.cjs` — ausgeführt und bestanden.
- `npm test` — nicht vollständig ausgeführt in der Codex-Cloud-Umgebung, da Electron-Run scheitert mit fehlender Systembibliothek (`libatk-1.0.so.0`), daher nur die gezielten Modultests als Nachweis möglich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c97decd308322bc549c36f7683192)