### PR TITLE
M33.6: Show Restarbeiten V2 preview in packaged app and surface errors

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,15 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+
+- M33.6 Restarbeiten-V2-Vorschau in App sichtbar + Fehlerstatus umgesetzt:
+  - `print:openHtmlPreview` blockiert packaged nicht mehr; bestehender V2-Preview-Pfad oeffnet sichtbar mit `show/focus` weiter ueber `createPrintWindow` + `getPrintAppUrl`.
+  - RestarbeitenScreen wertet das Ergebnis von `printOpenHtmlPreview` jetzt aus und meldet Bridge-fehlt, `{ok:false,error}` und Exceptions klar in der Statuszeile.
+  - Erfolgspfad setzt zusaetzlich `Druckvorschau geoeffnet.` als Rueckmeldung.
+  - Restarbeiten-Tests fuer Erfolgs-/Fehler-/Bridge-/Exception-Pfade ergaenzt; LayoutTools-Regression auf packaged-faehige Preview-Guard aktualisiert.
+  - geprueft mit `node scripts/tests/restarbeitenModule.test.cjs`, `node scripts/tests/projektverwaltungModule.test.cjs`, `node scripts/tests/licenseFeatureGuards.test.cjs`; `npm test` scheitert in Codex Cloud weiter an fehlendem `libatk-1.0.so.0`.
+  - Naechster offener Schritt: App-Sichtpruefung im echten packaged Build (Preview-Fenster oeffnet/fokussiert).
+
 - Arbeitsstand #117 Restarbeiten-Editbox-Layout:
   - Quicklane-Schloss-Icon vorbereitet.
   - Restarbeiten-Editbox-Layout optisch stabilisiert.

--- a/scripts/tests/layoutToolsRegression.test.cjs
+++ b/scripts/tests/layoutToolsRegression.test.cjs
@@ -33,12 +33,11 @@ function _assertDevPdfMarkersAreGated(run) {
   assert.match(css, /box-shadow:\s*inset/i, "DEV marker styles should use inset box-shadow (no layout shift).");
 }
 
-function _assertDevPrintPreviewIpcIsDevOnly() {
+function _assertPrintPreviewIpcAllowsPackagedBuilds() {
   const js = _readText("src/main/ipc/printIpc.js");
 
-  // DEV-only: html preview must be blocked in packaged builds.
   assert.match(js, /ipcMain\.handle\(["']print:openHtmlPreview["']/, "print:openHtmlPreview handler must exist.");
-  assert.match(js, /print:openHtmlPreview[\s\S]*if\s*\(\s*app\.isPackaged\s*\)/, "Preview must guard app.isPackaged.");
+  assert.doesNotMatch(js, /print:openHtmlPreview[\s\S]*if\s*\(\s*app\.isPackaged\s*\)/, "Preview must not be blocked for packaged builds.");
 
   // DevTools must not open automatically in the normal preview path.
   assert.match(js, /createPrintWindow\(\s*\{\s*show:\s*true,\s*devTools:\s*false\s*\}\s*\)/, "Preview must not open DevTools.");
@@ -205,8 +204,8 @@ async function runLayoutToolsRegressionTests(run) {
     _assertDevPdfMarkersAreGated(run);
   });
 
-  await run("layoutTools: Print-HTML Vorschau ist DEV-only und oeffnet DevTools nicht automatisch", () => {
-    _assertDevPrintPreviewIpcIsDevOnly();
+  await run("layoutTools: Print-HTML Vorschau laeuft auch packaged und oeffnet DevTools nicht automatisch", () => {
+    _assertPrintPreviewIpcAllowsPackagedBuilds();
   });
 
   await run("layoutTools: PDF-Exportpfad setzt devLayoutPreview nicht (keine Marker im echten PDF)", () => {

--- a/scripts/tests/licenseFeatureGuards.test.cjs
+++ b/scripts/tests/licenseFeatureGuards.test.cjs
@@ -37,6 +37,18 @@ async function runLicenseFeatureGuardTests(run) {
   const topsScreenSource = read("src/renderer/modules/protokoll/screens/TopsScreen.js");
   const dictationControllerSource = read("src/renderer/features/audio-dictation/DictationController.js");
 
+  await run("License-Guard: printIpc importiert ipcMain+app und Preview bleibt nicht DEV-only", () => {
+    assert.match(printIpc, /const\s*\{\s*ipcMain\s*,\s*app\s*\}\s*=\s*require\("electron"\)/);
+    assert.doesNotMatch(printIpc, /print:openHtmlPreview[\s\S]*if\s*\(\s*app\.isPackaged\s*\)/);
+  });
+
+  await run("License-Guard: printIpc nutzt app weiter fuer Hidden-PDF-Flow und Metadaten", () => {
+    assert.equal(printIpc.includes('app.getPath("downloads")'), true);
+    assert.equal(printIpc.includes('app.getPath("temp")'), true);
+    assert.equal(printIpc.includes('app.getVersion ? app.getVersion() : ""'), true);
+    assert.equal(printIpc.includes('app.isPackaged ? "STABLE" : "DEV"'), true);
+  });
+
   await run("License-Guard: PDF-IPC nutzt modebasierte Feature-Zuordnung", () => {
     assert.equal(printIpc.includes("function _featureForPrintMode(mode)"), true);
     assert.equal(printIpc.includes('if (m === "restarbeiten") return "restarbeiten";'), true);

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1872,6 +1872,7 @@ async function runRestarbeitenModuleTests(run) {
       await btnPrint.onclick();
 
       assert.equal(previewCalls.length, 1);
+      assert.equal(statusCalls.includes("Druckvorschau geöffnet."), true);
       assert.equal(printCalls.length, 0);
       assert.equal(previewCalls[0].mode, "restarbeiten");
       assert.equal(previewCalls[0].projectId, "p-1");
@@ -1900,6 +1901,63 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(previewCalls.length, 1);
       assert.equal(printCalls.length, 0);
       assert.equal(statusCalls.includes("Keine Restpunkte für den Druck vorhanden."), true);
+    } finally {
+      globalThis.window = prevWindow;
+      globalThis.document = prevDocument;
+    }
+  });
+
+
+  await run("M33.6 Restarbeiten-Druckvorschau meldet Fehler bei bridge/result/exception", async () => {
+    const prevWindow = globalThis.window;
+    const prevDocument = globalThis.document;
+    const statusCalls = [];
+
+    async function buildScreen(windowMock) {
+      globalThis.window = windowMock;
+      globalThis.document = createFakeDocument();
+      const RestarbeitenScreen = (await importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"))).default;
+      const screen = new RestarbeitenScreen({ projectId: "p-1" });
+      const root = screen.render();
+      await screen.load();
+      screen.editbox = { setStatus: (msg) => statusCalls.push(msg) };
+      const btnPrint = findButtonByText(root, "Drucken");
+      assert.ok(btnPrint);
+      return { btnPrint };
+    }
+
+    const sharedRows = [
+      {
+        id: "r-1", running_number: 1, item_class: "rest", short_text: "Rest A", long_text: "Lang A",
+        location_level_1: "Haus A", location_level_2: "EG", location_level_3: "WE 1", location_level_4: "Bad",
+        status: "offen", due_date: "2026-05-30", responsible_label: "Firma A", completed_at: "", completion_note: "",
+      },
+    ];
+    const baseDb = {
+      restarbeitenGetProjectSettings: async () => ({ ok: true, settings: {} }),
+      restarbeitenListByProject: async () => ({ ok: true, items: sharedRows.map((i) => ({ ...i })) }),
+      projectFirmsListByProject: async () => ({ ok: true, list: [] }),
+      restarbeitenListAttachments: async () => ({ ok: true, attachments: [] }),
+    };
+
+    try {
+      // result ok false
+      statusCalls.length = 0;
+      let prepared = await buildScreen({ bbmDb: { ...baseDb, printOpenHtmlPreview: async () => ({ ok: false, error: "DEV-only." }) } });
+      await prepared.btnPrint.onclick();
+      assert.equal(statusCalls.includes("Druckvorschau konnte nicht geöffnet werden: DEV-only."), true);
+
+      // bridge fehlt
+      statusCalls.length = 0;
+      prepared = await buildScreen({ bbmDb: { ...baseDb } });
+      await prepared.btnPrint.onclick();
+      assert.equal(statusCalls.includes("Druckvorschau ist nicht verfügbar."), true);
+
+      // exception
+      statusCalls.length = 0;
+      prepared = await buildScreen({ bbmDb: { ...baseDb, printOpenHtmlPreview: async () => { throw new Error("kaputt"); } } });
+      await prepared.btnPrint.onclick();
+      assert.equal(statusCalls.includes("Druckvorschau konnte nicht geöffnet werden."), true);
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;

--- a/src/main/ipc/printIpc.js
+++ b/src/main/ipc/printIpc.js
@@ -11,7 +11,7 @@
 // Der alte Name bleibt, die Implementierung nutzt jetzt die neue Print-Engine.
 // ============================================================
 
-const { ipcMain, app } = require("electron");
+const { ipcMain } = require("electron");
 const fs = require("fs");
 const path = require("path");
 const { createPrintWindow, getPrintAppUrl } = require("../print/printWindow");
@@ -513,10 +513,6 @@ function registerPrintIpc() {
     _runIpcTask(async () => {
       const p = payload || {};
       _enforceFeature(_featureForPrintMode(p.mode));
-      if (app.isPackaged) {
-        return { ok: false, error: "DEV-only." };
-      }
-
       const orientation = _resolveRequestedOrientation(p);
       const jobId = _randId();
       const win = createPrintWindow({ show: true, devTools: false });

--- a/src/main/ipc/printIpc.js
+++ b/src/main/ipc/printIpc.js
@@ -11,7 +11,7 @@
 // Der alte Name bleibt, die Implementierung nutzt jetzt die neue Print-Engine.
 // ============================================================
 
-const { ipcMain } = require("electron");
+const { ipcMain, app } = require("electron");
 const fs = require("fs");
 const path = require("path");
 const { createPrintWindow, getPrintAppUrl } = require("../print/printWindow");

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -730,11 +730,28 @@ export default class RestarbeitenScreen {
       this.editbox?.setStatus("Keine Restpunkte für den Druck vorhanden.");
       return;
     }
-    await globalThis.window?.bbmDb?.printOpenHtmlPreview?.({
-      mode: "restarbeiten",
-      projectId: this.effectiveProjectId,
-      restarbeitenRows,
-      restarbeitenLocationLabels: buildRestarbeitenLocationLabels(this.projectSettings),
-    });
+    const previewBridge = globalThis.window?.bbmDb?.printOpenHtmlPreview;
+    if (typeof previewBridge !== "function") {
+      this.editbox?.setStatus("Druckvorschau ist nicht verfügbar.");
+      return;
+    }
+
+    try {
+      const result = await previewBridge({
+        mode: "restarbeiten",
+        projectId: this.effectiveProjectId,
+        restarbeitenRows,
+        restarbeitenLocationLabels: buildRestarbeitenLocationLabels(this.projectSettings),
+      });
+      if (result?.ok === false) {
+        const errorText = normalizeText(result?.error) || "Unbekannter Fehler";
+        this.editbox?.setStatus(`Druckvorschau konnte nicht geöffnet werden: ${errorText}`);
+        return;
+      }
+      this.editbox?.setStatus("Druckvorschau geöffnet.");
+    } catch (error) {
+      console.warn("[Restarbeiten] Druckvorschau konnte nicht geöffnet werden", error);
+      this.editbox?.setStatus("Druckvorschau konnte nicht geöffnet werden.");
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- The Restarbeiten "Drucken" button did nothing in packaged builds because the preview IPC was intentionally guarded as DEV-only, so the user saw no feedback; this change makes the behavior visible and debuggable.
- The intent is to keep the existing V2 preview path and not replace the hidden PDF export, while ensuring clear user-facing error/status messages when the preview cannot open.
- Small, targeted change required: remove the packaged-only block preventing preview and make the renderer evaluate and display the preview call result or errors.

### Description
- Removed the `app.isPackaged` DEV-only guard from the `print:openHtmlPreview` handler so the existing V2 preview path can open in packaged builds and continues to use `createPrintWindow({ show: true, devTools: false })` with `win.show()` and `win.focus()`; change located in `src/main/ipc/printIpc.js`.
- Kept the hidden PDF export flows (`print:toPdf` / `print:htmlToPdf`) unchanged so real PDF generation remains via the hidden window and `printToPdf` function.
- Updated `RestarbeitenScreen` to await and interpret the `printOpenHtmlPreview` bridge call, and to set clear status messages for missing bridge, `{ ok:false, error }`, exceptions, and success (`Druckvorschau geöffnet.`); change located in `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`.
- Adjusted tests and a layout-regression assertion to reflect that the preview is allowed in packaged builds and added explicit tests for the success/error/bridge/exception cases; files changed under `scripts/tests/` and `STATUS.md` updated to record the milestone.

### Testing
- Ran `node scripts/tests/restarbeitenModule.test.cjs` and it passed for the added success/error/bridge/exception cases in the Restarbeiten preview flow.
- Ran `node scripts/tests/projektverwaltungModule.test.cjs` and `node scripts/tests/licenseFeatureGuards.test.cjs`, and both passed in this environment.
- Attempted `npm test` but the CI/runtime environment lacks GUI system libs (`libatk-1.0.so.0`), causing the full `npm test` run to fail to start Electron; this is an environment limitation and not a functional failure of the targeted changes.
- The focused unit/integration tests added/updated for this change are green in the current test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9eb86c54832280421a5be56f0af3)