### PR TITLE
M33.7: DEV/Test-Override für Restarbeiten-Featureguard + klare Lizenzmeldung

### DIFF
--- a/scripts/tests/featureGuardEnforcement.test.cjs
+++ b/scripts/tests/featureGuardEnforcement.test.cjs
@@ -59,6 +59,14 @@ async function runFeatureGuardEnforcementTests(run) {
     assert.equal(!!g.enforceLicensedFeature("mail"), true);
     assert.equal(!!g.enforceLicensedFeature("export"), true);
   });
+  await run("FeatureGuard: restarbeiten in DEV ohne Lizenzmodul via Module-Override erlaubt", () => {
+    const g = loadFeatureGuardWithStatus({ valid: true, reason: "OK", license: { modules: ["protokoll"], features: ["protokoll"] } }, { packaged: false });
+    assert.equal(!!g.enforceLicensedFeature("restarbeiten"), true);
+  });
+  await run("FeatureGuard: restarbeiten in packaged ohne Lizenzmodul bleibt gesperrt", () => {
+    const g = loadFeatureGuardWithStatus({ valid: true, reason: "OK", license: { modules: ["protokoll"], features: ["protokoll"] } }, { packaged: true });
+    assert.throws(() => g.enforceLicensedFeature("restarbeiten"), /FEATURE_NOT_ALLOWED:restarbeiten/);
+  });
   await run("FeatureGuard: audio ohne audio-Feature wirft FEATURE_NOT_ALLOWED:audio", () => {
     const g = loadFeatureGuardWithStatus({ valid: true, reason: "OK", license: { features: ["protokoll"] } });
     assert.throws(() => g.enforceLicensedFeature("audio"), /FEATURE_NOT_ALLOWED:diktat/);

--- a/scripts/tests/licenseFeatureGuards.test.cjs
+++ b/scripts/tests/licenseFeatureGuards.test.cjs
@@ -34,6 +34,8 @@ async function runLicenseFeatureGuardTests(run) {
   const audioIpc = read("src/main/ipc/audioIpc.js");
   const mainSource = read("src/main/main.js");
   const projectsIpc = read("src/main/ipc/projectsIpc.js");
+  const featureGuardSource = read("src/main/licensing/featureGuard.js");
+  const licenseFeaturesSource = read("src/main/licensing/licenseFeatures.js");
   const topsScreenSource = read("src/renderer/modules/protokoll/screens/TopsScreen.js");
   const dictationControllerSource = read("src/renderer/features/audio-dictation/DictationController.js");
 
@@ -221,6 +223,17 @@ async function runLicenseFeatureGuardTests(run) {
     } finally {
       global.window = previousWindow;
     }
+  });
+
+  await run("License-Guard: Restarbeiten ist als Lizenzmodul bekannt und Meldung ist klar", () => {
+    assert.equal(licenseFeaturesSource.includes('RESTARBEITEN: "restarbeiten"'), true);
+    assert.equal(featureGuardSource.includes('Modul Restarbeiten ist fuer diese Lizenz nicht freigeschaltet.'), true);
+  });
+
+  await run("License-Guard: DEV-Moduloverride bleibt auf bekannte Module und !packaged begrenzt", () => {
+    assert.equal(featureGuardSource.includes("function isDevModuleOverrideEnabled(moduleId)"), true);
+    assert.equal(featureGuardSource.includes("if (app.isPackaged) return false;"), true);
+    assert.equal(featureGuardSource.includes("normalizedModuleId === LICENSE_MODULES.PROTOKOLL || normalizedModuleId === LICENSE_MODULES.RESTARBEITEN"), true);
   });
 
   await run("License-Guard: Lizenzfehler werden payload-freundlich gemappt", () => {

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1943,9 +1943,9 @@ async function runRestarbeitenModuleTests(run) {
     try {
       // result ok false
       statusCalls.length = 0;
-      let prepared = await buildScreen({ bbmDb: { ...baseDb, printOpenHtmlPreview: async () => ({ ok: false, error: "DEV-only." }) } });
+      let prepared = await buildScreen({ bbmDb: { ...baseDb, printOpenHtmlPreview: async () => ({ ok: false, error: "Modul Restarbeiten ist fuer diese Lizenz nicht freigeschaltet." }) } });
       await prepared.btnPrint.onclick();
-      assert.equal(statusCalls.includes("Druckvorschau konnte nicht geöffnet werden: DEV-only."), true);
+      assert.equal(statusCalls.includes("Druckvorschau konnte nicht geöffnet werden: Modul Restarbeiten ist fuer diese Lizenz nicht freigeschaltet."), true);
 
       // bridge fehlt
       statusCalls.length = 0;

--- a/src/main/licensing/featureGuard.js
+++ b/src/main/licensing/featureGuard.js
@@ -84,6 +84,12 @@ function isDevAudioOverrideEnabled() {
 
 // Uebergangs-/Altlogik:
 // Legacy-Audio-Suggestions bleiben sichtbar getrennt von der eigentlichen Kern-Lizenzpruefung.
+function isDevModuleOverrideEnabled(moduleId) {
+  const normalizedModuleId = String(moduleId || "").trim().toLowerCase();
+  if (app.isPackaged) return false;
+  return normalizedModuleId === LICENSE_MODULES.PROTOKOLL || normalizedModuleId === LICENSE_MODULES.RESTARBEITEN;
+}
+
 function isDevAudioSuggestionsEnabled() {
   // Dev-only legacy audio suggestions flow.
   const explicit = _readEnvFlag("BBM_DEV_ENABLE_AUDIO_SUGGESTIONS");
@@ -98,6 +104,9 @@ function isDevAudioSuggestionsEnabled() {
 function enforceLicensedFeature(feature) {
   const normalizedFeature = String(feature || "").trim().toLowerCase();
   if (normalizedFeature === LICENSE_FEATURES.DIKTAT && isDevAudioOverrideEnabled()) {
+    return _extractLicenseInfo(getStatus({ fresh: true }));
+  }
+  if (isDevModuleOverrideEnabled(normalizedFeature)) {
     return _extractLicenseInfo(getStatus({ fresh: true }));
   }
   try {
@@ -193,6 +202,8 @@ function mapFeatureToMessage(feature) {
   switch (feature) {
     case LICENSE_MODULES.PROTOKOLL:
       return "Modul Protokoll ist fuer diese Lizenz nicht freigeschaltet.";
+    case LICENSE_MODULES.RESTARBEITEN:
+      return "Modul Restarbeiten ist fuer diese Lizenz nicht freigeschaltet.";
     case LICENSE_FEATURES.DIKTAT:
       return "Funktion Diktat ist fuer diese Lizenz nicht freigeschaltet.";
     default:
@@ -205,6 +216,7 @@ module.exports = {
   createLicenseBadgeText,
   enforceLicensedFeature,
   isDevAudioOverrideEnabled,
+  isDevModuleOverrideEnabled,
   isDevAudioSuggestionsEnabled,
   buildLicensedToText,
   toLicenseErrorPayload,


### PR DESCRIPTION
### Motivation
- Die Druckvorschau in `restarbeiten` scheiterte in DEV daran, dass die Renderer-UI das Modul zeigte, der Main-Feature-Guard `enforceLicensedFeature("restarbeiten")` aber ohne Lizenz blockte, was inkonsistente DEV-/Test-Erfahrung verursachte.
- Ziel war, DEV-/lokale Testsicherzustellen ohne Produktiv-Lizenzlogik aufzuweichen und die Fehlermeldung für Restarbeiten klarer zu machen.

### Description
- `src/main/licensing/featureGuard.js` wurde um `isDevModuleOverrideEnabled(moduleId)` ergänzt, das in `!app.isPackaged` nur die bekannten Module `protokoll` und `restarbeiten` als DEV-Override erlaubt, und `enforceLicensedFeature` respektiert diesen Override in DEV/Test-Runs.
- Die Funktion `mapFeatureToMessage` liefert jetzt für `restarbeiten` die präzisere Meldung `Modul Restarbeiten ist fuer diese Lizenz nicht freigeschaltet.`.
- Tests wurden erweitert/angepasst, um DEV-vs-packaged Verhalten für `restarbeiten` zu prüfen und die erwartete, verbesserte Fehlermeldung in der Restarbeiten-Druckvorschau zu erwarten.
- Geänderte Dateien: `src/main/licensing/featureGuard.js`, `scripts/tests/featureGuardEnforcement.test.cjs`, `scripts/tests/licenseFeatureGuards.test.cjs`, `scripts/tests/restarbeitenModule.test.cjs`.

### Testing
- Ausgeführte gezielte Tests: `node scripts/tests/restarbeitenModule.test.cjs`, `node scripts/tests/projektverwaltungModule.test.cjs`, `node scripts/tests/licenseFeatureGuards.test.cjs`, `node scripts/tests/featureGuardEnforcement.test.cjs`, und alle vier haben lokal in der Cloud-Umgebung für diese Änderungen die erwarteten Assertions bestanden.
- `npm test` wurde ebenfalls versucht und schlägt in der Codex-Cloud-Umgebung fehl aufgrund fehlender native Systembibliothek (`libatk-1.0.so.0`), weshalb der Full-`npm test`-CI-Run hier nicht grün nachgewiesen werden konnte.
- Die Änderungen erhalten das Produktivverhalten unverändert (packaged Builds benötigen weiterhin eine Lizenz mit Modul `restarbeiten`) und die DEV-Override ist klar begrenzt auf bekannte Module und nicht-packaged Builds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cbd574d648322a4bf67cb158fb523)