### PR TITLE
Make print preview dev-layout opt-in and disable layout calibration by default; opt-out Restarbeiten preview

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,14 @@ Sie ergÃ¤nzt:
 ## Aktueller Gesamtstand
 
 
+- M33.8 Restarbeiten-Druckvorschau ohne DEV-Layouteditor umgesetzt:
+  - `print:openHtmlPreview` setzt `devLayoutPreview` nicht mehr pauschal, sondern nur noch bei explizitem `payload.devLayoutPreview === true`; ohne explizite Anforderung bleibt die Vorschau im normalen Endanwender-Modus.
+  - `layoutCalibrationEnabled` wird im Preview-IPC nur noch fuer explizite DEV-Layoutvorschau durchgereicht, sonst erzwungen `false`.
+  - Restarbeiten-Preview-Aufruf setzt explizit `devLayoutPreview: false`, damit Header-Button `Drucken` keine Layouteditor-Werkzeuge/Zonen aktiviert.
+  - Regressionstests fuer Restarbeiten-Preview-Payload und LayoutTools-Preview-Guard auf den neuen Opt-in-Mechanismus angehoben.
+  - geprueft mit `node scripts/tests/restarbeitenModule.test.cjs`, `node scripts/tests/projektverwaltungModule.test.cjs`, `node scripts/tests/licenseFeatureGuards.test.cjs`, `node scripts/tests/layoutToolsRegression.test.cjs`; `npm test` scheitert in Codex Cloud weiter an fehlendem `libatk-1.0.so.0`.
+  - Naechster offener Schritt: App-Sichtpruefung, dass Restarbeiten-Drucken eine normale PDF-nahe Vorschau ohne Tabelleneditor-Werkzeuge oeffnet.
+
 - M33.6 Restarbeiten-V2-Vorschau in App sichtbar + Fehlerstatus umgesetzt:
   - `print:openHtmlPreview` blockiert packaged nicht mehr; bestehender V2-Preview-Pfad oeffnet sichtbar mit `show/focus` weiter ueber `createPrintWindow` + `getPrintAppUrl`.
   - RestarbeitenScreen wertet das Ergebnis von `printOpenHtmlPreview` jetzt aus und meldet Bridge-fehlt, `{ok:false,error}` und Exceptions klar in der Statuszeile.

--- a/scripts/tests/layoutToolsRegression.test.cjs
+++ b/scripts/tests/layoutToolsRegression.test.cjs
@@ -42,12 +42,12 @@ function _assertPrintPreviewIpcAllowsPackagedBuilds() {
   // DevTools must not open automatically in the normal preview path.
   assert.match(js, /createPrintWindow\(\s*\{\s*show:\s*true,\s*devTools:\s*false\s*\}\s*\)/, "Preview must not open DevTools.");
 
-  // Layout mode must be explicitly flagged to the print renderer.
-  assert.match(js, /devLayoutPreview:\s*true/, "Preview must set devLayoutPreview: true.");
+  // Layout mode must be opt-in and not forced for every preview.
+  assert.match(js, /devLayoutPreview:\s*p\.devLayoutPreview === true/, "Preview must only enable dev layout preview when explicitly requested.");
   assert.match(
     js,
-    /layoutCalibrationEnabled:\s*/s,
-    "Preview must forward the layout calibration flag to the print renderer."
+    /layoutCalibrationEnabled:[\s\S]*p\.devLayoutPreview === true[\s\S]*: false/s,
+    "Preview must disable layout calibration when devLayoutPreview is not explicitly enabled."
   );
 }
 

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1876,6 +1876,7 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(printCalls.length, 0);
       assert.equal(previewCalls[0].mode, "restarbeiten");
       assert.equal(previewCalls[0].projectId, "p-1");
+      assert.equal(previewCalls[0].devLayoutPreview, false);
       assert.equal(Array.isArray(previewCalls[0].restarbeitenRows), true);
       assert.equal(previewCalls[0].restarbeitenRows.length, 1);
       assert.equal(previewCalls[0].restarbeitenRows[0].running_number, 2);

--- a/src/main/ipc/printIpc.js
+++ b/src/main/ipc/printIpc.js
@@ -531,11 +531,13 @@ function registerPrintIpc() {
           orientation,
           testOrientation: p.testOrientation || null,
           debug: false,
-          devLayoutPreview: true,
+          devLayoutPreview: p.devLayoutPreview === true,
           layoutCalibrationEnabled:
-            p.layoutCalibrationEnabled == null
-              ? _readLayoutCalibrationEnabled()
-              : _normalizeLayoutCalibrationEnabled(p.layoutCalibrationEnabled, _readLayoutCalibrationEnabled()),
+            p.devLayoutPreview === true
+              ? p.layoutCalibrationEnabled == null
+                ? _readLayoutCalibrationEnabled()
+                : _normalizeLayoutCalibrationEnabled(p.layoutCalibrationEnabled, _readLayoutCalibrationEnabled())
+              : false,
         });
       });
 

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -742,6 +742,7 @@ export default class RestarbeitenScreen {
         projectId: this.effectiveProjectId,
         restarbeitenRows,
         restarbeitenLocationLabels: buildRestarbeitenLocationLabels(this.projectSettings),
+        devLayoutPreview: false,
       });
       if (result?.ok === false) {
         const errorText = normalizeText(result?.error) || "Unbekannter Fehler";


### PR DESCRIPTION
### Motivation

- Prevent developer-only layout editor markers and tools from appearing in normal user print previews by making dev layout preview an explicit opt-in. 
- Ensure layout calibration is only forwarded when the dev layout preview is explicitly enabled to avoid affecting normal previews. 
- Ensure the Restarbeiten preview call does not accidentally enable developer layout tools.

### Description

- Changed `print:openHtmlPreview` to set `devLayoutPreview` to `p.devLayoutPreview === true` instead of forcing `true`, and made `layoutCalibrationEnabled` forwarded only when `p.devLayoutPreview === true`, otherwise forced to `false` in `src/main/ipc/printIpc.js`. 
- Updated the Restarbeiten screen to explicitly pass `devLayoutPreview: false` when calling the preview bridge in `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`. 
- Adjusted tests in `scripts/tests/layoutToolsRegression.test.cjs` to assert the new opt-in behavior for `devLayoutPreview` and the conditional `layoutCalibrationEnabled`. 
- Added an assertion in `scripts/tests/restarbeitenModule.test.cjs` to verify the Restarbeiten preview payload includes `devLayoutPreview: false`. 
- Documented the change and next steps in `STATUS.md`.

### Testing

- Ran `node scripts/tests/restarbeitenModule.test.cjs`, `node scripts/tests/projektverwaltungModule.test.cjs`, `node scripts/tests/licenseFeatureGuards.test.cjs`, and `node scripts/tests/layoutToolsRegression.test.cjs`, and the updated unit tests passed. 
- Full `npm test` in the Codex Cloud environment still fails due to missing system library `libatk-1.0.so.0`. 
- No UI/runtime packaged build verification was performed in this change set; a manual app sighting check is listed as the next step in `STATUS.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cc39fef8c83228bf213724c619295)