### PR TITLE
M33.9: Restarbeiten „Drucken“ → erzeugt PDF und öffnet es (PDF-Druckvorschau)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -18,6 +18,15 @@ Sie ergÃ¤nzt:
 ## Aktueller Gesamtstand
 
 
+- M33.9 Restarbeiten-Drucken nutzt jetzt echte PDF-Druckvorschau (PDF erzeugen + PDF öffnen):
+  - Neuer IPC `print:toPdfAndOpen` erzeugt über den bestehenden V2-PDF-Pfad (`printToPdf(...)`) die Datei und öffnet sie anschließend mit `shell.openPath(filePath)`.
+  - Rückgabe ist bei Erfolg `{ ok: true, filePath }`; bei Öffnungsfehler `{ ok: false, error, filePath }`.
+  - Preload-Bridge `bbmPrint.printPdfAndOpen(...)` ergänzt.
+  - RestarbeitenScreen nutzt für den Button `Drucken` jetzt den PDF-und-Öffnen-Pfad statt HTML-Preview und meldet klare PDF-Statusmeldungen.
+  - HTML-Vorschau (`print:openHtmlPreview`) bleibt unverändert für andere Pfade erhalten.
+  - geprueft mit `node scripts/tests/restarbeitenModule.test.cjs`, `node scripts/tests/projektverwaltungModule.test.cjs`, `node scripts/tests/licenseFeatureGuards.test.cjs`, `node scripts/tests/layoutToolsRegression.test.cjs`, `node scripts/tests/printIpcToPdfAndOpen.test.cjs`; `npm test` scheitert in Codex Cloud weiter an fehlendem `libatk-1.0.so.0`.
+  - Naechster offener Schritt: App-Sichtpruefung, dass Restarbeiten-Drucken eine PDF-Datei erzeugt und im System-PDF-Viewer öffnet.
+
 - M33.8 Restarbeiten-Druckvorschau ohne DEV-Layouteditor umgesetzt:
   - `print:openHtmlPreview` setzt `devLayoutPreview` nicht mehr pauschal, sondern nur noch bei explizitem `payload.devLayoutPreview === true`; ohne explizite Anforderung bleibt die Vorschau im normalen Endanwender-Modus.
   - `layoutCalibrationEnabled` wird im Preview-IPC nur noch fuer explizite DEV-Layoutvorschau durchgereicht, sonst erzwungen `false`.

--- a/scripts/tests/printIpcToPdfAndOpen.test.cjs
+++ b/scripts/tests/printIpcToPdfAndOpen.test.cjs
@@ -1,0 +1,19 @@
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+
+function runPrintIpcToPdfAndOpenTests() {
+  const source = fs.readFileSync(path.join(__dirname, "../../src/main/ipc/printIpc.js"), "utf8");
+
+  assert.match(source, /ipcMain\.handle\("print:toPdfAndOpen"/);
+  assert.match(source, /const outPath = await printToPdf\(p\);/);
+  assert.match(source, /const openError = await shell\.openPath\(outPath\);/);
+  assert.match(source, /if \(String\(openError \|\| ""\)\.trim\(\)\) \{/);
+  assert.match(source, /return \{ ok: false, error: openError, filePath: outPath \};/);
+  assert.match(source, /return \{ ok: true, filePath: outPath \};/);
+
+  assert.match(source, /ipcMain\.handle\("print:toPdf"/);
+  assert.match(source, /ipcMain\.handle\("print:htmlToPdf"/);
+}
+
+module.exports = { runPrintIpcToPdfAndOpenTests };

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1819,9 +1819,10 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(source.includes("Restpunkte (RP)"), true);
   });
 
-  await run("M33.5 Restarbeiten-Druck: Button, Preview-Payload, deleted_at, keine Fotos, Leerfall", async () => {
+  await run("M33.9 Restarbeiten-Druck: PDF-und-Öffnen-Payload, deleted_at, keine Fotos, Leerfall", async () => {
     const prevWindow = globalThis.window;
     const prevDocument = globalThis.document;
+    const printPdfAndOpenCalls = [];
     const previewCalls = [];
     const printCalls = [];
     const statusCalls = [];
@@ -1844,7 +1845,13 @@ async function runRestarbeitenModuleTests(run) {
       },
     ];
     globalThis.window = {
-      bbmPrint: { printPdf: async (payload) => { printCalls.push(payload); return { ok: true }; } },
+      bbmPrint: {
+        printPdf: async (payload) => { printCalls.push(payload); return { ok: true }; },
+        printPdfAndOpen: async (payload) => {
+          printPdfAndOpenCalls.push(payload);
+          return { ok: true, filePath: "C:/tmp/Restarbeitenliste.pdf" };
+        },
+      },
       bbmDb: {
         printOpenHtmlPreview: async (payload) => { previewCalls.push(payload); return { ok: true }; },
         restarbeitenGetProjectSettings: async () => ({ ok: true, settings: { level_1_label: "Gebäude", level_2_label: "Stock", level_3_label: "Bereich", level_4_label: "Zone" } }),
@@ -1871,17 +1878,18 @@ async function runRestarbeitenModuleTests(run) {
       screen._renderList();
       await btnPrint.onclick();
 
-      assert.equal(previewCalls.length, 1);
-      assert.equal(statusCalls.includes("Druckvorschau geöffnet."), true);
+      assert.equal(printPdfAndOpenCalls.length, 1);
+      assert.equal(previewCalls.length, 0);
+      assert.equal(statusCalls.includes("PDF-Druckvorschau geöffnet."), true);
       assert.equal(printCalls.length, 0);
-      assert.equal(previewCalls[0].mode, "restarbeiten");
-      assert.equal(previewCalls[0].projectId, "p-1");
-      assert.equal(previewCalls[0].devLayoutPreview, false);
-      assert.equal(Array.isArray(previewCalls[0].restarbeitenRows), true);
-      assert.equal(previewCalls[0].restarbeitenRows.length, 1);
-      assert.equal(previewCalls[0].restarbeitenRows[0].running_number, 2);
-      assert.equal(previewCalls[0].restarbeitenRows[0].item_class, "mangel");
-      assert.deepEqual(previewCalls[0].restarbeitenLocationLabels, {
+      assert.equal(printPdfAndOpenCalls[0].mode, "restarbeiten");
+      assert.equal(printPdfAndOpenCalls[0].projectId, "p-1");
+      assert.equal(printPdfAndOpenCalls[0].devLayoutPreview, false);
+      assert.equal(Array.isArray(printPdfAndOpenCalls[0].restarbeitenRows), true);
+      assert.equal(printPdfAndOpenCalls[0].restarbeitenRows.length, 1);
+      assert.equal(printPdfAndOpenCalls[0].restarbeitenRows[0].running_number, 2);
+      assert.equal(printPdfAndOpenCalls[0].restarbeitenRows[0].item_class, "mangel");
+      assert.deepEqual(printPdfAndOpenCalls[0].restarbeitenLocationLabels, {
         level_1_label: "Gebäude",
         level_2_label: "Stock",
         level_3_label: "Bereich",

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1887,7 +1887,7 @@ async function runRestarbeitenModuleTests(run) {
         level_3_label: "Bereich",
         level_4_label: "Zone",
       });
-      const row = previewCalls[0].restarbeitenRows[0];
+      const row = printPdfAndOpenCalls[0].restarbeitenRows[0];
       for (const key of ["running_number","item_class","short_text","long_text","location_level_1","location_level_2","location_level_3","location_level_4","status","due_date","responsible_label","completed_at","completion_note"]) {
         assert.equal(Object.prototype.hasOwnProperty.call(row, key), true);
       }
@@ -1899,7 +1899,8 @@ async function runRestarbeitenModuleTests(run) {
       screen.filterState.location_level_1 = "Nicht vorhanden";
       screen._renderList();
       await btnPrint.onclick();
-      assert.equal(previewCalls.length, 1);
+      assert.equal(printPdfAndOpenCalls.length, 1);
+      assert.equal(previewCalls.length, 0);
       assert.equal(printCalls.length, 0);
       assert.equal(statusCalls.includes("Keine Restpunkte für den Druck vorhanden."), true);
     } finally {
@@ -1909,7 +1910,7 @@ async function runRestarbeitenModuleTests(run) {
   });
 
 
-  await run("M33.6 Restarbeiten-Druckvorschau meldet Fehler bei bridge/result/exception", async () => {
+  await run("M33.6 Restarbeiten-PDF-Druckvorschau meldet Fehler bei bridge/result/exception", async () => {
     const prevWindow = globalThis.window;
     const prevDocument = globalThis.document;
     const statusCalls = [];
@@ -1944,31 +1945,31 @@ async function runRestarbeitenModuleTests(run) {
     try {
       // result ok false
       statusCalls.length = 0;
-      let prepared = await buildScreen({ bbmDb: { ...baseDb, printOpenHtmlPreview: async () => ({ ok: false, error: "Modul Restarbeiten ist fuer diese Lizenz nicht freigeschaltet." }) } });
+      let prepared = await buildScreen({ bbmDb: { ...baseDb }, bbmPrint: { printPdfAndOpen: async () => ({ ok: false, error: "Modul Restarbeiten ist fuer diese Lizenz nicht freigeschaltet." }) } });
       await prepared.btnPrint.onclick();
-      assert.equal(statusCalls.includes("Druckvorschau konnte nicht geöffnet werden: Modul Restarbeiten ist fuer diese Lizenz nicht freigeschaltet."), true);
+      assert.equal(statusCalls.includes("PDF-Druckvorschau konnte nicht geöffnet werden: Modul Restarbeiten ist fuer diese Lizenz nicht freigeschaltet."), true);
 
       // bridge fehlt
       statusCalls.length = 0;
-      prepared = await buildScreen({ bbmDb: { ...baseDb } });
+      prepared = await buildScreen({ bbmDb: { ...baseDb }, bbmPrint: {} });
       await prepared.btnPrint.onclick();
-      assert.equal(statusCalls.includes("Druckvorschau ist nicht verfügbar."), true);
+      assert.equal(statusCalls.includes("PDF-Druckvorschau ist nicht verfügbar."), true);
 
       // exception
       statusCalls.length = 0;
-      prepared = await buildScreen({ bbmDb: { ...baseDb, printOpenHtmlPreview: async () => { throw new Error("kaputt"); } } });
+      prepared = await buildScreen({ bbmDb: { ...baseDb }, bbmPrint: { printPdfAndOpen: async () => { throw new Error("kaputt"); } } });
       await prepared.btnPrint.onclick();
-      assert.equal(statusCalls.includes("Druckvorschau konnte nicht geöffnet werden."), true);
+      assert.equal(statusCalls.includes("PDF-Druckvorschau konnte nicht geöffnet werden."), true);
     } finally {
       globalThis.window = prevWindow;
       globalThis.document = prevDocument;
     }
   });
 
-  await run("M33.5 Preload-Bridge: printOpenHtmlPreview -> print:openHtmlPreview", () => {
+  await run("M33.9 Preload-Bridge: printPdfAndOpen -> print:toPdfAndOpen", () => {
     const preloadPath = path.join(__dirname, "../../src/main/preload.js");
     const source = fs.readFileSync(preloadPath, "utf8");
-    assert.match(source, /printOpenHtmlPreview:\s*\(data\)\s*=>\s*ipcRenderer\.invoke\("print:openHtmlPreview",\s*data\)/);
+    assert.match(source, /printPdfAndOpen:\s*\(data\)\s*=>\s*ipcRenderer\.invoke\("print:toPdfAndOpen",\s*data\)/);
   });
 
 

--- a/src/main/ipc/printIpc.js
+++ b/src/main/ipc/printIpc.js
@@ -11,7 +11,7 @@
 // Der alte Name bleibt, die Implementierung nutzt jetzt die neue Print-Engine.
 // ============================================================
 
-const { ipcMain, app } = require("electron");
+const { ipcMain, app, shell } = require("electron");
 const fs = require("fs");
 const path = require("path");
 const { createPrintWindow, getPrintAppUrl } = require("../print/printWindow");
@@ -548,6 +548,19 @@ function registerPrintIpc() {
       } catch (_e) {}
 
       return { ok: true, jobId };
+    })
+  );
+
+  ipcMain.handle("print:toPdfAndOpen", async (_evt, payload) =>
+    _runIpcTask(async () => {
+      const p = payload || {};
+      _enforceFeature(_featureForPrintMode(p.mode));
+      const outPath = await printToPdf(p);
+      const openError = await shell.openPath(outPath);
+      if (String(openError || "").trim()) {
+        return { ok: false, error: openError, filePath: outPath };
+      }
+      return { ok: true, filePath: outPath };
     })
   );
 

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -127,6 +127,7 @@ contextBridge.exposeInMainWorld("bbmDb", {
   printOpenHtmlPreview: (data) => ipcRenderer.invoke("print:openHtmlPreview", data),
   printHtmlToPdf: (data) => ipcRenderer.invoke("print:htmlToPdf", data),
   printPdf: (data) => ipcRenderer.invoke("print:toPdf", data),
+  printPdfAndOpen: (data) => ipcRenderer.invoke("print:toPdfAndOpen", data),
 
   // ============================================================
   // Tabellenlayouts (intern)
@@ -254,6 +255,7 @@ contextBridge.exposeInMainWorld("bbmDb", {
 
 contextBridge.exposeInMainWorld("bbmPrint", {
   printPdf: (data) => ipcRenderer.invoke("print:toPdf", data),
+  printPdfAndOpen: (data) => ipcRenderer.invoke("print:toPdfAndOpen", data),
   findStoredProtocolPdf: (data) => ipcRenderer.invoke("protocol:findStoredPdf", data),
   listStoredFirmsPdfs: (data) => ipcRenderer.invoke("firms:listStoredPdfs", data),
   listStoredProjectPdfs: (data) => ipcRenderer.invoke("print:listStoredProjectPdfs", data),

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -730,14 +730,14 @@ export default class RestarbeitenScreen {
       this.editbox?.setStatus("Keine Restpunkte für den Druck vorhanden.");
       return;
     }
-    const previewBridge = globalThis.window?.bbmDb?.printOpenHtmlPreview;
-    if (typeof previewBridge !== "function") {
-      this.editbox?.setStatus("Druckvorschau ist nicht verfügbar.");
+    const pdfBridge = globalThis.window?.bbmPrint?.printPdfAndOpen;
+    if (typeof pdfBridge !== "function") {
+      this.editbox?.setStatus("PDF-Druckvorschau ist nicht verfügbar.");
       return;
     }
 
     try {
-      const result = await previewBridge({
+      const result = await pdfBridge({
         mode: "restarbeiten",
         projectId: this.effectiveProjectId,
         restarbeitenRows,
@@ -746,13 +746,13 @@ export default class RestarbeitenScreen {
       });
       if (result?.ok === false) {
         const errorText = normalizeText(result?.error) || "Unbekannter Fehler";
-        this.editbox?.setStatus(`Druckvorschau konnte nicht geöffnet werden: ${errorText}`);
+        this.editbox?.setStatus(`PDF-Druckvorschau konnte nicht geöffnet werden: ${errorText}`);
         return;
       }
-      this.editbox?.setStatus("Druckvorschau geöffnet.");
+      this.editbox?.setStatus("PDF-Druckvorschau geöffnet.");
     } catch (error) {
-      console.warn("[Restarbeiten] Druckvorschau konnte nicht geöffnet werden", error);
-      this.editbox?.setStatus("Druckvorschau konnte nicht geöffnet werden.");
+      console.warn("[Restarbeiten] PDF-Druckvorschau konnte nicht geöffnet werden", error);
+      this.editbox?.setStatus("PDF-Druckvorschau konnte nicht geöffnet werden.");
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Der Restarbeiten-Header-Button `Drucken` soll keine HTML-Vorschau mehr öffnen, sondern eine echte PDF-Datei über den vorhandenen V2-PDF-Pfad erzeugen und im System-PDF-Viewer öffnen. 
- Die Änderung soll bestehende Druckpfade, Feature-Guards und die V2-PDF-Engine unverändert weiterverwenden und nur den Restarbeiten-Printflow umleiten.

### Description
- Neuer Main-IPC-Handler `print:toPdfAndOpen` in `src/main/ipc/printIpc.js` hinzugefügt, der `printToPdf(...)` nutzt und danach die Datei per `shell.openPath(filePath)` öffnet, und bei Erfolg `{ ok: true, filePath }` bzw. bei Öffnungsfehler `{ ok: false, error, filePath }` zurückgibt. 
- Preload-Brücke erweitert mit `bbmPrint.printPdfAndOpen(...)` (mapped zu `print:toPdfAndOpen`) in `src/main/preload.js`. 
- `RestarbeitenScreen` (`src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`) so angepasst, dass der `Drucken`-Button `bbmPrint.printPdfAndOpen(...)` aufruft (Payload: `mode:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cc6c8fb148322a23e384cea346e4b)