### PR TITLE
M34.1: Restarbeiten right-side Quicklane (Ausgabe) scaffold

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,13 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M34.1 Restarbeiten: rechte Ausgabe-Toolbox/Quicklane vorbereitet:
+  - RestarbeitenScreen rendert jetzt eine modulnahe rechte Quicklane (`RestarbeitenQuicklane`) innerhalb des Arbeitsbereichs.
+  - Die Quicklane enthält eine kompakte Ausgabegruppe mit `Drucken` und nutzt denselben bestehenden M33-Druck-/Vorschaupfad.
+  - Header-Button `Drucken` bleibt unverändert erhalten; `+ Restpunkt` bleibt unverändert.
+  - Keine E-Mail, keine Fotos und keine neue Druckarchitektur.
+  - geprueft mit `node scripts/tests/restarbeitenModule.test.cjs`, `node scripts/tests/projektverwaltungModule.test.cjs`, `node scripts/tests/licenseFeatureGuards.test.cjs`, `node scripts/tests/layoutToolsRegression.test.cjs`, `node scripts/tests/printIpcToPdfAndOpen.test.cjs`, `node scripts/tests/printIpcInternalPdfPreview.test.cjs`; `npm test` in Codex Cloud weiter mit fehlendem `libatk-1.0.so.0`.
+
 
 - M33.9 Restarbeiten-Drucken nutzt jetzt echte PDF-Druckvorschau (PDF erzeugen + PDF öffnen):
   - Neuer IPC `print:toPdfAndOpen` erzeugt über den bestehenden V2-PDF-Pfad (`printToPdf(...)`) die Datei und öffnet sie anschließend mit `shell.openPath(filePath)`.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1869,8 +1869,17 @@ async function runRestarbeitenModuleTests(run) {
       await screen.load();
       screen.editbox = { setStatus: (msg) => statusCalls.push(msg) };
 
-      const btnPrint = findButtonByText(root, "Drucken");
+      const printButtons = findNodes(root, (n) => n?.tagName === "BUTTON" && String(n?.textContent || "").trim() === "Drucken");
+      assert.equal(printButtons.length >= 2, true);
+      const btnPrint = printButtons[0];
+      const btnQuicklanePrint = printButtons[1];
       assert.ok(btnPrint);
+      assert.ok(btnQuicklanePrint);
+      const quicklane = findNodes(root, (n) => n?.["data-bbm-restarbeiten-quicklane"] === "true")[0];
+      assert.ok(quicklane);
+      assert.match(collectText(quicklane), /Ausgabe/);
+      assert.doesNotMatch(collectText(quicklane), /E-?Mail/i);
+      assert.doesNotMatch(collectText(quicklane), /Foto|Attachment/i);
       assert.equal(findNodes(root, (n) => n?.tagName === "BUTTON" && String(n?.textContent || "").trim() === "+ Restpunkt").length >= 1, true);
       assert.equal(findNodes(screen.editHost, (n) => n?.tagName === "BUTTON" && String(n?.textContent || "").trim() === "Drucken").length, 0);
 
@@ -1878,7 +1887,7 @@ async function runRestarbeitenModuleTests(run) {
       screen._renderList();
       await btnPrint.onclick();
 
-      assert.equal(printPdfAndPreviewInternalCalls.length, 1);
+      assert.equal(printPdfAndPreviewInternalCalls.length, 2);
       assert.equal(previewCalls.length, 0);
       assert.equal(statusCalls.includes("PDF-Druckvorschau geöffnet."), true);
       assert.equal(printCalls.length, 0);
@@ -1902,6 +1911,12 @@ async function runRestarbeitenModuleTests(run) {
       for (const key of ["attachments", "photos", "file_path", "thumbnail_path"]) {
         assert.equal(Object.prototype.hasOwnProperty.call(row, key), false);
       }
+
+      await btnQuicklanePrint.onclick();
+      assert.equal(printPdfAndPreviewInternalCalls.length, 2);
+      assert.equal(printPdfAndPreviewInternalCalls[1].mode, "restarbeiten");
+      assert.equal(printPdfAndPreviewInternalCalls[1].devLayoutPreview, false);
+      assert.equal(printPdfAndPreviewInternalCalls[1].restarbeitenRows.length, 1);
 
       screen.filterState.item_class = "mangel";
       screen.filterState.location_level_1 = "Nicht vorhanden";

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1887,7 +1887,7 @@ async function runRestarbeitenModuleTests(run) {
       screen._renderList();
       await btnPrint.onclick();
 
-      assert.equal(printPdfAndPreviewInternalCalls.length, 2);
+      assert.equal(printPdfAndPreviewInternalCalls.length, 1);
       assert.equal(previewCalls.length, 0);
       assert.equal(statusCalls.includes("PDF-Druckvorschau geöffnet."), true);
       assert.equal(printCalls.length, 0);
@@ -1914,15 +1914,18 @@ async function runRestarbeitenModuleTests(run) {
 
       await btnQuicklanePrint.onclick();
       assert.equal(printPdfAndPreviewInternalCalls.length, 2);
-      assert.equal(printPdfAndPreviewInternalCalls[1].mode, "restarbeiten");
-      assert.equal(printPdfAndPreviewInternalCalls[1].devLayoutPreview, false);
-      assert.equal(printPdfAndPreviewInternalCalls[1].restarbeitenRows.length, 1);
+      for (const payload of printPdfAndPreviewInternalCalls.slice(0, 2)) {
+        assert.equal(payload.mode, "restarbeiten");
+        assert.equal(payload.devLayoutPreview, false);
+        assert.equal(Array.isArray(payload.restarbeitenRows), true);
+        assert.equal(payload.restarbeitenRows.length, 1);
+      }
 
       screen.filterState.item_class = "mangel";
       screen.filterState.location_level_1 = "Nicht vorhanden";
       screen._renderList();
       await btnPrint.onclick();
-      assert.equal(printPdfAndPreviewInternalCalls.length, 1);
+      assert.equal(printPdfAndPreviewInternalCalls.length, 2);
       assert.equal(previewCalls.length, 0);
       assert.equal(printCalls.length, 0);
       assert.equal(statusCalls.includes("Keine Restpunkte für den Druck vorhanden."), true);

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenQuicklane.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenQuicklane.js
@@ -1,0 +1,35 @@
+function createQuicklaneSection(doc, title) {
+  const section = doc.createElement("section");
+  section.className = "restarbeiten-quicklane__section";
+  const heading = doc.createElement("h3");
+  heading.className = "restarbeiten-quicklane__sectionTitle";
+  heading.textContent = title;
+  section.append(heading);
+  return section;
+}
+
+export default class RestarbeitenQuicklane {
+  constructor({ onPrint = null } = {}) {
+    this.onPrint = typeof onPrint === "function" ? onPrint : null;
+    this.root = null;
+  }
+
+  render(documentRef = globalThis.document) {
+    const doc = documentRef;
+    const root = doc.createElement("aside");
+    root.className = "restarbeiten-quicklane";
+    root.setAttribute("data-bbm-restarbeiten-quicklane", "true");
+
+    const outputSection = createQuicklaneSection(doc, "Ausgabe");
+    const printBtn = doc.createElement("button");
+    printBtn.type = "button";
+    printBtn.className = "restarbeiten-quicklane__button";
+    printBtn.textContent = "Drucken";
+    printBtn.onclick = () => this.onPrint?.();
+    outputSection.append(printBtn);
+
+    root.append(outputSection);
+    this.root = root;
+    return root;
+  }
+}

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -9,6 +9,7 @@ import {
 } from "../data/restarbeitenDataSource.js";
 import { mapRestarbeitenStatusLabel, toRestarbeitenListItems } from "../viewModel/restarbeitenListItems.js";
 import RestarbeitenEditbox from "./RestarbeitenEditbox.js";
+import RestarbeitenQuicklane from "./RestarbeitenQuicklane.js";
 import { ensureRestarbeitenListStyle } from "./restarbeitenListStyle.js";
 
 const LOCATION_KEYS = ["location_level_1", "location_level_2", "location_level_3", "location_level_4"];
@@ -58,6 +59,7 @@ export default class RestarbeitenScreen {
     this.projectSettings = null;
     this.locationOptions = { location_level_1: [], location_level_2: [], location_level_3: [], location_level_4: [] };
     this.editbox = null;
+    this.quicklane = null;
 
     this.filterState = {
       item_class: "",
@@ -90,9 +92,10 @@ export default class RestarbeitenScreen {
 
     this._buildHeader(doc);
     this._buildSheetArea(doc);
+    this._buildQuicklane(doc);
     this._buildEditArea(doc);
 
-    this.host.append(this.headerHost, this.sheetArea, this.editArea);
+    this.host.append(this.headerHost, this.workArea, this.editArea);
 
     this._renderHeaderFilters();
     this._renderList();
@@ -129,6 +132,9 @@ export default class RestarbeitenScreen {
   }
 
   _buildSheetArea(doc) {
+    this.workArea = doc.createElement("div");
+    this.workArea.className = "restarbeiten-workarea";
+
     this.sheetArea = doc.createElement("section");
     this.sheetArea.setAttribute("data-bbm-restarbeiten-screen-area", "sheet");
 
@@ -146,6 +152,15 @@ export default class RestarbeitenScreen {
     this.sheetArea.append(sheetCanvas);
 
     this.listHost = listHost;
+    this.workArea.append(this.sheetArea);
+  }
+
+  _buildQuicklane(doc) {
+    this.quicklane = new RestarbeitenQuicklane({
+      onPrint: () => this._printFilteredList(),
+    });
+    const quicklaneHost = this.quicklane.render(doc);
+    this.workArea.append(quicklaneHost);
   }
 
   _buildEditArea(doc) {

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -80,11 +80,17 @@ textarea.restarbeiten-editbox__control--long{min-height:74px}
 .restarbeiten-filterleiste__metaResponsibleRow .restarbeiten-filterleiste__field select{max-width:220px;width:100%}
 .restarbeiten-header__actions{display:flex;gap:6px;margin-left:auto;align-self:flex-start}
 @media (max-width:980px){.restarbeiten-filterleiste__locationFilters{grid-template-columns:1fr;min-width:280px}.restarbeiten-filterleiste__metaFilters{min-width:280px}.restarbeiten-filterleiste__metaTopRow{grid-template-columns:1fr}.restarbeiten-header__actions{margin-left:0}}
+.restarbeiten-workarea{display:flex;flex:1;min-height:0;align-items:stretch}
 [data-bbm-restarbeiten-screen-area="sheet"]{flex:1;min-height:0;overflow:auto;padding:12px 22px 14px}
 .restarbeiten-sheet__list{min-height:100%;display:flex;flex-direction:column;justify-content:flex-end}
 [data-bbm-restarbeiten-screen-sheet-canvas="true"],[data-bbm-restarbeiten-screen-edit-canvas="true"]{width:100%;max-width:940px;margin:0 auto}
 [data-bbm-restarbeiten-screen-sheet-paper="true"]{background:#fff;border:1px solid #dce6f2;border-radius:12px;box-shadow:0 10px 24px rgba(15,23,42,.08);padding:8px 12px 12px}
+[data-bbm-restarbeiten-quicklane="true"]{flex:0 0 auto;width:176px;border-left:1px solid #d9e2ec;background:linear-gradient(180deg,#f6f8fb,#eef3f9);padding:10px 8px;display:flex;flex-direction:column;gap:8px}
+.restarbeiten-quicklane__section{border:1px solid #d4deea;border-radius:8px;background:#fff;padding:8px;display:grid;gap:6px}
+.restarbeiten-quicklane__sectionTitle{margin:0;font-size:11px;line-height:1.1}
+.restarbeiten-quicklane__button{min-height:24px;padding:3px 8px;font-size:11px;border:1px solid #c4cedd;border-radius:6px;background:#f8fafc}
 [data-bbm-restarbeiten-screen-area="edit"]{border-top:1px solid #d9e2ec;background:linear-gradient(180deg,#f8f4ec,#f1ebdf);padding:6px 10px 8px}
+@media (max-width:1160px){.restarbeiten-workarea{flex-direction:column}[data-bbm-restarbeiten-quicklane="true"]{width:100%;border-left:none;border-top:1px solid #d9e2ec}}
 .restarbeiten-list{list-style:none;margin:0;padding:0;display:grid;gap:6px}
 .restarbeiten-list__row{border:1px solid #dae2ee;border-radius:8px;padding:6px;cursor:pointer}
 .restarbeiten-list__row[data-selected="1"]{background:#eef6ff;border-color:#95b8e8}


### PR DESCRIPTION
### Motivation
- Prepare a small, module-local right-side Quicklane/Toolbox for the `Restarbeiten` screen so output/tool actions can be bundled on the right like the `Protokoll` module without changing existing features. 
- Keep the existing M33 print path and header `Drucken` button untouched and reuse the same internal preview/print payload (`mode: "restarbeiten"`) to avoid introducing new print logic.

### Description
- Add a new module file `src/renderer/modules/restarbeiten/screens/RestarbeitenQuicklane.js` implementing a compact `Ausgabe` section with a `Drucken` button that calls a provided `onPrint` callback. 
- Integrate the Quicklane into `RestarbeitenScreen` by introducing a `workArea` (sheet + quicklane) and appending the quicklane host; the quicklane's print button reuses the existing `this._printFilteredList()` path. 
- Add minimal styles in `src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js` to place the quicklane at the right with a responsive fallback to stack on narrow viewports. 
- Update `scripts/tests/restarbeitenModule.test.cjs` to assert the quicklane exists, contains an `Ausgabe` group without mail/photo buttons, and that the quicklane print button invokes the same internal print preview payload; update `STATUS.md` with M34.1 notes.

### Testing
- Executed module tests: `node scripts/tests/restarbeitenModule.test.cjs`, `node scripts/tests/projektverwaltungModule.test.cjs`, `node scripts/tests/licenseFeatureGuards.test.cjs`, `node scripts/tests/layoutToolsRegression.test.cjs`, `node scripts/tests/printIpcToPdfAndOpen.test.cjs`, and `node scripts/tests/printIpcInternalPdfPreview.test.cjs`, which all ran and exited successfully in this environment. 
- Running `npm test` in Codex Cloud failed due to missing system library `libatk-1.0.so.0`, which is an environment issue and expected here and does not reflect the module-level test results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd1b67c688322b445364a0ca18f71)