### PR TITLE
M34.2 Restarbeiten-Quicklane: Add "Ordner öffnen" to Ausgabe group

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,13 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M34.2 Restarbeiten: Quicklane-Ausgabe um „Ordner öffnen“ ergänzt:
+  - RestarbeitenQuicklane enthält in der Ausgabegruppe jetzt `Drucken` und `Ordner öffnen`.
+  - `Ordner öffnen` nutzt den neuen IPC-/Preload-Pfad `projects:openRestarbeitenDir` / `projectsOpenRestarbeitenDir` und öffnet den Restarbeiten-Ausgabeordner des aktuellen Projekts.
+  - Die Ordnerauflösung basiert weiter auf `buildStoragePreviewPaths(...)` inkl. `restarbeitenDir`; der Ordner wird bei Bedarf erstellt und dann per `shell.openPath(dir)` geöffnet.
+  - M33-Druckpfad (`printPdfAndPreviewInternal`) inkl. interner BBM/Chromium-PDF-Vorschau bleibt unverändert.
+  - Header-/Filterleisten-Reorganisation bleibt bewusst offen.
+
 - M34.1 Restarbeiten: rechte Ausgabe-Toolbox/Quicklane vorbereitet:
   - RestarbeitenScreen rendert jetzt eine modulnahe rechte Quicklane (`RestarbeitenQuicklane`) innerhalb des Arbeitsbereichs.
   - Die Quicklane enthält eine kompakte Ausgabegruppe mit `Drucken` und nutzt denselben bestehenden M33-Druck-/Vorschaupfad.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -525,7 +525,6 @@ async function runRestarbeitenModuleTests(run) {
           return { ok: true, item: { id: payload.id, ...payload.patch } };
         },
         restarbeitenListAttachments: async () => ({ ok: true, attachments: [] }),
-        projectsOpenRestarbeitenDir: async (payload) => { openRestarbeitenDirCalls.push(payload); return { ok: true, dir: "C:/tmp/Restarbeiten" }; },
         restarbeitenSetPrimaryAttachment: async () => ({ ok: true }),
         restarbeitenSoftDeleteItem: async (payload) => {
           calls.push({ type: "soft-delete", payload });
@@ -1076,7 +1075,6 @@ async function runRestarbeitenModuleTests(run) {
         restarbeitenGetProjectSettings: async () => ({ ok: true, settings: {} }),
         restarbeitenListByProject: async () => ({ ok: true, items: items.map((i) => ({ ...i })) }),
         restarbeitenListAttachments: async () => ({ ok: true, attachments: [] }),
-        projectsOpenRestarbeitenDir: async (payload) => { openRestarbeitenDirCalls.push(payload); return { ok: true, dir: "C:/tmp/Restarbeiten" }; },
         restarbeitenSetPrimaryAttachment: async () => ({ ok: true }),
         restarbeitenSoftDeleteItem: async (payload) => {
           calls.push({ type: "soft-delete", payload });
@@ -1861,7 +1859,6 @@ async function runRestarbeitenModuleTests(run) {
         restarbeitenListByProject: async () => ({ ok: true, items: items.map((i) => ({ ...i })) }),
         projectFirmsListByProject: async () => ({ ok: true, list: [] }),
         restarbeitenListAttachments: async () => ({ ok: true, attachments: [] }),
-        projectsOpenRestarbeitenDir: async (payload) => { openRestarbeitenDirCalls.push(payload); return { ok: true, dir: "C:/tmp/Restarbeiten" }; },
       },
     };
     globalThis.document = createFakeDocument();

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -2066,6 +2066,20 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(source, /projectsOpenRestarbeitenDir:\s*\(data\)\s*=>\s*ipcRenderer\.invoke\("projects:openRestarbeitenDir",\s*data\)/);
   });
 
+  await run("M34.2 IPC projects:openRestarbeitenDir faengt Async-Fehler strukturiert ab", () => {
+    const projectsIpcPath = path.join(__dirname, "../../src/main/ipc/projectsIpc.js");
+    const source = fs.readFileSync(projectsIpcPath, "utf8");
+    assert.match(source, /ipcMain\.handle\("projects:openRestarbeitenDir",\s*async\s*\(_e,\s*data\)\s*=>\s*\{/);
+    assert.doesNotMatch(source, /projects:openRestarbeitenDir"[\s\S]*?_runProjectTask\(async\s*\(\)\s*=>/);
+    assert.match(source, /fs\.mkdirSync\(dir,\s*\{\s*recursive:\s*true\s*\}\)/);
+    assert.match(source, /await\s+shell\.openPath\(dir\)/);
+    assert.match(source, /buildStoragePreviewPaths\(/);
+    assert.match(source, /restarbeitenDir/);
+    assert.match(source, /catch\s*\(err\)\s*\{/);
+    assert.match(source, /return\s*\{\s*ok:\s*false,\s*error:\s*err\?\.message\s*\|\|\s*String\(err\),\s*dir\s*\}/);
+  });
+
+
 
   await run("M30.1 Guardrails: Create-Pfade bereinigen running_number/deleted_at", () => {
     const dsPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js");

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -525,6 +525,7 @@ async function runRestarbeitenModuleTests(run) {
           return { ok: true, item: { id: payload.id, ...payload.patch } };
         },
         restarbeitenListAttachments: async () => ({ ok: true, attachments: [] }),
+        projectsOpenRestarbeitenDir: async (payload) => { openRestarbeitenDirCalls.push(payload); return { ok: true, dir: "C:/tmp/Restarbeiten" }; },
         restarbeitenSetPrimaryAttachment: async () => ({ ok: true }),
         restarbeitenSoftDeleteItem: async (payload) => {
           calls.push({ type: "soft-delete", payload });
@@ -1075,6 +1076,7 @@ async function runRestarbeitenModuleTests(run) {
         restarbeitenGetProjectSettings: async () => ({ ok: true, settings: {} }),
         restarbeitenListByProject: async () => ({ ok: true, items: items.map((i) => ({ ...i })) }),
         restarbeitenListAttachments: async () => ({ ok: true, attachments: [] }),
+        projectsOpenRestarbeitenDir: async (payload) => { openRestarbeitenDirCalls.push(payload); return { ok: true, dir: "C:/tmp/Restarbeiten" }; },
         restarbeitenSetPrimaryAttachment: async () => ({ ok: true }),
         restarbeitenSoftDeleteItem: async (payload) => {
           calls.push({ type: "soft-delete", payload });
@@ -1783,7 +1785,7 @@ async function runRestarbeitenModuleTests(run) {
     const prevDocument2 = globalThis.document;
     globalThis.document = createFakeDocument();
     try {
-      const screen = new RestarbeitenScreen({ projectId: "p-1" });
+      const screen = new RestarbeitenScreen({ projectId: "p-1", project: { id: "p-1", project_number: "P-100", short: "Kurz", name: "Name" } });
       const options = screen._collectLocationOptionsFromRows([
         { location_level_1: "Haus 2", location_level_2: "OG", location_level_3: "WE 10", location_level_4: "Wohnen" },
         { location_level_1: "Haus 1", location_level_2: "EG", location_level_3: "WE 01", location_level_4: "Bad" },
@@ -1825,6 +1827,7 @@ async function runRestarbeitenModuleTests(run) {
     const printPdfAndPreviewInternalCalls = [];
     const previewCalls = [];
     const printCalls = [];
+    const openRestarbeitenDirCalls = [];
     const statusCalls = [];
     const items = [
       {
@@ -1858,13 +1861,14 @@ async function runRestarbeitenModuleTests(run) {
         restarbeitenListByProject: async () => ({ ok: true, items: items.map((i) => ({ ...i })) }),
         projectFirmsListByProject: async () => ({ ok: true, list: [] }),
         restarbeitenListAttachments: async () => ({ ok: true, attachments: [] }),
+        projectsOpenRestarbeitenDir: async (payload) => { openRestarbeitenDirCalls.push(payload); return { ok: true, dir: "C:/tmp/Restarbeiten" }; },
       },
     };
     globalThis.document = createFakeDocument();
 
     try {
       const RestarbeitenScreen = (await importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"))).default;
-      const screen = new RestarbeitenScreen({ projectId: "p-1" });
+      const screen = new RestarbeitenScreen({ projectId: "p-1", project: { id: "p-1", project_number: "P-100", short: "Kurz", name: "Name" } });
       const root = screen.render();
       await screen.load();
       screen.editbox = { setStatus: (msg) => statusCalls.push(msg) };
@@ -1873,11 +1877,14 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(printButtons.length >= 2, true);
       const btnPrint = printButtons[0];
       const btnQuicklanePrint = printButtons[1];
+      const btnOpenDir = findNodes(root, (n) => n?.tagName === "BUTTON" && String(n?.textContent || "").trim() === "Ordner öffnen")[0];
       assert.ok(btnPrint);
       assert.ok(btnQuicklanePrint);
+      assert.ok(btnOpenDir);
       const quicklane = findNodes(root, (n) => n?.["data-bbm-restarbeiten-quicklane"] === "true")[0];
       assert.ok(quicklane);
       assert.match(collectText(quicklane), /Ausgabe/);
+      assert.match(collectText(quicklane), /Ordner öffnen/);
       assert.doesNotMatch(collectText(quicklane), /E-?Mail/i);
       assert.doesNotMatch(collectText(quicklane), /Foto|Attachment/i);
       assert.equal(findNodes(root, (n) => n?.tagName === "BUTTON" && String(n?.textContent || "").trim() === "+ Restpunkt").length >= 1, true);
@@ -1913,6 +1920,12 @@ async function runRestarbeitenModuleTests(run) {
       }
 
       await btnQuicklanePrint.onclick();
+      await btnOpenDir.onclick();
+      assert.equal(openRestarbeitenDirCalls.length, 1);
+      assert.equal(openRestarbeitenDirCalls[0].project_number, "P-100");
+      assert.equal(openRestarbeitenDirCalls[0].short, "Kurz");
+      assert.equal(openRestarbeitenDirCalls[0].name, "Name");
+      assert.equal(statusCalls.includes("Ausgabeordner geöffnet."), true);
       assert.equal(printPdfAndPreviewInternalCalls.length, 2);
       for (const payload of printPdfAndPreviewInternalCalls.slice(0, 2)) {
         assert.equal(payload.mode, "restarbeiten");
@@ -1945,7 +1958,7 @@ async function runRestarbeitenModuleTests(run) {
       globalThis.window = windowMock;
       globalThis.document = createFakeDocument();
       const RestarbeitenScreen = (await importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"))).default;
-      const screen = new RestarbeitenScreen({ projectId: "p-1" });
+      const screen = new RestarbeitenScreen({ projectId: "p-1", project: { id: "p-1", project_number: "P-100", short: "Kurz", name: "Name" } });
       const root = screen.render();
       await screen.load();
       screen.editbox = { setStatus: (msg) => statusCalls.push(msg) };
@@ -1992,10 +2005,68 @@ async function runRestarbeitenModuleTests(run) {
     }
   });
 
+
+
+  await run("M34.2 Restarbeiten-Ausgabeordner: bridge/result/exception/kein Projekt", async () => {
+    const prevWindow = globalThis.window;
+    const prevDocument = globalThis.document;
+    const statusCalls = [];
+
+    async function buildScreen(windowMock, options = {}) {
+      globalThis.window = windowMock;
+      globalThis.document = createFakeDocument();
+      const RestarbeitenScreen = (await importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"))).default;
+      const screen = new RestarbeitenScreen({
+        projectId: options.projectId ?? "p-1",
+        project: options.project ?? { id: "p-1", project_number: "P-100", short: "Kurz", name: "Name" },
+      });
+      const root = screen.render();
+      await screen.load();
+      screen.editbox = { setStatus: (msg) => statusCalls.push(msg) };
+      const btnOpenDir = findButtonByText(root, "Ordner öffnen");
+      assert.ok(btnOpenDir);
+      return { btnOpenDir };
+    }
+
+    const sharedRows = [{ id: "r-1", running_number: 1, item_class: "rest", short_text: "Rest A", long_text: "Lang A" }];
+    const baseDb = {
+      restarbeitenGetProjectSettings: async () => ({ ok: true, settings: {} }),
+      restarbeitenListByProject: async () => ({ ok: true, items: sharedRows.map((i) => ({ ...i })) }),
+      projectFirmsListByProject: async () => ({ ok: true, list: [] }),
+      restarbeitenListAttachments: async () => ({ ok: true, attachments: [] }),
+    };
+
+    try {
+      statusCalls.length = 0;
+      let prepared = await buildScreen({ bbmDb: { ...baseDb, projectsOpenRestarbeitenDir: async () => ({ ok: false, error: "kaputt" }) }, bbmPrint: {} });
+      await prepared.btnOpenDir.onclick();
+      assert.equal(statusCalls.includes("Ausgabeordner konnte nicht geöffnet werden: kaputt"), true);
+
+      statusCalls.length = 0;
+      prepared = await buildScreen({ bbmDb: { ...baseDb }, bbmPrint: {} });
+      await prepared.btnOpenDir.onclick();
+      assert.equal(statusCalls.includes("Ausgabeordner ist nicht verfügbar."), true);
+
+      statusCalls.length = 0;
+      prepared = await buildScreen({ bbmDb: { ...baseDb, projectsOpenRestarbeitenDir: async () => { throw new Error("x"); } }, bbmPrint: {} });
+      await prepared.btnOpenDir.onclick();
+      assert.equal(statusCalls.includes("Ausgabeordner konnte nicht geöffnet werden."), true);
+
+      statusCalls.length = 0;
+      prepared = await buildScreen({ bbmDb: { ...baseDb, projectsOpenRestarbeitenDir: async () => ({ ok: true, dir: "C:/tmp" }) }, bbmPrint: {} }, { project: null });
+      await prepared.btnOpenDir.onclick();
+      assert.equal(statusCalls.includes("Ausgabeordner ist nicht verfügbar."), true);
+    } finally {
+      globalThis.window = prevWindow;
+      globalThis.document = prevDocument;
+    }
+  });
+
   await run("M33.10 Preload-Bridge: printPdfAndPreviewInternal -> print:toPdfAndPreviewInternal", () => {
     const preloadPath = path.join(__dirname, "../../src/main/preload.js");
     const source = fs.readFileSync(preloadPath, "utf8");
     assert.match(source, /printPdfAndPreviewInternal:\s*\(data\)\s*=>\s*ipcRenderer\.invoke\("print:toPdfAndPreviewInternal",\s*data\)/);
+    assert.match(source, /projectsOpenRestarbeitenDir:\s*\(data\)\s*=>\s*ipcRenderer\.invoke\("projects:openRestarbeitenDir",\s*data\)/);
   });
 
 

--- a/src/main/ipc/projectsIpc.js
+++ b/src/main/ipc/projectsIpc.js
@@ -131,8 +131,9 @@ function registerProjectsIpc() {
     })
   );
 
-  ipcMain.handle("projects:openRestarbeitenDir", (_e, data) =>
-    _runProjectTask(async () => {
+  ipcMain.handle("projects:openRestarbeitenDir", async (_e, data) => {
+    let dir = "";
+    try {
       const d = data && typeof data === "object" ? data : {};
       const settings = appSettingsGetMany(["pdf.protocolsDir"]) || {};
       const baseDirRaw = String(settings["pdf.protocolsDir"] || "").trim();
@@ -145,14 +146,19 @@ function registerProjectsIpc() {
           name: d.name ?? "",
         },
       });
-      const dir = String(preview.restarbeitenDir || "").trim();
+      dir = String(preview.restarbeitenDir || "").trim();
       if (!dir) return { ok: false, error: "Ordnerpfad fehlt", dir: "" };
       fs.mkdirSync(dir, { recursive: true });
       const errorText = await shell.openPath(dir);
       if (errorText) return { ok: false, error: String(errorText), dir };
       return { ok: true, dir };
-    })
-  );
+    } catch (err) {
+      if (_isLicenseError(err)) {
+        return toLicenseErrorPayload(err);
+      }
+      return { ok: false, error: err?.message || String(err), dir };
+    }
+  });
 
 }
 

--- a/src/main/ipc/projectsIpc.js
+++ b/src/main/ipc/projectsIpc.js
@@ -1,11 +1,12 @@
 ﻿// src/main/ipc/projectsIpc.js
 // TECH-CONTRACT (verbindlich): docs/UI-TECH-CONTRACT.md
 // CONTRACT-VERSION: 1.0.1
-const { ipcMain, app } = require("electron");
+const { ipcMain, app, shell } = require("electron");
 const { appSettingsGetMany } = require("../db/appSettingsRepo");
 const projectsRepo = require("../db/projectsRepo");
 const { buildStoragePreviewPaths } = require("./projectStoragePaths");
 const { toLicenseErrorPayload } = require("../licensing/featureGuard");
+const fs = require("fs");
 
 function _isLicenseError(err) {
   const message = String(err?.message || "");
@@ -129,6 +130,30 @@ function registerProjectsIpc() {
       return { ok: true, ...preview };
     })
   );
+
+  ipcMain.handle("projects:openRestarbeitenDir", (_e, data) =>
+    _runProjectTask(async () => {
+      const d = data && typeof data === "object" ? data : {};
+      const settings = appSettingsGetMany(["pdf.protocolsDir"]) || {};
+      const baseDirRaw = String(settings["pdf.protocolsDir"] || "").trim();
+      const baseDir = baseDirRaw || app.getPath("downloads");
+      const preview = buildStoragePreviewPaths({
+        baseDir,
+        project: {
+          project_number: d.project_number ?? d.projectNumber ?? d.number ?? "",
+          short: d.short ?? "",
+          name: d.name ?? "",
+        },
+      });
+      const dir = String(preview.restarbeitenDir || "").trim();
+      if (!dir) return { ok: false, error: "Ordnerpfad fehlt", dir: "" };
+      fs.mkdirSync(dir, { recursive: true });
+      const errorText = await shell.openPath(dir);
+      if (errorText) return { ok: false, error: String(errorText), dir };
+      return { ok: true, dir };
+    })
+  );
+
 }
 
 module.exports = { registerProjectsIpc };

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -20,6 +20,7 @@ contextBridge.exposeInMainWorld("bbmDb", {
   projectsCreate: (data) => ipcRenderer.invoke("projects:create", data),
   projectsUpdate: (data) => ipcRenderer.invoke("projects:update", data),
   projectsStoragePreview: (data) => ipcRenderer.invoke("projects:storagePreview", data),
+  projectsOpenRestarbeitenDir: (data) => ipcRenderer.invoke("projects:openRestarbeitenDir", data),
 
   // Archiv
   projectsArchive: _wrapIdArg("projects:archive", "projectId"),

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenQuicklane.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenQuicklane.js
@@ -9,8 +9,9 @@ function createQuicklaneSection(doc, title) {
 }
 
 export default class RestarbeitenQuicklane {
-  constructor({ onPrint = null } = {}) {
+  constructor({ onPrint = null, onOpenOutputDir = null } = {}) {
     this.onPrint = typeof onPrint === "function" ? onPrint : null;
+    this.onOpenOutputDir = typeof onOpenOutputDir === "function" ? onOpenOutputDir : null;
     this.root = null;
   }
 
@@ -27,6 +28,13 @@ export default class RestarbeitenQuicklane {
     printBtn.textContent = "Drucken";
     printBtn.onclick = () => this.onPrint?.();
     outputSection.append(printBtn);
+
+    const openDirBtn = doc.createElement("button");
+    openDirBtn.type = "button";
+    openDirBtn.className = "restarbeiten-quicklane__button";
+    openDirBtn.textContent = "Ordner öffnen";
+    openDirBtn.onclick = () => this.onOpenOutputDir?.();
+    outputSection.append(openDirBtn);
 
     root.append(outputSection);
     this.root = root;

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -158,6 +158,7 @@ export default class RestarbeitenScreen {
   _buildQuicklane(doc) {
     this.quicklane = new RestarbeitenQuicklane({
       onPrint: () => this._printFilteredList(),
+      onOpenOutputDir: () => this._openOutputDir(),
     });
     const quicklaneHost = this.quicklane.render(doc);
     this.workArea.append(quicklaneHost);
@@ -711,6 +712,36 @@ export default class RestarbeitenScreen {
     const target = Number(this.sheetArea.scrollHeight || 0) - Number(this.sheetArea.clientHeight || 0);
     this.sheetArea.scrollTop = target > 0 ? target : 0;
     this.createScrollPending = false;
+  }
+
+
+  async _openOutputDir() {
+    if (!this.effectiveProjectId || !this.project) {
+      this.editbox?.setStatus("Ausgabeordner ist nicht verfügbar.");
+      return;
+    }
+    const openDirBridge = globalThis.window?.bbmDb?.projectsOpenRestarbeitenDir;
+    if (typeof openDirBridge !== "function") {
+      this.editbox?.setStatus("Ausgabeordner ist nicht verfügbar.");
+      return;
+    }
+
+    try {
+      const result = await openDirBridge({
+        project_number: this.project.project_number || "",
+        short: this.project.short || "",
+        name: this.project.name || "",
+      });
+      if (result?.ok === false) {
+        const errorText = normalizeText(result?.error) || "Unbekannter Fehler";
+        this.editbox?.setStatus(`Ausgabeordner konnte nicht geöffnet werden: ${errorText}`);
+        return;
+      }
+      this.editbox?.setStatus("Ausgabeordner geöffnet.");
+    } catch (error) {
+      console.warn("[Restarbeiten] Ausgabeordner konnte nicht geöffnet werden", error);
+      this.editbox?.setStatus("Ausgabeordner konnte nicht geöffnet werden.");
+    }
   }
 
   async _printFilteredList() {


### PR DESCRIPTION
### Motivation
- Provide a quick action in the right Restarbeiten quicklane to open the project's Restarbeiten output folder without changing existing print behavior or header controls.

### Description
- UI: `RestarbeitenQuicklane` now shows an additional `Ordner öffnen` button and accepts an `onOpenOutputDir` callback. (`src/renderer/modules/restarbeiten/screens/RestarbeitenQuicklane.js`)
- Renderer: `RestarbeitenScreen` wires `onOpenOutputDir` to a new `_openOutputDir()` method that calls the preload bridge, reports status messages for missing project/bridge, `{ok:false}` results and exceptions, and leaves the existing print flow unchanged. (`src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`)
- Main IPC: added `projects:openRestarbeitenDir` which reuses `buildStoragePreviewPaths(...)` to resolve `restarbeitenDir`, ensures the folder exists (`fs.mkdirSync(..., { recursive: true })`) and opens it via `shell.openPath(dir)` returning `{ ok:true, dir }` or `{ ok:false, error, dir }`. (`src/main/ipc/projectsIpc.js`)
- Preload: exposed `bbmDb.projectsOpenRestarbeitenDir(data)` that invokes the new IPC. (`src/main/preload.js`)
- Tests and docs: extended `scripts/tests/restarbeitenModule.test.cjs` with checks for the new button, bridge calls and status paths, and updated `STATUS.md` with M34.2 notes.

### Testing
- Ran targeted test scripts: `node scripts/tests/restarbeitenModule.test.cjs`, `node scripts/tests/projektverwaltungModule.test.cjs`, `node scripts/tests/licenseFeatureGuards.test.cjs`, `node scripts/tests/layoutToolsRegression.test.cjs`, `node scripts/tests/printIpcToPdfAndOpen.test.cjs`, and `node scripts/tests/printIpcInternalPdfPreview.test.cjs`; these focused tests completed in the environment used for the change (no failing assertions observed). 
- Full `npm test` (Electron-based) failed in this cloud environment due to missing system library `libatk-1.0.so.0`, so the full suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd5ec870c8322a04693555bd1e104)