### PR TITLE
M34.3 Restarbeiten-Quicklane: Beschriftung und stabiles Rechtsverhalten

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,13 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M34.3 Restarbeiten: Quicklane-Beschriftung und stabiles Rechtsverhalten angepasst:
+  - RestarbeitenQuicklane enthält in der Ausgabegruppe jetzt `Vorschau` und `Drucken`.
+  - `Vorschau` nutzt weiterhin den bestehenden M33.10-Pfad `printPdfAndPreviewInternal` (inkl. `mode: "restarbeiten"` und `devLayoutPreview: false`).
+  - `Drucken` nutzt weiterhin den bestehenden M34.2-Pfad `projectsOpenRestarbeitenDir`.
+  - Quicklane ist rechts sticky/stabil ausgerichtet; die Liste bleibt beim Hover ohne Breiten-/Layoutsprung stabil, inklusive responsive Rückfall auf schmale Breiten.
+  - Keine neue Drucklogik und keine Header-/Filterleisten-Reorganisation.
+
 - M34.2 Restarbeiten: Quicklane-Ausgabe um „Ordner öffnen“ ergänzt:
   - RestarbeitenQuicklane enthält in der Ausgabegruppe jetzt `Drucken` und `Ordner öffnen`.
   - `Ordner öffnen` nutzt den neuen IPC-/Preload-Pfad `projects:openRestarbeitenDir` / `projectsOpenRestarbeitenDir` und öffnet den Restarbeiten-Ausgabeordner des aktuellen Projekts.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1873,15 +1873,16 @@ async function runRestarbeitenModuleTests(run) {
       const printButtons = findNodes(root, (n) => n?.tagName === "BUTTON" && String(n?.textContent || "").trim() === "Drucken");
       assert.equal(printButtons.length >= 2, true);
       const btnPrint = printButtons[0];
-      const btnQuicklanePrint = printButtons[1];
-      const btnOpenDir = findNodes(root, (n) => n?.tagName === "BUTTON" && String(n?.textContent || "").trim() === "Ordner öffnen")[0];
       assert.ok(btnPrint);
-      assert.ok(btnQuicklanePrint);
-      assert.ok(btnOpenDir);
       const quicklane = findNodes(root, (n) => n?.["data-bbm-restarbeiten-quicklane"] === "true")[0];
       assert.ok(quicklane);
+      const quicklanePreviewBtn = findButtonByText(quicklane, "Vorschau");
+      const quicklanePrintBtn = findButtonByText(quicklane, "Drucken");
+      assert.ok(quicklanePreviewBtn);
+      assert.ok(quicklanePrintBtn);
       assert.match(collectText(quicklane), /Ausgabe/);
-      assert.match(collectText(quicklane), /Ordner öffnen/);
+      assert.match(collectText(quicklane), /Vorschau/);
+      assert.match(collectText(quicklane), /Drucken/);
       assert.doesNotMatch(collectText(quicklane), /E-?Mail/i);
       assert.doesNotMatch(collectText(quicklane), /Foto|Attachment/i);
       assert.equal(findNodes(root, (n) => n?.tagName === "BUTTON" && String(n?.textContent || "").trim() === "+ Restpunkt").length >= 1, true);
@@ -1916,8 +1917,8 @@ async function runRestarbeitenModuleTests(run) {
         assert.equal(Object.prototype.hasOwnProperty.call(row, key), false);
       }
 
-      await btnQuicklanePrint.onclick();
-      await btnOpenDir.onclick();
+      await quicklanePreviewBtn.onclick();
+      await quicklanePrintBtn.onclick();
       assert.equal(openRestarbeitenDirCalls.length, 1);
       assert.equal(openRestarbeitenDirCalls[0].project_number, "P-100");
       assert.equal(openRestarbeitenDirCalls[0].short, "Kurz");
@@ -1959,9 +1960,11 @@ async function runRestarbeitenModuleTests(run) {
       const root = screen.render();
       await screen.load();
       screen.editbox = { setStatus: (msg) => statusCalls.push(msg) };
-      const btnPrint = findButtonByText(root, "Drucken");
-      assert.ok(btnPrint);
-      return { btnPrint };
+      const quicklane = findNodes(root, (n) => n?.["data-bbm-restarbeiten-quicklane"] === "true")[0];
+      assert.ok(quicklane);
+      const btnPreview = findButtonByText(quicklane, "Vorschau");
+      assert.ok(btnPreview);
+      return { btnPreview };
     }
 
     const sharedRows = [
@@ -1982,19 +1985,19 @@ async function runRestarbeitenModuleTests(run) {
       // result ok false
       statusCalls.length = 0;
       let prepared = await buildScreen({ bbmDb: { ...baseDb }, bbmPrint: { printPdfAndPreviewInternal: async () => ({ ok: false, error: "Modul Restarbeiten ist fuer diese Lizenz nicht freigeschaltet." }) } });
-      await prepared.btnPrint.onclick();
+      await prepared.btnPreview.onclick();
       assert.equal(statusCalls.includes("PDF-Druckvorschau konnte nicht geöffnet werden: Modul Restarbeiten ist fuer diese Lizenz nicht freigeschaltet."), true);
 
       // bridge fehlt
       statusCalls.length = 0;
       prepared = await buildScreen({ bbmDb: { ...baseDb }, bbmPrint: {} });
-      await prepared.btnPrint.onclick();
+      await prepared.btnPreview.onclick();
       assert.equal(statusCalls.includes("PDF-Druckvorschau ist nicht verfügbar."), true);
 
       // exception
       statusCalls.length = 0;
       prepared = await buildScreen({ bbmDb: { ...baseDb }, bbmPrint: { printPdfAndPreviewInternal: async () => { throw new Error("kaputt"); } } });
-      await prepared.btnPrint.onclick();
+      await prepared.btnPreview.onclick();
       assert.equal(statusCalls.includes("PDF-Druckvorschau konnte nicht geöffnet werden."), true);
     } finally {
       globalThis.window = prevWindow;
@@ -2020,7 +2023,9 @@ async function runRestarbeitenModuleTests(run) {
       const root = screen.render();
       await screen.load();
       screen.editbox = { setStatus: (msg) => statusCalls.push(msg) };
-      const btnOpenDir = findButtonByText(root, "Ordner öffnen");
+      const quicklane = findNodes(root, (n) => n?.["data-bbm-restarbeiten-quicklane"] === "true")[0];
+      assert.ok(quicklane);
+      const btnOpenDir = findButtonByText(quicklane, "Drucken");
       assert.ok(btnOpenDir);
       return { btnOpenDir };
     }

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenQuicklane.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenQuicklane.js
@@ -25,14 +25,14 @@ export default class RestarbeitenQuicklane {
     const printBtn = doc.createElement("button");
     printBtn.type = "button";
     printBtn.className = "restarbeiten-quicklane__button";
-    printBtn.textContent = "Drucken";
+    printBtn.textContent = "Vorschau";
     printBtn.onclick = () => this.onPrint?.();
     outputSection.append(printBtn);
 
     const openDirBtn = doc.createElement("button");
     openDirBtn.type = "button";
     openDirBtn.className = "restarbeiten-quicklane__button";
-    openDirBtn.textContent = "Ordner öffnen";
+    openDirBtn.textContent = "Drucken";
     openDirBtn.onclick = () => this.onOpenOutputDir?.();
     outputSection.append(openDirBtn);
 

--- a/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
+++ b/src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js
@@ -85,12 +85,13 @@ textarea.restarbeiten-editbox__control--long{min-height:74px}
 .restarbeiten-sheet__list{min-height:100%;display:flex;flex-direction:column;justify-content:flex-end}
 [data-bbm-restarbeiten-screen-sheet-canvas="true"],[data-bbm-restarbeiten-screen-edit-canvas="true"]{width:100%;max-width:940px;margin:0 auto}
 [data-bbm-restarbeiten-screen-sheet-paper="true"]{background:#fff;border:1px solid #dce6f2;border-radius:12px;box-shadow:0 10px 24px rgba(15,23,42,.08);padding:8px 12px 12px}
-[data-bbm-restarbeiten-quicklane="true"]{flex:0 0 auto;width:176px;border-left:1px solid #d9e2ec;background:linear-gradient(180deg,#f6f8fb,#eef3f9);padding:10px 8px;display:flex;flex-direction:column;gap:8px}
+[data-bbm-restarbeiten-quicklane="true"]{position:sticky;top:12px;align-self:flex-start;flex:0 0 176px;width:176px;border-left:1px solid #d9e2ec;background:linear-gradient(180deg,#f6f8fb,#eef3f9);padding:10px 8px;display:flex;flex-direction:column;gap:8px}
 .restarbeiten-quicklane__section{border:1px solid #d4deea;border-radius:8px;background:#fff;padding:8px;display:grid;gap:6px}
 .restarbeiten-quicklane__sectionTitle{margin:0;font-size:11px;line-height:1.1}
 .restarbeiten-quicklane__button{min-height:24px;padding:3px 8px;font-size:11px;border:1px solid #c4cedd;border-radius:6px;background:#f8fafc}
+.restarbeiten-quicklane__button:hover{background:#f1f5f9;border-color:#9fb2ca}
 [data-bbm-restarbeiten-screen-area="edit"]{border-top:1px solid #d9e2ec;background:linear-gradient(180deg,#f8f4ec,#f1ebdf);padding:6px 10px 8px}
-@media (max-width:1160px){.restarbeiten-workarea{flex-direction:column}[data-bbm-restarbeiten-quicklane="true"]{width:100%;border-left:none;border-top:1px solid #d9e2ec}}
+@media (max-width:1160px){.restarbeiten-workarea{flex-direction:column}[data-bbm-restarbeiten-quicklane="true"]{position:static;top:auto;width:100%;flex-basis:auto;border-left:none;border-top:1px solid #d9e2ec}}
 .restarbeiten-list{list-style:none;margin:0;padding:0;display:grid;gap:6px}
 .restarbeiten-list__row{border:1px solid #dae2ee;border-radius:8px;padding:6px;cursor:pointer}
 .restarbeiten-list__row[data-selected="1"]{background:#eef6ff;border-color:#95b8e8}


### PR DESCRIPTION
### Motivation
- Die rechte Restarbeiten-Quicklane soll fachlich klarer beschriftet werden und optisch stabiler wie die Protokoll-Quicklane eingebunden sein, damit die Liste beim Hover nicht springt oder schmaler wird.

### Description
- In `src/renderer/modules/restarbeiten/screens/RestarbeitenQuicklane.js` wurde die Quicklane-Beschriftung geändert: der bisherige `Drucken`-Button heißt jetzt `Vorschau` und der bisherige `Ordner öffnen`-Button heißt jetzt `Drucken`, dabei bleiben die Callback-Pfade unverändert (`onPrint` / `onOpenOutputDir`).
- In `src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js` wurde die Quicklane optisch stabilisiert durch `position: sticky` (Desktop), eine responsive Rückfall-Variante (`position: static`) für schmale Viewports und eine dezente Hover-Optik für Quicklane-Buttons, ohne die Listenbreite beim Hover zu verändern.
- In `scripts/tests/restarbeitenModule.test.cjs` wurden die Tests angepasst, um die Quicklane gezielt über `data-bbm-restarbeiten-quicklane` zu selektieren und die neuen Button-Begriffe `Vorschau` und `Drucken` zu prüfen sowie die bestehenden Callback-/IPC-Pfade abzusichern.
- `STATUS.md` wurde um den M34.3-Eintrag ergänzt.

### Testing
- `node scripts/tests/restarbeitenModule.test.cjs` wurde ausgeführt und die angepassten Quicklane-Assertions liefen grün in dieser Umgebung.
- Die weiteren targeted tests `node scripts/tests/projektverwaltungModule.test.cjs`, `node scripts/tests/licenseFeatureGuards.test.cjs`, `node scripts/tests/layoutToolsRegression.test.cjs`, `node scripts/tests/printIpcToPdfAndOpen.test.cjs`, und `node scripts/tests/printIpcInternalPdfPreview.test.cjs` wurden ausgeführt and sind in dieser Laufumgebung grün gelaufen.
- `npm test` wurde ausgeführt und schlägt in Codex-Cloud-Umgebung fehl aufgrund fehlender Systembibliothek `libatk-1.0.so.0`, was die vollständige Electron-basierte Testausführung verhindert; dies ist ein bekannte CI/environmental Limit und kein Regression der Änderungen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7b2b559c83229854b19a5677986f)