### PR TITLE
Layout-Kalibrator fuer Layout-Surfaces vorbereiten

### DIFF
--- a/scripts/tests/tableLayoutRegistry.test.cjs
+++ b/scripts/tests/tableLayoutRegistry.test.cjs
@@ -18,10 +18,16 @@ async function runTableLayoutRegistryTests(run) {
     assert.equal(Array.isArray(modules[0].tables), true);
     assert.equal(modules[0].tables[0].tableKey, "protokoll_tops");
     assert.equal(modules[0].tables[0].tableLabel, "TOP-Liste");
+    assert.equal(modules[0].tables[0].surfaceKey, "protokoll_tops");
+    assert.equal(modules[0].tables[0].surfaceKind, "table");
+    assert.equal(modules[0].tables[0].surfaceLabel, "TOP-Liste");
     assert.equal(modules[0].tables[0].tableKind, "content");
     assert.equal(modules[0].tables[0].editorEnabled, true);
     assert.equal(modules[0].tables[1].tableKey, "protokoll_participants");
     assert.equal(modules[0].tables[1].tableLabel, "Teilnehmerliste");
+    assert.equal(modules[0].tables[1].surfaceKey, "protokoll_participants");
+    assert.equal(modules[0].tables[1].surfaceKind, "table");
+    assert.equal(modules[0].tables[1].surfaceLabel, "Teilnehmerliste");
     assert.equal(modules[0].tables[1].tableKind, "content");
     assert.equal(modules[0].tables[1].editorEnabled, true);
     const projectModule = modules.find((moduleDef) => moduleDef.moduleId === "projektverwaltung");
@@ -29,6 +35,9 @@ async function runTableLayoutRegistryTests(run) {
     assert.equal(projectModule.moduleLabel, "Projektverwaltung");
     assert.equal(projectModule.tables[0].tableKey, "project_firms");
     assert.equal(projectModule.tables[0].tableLabel, "Projekt-Firmenliste");
+    assert.equal(projectModule.tables[0].surfaceKey, "project_firms");
+    assert.equal(projectModule.tables[0].surfaceKind, "table");
+    assert.equal(projectModule.tables[0].surfaceLabel, "Projekt-Firmenliste");
     assert.equal(projectModule.tables[0].tableKind, "content");
     assert.equal(projectModule.tables[0].editorEnabled, true);
 
@@ -42,6 +51,10 @@ async function runTableLayoutRegistryTests(run) {
     assert.equal(definitions[0].moduleLabel, "Protokoll");
     assert.equal(definitions[0].tableKey, "protokoll_tops");
     assert.equal(definitions[0].tableLabel, "TOP-Liste");
+    assert.equal(definitions[0].surfaceKey, "protokoll_tops");
+    assert.equal(definitions[0].surfaceKind, "table");
+    assert.equal(definitions[0].surfaceLabel, "TOP-Liste");
+    assert.equal(definitions[0].surfaceDescription, "Kalibrierbare Layout-Surface fuer die Protokoll-TOP-Liste.");
     assert.equal(Array.isArray(definitions[0].supportedOrientations), true);
     assert.equal(definitions[0].supportedOrientations.includes("portrait"), true);
     assert.equal(definitions[0].supportedOrientations.includes("landscape"), true);
@@ -72,6 +85,9 @@ async function runTableLayoutRegistryTests(run) {
     assert.ok(participantsDef, "protokoll_participants definition missing");
     assert.equal(participantsDef.moduleId, "protokoll");
     assert.equal(participantsDef.tableLabel, "Teilnehmerliste");
+    assert.equal(participantsDef.surfaceKey, "protokoll_participants");
+    assert.equal(participantsDef.surfaceKind, "table");
+    assert.equal(participantsDef.surfaceLabel, "Teilnehmerliste");
     assert.equal(participantsDef.tableKind, "content");
     assert.equal(participantsDef.editorEnabled, true);
     assert.equal(participantsDef.uiAvailable, true);
@@ -97,6 +113,9 @@ async function runTableLayoutRegistryTests(run) {
     assert.ok(projectFirmsDef, "project_firms definition missing");
     assert.equal(projectFirmsDef.moduleId, "projektverwaltung");
     assert.equal(projectFirmsDef.tableLabel, "Projekt-Firmenliste");
+    assert.equal(projectFirmsDef.surfaceKey, "project_firms");
+    assert.equal(projectFirmsDef.surfaceKind, "table");
+    assert.equal(projectFirmsDef.surfaceLabel, "Projekt-Firmenliste");
     assert.equal(projectFirmsDef.tableKind, "content");
     assert.equal(projectFirmsDef.editorEnabled, true);
     assert.equal(projectFirmsDef.uiAvailable, true);
@@ -115,11 +134,17 @@ async function runTableLayoutRegistryTests(run) {
     assert.equal(def?.moduleLabel, "Protokoll");
     assert.equal(def?.tableKey, "protokoll_tops");
     assert.equal(def?.tableLabel, "TOP-Liste");
+    assert.equal(def?.surfaceKey, "protokoll_tops");
+    assert.equal(def?.surfaceKind, "table");
+    assert.equal(def?.surfaceLabel, "TOP-Liste");
     assert.equal(typeof def?.loadStandardLayout, "function");
 
     const participantsDef = getTableLayoutDefinition({ moduleId: "protokoll", tableKey: "protokoll_participants" });
     assert.equal(participantsDef?.moduleId, "protokoll");
     assert.equal(participantsDef?.tableLabel, "Teilnehmerliste");
+    assert.equal(participantsDef?.surfaceKey, "protokoll_participants");
+    assert.equal(participantsDef?.surfaceKind, "table");
+    assert.equal(participantsDef?.surfaceLabel, "Teilnehmerliste");
     assert.equal(participantsDef?.tableKind, "content");
     assert.equal(participantsDef?.editorEnabled, true);
     assert.equal(typeof participantsDef?.loadStandardLayout, "function");

--- a/src/renderer/views/TableLayoutPrototypeEditor.js
+++ b/src/renderer/views/TableLayoutPrototypeEditor.js
@@ -72,6 +72,10 @@ function _normalizeDefinitionsList(definitions = []) {
           tableKey: _normalizeId(item.tableKey),
           tableLabel: _formatText(item.tableLabel, "TOP-Liste"),
           description: _formatText(item.description, ""),
+          surfaceKey: _formatText(item.surfaceKey, _normalizeId(item.tableKey)),
+          surfaceKind: _formatText(item.surfaceKind, "table"),
+          surfaceLabel: _formatText(item.surfaceLabel, _formatText(item.tableLabel, "TOP-Liste")),
+          surfaceDescription: _formatText(item.surfaceDescription, _formatText(item.description, "")),
           supportedOrientations: Array.isArray(item.supportedOrientations)
             ? item.supportedOrientations.map((entry) => _normalizeOrientation(entry))
             : ["portrait"],

--- a/src/shared/tableLayouts/tableLayoutRegistry.js
+++ b/src/shared/tableLayouts/tableLayoutRegistry.js
@@ -34,6 +34,25 @@ function _normalizeIdentity(identity = {}) {
   return { tableKey, moduleId };
 }
 
+function _resolveSurfaceMetadata(source = {}, fallback = {}) {
+  const tableKey = _normalizeText(source.tableKey) || _normalizeText(fallback.tableKey);
+  return {
+    // tableKey bleibt der stabile Layout-Surface-Schluessel fuer Speicherung und Aufloesung.
+    surfaceKey: _normalizeText(source.surfaceKey) || tableKey,
+    surfaceKind: _normalizeText(source.surfaceKind) || _normalizeText(fallback.surfaceKind) || "table",
+    surfaceLabel:
+      _normalizeText(source.surfaceLabel) ||
+      _normalizeText(source.tableLabel) ||
+      _normalizeText(fallback.surfaceLabel) ||
+      tableKey,
+    surfaceDescription:
+      _normalizeText(source.surfaceDescription) ||
+      _normalizeText(source.description) ||
+      _normalizeText(fallback.surfaceDescription) ||
+      "",
+  };
+}
+
 async function _loadProtokollTopsLayout() {
   if (!_protokollTopsLayoutPromise) {
     const layoutPath = path.join(__dirname, "protokollTopsLayout.js");
@@ -283,6 +302,9 @@ const TABLE_LAYOUT_MODULES = Object.freeze([
         tableKey: "protokoll_tops",
         tableLabel: "TOP-Liste",
         description: "Pilotlayout fuer die Protokoll-TOP-Liste.",
+        surfaceKind: "table",
+        surfaceLabel: "TOP-Liste",
+        surfaceDescription: "Kalibrierbare Layout-Surface fuer die Protokoll-TOP-Liste.",
         tableKind: "content",
         editorEnabled: true,
         uiAvailable: true,
@@ -419,6 +441,9 @@ const TABLE_LAYOUT_MODULES = Object.freeze([
         tableKey: "protokoll_participants",
         tableLabel: "Teilnehmerliste",
         description: "Teilnehmerliste im Protokollkontext.",
+        surfaceKind: "table",
+        surfaceLabel: "Teilnehmerliste",
+        surfaceDescription: "Kalibrierbare Layout-Surface fuer die Protokoll-Teilnehmerliste.",
         tableKind: "content",
         editorEnabled: true,
         uiAvailable: true,
@@ -442,6 +467,9 @@ const TABLE_LAYOUT_MODULES = Object.freeze([
         tableKey: "project_firms",
         tableLabel: "Projekt-Firmenliste",
         description: "Projektbezogene Firmenliste fuer den naechsten Firmenlayout-Pilot.",
+        surfaceKind: "table",
+        surfaceLabel: "Projekt-Firmenliste",
+        surfaceDescription: "Kalibrierbare Layout-Surface fuer die Projekt-Firmenliste.",
         tableKind: "content",
         editorEnabled: true,
         uiAvailable: true,
@@ -458,6 +486,7 @@ const TABLE_LAYOUT_MODULES = Object.freeze([
 ]);
 
 function _cloneModuleTableDefinition(moduleDef, tableDef, defaultLayout = null) {
+  const surface = _resolveSurfaceMetadata(tableDef, { tableKey: tableDef.tableKey });
   return {
     moduleId: moduleDef.moduleId,
     moduleLabel: moduleDef.moduleLabel,
@@ -468,6 +497,10 @@ function _cloneModuleTableDefinition(moduleDef, tableDef, defaultLayout = null) 
     tableKey: tableDef.tableKey,
     tableLabel: tableDef.tableLabel,
     description: tableDef.description || "",
+    surfaceKey: surface.surfaceKey,
+    surfaceKind: surface.surfaceKind,
+    surfaceLabel: surface.surfaceLabel,
+    surfaceDescription: surface.surfaceDescription,
     tableKind: _normalizeTableKind(tableDef.tableKind),
     editorEnabled: _normalizeBool(tableDef.editorEnabled, true),
     uiAvailable: _normalizeBool(tableDef.uiAvailable, true),
@@ -522,6 +555,10 @@ function _createGenericAutoPrintTableDefinition(identity = {}) {
     tableKey: norm.tableKey,
     tableLabel: norm.tableKey,
     description: "Generische Auto-Layout-Surface aus der Print-Vorschau.",
+    surfaceKey: norm.tableKey,
+    surfaceKind: "surface",
+    surfaceLabel: norm.tableKey,
+    surfaceDescription: "Generische Auto-Layout-Surface aus der Print-Vorschau.",
     tableKind: "content",
     editorEnabled: false,
     uiAvailable: false,
@@ -647,6 +684,7 @@ function getTableLayoutModuleDefinition(moduleId) {
       ? [...moduleDef.supportedOrientations]
       : ["portrait"],
     tables: moduleDef.tables.map((tableDef) => ({
+      ..._resolveSurfaceMetadata(tableDef, { tableKey: tableDef.tableKey }),
       tableKey: tableDef.tableKey,
       tableLabel: tableDef.tableLabel,
       description: tableDef.description || "",
@@ -694,6 +732,7 @@ function getTableLayoutDefinition(identity = {}) {
     tableKey: tableDef.tableKey,
     tableLabel: tableDef.tableLabel,
     description: tableDef.description || "",
+    ..._resolveSurfaceMetadata(tableDef, { tableKey: tableDef.tableKey }),
     tableKind: _normalizeTableKind(tableDef.tableKind),
     editorEnabled: _normalizeBool(tableDef.editorEnabled, true),
     uiAvailable: _normalizeBool(tableDef.uiAvailable, true),


### PR DESCRIPTION
Bereitet den vorhandenen Tabellen-Kalibrator technisch auf allgemeine Layout-Surfaces vor.

Umfang:
- optionale Surface-Metadaten eingeführt
- surfaceKey, surfaceKind, surfaceLabel, surfaceDescription ergänzt
- bestehende Tabellenlayouts bleiben rückwärtskompatibel
- Prototype-Editor reicht Surface-Metadaten mit durch
- Registry-Tests erweitert

Keine Änderungen an:
- Restarbeiten-UI
- Router
- Print/PDF
- STATUS.md
- docs/MODULARISIERUNGSPLAN.md

Tests:
- node scripts/tests/tableLayoutRegistry.test.cjs
- node scripts/tests/layoutToolsRegression.test.cjs
- npm test