### PR TITLE
docs: M3 UI-Inspektor – Projektgedächtnis strukturieren

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,11 +393,13 @@ Ohne diesen Layout-Steckbrief keine spÃ¤tere Breitenpflege per Codex-Prompt.
 
 Regeln:
 - Vor Arbeiten am UI-Inspektor zuerst lesen:
+  - `docs/UI_INSPEKTOR_START_HIER.md`
   - `docs/UI_INSPEKTOR_PROJEKTAUFTRAG.md`
   - `docs/UI_INSPEKTOR_ARCHITEKTUR.md`
   - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
   - `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`
   - `docs/UI_INSPEKTOR_ARBEITSVERTRAG.md`
+- Die verbindliche Lesereihenfolge steht in `docs/UI_INSPEKTOR_START_HIER.md` (Startpunkt für neue Chats und Codex-Läufe).
 - Keine UI-Inspektor-Aufgabe ohne Aufgabenheft-Update abschließen.
 - UI-Inspektor-Core muss exportierbar und frei von BBM-Fachlogik bleiben.
 - Tabellen-Kalibrator nicht als UI-Inspektor-Bedienoberfläche weiterentwickeln.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -15,7 +15,7 @@ Aktueller Stand:
 - [x] M1 Projektklärung fachlich freigegeben
 - [x] M1.1 Projektdateien im Repo angelegt
 - [x] M2 Arbeitsvertrag und Regeln finalisiert
-- [ ] M3 Projektgedächtnis vollständig
+- [x] M3 Projektgedächtnis vollständig
 - [ ] M4 Architektur des exportierbaren Moduls final
 - [ ] M5 Umsetzungsplan ohne Code final
 - [ ] M6 erster Code-Schritt: Modulgerüst
@@ -39,9 +39,33 @@ Kein Codex-Auftrag gilt als fertig, wenn das Aufgabenheft nicht aktualisiert wur
   - `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`
   - `AGENTS.md`
 
+## M3 Abschlussnotiz
+- M3 Projektgedächtnis vollständig strukturiert.
+- Geänderte Dateien:
+  - `docs/UI_INSPEKTOR_START_HIER.md` (neu)
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`
+  - `AGENTS.md`
+- Einstiegspunkt für neue Chats und Codex-Läufe:
+  - `docs/UI_INSPEKTOR_START_HIER.md`
+
+## Lesereihenfolge für neue Chats
+1. `docs/UI_INSPEKTOR_START_HIER.md`
+2. `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+3. `docs/UI_INSPEKTOR_PROJEKTAUFTRAG.md`
+4. `docs/UI_INSPEKTOR_ARBEITSVERTRAG.md`
+5. `docs/UI_INSPEKTOR_ARCHITEKTUR.md`
+6. `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`
+
+## Aktueller Stand für neue Chats
+- Projektphase: Dokumentationsgrundlagen vorhanden
+- Implementierungscode: noch keiner
+- UI-Inspector-Modul: noch nicht angelegt
+- App-Funktionen: keine Änderungen
+
 ## Nächster Schritt
 Als nächster Schritt folgt:
-- **M3 Projektgedächtnis vollständig strukturieren**
-
-Alternativ (falls M3 im Folgeauftrag bereits abgedeckt ist):
 - **M4 Architektur des exportierbaren Moduls vertiefen**
+
+Hinweis:
+- Noch kein Code, noch kein Modulgerüst

--- a/docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md
+++ b/docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md
@@ -30,3 +30,8 @@
 
 **Begründung:** Damit ChatGPT, Codex Cloud, Codex lokal und der Nutzer nach festen Regeln arbeiten und neue Chats nicht wieder bei null beginnen.
 
+## Entscheidung 007
+**Beschluss:** Das Projekt erhält mit `docs/UI_INSPEKTOR_START_HIER.md` einen festen Einstiegspunkt.
+
+**Begründung:** Neue Chats und Codex-Läufe sollen nicht aus verstreuten Informationen den Projektstand zusammensuchen müssen.
+

--- a/docs/UI_INSPEKTOR_START_HIER.md
+++ b/docs/UI_INSPEKTOR_START_HIER.md
@@ -24,16 +24,13 @@ Pflichtreihenfolge:
 ## 4. Aktueller Projektstand
 - M1.1 Projektfundament erledigt
 - M2 Arbeitsvertrag erledigt
-- M3 Projektgedächtnis wird mit diesem Auftrag strukturiert
+- M3 Projektgedächtnis erledigt
 - Noch kein Implementierungscode
 - Noch kein UI-Inspector-Modul
 - Noch keine App-Funktion
 
 ## 5. Nächster geplanter Schritt
-Nach M3:
-- M4 Architektur des exportierbaren Moduls vertiefen
-oder
-- falls M4 bereits ausreichend ist: M5 Umsetzungsplan ohne Code vorbereiten
+- Nächster Schritt: M4 Architektur des exportierbaren Moduls vertiefen
 
 ## 6. Harte Stopps
 Nicht fortführen:
@@ -46,4 +43,4 @@ Nicht fortführen:
 ## 7. Definition für neue Chats
 Ein neuer Chat soll mit dieser Zusammenfassung starten können:
 
-„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Bisher wurden nur Dokumentationsgrundlagen erstellt. Es gibt noch keinen Code. Nächster Schritt laut Aufgabenheft ist M4/M5, abhängig vom Stand.“
+„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Bisher wurden nur Dokumentationsgrundlagen erstellt. Es gibt noch keinen Code. Nächster Schritt laut Aufgabenheft ist M4.“

--- a/docs/UI_INSPEKTOR_START_HIER.md
+++ b/docs/UI_INSPEKTOR_START_HIER.md
@@ -1,0 +1,49 @@
+# UI-Inspektor – Start hier
+
+## 1. Zweck dieser Datei
+- Diese Datei ist der erste Einstieg in das UI-Inspektor-Projekt.
+- Neue Chats und Codex-Läufe lesen diese Datei zuerst.
+
+## 2. Lesereihenfolge
+Pflichtreihenfolge:
+1. `docs/UI_INSPEKTOR_START_HIER.md`
+2. `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+3. `docs/UI_INSPEKTOR_PROJEKTAUFTRAG.md`
+4. `docs/UI_INSPEKTOR_ARBEITSVERTRAG.md`
+5. `docs/UI_INSPEKTOR_ARCHITEKTUR.md`
+6. `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`
+
+## 3. Kurzfassung Projektziel
+- Neues exportierbares UI-Inspector-Modul.
+- Kein Tabellen-Kalibrator-Umbau.
+- Kein BBM-Sonderding.
+- Kein freier Drag-and-drop-Baukasten.
+- Zielgruppe: fachlicher Anwender ohne Programmierkenntnisse.
+- Bedienziel: echte UI-Bereiche sichtbar machen, anklicken, verständliche Stellschrauben anzeigen, später speichern/zurücksetzen.
+
+## 4. Aktueller Projektstand
+- M1.1 Projektfundament erledigt
+- M2 Arbeitsvertrag erledigt
+- M3 Projektgedächtnis wird mit diesem Auftrag strukturiert
+- Noch kein Implementierungscode
+- Noch kein UI-Inspector-Modul
+- Noch keine App-Funktion
+
+## 5. Nächster geplanter Schritt
+Nach M3:
+- M4 Architektur des exportierbaren Moduls vertiefen
+oder
+- falls M4 bereits ausreichend ist: M5 Umsetzungsplan ohne Code vorbereiten
+
+## 6. Harte Stopps
+Nicht fortführen:
+- Tabellen-Kalibrator als Bedienoberfläche des UI-Inspektors
+- direkte UI-Frickelei als Ersatz für den Inspektor
+- BBM-Fachlogik im Inspector-Core
+- vage Aufgaben wie „mach schöner“
+- Codearbeiten ohne Aufgabenheft-Update
+
+## 7. Definition für neue Chats
+Ein neuer Chat soll mit dieser Zusammenfassung starten können:
+
+„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Bisher wurden nur Dokumentationsgrundlagen erstellt. Es gibt noch keinen Code. Nächster Schritt laut Aufgabenheft ist M4/M5, abhängig vom Stand.“


### PR DESCRIPTION
### Motivation
- Einen klaren Einstiegspunkt und ein dauerhaftes Projektgedächtnis schaffen, damit neue Chats und Codex-Läufe den Projektstand nicht aus verstreuten Dateien zusammensuchen müssen. 
- Den aktuellen Stand dokumentieren und M3 formal abschließen, damit Folge-Meilensteine (vor allem M4) konsistent starten können. 
- Verbindliche Lese- und Arbeitsregeln für das UI-Inspektor-Projekt deutlich machen, ohne Code oder bestehende App-Funktionen zu ändern.

### Description
- Neue Datei `docs/UI_INSPEKTOR_START_HIER.md` angelegt mit Zweck, Pflicht-Lesereihenfolge, Kurzfassung des Projektziels, aktuellem Stand, nächstem Schritt, harten Stopps und einer Start-Zusammenfassung für neue Chats. 
- `docs/UI_INSPEKTOR_AUFGABENHEFT.md` aktualisiert: `M3` als erledigt markiert, `M3`-Abschlussnotiz, Lesereihenfolge und Abschnitt „Aktueller Stand für neue Chats“ ergänzt sowie der nächste Schritt auf `M4` gesetzt (Hinweis: noch kein Code / kein Modulgerüst). 
- `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md` ergänzt um `Entscheidung 007`, die `docs/UI_INSPEKTOR_START_HIER.md` als festen Einstiegspunkt festschreibt. 
- `AGENTS.md` im Abschnitt „UI-Inspektor-Projekt“ additiv ergänzt, so dass `docs/UI_INSPEKTOR_START_HIER.md` jetzt als erste Pflichtlektüre genannt wird und auf die verbindliche Lesereihenfolge verwiesen wird; keine bestehenden Regeln entfernt. 
- Geänderte Dateien: `docs/UI_INSPEKTOR_START_HIER.md` (neu), `docs/UI_INSPEKTOR_AUFGABENHEFT.md`, `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`, `AGENTS.md`.

### Testing
- Automatische Prüfungen ausgeführt: `git diff --stat`, `git diff --name-only` und `git status --short --branch`, die bestätigt haben, dass ausschließlich die erwarteten Dokumentdateien geändert wurden. 
- Keine App-/Unit-Tests notwendig, da es sich um reine Dokumentationsänderungen handelt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f8aa87bd88322ba64e1ebbd63060b)