### PR TITLE
docs(ui-inspektor): M4 – Architektur des UI‑Inspektor-Moduls vertieft

### DIFF
--- a/docs/UI_INSPEKTOR_ARCHITEKTUR.md
+++ b/docs/UI_INSPEKTOR_ARCHITEKTUR.md
@@ -1,54 +1,277 @@
-# UI-Inspektor Zielarchitektur
+# UI-Inspektor Architektur
 
-## Architekturziel
-Der UI-Inspektor wird als exportierbares Modul aufgebaut.
+## 1. Architekturziel
+Der UI-Inspektor wird als neues exportierbares Modul aufgebaut.
 
-Kernprinzip:
-- allgemeiner Core ohne BBM-Fachlogik
-- App-spezifisches Wissen nur in klar abgegrenzten Integrationsschichten
-
-## Modulare Trennung
-Die Zielarchitektur trennt diese Bausteine:
-
-1. **Core**
-   - enthält allgemeine Inspektor-Logik
-   - kennt keine BBM-Fachdaten und keine BBM-Screens
-
-2. **Overlay**
-   - visualisiert markierbare UI-Bereiche
-   - steuert Hervorhebung, Fokus, Auswahlrückmeldung
-
-3. **Panel**
-   - zeigt laienverständliche Bedienoberfläche
-   - bietet fachlich benannte Änderoptionen
-
-4. **Registry**
-   - verwaltet registrierte Bereichstypen und Bearbeitungsoptionen
-   - bleibt technisch allgemein
-
-5. **Store**
-   - hält Inspektor-Zustand (aktiv, Auswahl, Änderstatus)
-   - bleibt von App-Fachlogik entkoppelt
-
-6. **Adapter**
-   - bindet konkrete App-Strukturen an den Core an
-   - enthält app-spezifische Übersetzung von Bereichsdaten
-
-7. **Layout-Landkarte**
-   - beschreibt echte sichtbare UI-Bereiche pro App
-   - liefert fachliche Bereichsnamen und editierbare Eigenschaften
-
-## Trennregel Core vs. App
-- Der Core darf keine BBM-Fachlogik enthalten.
-- App-spezifisches gehört ausschließlich in Adapter und Layout-Landkarten.
-- Der Core bleibt dadurch portierbar und wiederverwendbar.
-
-## Beispielhafte spätere Zielstruktur
-Diese Struktur ist ein Zielbild, noch keine Implementierung:
-
-- `src/shared/uiInspector/`
-- `src/renderer/uiInspector/`
+Zielbild:
+- nicht BBM-spezifisch
+- kein Umbau des Tabellen-Kalibrators zur Hauptlösung
+- keine freie Drag-and-drop-Lösung
+- echte UI-Bereiche sichtbar machen, anklickbar machen und später kontrolliert einstellbar machen
 
 Wichtig:
-- In diesem Meilenstein werden dort noch keine Code-Dateien angelegt.
-- Es wird nur das Projektfundament dokumentiert.
+- In diesem Meilenstein wird nur Architektur dokumentiert.
+- Es wird kein Modulgerüst angelegt.
+- Es wird keine App-Funktion geändert.
+
+## 2. Schichtenmodell
+
+### 2.1 Core
+**Aufgaben:**
+- Inspektor-Zustand verwalten
+- registrierte Bereiche kennen
+- aktive Auswahl verwalten
+- Regeln für Auswahl-/Bearbeitungsfluss bereitstellen
+
+**Muss einhalten:**
+- keine direkte DOM-Manipulation
+- keine BBM-Fachlogik
+- keine app-spezifischen Begriffe
+
+**Darf nicht:**
+- Restarbeiten, Protokoll, Rechnung, TOP, Bauvorhaben kennen
+- direkt CSS einer konkreten App ändern
+- Fachlogik ausführen
+
+### 2.2 Registry
+**Aufgaben:**
+- Layout-Landkarten aufnehmen
+- Bereiche, Container, Felder und erlaubte Einstellungen kennen
+- Standardwerte bereitstellen
+- Typen von Einstellwerten verwalten (z. B. Breite, Höhe, Abstand, Verschiebung, Spaltenbreite)
+
+**Rolle im System:**
+- fachliche Erlaubnisliste, welche Stellschrauben pro Bereich sichtbar und änderbar sind
+- keine direkte Darstellung und keine Persistenzlogik
+
+### 2.3 Overlay
+**Aufgaben:**
+- sichtbare Bereiche auf der echten UI markieren
+- Hover, Auswahl und aktiven Bereich anzeigen
+- Rückmeldung geben, welcher Bereich gerade getroffen wurde
+
+**Muss einhalten:**
+- keine dauerhaften Layoutänderungen speichern
+- keine Fachlogik ausführen
+- nur anzeigen und auswählen
+
+### 2.4 Panel
+**Aufgaben:**
+- laienverständliche Bedienung anzeigen
+- nur freigegebene Stellschrauben zeigen
+- Werte für den ausgewählten Bereich ändern lassen
+
+**Sprachregeln:**
+- keine CSS-Fachsprache in der Hauptbedienung
+- Begriffe wie Bereich, Container, Feld, Breite, Höhe, Abstand, links/rechts, oben/unten verwenden
+
+### 2.5 Store
+**Aufgaben:**
+- Werte laden
+- Werte speichern
+- Standards wiederherstellen
+- Speicher austauschbar halten (z. B. lokaler Speicher, später andere Backends)
+
+**Muss einhalten:**
+- kein app-spezifisches Fachwissen
+- keine Kenntnis über konkrete BBM-Screens
+
+### 2.6 Adapter
+**Aufgaben:**
+- konkrete App mit dem Inspektor verbinden
+- DOM-Elemente und Layout-Landkarte zusammenbringen
+- app-spezifische Umsetzung kapseln
+
+**Beispiele:**
+- BBM-Adapter
+- Adapter einer späteren Rechnungs-App
+
+### 2.7 Layout-Landkarte
+**Aufgaben:**
+- sichtbare Bereiche einer konkreten App beschreiben
+- fachliche Namen liefern
+- Hierarchie liefern
+- erlaubte Stellschrauben pro Bereich liefern
+- sowohl Bestand als auch neue UI unterstützen
+
+**Nutzen:**
+- Brücke zwischen generischem Inspektor und konkreter Oberfläche
+- Grundlage für nachvollziehbare, kontrollierte Bedienung
+
+## 3. Trennung allgemein / app-spezifisch
+
+| Allgemein im Core | App-spezifisch im Adapter / in der Landkarte |
+| --- | --- |
+| Bereich | Restarbeiten |
+| Container | Protokoll |
+| Feld | Rechnung |
+| Liste | TOP |
+| Eingabebereich | Bauvorhaben |
+| Einstellung | Positionsliste |
+| Wert | Summenblock |
+| Auswahl | konkrete Feldnamen je Screen |
+| Overlayzustand | app-spezifische Hierarchien |
+
+Regel:
+- Allgemeine Begriffe und Abläufe bleiben im Core.
+- Fachliche Domänenbegriffe bleiben außerhalb des Cores.
+
+## 4. Bedienmodell für den Laien
+Geplanter Bedienablauf:
+1. Layoutmodus einschalten
+2. sichtbare Bereiche werden gerahmt
+3. Bereich anklicken
+4. Panel zeigt verständliche Optionen
+5. Werte ändern
+6. übernehmen / speichern / Standard wiederherstellen
+
+Geeignete Begriffe in der Bedienung:
+- Meta-Container
+- Liste
+- Editbox
+- Feldbreite
+- Abstand links/rechts
+- nach oben/unten
+
+Verboten in der Hauptbedienung:
+- gridTrack
+- minmax
+- fr
+- DOM
+- data-Attribute
+- CSS-Variablenpfade
+- surfaceKey
+
+Hinweis:
+- Technische Begriffe können intern existieren, werden aber nicht als primäre Nutzerbegriffe präsentiert.
+
+## 5. Einstell-Ebenen
+
+### 5.1 Bereichsebene
+Beispiele:
+- Kopfbereich
+- Hauptbereich
+- Eingabebereich
+
+Typische Einstellungen:
+- Gesamtbreite/-höhe
+- Außenabstände
+- Position im übergeordneten Layout
+
+### 5.2 Containerebene
+Beispiele:
+- Filterleiste
+- Meta-Container
+- Summenblock
+
+Typische Einstellungen:
+- Innenabstände
+- Abstände zwischen Elementen
+- Breite/Höhe des Containers
+
+### 5.3 Feldebene
+Beispiele:
+- Status
+- Fertig bis
+- Menge
+- Einzelpreis
+
+Typische Einstellungen:
+- Feldbreite
+- Feldhöhe
+- horizontale/vertikale Verschiebung im erlaubten Rahmen
+
+### 5.4 Listen-/Tabellenebene
+Beispiele:
+- normale Spalten
+- Metaspalten
+- Ampelspalte
+- Positionsspalten
+
+Typische Einstellungen:
+- Spaltenbreiten
+- Spaltenreihenfolge nur, falls explizit freigegeben
+- Abstände und Darstellungsdichte im erlaubten Rahmen
+
+### 5.5 Sonderbereiche
+Beispiele:
+- Editbox
+- Foto-/Anlagenbereich
+- Quicklane / Werkzeugleiste
+
+Typische Einstellungen:
+- Bereichsgröße
+- relative Position
+- Sichtbarkeitsnahe Darstellungsparameter (ohne Fachlogikänderung)
+
+## 6. Bestand vs. neue UI
+
+### Bestand
+- UI ist bereits gewachsen
+- Bereiche müssen nachträglich erkannt und markiert werden
+- Inspektor hilft beim Sichtbarmachen und kontrollierten Einstellen
+- Adapter und Landkarte dokumentieren nachträglich, was fachlich anfassbar ist
+
+### Neue UI
+- bei UI-Neubau muss eine Bereichs-Landkarte mitgeliefert werden
+- neue UI darf nicht anonym entstehen
+- spätere Einstellbarkeit wird beim Bau mitgedacht
+- Nutzer prüft fachlich, ohne technische Details kennen zu müssen
+
+## 7. Exportierbarkeit
+Leitplanken:
+- Core darf keine BBM-Importe haben
+- Adapter kapseln App-Spezifik
+- Modul soll in andere eigene Apps übertragbar sein
+- keine harten BBM-Pfade im Core
+- BBM ist erster Pilot, nicht Architekturgrundlage
+
+Folge:
+- Portierung in weitere Apps erfolgt über neue Adapter + neue Landkarten, nicht über Core-Abzweigungen.
+
+## 8. Grenzen und Nicht-Ziele
+Festgelegt als Nicht-Ziele:
+- kein freies Drag-and-drop
+- keine automatische Magie für fremde Apps ohne Codezugriff
+- keine Änderung von Fachlogik
+- keine direkte UI-Frickelei
+- kein Ersatz für Tests
+- kein Tabellen-Kalibrator als Bedienoberfläche
+
+## 9. Grobe spätere Zielstruktur
+Nur Zielbild, keine Anlage in M4:
+
+```text
+src/shared/uiInspector/
+- uiInspectorCore.js
+- uiInspectorRegistry.js
+- uiInspectorStore.js
+- uiInspectorTypes.js
+
+src/renderer/uiInspector/
+- UiInspectorOverlay.js
+- UiInspectorPanel.js
+- UiInspectorRuntime.js
+
+src/renderer/uiInspector/adapters/
+- bbmRestarbeitenInspectorAdapter.js
+- weitere Adapter später
+
+docs/ui-landkarten/
+- RESTARBEITEN.md
+- PROTOKOLL.md
+- RECHNUNG.md
+```
+
+Wichtig:
+- In M4 werden diese Dateien/Ordner **nicht** angelegt.
+- Die Struktur dient nur als Architektur-Zielbild für spätere Meilensteine.
+
+## 10. Offene Architekturfragen für M5
+- Wie genau wird der Store angebunden?
+- Wie werden Layout-Landkarten formal beschrieben?
+- Welche Einstellwert-Typen gibt es im MVP?
+- Wie wird Overlay aktiviert?
+- Wo sitzt der Einstieg in der App?
+- Wie werden visuelle Prüfungen später gemacht?
+- Was ist MVP und was kommt später?

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -16,7 +16,7 @@ Aktueller Stand:
 - [x] M1.1 Projektdateien im Repo angelegt
 - [x] M2 Arbeitsvertrag und Regeln finalisiert
 - [x] M3 Projektgedächtnis vollständig
-- [ ] M4 Architektur des exportierbaren Moduls final
+- [x] M4 Architektur des exportierbaren Moduls final
 - [ ] M5 Umsetzungsplan ohne Code final
 - [ ] M6 erster Code-Schritt: Modulgerüst
 
@@ -65,7 +65,20 @@ Kein Codex-Auftrag gilt als fertig, wenn das Aufgabenheft nicht aktualisiert wur
 
 ## Nächster Schritt
 Als nächster Schritt folgt:
-- **M4 Architektur des exportierbaren Moduls vertiefen**
+- **M5 Umsetzungsplan ohne Code finalisieren**
 
 Hinweis:
 - Noch kein Code, noch kein Modulgerüst
+
+
+## M4 Abschlussnotiz
+- M4 Architektur des exportierbaren UI-Inspektor-Moduls vertieft und als Schichtenmodell konkretisiert.
+- Geänderte Dateien:
+  - `docs/UI_INSPEKTOR_ARCHITEKTUR.md`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`
+  - `docs/UI_INSPEKTOR_START_HIER.md`
+- Nächster Schritt:
+  - **M5 Umsetzungsplan ohne Code finalisieren**
+- Hinweis:
+  - Noch kein Code, noch kein Modulgerüst

--- a/docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md
+++ b/docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md
@@ -35,3 +35,9 @@
 
 **Begründung:** Neue Chats und Codex-Läufe sollen nicht aus verstreuten Informationen den Projektstand zusammensuchen müssen.
 
+
+
+## Entscheidung 008
+**Beschluss:** Die Architektur wird als exportierbares Schichtenmodell festgelegt.
+
+**Begründung:** Core, Overlay, Panel, Registry, Store, Adapter und Layout-Landkarte müssen getrennt bleiben, damit der UI-Inspektor nicht BBM-spezifisch wird und später in andere Apps exportiert werden kann.

--- a/docs/UI_INSPEKTOR_START_HIER.md
+++ b/docs/UI_INSPEKTOR_START_HIER.md
@@ -25,12 +25,13 @@ Pflichtreihenfolge:
 - M1.1 Projektfundament erledigt
 - M2 Arbeitsvertrag erledigt
 - M3 Projektgedächtnis erledigt
+- M4 Architekturvertiefung erledigt
 - Noch kein Implementierungscode
 - Noch kein UI-Inspector-Modul
 - Noch keine App-Funktion
 
 ## 5. Nächster geplanter Schritt
-- Nächster Schritt: M4 Architektur des exportierbaren Moduls vertiefen
+- Nächster Schritt: M5 Umsetzungsplan ohne Code finalisieren
 
 ## 6. Harte Stopps
 Nicht fortführen:
@@ -43,4 +44,4 @@ Nicht fortführen:
 ## 7. Definition für neue Chats
 Ein neuer Chat soll mit dieser Zusammenfassung starten können:
 
-„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Bisher wurden nur Dokumentationsgrundlagen erstellt. Es gibt noch keinen Code. Nächster Schritt laut Aufgabenheft ist M4.“
+„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Bisher wurden nur Dokumentationsgrundlagen erstellt. Es gibt noch keinen Code. Nächster Schritt laut Aufgabenheft ist M5.“


### PR DESCRIPTION
### Motivation
- Das Ziel ist, die Architektur des später exportierbaren UI‑Inspektor‑Moduls so weit zu konkretisieren, dass ein anschließender Umsetzungsplan ohne Code erstellt werden kann. 
- Die Änderungen sollen klare Grenzen zwischen generischem Core und App‑spezifischen Komponenten definieren, um Portierbarkeit sicherzustellen. 
- Die Arbeit ist ein reines Dokumentationspaket; es darf kein Code, kein UI‑Modul und keine App‑Logik geändert werden. 

### Description
- `docs/UI_INSPEKTOR_ARCHITEKTUR.md` wurde deutlich erweitert und strukturiert; es enthält jetzt ein nummeriertes Schichtenmodell (Core, Registry, Overlay, Panel, Store, Adapter, Layout‑Landkarte), Trennregeln, Bedienmodell, Einstell‑Ebenen, Bestand vs. neue UI, Exportierbarkeitsleitplanken, Grenzen/Nicht‑Ziele, ein grobes Zielstruktur‑Bild und offene Fragen für M5. 
- `docs/UI_INSPEKTOR_AUFGABENHEFT.md` wurde aktualisiert: M4 ist als erledigt markiert, eine M4‑Abschlussnotiz wurde ergänzt und der nächste Schritt auf M5 gesetzt. 
- `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md` wurde um Entscheidung 008 ergänzt, die das Schichtenmodell (Core/Overlay/Panel/Registry/Store/Adapter/Layout‑Landkarte) als Architekturentscheidung festlegt. 
- `docs/UI_INSPEKTOR_START_HIER.md` wurde angepasst, um M4 als erledigt zu zeigen und M5 als nächsten Schritt zu nennen; es wurden keine `src`‑Dateien oder sonstige Code‑ bzw. App‑Bereiche angefasst. 

### Testing
- Repository‑Konsistenzprüfungen (Diff/Stat, Namensliste der geänderten Dateien und Status/Branch‑Übersicht) wurden ausgeführt und lieferten erwartete Ergebnisse (Änderungen beschränken sich auf die vier Dokumente). 
- Es wurden keine App‑ oder Unit‑Tests ausgeführt, weil dies ein rein dokumentäres Meilensteinpaket ist. 
- Alle Änderungen sind ausschließlich Dokumentation und betreffen keine Build‑ oder Laufzeitartefakte.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10125c8b8c8322804a5a762ae767aa)