### PR TITLE
docs(ui-inspektor): finalize M5 implementation plan without code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -404,3 +404,5 @@ Regeln:
 - UI-Inspektor-Core muss exportierbar und frei von BBM-Fachlogik bleiben.
 - Tabellen-Kalibrator nicht als UI-Inspektor-Bedienoberfläche weiterentwickeln.
 - Keine bestehenden App-Bereiche ändern, wenn der Auftrag nur Dokumentation betrifft.
+- M6 ist der erste Code-Schritt, aber nur Modulgerüst.
+- Kein Overlay und keine Restarbeiten-Anbindung in M6.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -17,7 +17,7 @@ Aktueller Stand:
 - [x] M2 Arbeitsvertrag und Regeln finalisiert
 - [x] M3 Projektgedächtnis vollständig
 - [x] M4 Architektur des exportierbaren Moduls final
-- [ ] M5 Umsetzungsplan ohne Code final
+- [x] M5 Umsetzungsplan ohne Code final
 - [ ] M6 erster Code-Schritt: Modulgerüst
 
 ## Definition of Done (DoD)
@@ -65,10 +65,10 @@ Kein Codex-Auftrag gilt als fertig, wenn das Aufgabenheft nicht aktualisiert wur
 
 ## Nächster Schritt
 Als nächster Schritt folgt:
-- **M5 Umsetzungsplan ohne Code finalisieren**
+- **M6 erster Code-Schritt: Modulgerüst**
 
 Hinweis:
-- Noch kein Code, noch kein Modulgerüst
+- Ab M6 beginnt Code, aber nur Modulgerüst ohne sichtbare Funktion
 
 
 ## M4 Abschlussnotiz
@@ -82,3 +82,17 @@ Hinweis:
   - **M5 Umsetzungsplan ohne Code finalisieren**
 - Hinweis:
   - Noch kein Code, noch kein Modulgerüst
+
+
+## M5 Abschlussnotiz
+- M5 Umsetzungsplan ohne Code finalisiert.
+- Geänderte Dateien:
+  - `docs/UI_INSPEKTOR_UMSETZUNGSPLAN.md` (neu)
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`
+  - `docs/UI_INSPEKTOR_START_HIER.md`
+  - `AGENTS.md`
+- Nächster Schritt:
+  - **M6 erster Code-Schritt: Modulgerüst**
+- Hinweis:
+  - Ab M6 beginnt Code, aber nur Modulgerüst ohne sichtbare Funktion

--- a/docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md
+++ b/docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md
@@ -41,3 +41,9 @@
 **Beschluss:** Die Architektur wird als exportierbares Schichtenmodell festgelegt.
 
 **Begründung:** Core, Overlay, Panel, Registry, Store, Adapter und Layout-Landkarte müssen getrennt bleiben, damit der UI-Inspektor nicht BBM-spezifisch wird und später in andere Apps exportiert werden kann.
+
+
+## Entscheidung 009
+**Beschluss:** Der UI-Inspektor wird schrittweise ab M6 über ein Modulgerüst, Landkartenformat, Pilot-Landkarte, Markierungen, Overlay, Auswahl, Panel, temporäre Anwendung und Speicherung aufgebaut.
+
+**Begründung:** Der Inspektor darf nicht als Großpaket entstehen. Die schrittweise Umsetzung verhindert Nebenwirkungen und hält das Modul exportierbar.

--- a/docs/UI_INSPEKTOR_START_HIER.md
+++ b/docs/UI_INSPEKTOR_START_HIER.md
@@ -26,12 +26,17 @@ Pflichtreihenfolge:
 - M2 Arbeitsvertrag erledigt
 - M3 Projektgedächtnis erledigt
 - M4 Architekturvertiefung erledigt
+- M5 Umsetzungsplan ohne Code erledigt
 - Noch kein Implementierungscode
 - Noch kein UI-Inspector-Modul
 - Noch keine App-Funktion
 
 ## 5. Nächster geplanter Schritt
-- Nächster Schritt: M5 Umsetzungsplan ohne Code finalisieren
+- Nächster Schritt: M6 erster Code-Schritt: Modulgerüst
+- Ab M6 beginnt Code
+- M6 ist nur Modulgerüst
+- Noch keine sichtbare UI-Funktion
+- Noch keine App-Integration
 
 ## 6. Harte Stopps
 Nicht fortführen:
@@ -44,4 +49,4 @@ Nicht fortführen:
 ## 7. Definition für neue Chats
 Ein neuer Chat soll mit dieser Zusammenfassung starten können:
 
-„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Bisher wurden nur Dokumentationsgrundlagen erstellt. Es gibt noch keinen Code. Nächster Schritt laut Aufgabenheft ist M5.“
+„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Bisher wurden nur Dokumentationsgrundlagen erstellt. Es gibt noch keinen Code. Nächster Schritt laut Aufgabenheft ist M6 (erster Code-Schritt: Modulgerüst ohne sichtbare UI-Funktion und ohne App-Integration).“

--- a/docs/UI_INSPEKTOR_UMSETZUNGSPLAN.md
+++ b/docs/UI_INSPEKTOR_UMSETZUNGSPLAN.md
@@ -1,0 +1,298 @@
+# UI-Inspektor Umsetzungsplan
+
+## 1. Zweck des Umsetzungsplans
+- Dieser Plan übersetzt Projektauftrag, Arbeitsvertrag und Architektur in konkrete Baupakete.
+- Er ist noch kein Code.
+- Er verhindert, dass der UI-Inspektor wieder als zu großes Paket begonnen wird.
+
+## 2. Grundregel der Umsetzung
+- Ein Meilenstein = ein klarer Zweck.
+- Ein Paket = ein Branch = ein Commit = ein PR/Merge.
+- Keine sichtbare UI-Funktion, solange nur ein Modulgerüst beauftragt ist.
+- Keine BBM-Fachlogik im Core.
+- Kein Tabellen-Kalibrator-Umbau.
+- Kein Restarbeiten-Umbau als Abkürzung.
+- Aufgabenheft wird nach jedem Paket aktualisiert.
+
+## 3. Meilensteinplan ab M6
+
+### M6 – Modulgerüst anlegen
+**Ziel:**
+- leeres, exportierbares UI-Inspector-Modulgerüst anlegen
+- keine sichtbare Funktion
+- keine App-Integration
+- keine Restarbeiten-Anbindung
+- nur Struktur, Exporte und Grundtests
+
+**Voraussichtliche Zielstruktur:**
+```text
+src/shared/uiInspector/
+- uiInspectorCore.js
+- uiInspectorRegistry.js
+- uiInspectorStore.js
+- uiInspectorTypes.js
+- index.js
+
+src/renderer/uiInspector/
+- UiInspectorRuntime.js
+- UiInspectorOverlay.js
+- UiInspectorPanel.js
+- index.js
+
+scripts/tests/
+- uiInspectorCore.test.cjs
+- uiInspectorRegistry.test.cjs
+```
+
+**Noch nicht:**
+- keine echte UI öffnen
+- kein Overlay anzeigen
+- kein Speichern
+- kein BBM-Adapter
+- keine Layout-Landkarte für Restarbeiten
+
+**Geeignet:**
+- Codex Cloud
+
+**Prüfung:**
+- Importierbarkeit
+- Tests für leere Registry/Core-Grundverhalten
+- `npm test`, falls passend
+
+### M7 – Layout-Landkarten-Format definieren
+**Ziel:**
+- formales Format für Layout-Landkarten definieren
+- noch keine echte App markieren
+- Beispiel-Landkarte nur als Testdaten
+- Begriffe: Bereich, Container, Feld, Liste, Eingabebereich, Einstellung
+
+**Noch nicht:**
+- keine Restarbeiten-UI ändern
+- kein Overlay
+- kein Panel
+
+**Geeignet:**
+- Codex Cloud
+
+**Prüfung:**
+- Tests für Validierung/Normalisierung einer Landkarte
+- keine App-Dateien betroffen
+
+### M8 – Restarbeiten als erste Pilot-Landkarte dokumentieren
+**Ziel:**
+- Restarbeiten-Landkarte als Dokument und/oder reine Datenstruktur vorbereiten
+- vorhandene UI fachlich beschreiben:
+  - Kopfbereich
+  - Filterleiste
+  - Klassenfilter
+  - Verortung
+  - Meta-Filter
+  - Liste
+  - Editbox
+- noch keine DOM-Markierung in der App
+- noch keine UI-Änderung
+
+**Geeignet:**
+- Codex Cloud
+
+**Prüfung:**
+- nur Dokumentation/Testdaten
+- keine Restarbeiten-Screen-Änderung
+
+### M9 – Restarbeiten-DOM-Markierungen minimal einführen
+**Ziel:**
+- bestehende Restarbeiten-UI bekommt minimale, stabile Markierungen, damit der Inspektor Bereiche später finden kann
+- keine sichtbare Layoutänderung
+- keine Stiländerung
+- keine Fachlogikänderung
+
+**Noch nicht:**
+- kein Overlay
+- kein Panel
+- keine Werte ändern
+
+**Geeignet:**
+- eher lokal oder Cloud mit sehr enger Prüfung
+- lokale Sichtprüfung erforderlich
+
+**Prüfung:**
+- Diff darf nur Markierungen/Attribute betreffen
+- Restarbeiten-Tests laufen
+- Sichtprüfung: Oberfläche sieht unverändert aus
+
+### M10 – Overlay nur anzeigen
+**Ziel:**
+- Layoutmodus kann Rahmen über erkannte Bereiche legen
+- nur Anzeige
+- keine Werte ändern
+- keine Speicherung
+
+**Geeignet:**
+- lokal, weil sichtbare UI geprüft werden muss
+
+**Prüfung durch Nutzer:**
+- Sind die richtigen Bereiche gerahmt?
+- Sind die Namen verständlich?
+- Fehlt ein Bereich?
+- Ist ein Bereich falsch gruppiert?
+
+### M11 – Bereich anklicken und Auswahl anzeigen
+**Ziel:**
+- Klick auf gerahmten Bereich wählt diesen Bereich aus
+- Panel oder einfache Anzeige zeigt:
+  - gewählter Bereich
+  - Hierarchie
+  - Typ
+- noch keine Werte ändern
+
+**Geeignet:**
+- lokal
+
+**Prüfung durch Nutzer:**
+- Klickt man wirklich den Bereich an, den man meint?
+- Wird z. B. Meta-Container von einzelnen Feldern unterscheidbar?
+- Ist die Hierarchie verständlich?
+
+### M12 – Panel zeigt erlaubte Stellschrauben
+**Ziel:**
+- Panel zeigt nur erlaubte Einstellungen aus der Landkarte
+- noch keine dauerhafte Speicherung
+- Begriffe laientauglich:
+  - Breite
+  - Höhe
+  - Abstand
+  - nach links/rechts
+  - nach oben/unten
+  - Feldbreite
+
+**Noch nicht:**
+- keine echten Layoutänderungen speichern
+- keine CSS-Fachsprache in der Hauptbedienung
+
+**Geeignet:**
+- lokal
+
+**Prüfung durch Nutzer:**
+- Versteht man die Stellschrauben?
+- Sind es die richtigen für den gewählten Bereich?
+- Werden keine technischen Begriffe angezeigt?
+
+### M13 – Werte temporär anwenden
+**Ziel:**
+- Änderungen können als Vorschau auf die echte UI angewendet werden
+- Abbrechen setzt zurück
+- Speichern noch nicht dauerhaft oder nur bewusst begrenzt
+
+**Geeignet:**
+- lokal
+
+**Prüfung:**
+- Nur der gewählte Bereich verändert sich
+- keine Liste/Editbox als Seiteneffekt, wenn Meta-Container geändert wird
+- Rücksetzen funktioniert
+
+### M14 – Speichern und Standard wiederherstellen
+**Ziel:**
+- Layoutwerte dauerhaft speichern
+- Standard wiederherstellen
+- Werte beim Öffnen anwenden
+- Store-Anbindung finalisieren
+
+**Geeignet:**
+- lokal mit Tests
+
+**Prüfung:**
+- Speichern funktioniert
+- Neustart/Reload übernimmt Werte
+- Standard zurück funktioniert
+- Aufgabenheft aktualisiert
+
+### M15 – Zweiter Pilot außerhalb Restarbeiten
+**Ziel:**
+- Nachweis, dass der Inspektor nicht Restarbeiten-spezifisch ist
+- mögliche Kandidaten:
+  - Protokoll TOP-Liste
+  - Projektfirmenliste
+  - spätere Rechnungs-/Angebots-App
+
+**Geeignet:**
+- abhängig vom Pilot
+
+**Prüfung:**
+- Core bleibt unverändert allgemein
+- neue App-Anbindung erfolgt über Adapter/Landkarte
+
+## 4. MVP-Definition
+
+**MVP bedeutet:**
+- Layoutmodus aktivierbar
+- echte UI-Bereiche werden gerahmt
+- Bereich anklickbar
+- Auswahl wird verständlich angezeigt
+- einfache Stellschrauben werden angezeigt
+- noch nicht zwingend dauerhaft speichern
+
+**Nicht im MVP:**
+- freies Drag-and-drop
+- Export als npm-Paket
+- mehrere Apps
+- vollständige visuelle Regressionstests
+- vollständige Wertpersistenz für alle Bereiche
+
+## 5. Rollen je Phase
+
+**Codex Cloud:**
+- Dokumentation
+- Modulgerüst
+- reine Core-/Registry-Tests
+- Landkartenformat
+- PRs
+
+**Lokal:**
+- sichtbares Overlay
+- App starten
+- Bedienbarkeit prüfen
+- visuelle Seiteneffekte erkennen
+- Nutzerabnahme
+
+**Nutzer:**
+- prüft Sprache
+- prüft sichtbare Bereiche
+- prüft Bedienbarkeit
+- muss keine Technik verstehen
+
+**ChatGPT:**
+- orchestriert
+- begrenzt Aufträge
+- prüft Diffs
+- gibt nächsten Schritt frei
+
+## 6. Harte Stopps im Umsetzungsplan
+
+Kein Paket darf:
+- Tabellen-Kalibrator als Bedienoberfläche verwenden
+- BBM-Fachlogik in den Core schreiben
+- Restarbeiten optisch verändern, wenn nur Markierung beauftragt ist
+- neue UI-Frickelei als Abkürzung machen
+- Aufgabenheft vergessen
+- mehrere Meilensteine in einem PR vermischen
+
+## 7. Prüfmodell
+
+Je Paket dokumentieren:
+- erwartete Dateien
+- verbotene Dateien
+- Tests/Prüfungen
+- Sichtprüfung ja/nein
+- Codex Cloud oder lokal
+- Aufgabenheft-Update
+
+## 8. Erster Code-Auftrag nach M5
+
+Nach M5 folgt:
+**M6 – Modulgerüst anlegen**
+
+Noch kein Overlay.
+Noch keine Restarbeiten-Integration.
+Noch keine sichtbare UI.
+Noch kein Speichern.


### PR DESCRIPTION
### Motivation
- Finalize M5 by producing a concrete, code-free Umsetzungsplan that maps architecture and the working contract into safe, incrementally deliverable milestones. 
- Prevent starting a too-large implementation by naming the exact first code step (M6) and by defining what each milestone may and must not change. 
- Ensure project rules (tasksheet, decision log, AGENTS) reflect the new plan so subsequent work follows the agreed small-step process. 

### Description
- Added `docs/UI_INSPEKTOR_UMSETZUNGSPLAN.md` containing the M6–M15 milestone plan, MVP definition, roles, hard stops and the per-package Prüfmodell. 
- Updated `docs/UI_INSPEKTOR_AUFGABENHEFT.md` to mark M5 done, add a M5 Abschlussnotiz and set the next step to `M6 – Modulgerüst` with the explicit constraint that M6 is only a module skeleton. 
- Appended `Entscheidung 009` to `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md` to record the stepwise implementation decision, and updated `docs/UI_INSPEKTOR_START_HIER.md` to show M5 completed and M6 as the first code step without visible UI or app integration. 
- Touched `AGENTS.md` to clarify that M6 is the first code step and must not include an overlay or Restarbeiten binding; no `src`/test/config/app logic files were created or modified. 

### Testing
- Ran repository checks: `git diff --stat`, `git diff --name-only` and `git status --short --branch`, which reported the changed documentation files and a clean working state for this docs-only change. 
- No application/unit tests were required or executed because this is a documentation-only change. 
- Verified that only the following documentation files were added/modified: `docs/UI_INSPEKTOR_UMSETZUNGSPLAN.md`, `docs/UI_INSPEKTOR_AUFGABENHEFT.md`, `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`, `docs/UI_INSPEKTOR_START_HIER.md`, and `AGENTS.md`, and that `STATUS.md` and `docs/MODULARISIERUNGSPLAN.md` remained unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1013cd626c8322a1fa546be3c749f5)