### PR TITLE
M6: Add UI-Inspector module scaffold with core & registry tests

### DIFF
--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -1,10 +1,10 @@
 # UI-Inspektor Aufgabenheft
 
 ## Projektstatus
-Status: in Vorbereitung, ohne Implementierungscode.
+Status: M6 abgeschlossen (Modulgerüst vorhanden, ohne sichtbare UI-Funktion).
 
 Aktueller Stand:
-- M1.1 Projektfundament wird angelegt.
+- M1 bis M6 abgeschlossen.
 
 ## Haken-System
 - `[x]` erledigt
@@ -18,7 +18,7 @@ Aktueller Stand:
 - [x] M3 Projektgedächtnis vollständig
 - [x] M4 Architektur des exportierbaren Moduls final
 - [x] M5 Umsetzungsplan ohne Code final
-- [ ] M6 erster Code-Schritt: Modulgerüst
+- [x] M6 erster Code-Schritt: Modulgerüst
 
 ## Definition of Done (DoD)
 Ein UI-Inspektor-Meilenstein gilt nur als erledigt, wenn:
@@ -58,17 +58,17 @@ Kein Codex-Auftrag gilt als fertig, wenn das Aufgabenheft nicht aktualisiert wur
 6. `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`
 
 ## Aktueller Stand für neue Chats
-- Projektphase: Dokumentationsgrundlagen vorhanden
-- Implementierungscode: noch keiner
-- UI-Inspector-Modul: noch nicht angelegt
+- Projektphase: Modulgerüst vorhanden
+- Implementierungscode: M6-Grundgerüst angelegt
+- UI-Inspector-Modul: vorhanden (ohne sichtbare UI)
 - App-Funktionen: keine Änderungen
 
 ## Nächster Schritt
 Als nächster Schritt folgt:
-- **M6 erster Code-Schritt: Modulgerüst**
+- **M7 Layout-Landkarten-Format definieren**
 
 Hinweis:
-- Ab M6 beginnt Code, aber nur Modulgerüst ohne sichtbare Funktion
+- M6 hat nur ein Modulgerüst gebaut, ohne sichtbare UI-Funktion
 
 
 ## M4 Abschlussnotiz
@@ -96,3 +96,29 @@ Hinweis:
   - **M6 erster Code-Schritt: Modulgerüst**
 - Hinweis:
   - Ab M6 beginnt Code, aber nur Modulgerüst ohne sichtbare Funktion
+
+
+## M6 Abschlussnotiz
+- M6 erstes Code-Paket als reines UI-Inspector-Modulgerüst umgesetzt.
+- Geänderte/neu angelegte Dateien:
+  - `src/shared/uiInspector/uiInspectorCore.js`
+  - `src/shared/uiInspector/uiInspectorRegistry.js`
+  - `src/shared/uiInspector/uiInspectorStore.js`
+  - `src/shared/uiInspector/uiInspectorTypes.js`
+  - `src/shared/uiInspector/index.js`
+  - `src/renderer/uiInspector/UiInspectorRuntime.js`
+  - `src/renderer/uiInspector/UiInspectorOverlay.js`
+  - `src/renderer/uiInspector/UiInspectorPanel.js`
+  - `src/renderer/uiInspector/index.js`
+  - `scripts/tests/uiInspectorCore.test.cjs`
+  - `scripts/tests/uiInspectorRegistry.test.cjs`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `docs/UI_INSPEKTOR_START_HIER.md`
+- Tests:
+  - `node scripts/tests/uiInspectorCore.test.cjs`
+  - `node scripts/tests/uiInspectorRegistry.test.cjs`
+  - `npm test`
+- Nächster Schritt:
+  - **M7 Layout-Landkarten-Format definieren**
+- Hinweis:
+  - M6 enthält nur Modulgerüst, kein Overlay, keine Restarbeiten-Anbindung, keine sichtbare App-Funktion.

--- a/docs/UI_INSPEKTOR_START_HIER.md
+++ b/docs/UI_INSPEKTOR_START_HIER.md
@@ -27,14 +27,15 @@ Pflichtreihenfolge:
 - M3 Projektgedächtnis erledigt
 - M4 Architekturvertiefung erledigt
 - M5 Umsetzungsplan ohne Code erledigt
-- Noch kein Implementierungscode
-- Noch kein UI-Inspector-Modul
-- Noch keine App-Funktion
+- M6 Modulgerüst erledigt
+- UI-Inspector-Modulgerüst existiert
+- Noch kein Overlay
+- Noch keine Restarbeiten-Anbindung
+- Noch keine sichtbare App-Funktion
 
 ## 5. Nächster geplanter Schritt
-- Nächster Schritt: M6 erster Code-Schritt: Modulgerüst
-- Ab M6 beginnt Code
-- M6 ist nur Modulgerüst
+- Nächster Schritt: M7 Layout-Landkarten-Format definieren
+- M6 wurde als reines Modulgerüst umgesetzt
 - Noch keine sichtbare UI-Funktion
 - Noch keine App-Integration
 
@@ -49,4 +50,4 @@ Nicht fortführen:
 ## 7. Definition für neue Chats
 Ein neuer Chat soll mit dieser Zusammenfassung starten können:
 
-„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Bisher wurden nur Dokumentationsgrundlagen erstellt. Es gibt noch keinen Code. Nächster Schritt laut Aufgabenheft ist M6 (erster Code-Schritt: Modulgerüst ohne sichtbare UI-Funktion und ohne App-Integration).“
+„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Bisher wurden nur Dokumentationsgrundlagen erstellt. Es gibt jetzt ein UI-Inspector-Modulgerüst. Nächster Schritt laut Aufgabenheft ist M7 (Layout-Landkarten-Format definieren, weiterhin ohne sichtbare UI-Funktion und ohne App-Integration).“

--- a/scripts/tests/uiInspectorCore.test.cjs
+++ b/scripts/tests/uiInspectorCore.test.cjs
@@ -1,0 +1,28 @@
+const assert = require('node:assert/strict');
+const { createUiInspectorCore } = require('../../src/shared/uiInspector');
+
+function run() {
+  const core = createUiInspectorCore();
+
+  assert.equal(core.isActive(), false, 'core should start inactive');
+
+  core.activate();
+  assert.equal(core.isActive(), true, 'activate() should switch core to active');
+
+  core.deactivate();
+  assert.equal(core.isActive(), false, 'deactivate() should switch core to inactive');
+
+  core.selectElement(' area.main ');
+  assert.equal(
+    core.getState().selectedElementId,
+    'area.main',
+    'selectElement() should normalize and set selection'
+  );
+
+  core.clearSelection();
+  assert.equal(core.getState().selectedElementId, null, 'clearSelection() should clear selection');
+
+  console.log('uiInspectorCore.test.cjs passed');
+}
+
+run();

--- a/scripts/tests/uiInspectorRegistry.test.cjs
+++ b/scripts/tests/uiInspectorRegistry.test.cjs
@@ -1,0 +1,33 @@
+const assert = require('node:assert/strict');
+const { createUiInspectorRegistry } = require('../../src/shared/uiInspector');
+
+function run() {
+  const registry = createUiInspectorRegistry();
+
+  const initial = registry.registerMap({ id: ' map.a ', label: 'Map A' });
+  assert.equal(initial.id, 'map.a', 'registerMap() should normalize id');
+
+  const listed = registry.listMaps();
+  assert.equal(listed.length, 1, 'listMaps() should return registered map');
+  assert.equal(listed[0].id, 'map.a', 'listMaps() should contain normalized id');
+
+  const found = registry.getMap(' map.a ');
+  assert.equal(found?.label, 'Map A', 'getMap() should find map by normalized id');
+
+  assert.throws(
+    () => registry.registerMap({ label: 'Missing id' }),
+    /map id must not be empty/i,
+    'registerMap() should reject maps without id'
+  );
+
+  registry.registerMap({ id: 'map.a', label: 'Map A newer' });
+  assert.equal(
+    registry.getMap('map.a')?.label,
+    'Map A newer',
+    'duplicate id should be overwritten by latest map'
+  );
+
+  console.log('uiInspectorRegistry.test.cjs passed');
+}
+
+run();

--- a/src/renderer/uiInspector/UiInspectorOverlay.js
+++ b/src/renderer/uiInspector/UiInspectorOverlay.js
@@ -1,0 +1,14 @@
+function createUiInspectorOverlay() {
+  return {
+    mount() {
+      return false;
+    },
+    unmount() {
+      return false;
+    },
+  };
+}
+
+module.exports = {
+  createUiInspectorOverlay,
+};

--- a/src/renderer/uiInspector/UiInspectorPanel.js
+++ b/src/renderer/uiInspector/UiInspectorPanel.js
@@ -1,0 +1,14 @@
+function createUiInspectorPanel() {
+  return {
+    mount() {
+      return false;
+    },
+    unmount() {
+      return false;
+    },
+  };
+}
+
+module.exports = {
+  createUiInspectorPanel,
+};

--- a/src/renderer/uiInspector/UiInspectorRuntime.js
+++ b/src/renderer/uiInspector/UiInspectorRuntime.js
@@ -1,0 +1,22 @@
+const {
+  createUiInspectorCore,
+  createUiInspectorRegistry,
+  createMemoryUiInspectorStore,
+} = require('../../shared/uiInspector');
+
+function createUiInspectorRuntime({ registry, store, core } = {}) {
+  const resolvedRegistry = registry || createUiInspectorRegistry();
+  const resolvedStore = store || createMemoryUiInspectorStore();
+  const resolvedCore =
+    core || createUiInspectorCore({ registry: resolvedRegistry, store: resolvedStore });
+
+  return {
+    registry: resolvedRegistry,
+    store: resolvedStore,
+    core: resolvedCore,
+  };
+}
+
+module.exports = {
+  createUiInspectorRuntime,
+};

--- a/src/renderer/uiInspector/index.js
+++ b/src/renderer/uiInspector/index.js
@@ -1,0 +1,9 @@
+const { createUiInspectorRuntime } = require('./UiInspectorRuntime');
+const { createUiInspectorOverlay } = require('./UiInspectorOverlay');
+const { createUiInspectorPanel } = require('./UiInspectorPanel');
+
+module.exports = {
+  createUiInspectorRuntime,
+  createUiInspectorOverlay,
+  createUiInspectorPanel,
+};

--- a/src/shared/uiInspector/index.js
+++ b/src/shared/uiInspector/index.js
@@ -1,0 +1,12 @@
+const { createUiInspectorCore } = require('./uiInspectorCore');
+const { createUiInspectorRegistry } = require('./uiInspectorRegistry');
+const { createMemoryUiInspectorStore } = require('./uiInspectorStore');
+const { LAYOUT_ELEMENT_KINDS, SETTING_KINDS } = require('./uiInspectorTypes');
+
+module.exports = {
+  createUiInspectorCore,
+  createUiInspectorRegistry,
+  createMemoryUiInspectorStore,
+  LAYOUT_ELEMENT_KINDS,
+  SETTING_KINDS,
+};

--- a/src/shared/uiInspector/uiInspectorCore.js
+++ b/src/shared/uiInspector/uiInspectorCore.js
@@ -1,0 +1,51 @@
+const { createUiInspectorRegistry } = require('./uiInspectorRegistry');
+const { createMemoryUiInspectorStore } = require('./uiInspectorStore');
+
+function _normalizeElementId(value) {
+  return String(value == null ? '' : value).trim();
+}
+
+function createUiInspectorCore({ registry, store } = {}) {
+  const resolvedRegistry = registry || createUiInspectorRegistry();
+  const resolvedStore = store || createMemoryUiInspectorStore();
+
+  const state = {
+    active: false,
+    selectedElementId: null,
+  };
+
+  return {
+    registry: resolvedRegistry,
+    store: resolvedStore,
+    getState() {
+      return { ...state };
+    },
+    activate() {
+      state.active = true;
+      return this.getState();
+    },
+    deactivate() {
+      state.active = false;
+      return this.getState();
+    },
+    isActive() {
+      return state.active;
+    },
+    selectElement(id) {
+      const normalizedId = _normalizeElementId(id);
+      if (!normalizedId) {
+        throw new Error('UiInspectorCore: selected element id must not be empty.');
+      }
+      state.selectedElementId = normalizedId;
+      return this.getState();
+    },
+    clearSelection() {
+      state.selectedElementId = null;
+      return this.getState();
+    },
+  };
+}
+
+module.exports = {
+  createUiInspectorCore,
+};

--- a/src/shared/uiInspector/uiInspectorRegistry.js
+++ b/src/shared/uiInspector/uiInspectorRegistry.js
@@ -1,0 +1,43 @@
+function _normalizeId(value) {
+  return String(value == null ? '' : value).trim();
+}
+
+function _normalizeMap(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('UiInspectorRegistry: map must be an object.');
+  }
+
+  const id = _normalizeId(input.id);
+  if (!id) {
+    throw new Error('UiInspectorRegistry: map id must not be empty.');
+  }
+
+  return { ...input, id };
+}
+
+function createUiInspectorRegistry() {
+  const maps = new Map();
+
+  return {
+    registerMap(map) {
+      const normalized = _normalizeMap(map);
+      maps.set(normalized.id, normalized); // duplicate ids are overwritten by newest map
+      return normalized;
+    },
+    listMaps() {
+      return Array.from(maps.values());
+    },
+    getMap(id) {
+      const normalizedId = _normalizeId(id);
+      if (!normalizedId) return null;
+      return maps.get(normalizedId) || null;
+    },
+    clear() {
+      maps.clear();
+    },
+  };
+}
+
+module.exports = {
+  createUiInspectorRegistry,
+};

--- a/src/shared/uiInspector/uiInspectorStore.js
+++ b/src/shared/uiInspector/uiInspectorStore.js
@@ -1,0 +1,33 @@
+function _normalizeKey(key) {
+  return String(key == null ? '' : key).trim();
+}
+
+function createMemoryUiInspectorStore() {
+  const values = new Map();
+
+  return {
+    getValue(key) {
+      const normalizedKey = _normalizeKey(key);
+      if (!normalizedKey) return undefined;
+      return values.get(normalizedKey);
+    },
+    setValue(key, value) {
+      const normalizedKey = _normalizeKey(key);
+      if (!normalizedKey) throw new Error('UiInspectorStore: key must not be empty.');
+      values.set(normalizedKey, value);
+      return value;
+    },
+    removeValue(key) {
+      const normalizedKey = _normalizeKey(key);
+      if (!normalizedKey) return false;
+      return values.delete(normalizedKey);
+    },
+    clear() {
+      values.clear();
+    },
+  };
+}
+
+module.exports = {
+  createMemoryUiInspectorStore,
+};

--- a/src/shared/uiInspector/uiInspectorTypes.js
+++ b/src/shared/uiInspector/uiInspectorTypes.js
@@ -1,0 +1,23 @@
+const LAYOUT_ELEMENT_KINDS = Object.freeze({
+  AREA: 'area',
+  CONTAINER: 'container',
+  FIELD: 'field',
+  LIST: 'list',
+  INPUT_AREA: 'inputArea',
+  SPECIAL: 'special',
+});
+
+const SETTING_KINDS = Object.freeze({
+  WIDTH: 'width',
+  HEIGHT: 'height',
+  SPACING: 'spacing',
+  OFFSET_X: 'offsetX',
+  OFFSET_Y: 'offsetY',
+  COLUMN_WIDTH: 'columnWidth',
+  FIELD_WIDTH: 'fieldWidth',
+});
+
+module.exports = {
+  LAYOUT_ELEMENT_KINDS,
+  SETTING_KINDS,
+};


### PR DESCRIPTION
### Motivation
- Implement the M6 work item: create an exportable, app-agnostic UI-Inspector module scaffold without any visible UI or app integration. 
- Keep the Core free of BBM domain terms and side effects so the module remains portable and adapter-driven.

### Description
- Added shared core pieces under `src/shared/uiInspector/`: `uiInspectorTypes.js` (constants), `uiInspectorRegistry.js` (in-memory registry), `uiInspectorStore.js` (memory store), `uiInspectorCore.js` (state-only core) and `index.js` (barrel export). 
- Registry behavior: `registerMap()` normalizes input, rejects empty IDs and makes duplicate IDs deterministic by overwriting with the newest entry (documented and tested). 
- Core behavior: state-only API via `createUiInspectorCore()` exposing `getState()`, `activate()`, `deactivate()`, `isActive()`, `selectElement()` and `clearSelection()` with input normalization and no DOM/app logic. 
- Renderer stubs under `src/renderer/uiInspector/`: `UiInspectorRuntime.js`, `UiInspectorOverlay.js`, `UiInspectorPanel.js` and `index.js`; these are non-visual, no DOM side effects, and act as importable placeholders for later integration. 
- Documentation updates: `docs/UI_INSPEKTOR_AUFGABENHEFT.md` and `docs/UI_INSPEKTOR_START_HIER.md` were updated to mark M6 done and set next step to M7.

### Testing
- Ran `node scripts/tests/uiInspectorCore.test.cjs` and it passed (core lifecycle and selection behavior). 
- Ran `node scripts/tests/uiInspectorRegistry.test.cjs` and it passed (register/list/get, missing-id rejection, duplicate-id overwrite behavior). 
- Ran `npm test` in this environment and it failed due to missing system library required by Electron (`libatk-1.0.so.0`), so full project test-suite could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a101d752d50832291c7069952317999)