### PR TITLE
M7: Layout-Landkarten-Format im UI-Inspector-Core definieren

### DIFF
--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -1,10 +1,10 @@
 # UI-Inspektor Aufgabenheft
 
 ## Projektstatus
-Status: M6 abgeschlossen (Modulgerüst vorhanden, ohne sichtbare UI-Funktion).
+Status: M7 abgeschlossen (Layout-Landkarten-Format vorhanden, ohne sichtbare UI-Funktion).
 
 Aktueller Stand:
-- M1 bis M6 abgeschlossen.
+- M1 bis M7 abgeschlossen.
 
 ## Haken-System
 - `[x]` erledigt
@@ -19,6 +19,7 @@ Aktueller Stand:
 - [x] M4 Architektur des exportierbaren Moduls final
 - [x] M5 Umsetzungsplan ohne Code final
 - [x] M6 erster Code-Schritt: Modulgerüst
+- [x] M7 Layout-Landkarten-Format definieren
 
 ## Definition of Done (DoD)
 Ein UI-Inspektor-Meilenstein gilt nur als erledigt, wenn:
@@ -65,7 +66,7 @@ Kein Codex-Auftrag gilt als fertig, wenn das Aufgabenheft nicht aktualisiert wur
 
 ## Nächster Schritt
 Als nächster Schritt folgt:
-- **M7 Layout-Landkarten-Format definieren**
+- **M8 Restarbeiten als erste Pilot-Landkarte dokumentieren**
 
 Hinweis:
 - M6 hat nur ein Modulgerüst gebaut, ohne sichtbare UI-Funktion
@@ -119,6 +120,27 @@ Hinweis:
   - `node scripts/tests/uiInspectorRegistry.test.cjs`
   - `npm test`
 - Nächster Schritt:
-  - **M7 Layout-Landkarten-Format definieren**
+  - **M8 Restarbeiten als erste Pilot-Landkarte dokumentieren**
 - Hinweis:
   - M6 enthält nur Modulgerüst, kein Overlay, keine Restarbeiten-Anbindung, keine sichtbare App-Funktion.
+
+
+## M7 Abschlussnotiz
+- M7 Layout-Landkarten-Format als reines Core-/Registry-Schema definiert und mit Tests abgesichert.
+- Geänderte/neu angelegte Dateien:
+  - `src/shared/uiInspector/uiInspectorMapSchema.js`
+  - `src/shared/uiInspector/uiInspectorRegistry.js`
+  - `src/shared/uiInspector/index.js`
+  - `scripts/tests/uiInspectorMapSchema.test.cjs`
+  - `scripts/tests/uiInspectorRegistry.test.cjs`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `docs/UI_INSPEKTOR_START_HIER.md`
+- Tests:
+  - `node scripts/tests/uiInspectorCore.test.cjs`
+  - `node scripts/tests/uiInspectorRegistry.test.cjs`
+  - `node scripts/tests/uiInspectorMapSchema.test.cjs`
+  - `npm test`
+- Nächster Schritt:
+  - **M8 Restarbeiten als erste Pilot-Landkarte dokumentieren**
+- Hinweis:
+  - M7 definiert nur das Layout-Landkarten-Format, noch keine echte App-Anbindung, kein Overlay, keine Restarbeiten-DOM-Markierung und keine sichtbare App-Funktion.

--- a/docs/UI_INSPEKTOR_START_HIER.md
+++ b/docs/UI_INSPEKTOR_START_HIER.md
@@ -28,16 +28,18 @@ Pflichtreihenfolge:
 - M4 Architekturvertiefung erledigt
 - M5 Umsetzungsplan ohne Code erledigt
 - M6 Modulgerüst erledigt
-- UI-Inspector-Modulgerüst existiert
+- M7 Layout-Landkarten-Format erledigt
+- UI-Inspector-Modulgerüst und Layout-Landkarten-Format existieren
 - Noch kein Overlay
-- Noch keine Restarbeiten-Anbindung
+- Noch keine Restarbeiten-DOM-Markierung
 - Noch keine sichtbare App-Funktion
 
 ## 5. Nächster geplanter Schritt
-- Nächster Schritt: M7 Layout-Landkarten-Format definieren
-- M6 wurde als reines Modulgerüst umgesetzt
+- Nächster Schritt: M8 Restarbeiten als erste Pilot-Landkarte dokumentieren
+- M7 hat nur das Layout-Landkarten-Format definiert
+- Noch kein Overlay
+- Noch keine Restarbeiten-DOM-Markierung
 - Noch keine sichtbare UI-Funktion
-- Noch keine App-Integration
 
 ## 6. Harte Stopps
 Nicht fortführen:
@@ -50,4 +52,4 @@ Nicht fortführen:
 ## 7. Definition für neue Chats
 Ein neuer Chat soll mit dieser Zusammenfassung starten können:
 
-„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Bisher wurden nur Dokumentationsgrundlagen erstellt. Es gibt jetzt ein UI-Inspector-Modulgerüst. Nächster Schritt laut Aufgabenheft ist M7 (Layout-Landkarten-Format definieren, weiterhin ohne sichtbare UI-Funktion und ohne App-Integration).“
+„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Bisher wurden nur Dokumentationsgrundlagen erstellt. Es gibt jetzt ein UI-Inspector-Modulgerüst. Nächster Schritt laut Aufgabenheft ist M8 (Restarbeiten als erste Pilot-Landkarte dokumentieren, weiterhin ohne Overlay, ohne Restarbeiten-DOM-Markierung und ohne sichtbare App-Funktion).“

--- a/scripts/tests/uiInspectorMapSchema.test.cjs
+++ b/scripts/tests/uiInspectorMapSchema.test.cjs
@@ -1,0 +1,117 @@
+const assert = require('node:assert/strict');
+const {
+  normalizeUiInspectorMap,
+  LAYOUT_ELEMENT_KINDS,
+  SETTING_KINDS,
+} = require('../../src/shared/uiInspector');
+
+function run() {
+  const normalized = normalizeUiInspectorMap({
+    id: '  map.rest  ',
+    label: '  Test Map  ',
+    version: '  1  ',
+    elements: [
+      {
+        id: '  root  ',
+        kind: LAYOUT_ELEMENT_KINDS.AREA,
+        label: '  Root  ',
+      },
+      {
+        id: '  child  ',
+        kind: LAYOUT_ELEMENT_KINDS.CONTAINER,
+        label: '  Child  ',
+        parentId: ' root ',
+        settings: [
+          {
+            id: '  width.main  ',
+            kind: SETTING_KINDS.WIDTH,
+            label: '  Width  ',
+            defaultValue: 100,
+          },
+        ],
+      },
+      {
+        id: '  field.a  ',
+        kind: LAYOUT_ELEMENT_KINDS.FIELD,
+        label: '  Field A  ',
+        parentId: ' child ',
+      },
+    ],
+  });
+
+  assert.equal(normalized.id, 'map.rest');
+  assert.equal(normalized.label, 'Test Map');
+  assert.equal(normalized.version, '1');
+  assert.equal(normalized.elements[0].id, 'root');
+  assert.equal(normalized.elements[1].parentId, 'root');
+  assert.equal(normalized.elements[1].settings[0].id, 'width.main');
+  assert.equal(normalized.elements[1].settings[0].label, 'Width');
+
+  assert.throws(() => normalizeUiInspectorMap({ label: 'Missing id', elements: [] }), /map id must not be empty/i);
+
+  assert.throws(
+    () =>
+      normalizeUiInspectorMap({
+        id: 'map.a',
+        label: 'Map A',
+        elements: [{ kind: LAYOUT_ELEMENT_KINDS.AREA, label: 'X' }],
+      }),
+    /element id.*must not be empty/i
+  );
+
+  assert.throws(
+    () =>
+      normalizeUiInspectorMap({
+        id: 'map.a',
+        label: 'Map A',
+        elements: [{ id: 'el1', kind: 'invalid-kind', label: 'X' }],
+      }),
+    /element kind/i
+  );
+
+  assert.throws(
+    () =>
+      normalizeUiInspectorMap({
+        id: 'map.a',
+        label: 'Map A',
+        elements: [
+          { id: 'dup', kind: LAYOUT_ELEMENT_KINDS.AREA, label: 'A' },
+          { id: 'dup', kind: LAYOUT_ELEMENT_KINDS.FIELD, label: 'B' },
+        ],
+      }),
+    /duplicate element id/i
+  );
+
+  assert.throws(
+    () =>
+      normalizeUiInspectorMap({
+        id: 'map.a',
+        label: 'Map A',
+        elements: [
+          {
+            id: 'el1',
+            kind: LAYOUT_ELEMENT_KINDS.AREA,
+            label: 'X',
+            settings: [{ id: 's1', kind: 'bad-kind', label: 'Bad' }],
+          },
+        ],
+      }),
+    /setting kind/i
+  );
+
+  assert.throws(
+    () =>
+      normalizeUiInspectorMap({
+        id: 'map.a',
+        label: 'Map A',
+        elements: [
+          { id: 'el1', kind: LAYOUT_ELEMENT_KINDS.AREA, label: 'A', parentId: 'unknown' },
+        ],
+      }),
+    /parentId.*does not reference a known element/i
+  );
+
+  console.log('uiInspectorMapSchema.test.cjs passed');
+}
+
+run();

--- a/scripts/tests/uiInspectorRegistry.test.cjs
+++ b/scripts/tests/uiInspectorRegistry.test.cjs
@@ -1,11 +1,53 @@
 const assert = require('node:assert/strict');
-const { createUiInspectorRegistry } = require('../../src/shared/uiInspector');
+const {
+  createUiInspectorRegistry,
+  LAYOUT_ELEMENT_KINDS,
+  SETTING_KINDS,
+} = require('../../src/shared/uiInspector');
+
+function createBaseMap(overrides = {}) {
+  return {
+    id: ' map.a ',
+    label: ' Map A ',
+    elements: [
+      { id: ' area.main ', kind: LAYOUT_ELEMENT_KINDS.AREA, label: ' Area Main ' },
+      {
+        id: ' container.main ',
+        kind: LAYOUT_ELEMENT_KINDS.CONTAINER,
+        label: ' Container Main ',
+        parentId: ' area.main ',
+      },
+      {
+        id: ' field.name ',
+        kind: LAYOUT_ELEMENT_KINDS.FIELD,
+        label: ' Field Name ',
+        parentId: ' container.main ',
+        settings: [
+          {
+            id: ' width.name ',
+            kind: SETTING_KINDS.FIELD_WIDTH,
+            label: ' Field Width ',
+            defaultValue: 160,
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
 
 function run() {
   const registry = createUiInspectorRegistry();
 
-  const initial = registry.registerMap({ id: ' map.a ', label: 'Map A' });
-  assert.equal(initial.id, 'map.a', 'registerMap() should normalize id');
+  const initial = registry.registerMap(createBaseMap());
+  assert.equal(initial.id, 'map.a', 'registerMap() should normalize map id');
+  assert.equal(initial.label, 'Map A', 'registerMap() should normalize map label');
+  assert.equal(initial.elements[0].id, 'area.main', 'registerMap() should normalize element ids');
+  assert.equal(
+    initial.elements[2].settings[0].id,
+    'width.name',
+    'registerMap() should normalize setting ids'
+  );
 
   const listed = registry.listMaps();
   assert.equal(listed.length, 1, 'listMaps() should return registered map');
@@ -14,13 +56,59 @@ function run() {
   const found = registry.getMap(' map.a ');
   assert.equal(found?.label, 'Map A', 'getMap() should find map by normalized id');
 
+  assert.throws(() => registry.registerMap({ label: 'Missing id', elements: [] }), /map id must not be empty/i);
+
   assert.throws(
-    () => registry.registerMap({ label: 'Missing id' }),
-    /map id must not be empty/i,
-    'registerMap() should reject maps without id'
+    () => registry.registerMap(createBaseMap({ elements: [{ id: '', kind: LAYOUT_ELEMENT_KINDS.AREA }] })),
+    /element id.*must not be empty/i
   );
 
-  registry.registerMap({ id: 'map.a', label: 'Map A newer' });
+  assert.throws(
+    () => registry.registerMap(createBaseMap({ elements: [{ id: 'x', kind: 'bad-kind' }] })),
+    /element kind/i
+  );
+
+  assert.throws(
+    () =>
+      registry.registerMap(
+        createBaseMap({
+          elements: [
+            { id: 'dup', kind: LAYOUT_ELEMENT_KINDS.AREA, label: 'A' },
+            { id: 'dup', kind: LAYOUT_ELEMENT_KINDS.FIELD, label: 'B' },
+          ],
+        })
+      ),
+    /duplicate element id/i
+  );
+
+  assert.throws(
+    () =>
+      registry.registerMap(
+        createBaseMap({
+          elements: [
+            {
+              id: 'el1',
+              kind: LAYOUT_ELEMENT_KINDS.AREA,
+              label: 'A',
+              settings: [{ id: 's1', kind: 'invalid' }],
+            },
+          ],
+        })
+      ),
+    /setting kind/i
+  );
+
+  assert.throws(
+    () =>
+      registry.registerMap(
+        createBaseMap({
+          elements: [{ id: 'el1', kind: LAYOUT_ELEMENT_KINDS.AREA, label: 'A', parentId: 'unknown' }],
+        })
+      ),
+    /parentId.*does not reference a known element/i
+  );
+
+  registry.registerMap(createBaseMap({ id: 'map.a', label: 'Map A newer' }));
   assert.equal(
     registry.getMap('map.a')?.label,
     'Map A newer',

--- a/src/shared/uiInspector/index.js
+++ b/src/shared/uiInspector/index.js
@@ -2,11 +2,13 @@ const { createUiInspectorCore } = require('./uiInspectorCore');
 const { createUiInspectorRegistry } = require('./uiInspectorRegistry');
 const { createMemoryUiInspectorStore } = require('./uiInspectorStore');
 const { LAYOUT_ELEMENT_KINDS, SETTING_KINDS } = require('./uiInspectorTypes');
+const { normalizeUiInspectorMap } = require('./uiInspectorMapSchema');
 
 module.exports = {
   createUiInspectorCore,
   createUiInspectorRegistry,
   createMemoryUiInspectorStore,
+  normalizeUiInspectorMap,
   LAYOUT_ELEMENT_KINDS,
   SETTING_KINDS,
 };

--- a/src/shared/uiInspector/uiInspectorMapSchema.js
+++ b/src/shared/uiInspector/uiInspectorMapSchema.js
@@ -1,0 +1,128 @@
+const { LAYOUT_ELEMENT_KINDS, SETTING_KINDS } = require('./uiInspectorTypes');
+
+const ALLOWED_ELEMENT_KINDS = new Set(Object.values(LAYOUT_ELEMENT_KINDS));
+const ALLOWED_SETTING_KINDS = new Set(Object.values(SETTING_KINDS));
+
+function normalizeText(value) {
+  return String(value == null ? '' : value).trim();
+}
+
+function normalizeOptionalText(value) {
+  const normalized = normalizeText(value);
+  return normalized || undefined;
+}
+
+function normalizeSetting(setting, elementId, index) {
+  if (!setting || typeof setting !== 'object' || Array.isArray(setting)) {
+    throw new Error(`UiInspectorMapSchema: setting at index ${index} of element "${elementId}" must be an object.`);
+  }
+
+  const id = normalizeText(setting.id);
+  if (!id) {
+    throw new Error(`UiInspectorMapSchema: setting id at index ${index} of element "${elementId}" must not be empty.`);
+  }
+
+  const kind = normalizeText(setting.kind);
+  if (!ALLOWED_SETTING_KINDS.has(kind)) {
+    throw new Error(`UiInspectorMapSchema: setting kind "${kind}" is not allowed.`);
+  }
+
+  const label = normalizeText(setting.label);
+
+  const normalizedSetting = {
+    ...setting,
+    id,
+    kind,
+    label,
+  };
+
+  if (!label) {
+    delete normalizedSetting.label;
+  }
+
+  return normalizedSetting;
+}
+
+function normalizeElement(element, index, seenElementIds) {
+  if (!element || typeof element !== 'object' || Array.isArray(element)) {
+    throw new Error(`UiInspectorMapSchema: element at index ${index} must be an object.`);
+  }
+
+  const id = normalizeText(element.id);
+  if (!id) {
+    throw new Error(`UiInspectorMapSchema: element id at index ${index} must not be empty.`);
+  }
+
+  if (seenElementIds.has(id)) {
+    throw new Error(`UiInspectorMapSchema: duplicate element id "${id}" is not allowed.`);
+  }
+  seenElementIds.add(id);
+
+  const kind = normalizeText(element.kind);
+  if (!ALLOWED_ELEMENT_KINDS.has(kind)) {
+    throw new Error(`UiInspectorMapSchema: element kind "${kind}" is not allowed.`);
+  }
+
+  const label = normalizeText(element.label);
+  const parentId = normalizeOptionalText(element.parentId);
+
+  const settingsInput = element.settings == null ? [] : element.settings;
+  if (!Array.isArray(settingsInput)) {
+    throw new Error(`UiInspectorMapSchema: settings for element "${id}" must be an array.`);
+  }
+
+  const settings = settingsInput.map((setting, settingIndex) =>
+    normalizeSetting(setting, id, settingIndex)
+  );
+
+  return {
+    ...element,
+    id,
+    kind,
+    label,
+    parentId,
+    settings,
+  };
+}
+
+function normalizeUiInspectorMap(map) {
+  if (!map || typeof map !== 'object' || Array.isArray(map)) {
+    throw new Error('UiInspectorMapSchema: map must be an object.');
+  }
+
+  const id = normalizeText(map.id);
+  if (!id) {
+    throw new Error('UiInspectorMapSchema: map id must not be empty.');
+  }
+
+  const label = normalizeText(map.label);
+  const version = normalizeOptionalText(map.version);
+
+  const elementsInput = map.elements == null ? [] : map.elements;
+  if (!Array.isArray(elementsInput)) {
+    throw new Error('UiInspectorMapSchema: map elements must be an array.');
+  }
+
+  const seenElementIds = new Set();
+  const elements = elementsInput.map((element, index) => normalizeElement(element, index, seenElementIds));
+
+  for (const element of elements) {
+    if (element.parentId && !seenElementIds.has(element.parentId)) {
+      throw new Error(
+        `UiInspectorMapSchema: parentId "${element.parentId}" of element "${element.id}" does not reference a known element.`
+      );
+    }
+  }
+
+  return {
+    ...map,
+    id,
+    label,
+    version,
+    elements,
+  };
+}
+
+module.exports = {
+  normalizeUiInspectorMap,
+};

--- a/src/shared/uiInspector/uiInspectorRegistry.js
+++ b/src/shared/uiInspector/uiInspectorRegistry.js
@@ -1,18 +1,7 @@
+const { normalizeUiInspectorMap } = require('./uiInspectorMapSchema');
+
 function _normalizeId(value) {
   return String(value == null ? '' : value).trim();
-}
-
-function _normalizeMap(input) {
-  if (!input || typeof input !== 'object' || Array.isArray(input)) {
-    throw new Error('UiInspectorRegistry: map must be an object.');
-  }
-
-  const id = _normalizeId(input.id);
-  if (!id) {
-    throw new Error('UiInspectorRegistry: map id must not be empty.');
-  }
-
-  return { ...input, id };
 }
 
 function createUiInspectorRegistry() {
@@ -20,7 +9,7 @@ function createUiInspectorRegistry() {
 
   return {
     registerMap(map) {
-      const normalized = _normalizeMap(map);
+      const normalized = normalizeUiInspectorMap(map);
       maps.set(normalized.id, normalized); // duplicate ids are overwritten by newest map
       return normalized;
     },


### PR DESCRIPTION
### Motivation
- Ziel dieses Pakets ist M7: ein formales, allgemeines Layout-Landkarten-Format für das UI-Inspector-Modul definieren, validieren und in die Registry integrieren, ohne sichtbare UI-Änderungen oder BBM-spezifische Logik einzuführen.
- Die Map-/Element-/Setting-Struktur soll IDs/Labels normalisieren, erlaubte `kind`-Werte gegen `uiInspectorTypes` prüfen und fehlerhafte Eingaben ablehnen.
- Änderungen müssen klein, reversibel und testbar bleiben und dürfen keine DOM-/App-Logik, keine Restarbeiten-Änderungen oder UI-Komponenten erzeugen.

### Description
- Neu: `src/shared/uiInspector/uiInspectorMapSchema.js` mit der reinen Funktion `normalizeUiInspectorMap(map)` zur Trim-/Validierungs-Logik für Map, Elemente und Settings.\n
- Registry angepasst: `src/shared/uiInspector/uiInspectorRegistry.js` verwendet nun `normalizeUiInspectorMap(map)` in `registerMap(map)`; das Verhalten, dass eine doppelte `map.id` die ältere Map überschreibt, bleibt erhalten.\n
- Shared-Exports erweitert: `src/shared/uiInspector/index.js` exportiert jetzt `normalizeUiInspectorMap` zusätzlich zu bestehenden Exporten.\n
- Tests hinzugefügt/erweitert: `scripts/tests/uiInspectorMapSchema.test.cjs` (neu) und `scripts/tests/uiInspectorRegistry.test.cjs` (erweitert) prüfen Normalisierung, Trim, erlaubte Kinds, duplicate-element-IDs, parentId-Referenzen und Setting-Validierung.\n
- Dokumentation aktualisiert: `docs/UI_INSPEKTOR_AUFGABENHEFT.md` und `docs/UI_INSPEKTOR_START_HIER.md` wurden um den M7-Abschluss, geänderte Dateien, Tests und den nächsten Schritt (M8) ergänzt.
- Geänderte / neu angelegte Dateien: `src/shared/uiInspector/uiInspectorMapSchema.js`, `src/shared/uiInspector/uiInspectorRegistry.js`, `src/shared/uiInspector/index.js`, `scripts/tests/uiInspectorMapSchema.test.cjs`, `scripts/tests/uiInspectorRegistry.test.cjs`, `docs/UI_INSPEKTOR_AUFGABENHEFT.md`, `docs/UI_INSPEKTOR_START_HIER.md`.
- Branch-Info: Base-Branch: `arch/ui-inspector-layout-map-format`; Ergebnis-Branch: `work` (keine remote-URL in dieser Umgebung verfügbar).

### Testing
- Einheitstests ausgeführt: `node scripts/tests/uiInspectorCore.test.cjs` — bestanden.\n- Registry- und Schema-Tests ausgeführt: `node scripts/tests/uiInspectorRegistry.test.cjs` — bestanden; `node scripts/tests/uiInspectorMapSchema.test.cjs` — bestanden.\n- `npm test` in der Cloud schlug fehl wegen fehlender Electron-Systembibliothek (`libatk-1.0.so.0`); deshalb vollständiger `npm test`-Durchlauf muss lokal in einer Umgebung mit kompletten Electron-Systembibliotheken nachgeholt werden.\n- Ergebnis: alle neuen/angepassten Unit-Tests in `scripts/tests` laufen erfolgreich in dieser Umgebung; der projektweite `npm test` läuft wegen Umgebungsbegrenzung nicht vollständig hier.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1022fe60748322bfa9b67b7cf13099)