### PR TITLE
docs(ui-inspector): M8 Restarbeiten-Pilot-Landkarte dokumentieren

### DIFF
--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -1,10 +1,10 @@
 # UI-Inspektor Aufgabenheft
 
 ## Projektstatus
-Status: M7 abgeschlossen (Layout-Landkarten-Format vorhanden, ohne sichtbare UI-Funktion).
+Status: M8 abgeschlossen (Restarbeiten-Pilot-Landkarte dokumentiert, ohne sichtbare UI-Funktion).
 
 Aktueller Stand:
-- M1 bis M7 abgeschlossen.
+- M1 bis M8 abgeschlossen.
 
 ## Haken-System
 - `[x]` erledigt
@@ -20,6 +20,7 @@ Aktueller Stand:
 - [x] M5 Umsetzungsplan ohne Code final
 - [x] M6 erster Code-Schritt: Modulgerüst
 - [x] M7 Layout-Landkarten-Format definieren
+- [x] M8 Restarbeiten als erste Pilot-Landkarte dokumentieren
 
 ## Definition of Done (DoD)
 Ein UI-Inspektor-Meilenstein gilt nur als erledigt, wenn:
@@ -66,7 +67,7 @@ Kein Codex-Auftrag gilt als fertig, wenn das Aufgabenheft nicht aktualisiert wur
 
 ## Nächster Schritt
 Als nächster Schritt folgt:
-- **M8 Restarbeiten als erste Pilot-Landkarte dokumentieren**
+- **M9 Restarbeiten-DOM-Markierungen minimal einführen**
 
 Hinweis:
 - M6 hat nur ein Modulgerüst gebaut, ohne sichtbare UI-Funktion
@@ -120,7 +121,7 @@ Hinweis:
   - `node scripts/tests/uiInspectorRegistry.test.cjs`
   - `npm test`
 - Nächster Schritt:
-  - **M8 Restarbeiten als erste Pilot-Landkarte dokumentieren**
+  - **M9 Restarbeiten-DOM-Markierungen minimal einführen**
 - Hinweis:
   - M6 enthält nur Modulgerüst, kein Overlay, keine Restarbeiten-Anbindung, keine sichtbare App-Funktion.
 
@@ -141,6 +142,22 @@ Hinweis:
   - `node scripts/tests/uiInspectorMapSchema.test.cjs`
   - `npm test`
 - Nächster Schritt:
-  - **M8 Restarbeiten als erste Pilot-Landkarte dokumentieren**
+  - **M9 Restarbeiten-DOM-Markierungen minimal einführen**
 - Hinweis:
   - M7 definiert nur das Layout-Landkarten-Format, noch keine echte App-Anbindung, kein Overlay, keine Restarbeiten-DOM-Markierung und keine sichtbare App-Funktion.
+
+
+## M8 Abschlussnotiz
+- M8 Restarbeiten als erste Pilot-Landkarte rein dokumentarisch festgehalten.
+- Geänderte/neu angelegte Dateien:
+  - `docs/ui-landkarten/RESTARBEITEN.md` (neu)
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `docs/UI_INSPEKTOR_START_HIER.md`
+- Tests/Prüfung:
+  - `git diff --stat`
+  - `git diff --name-only`
+  - `git status --short --branch`
+- Nächster Schritt:
+  - **M9 Restarbeiten-DOM-Markierungen minimal einführen**
+- Hinweis:
+  - M8 hat nur dokumentiert, keine DOM-Markierungen eingebaut, kein Overlay gebaut und keine sichtbare UI-Funktion ergänzt.

--- a/docs/UI_INSPEKTOR_START_HIER.md
+++ b/docs/UI_INSPEKTOR_START_HIER.md
@@ -29,14 +29,15 @@ Pflichtreihenfolge:
 - M5 Umsetzungsplan ohne Code erledigt
 - M6 Modulgerüst erledigt
 - M7 Layout-Landkarten-Format erledigt
+- M8 Restarbeiten-Pilot-Landkarte dokumentiert
 - UI-Inspector-Modulgerüst und Layout-Landkarten-Format existieren
 - Noch kein Overlay
 - Noch keine Restarbeiten-DOM-Markierung
 - Noch keine sichtbare App-Funktion
 
 ## 5. Nächster geplanter Schritt
-- Nächster Schritt: M8 Restarbeiten als erste Pilot-Landkarte dokumentieren
-- M7 hat nur das Layout-Landkarten-Format definiert
+- Nächster Schritt: M9 Restarbeiten-DOM-Markierungen minimal einführen
+- M8 hat die Restarbeiten-Pilot-Landkarte dokumentiert
 - Noch kein Overlay
 - Noch keine Restarbeiten-DOM-Markierung
 - Noch keine sichtbare UI-Funktion
@@ -52,4 +53,4 @@ Nicht fortführen:
 ## 7. Definition für neue Chats
 Ein neuer Chat soll mit dieser Zusammenfassung starten können:
 
-„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Bisher wurden nur Dokumentationsgrundlagen erstellt. Es gibt jetzt ein UI-Inspector-Modulgerüst. Nächster Schritt laut Aufgabenheft ist M8 (Restarbeiten als erste Pilot-Landkarte dokumentieren, weiterhin ohne Overlay, ohne Restarbeiten-DOM-Markierung und ohne sichtbare App-Funktion).“
+„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Das Modulgerüst und die erste Restarbeiten-Pilot-Landkarte sind dokumentiert. Nächster Schritt laut Aufgabenheft ist M9 (Restarbeiten-DOM-Markierungen minimal einführen, weiterhin ohne Overlay und ohne sichtbare App-Funktion).“

--- a/docs/ui-landkarten/RESTARBEITEN.md
+++ b/docs/ui-landkarten/RESTARBEITEN.md
@@ -1,0 +1,146 @@
+# UI-Landkarte Restarbeiten
+
+## 1. Zweck
+- Diese Datei beschreibt die Restarbeiten-Oberfläche als erste Pilot-Landkarte für den UI-Inspektor.
+- Sie ist fachliche Dokumentation und Vorbereitung.
+- Sie verändert die App nicht.
+
+## 2. Status
+- M8 dokumentiert nur.
+- Noch keine DOM-Markierungen.
+- Noch kein Overlay.
+- Noch kein Panel.
+- Noch keine sichtbare UI-Funktion.
+- Noch keine Layoutänderung.
+
+## 3. Fachliche Bereichsstruktur
+
+Restarbeiten
+- Kopfbereich
+  - Filterleiste
+    - Klassenfilter
+    - Verortungsfilter
+    - Meta-Filter
+- Hauptbereich
+  - Restarbeiten-Liste
+    - Text-/Beschreibungsteil
+    - normale Spalten
+    - Metaspalten
+    - Ampel-/Statusdarstellung
+- Eingabebereich
+  - Editbox
+    - Kurztext
+    - Langtext / Notiz
+    - Status
+    - Fertig bis
+    - Verantwortlich
+    - Erledigt
+    - Foto-/Anlagenbereich, falls vorhanden oder fachlich vorgesehen
+
+## 4. Erste technische Landkarten-IDs
+- `restarbeiten.root`
+- `restarbeiten.header`
+- `restarbeiten.filterleiste`
+- `restarbeiten.filterleiste.klassenfilter`
+- `restarbeiten.filterleiste.verortung`
+- `restarbeiten.filterleiste.meta`
+- `restarbeiten.filterleiste.meta.fertig_bis`
+- `restarbeiten.filterleiste.meta.status`
+- `restarbeiten.filterleiste.meta.verantwortlich`
+- `restarbeiten.filterleiste.meta.erledigt`
+- `restarbeiten.main`
+- `restarbeiten.liste`
+- `restarbeiten.liste.textbereich`
+- `restarbeiten.liste.metabereich`
+- `restarbeiten.editbox`
+- `restarbeiten.editbox.kurztext`
+- `restarbeiten.editbox.langtext`
+- `restarbeiten.editbox.meta`
+
+Hinweis:
+- Die IDs sind fachliche Vorschläge für die spätere Landkarten-/Adapterarbeit.
+- In M8 werden keine App-Dateien markiert oder angebunden.
+
+## 5. Einstell-Ebenen
+
+### Bereichsebene
+- Kopfbereich
+- Hauptbereich
+- Eingabebereich
+
+### Containerebene
+- Filterleiste
+- Klassenfilter
+- Verortungsfilter
+- Meta-Filter
+- Editbox-Metabereich
+
+### Feldebene
+- Fertig bis
+- Status
+- Verantwortlich
+- Erledigt
+- Kurztext
+- Langtext
+
+### Listenebene
+- Textbereich
+- Metabereich
+- Ampel/Statusbereich
+
+### Sonderbereiche
+- Foto-/Anlagenbereich
+- ggf. Quicklane / Werkzeugleiste, falls fachlich vorhanden
+
+## 6. Denkbare Stellschrauben
+
+Noch nicht umsetzen, nur dokumentieren.
+
+Meta-Filter:
+- Breite
+- Höhe
+- Abstand links/rechts
+- Abstand oben/unten
+- nach links/rechts
+- nach oben/unten
+- Feldbreiten:
+  - Fertig bis
+  - Status
+  - Verantwortlich
+  - Erledigt
+
+Filterleiste:
+- Abstand zwischen Containern
+- Containerbreiten
+- vertikale Ausrichtung
+
+Liste:
+- Textspaltenbreite
+- Metaspaltenbreite
+- Ampelspaltenbreite
+- Zeilenhöhe
+
+Editbox:
+- Kurztextbreite
+- Langtexthöhe
+- Metabereichbreite
+- Abstand zwischen Eingabefeldern
+
+## 7. Harte Grenzen
+- M8 verändert keine Restarbeiten-Dateien.
+- M8 verändert keine CSS-Dateien.
+- M8 verändert keine Datenbank.
+- M8 verändert keine Fachlogik.
+- M8 verändert keine Router-/IPC-/Preload-Dateien.
+- M8 baut kein Overlay.
+- M8 baut kein Panel.
+- M8 speichert keine Layoutwerte.
+
+## 8. Offene Prüffragen für spätere lokale Sichtung
+- Sind alle sichtbaren Restarbeiten-Bereiche korrekt benannt?
+- Fehlt ein Bereich?
+- Ist Meta-Filter wirklich ein eigener Container?
+- Ist Verortung ein eigener Container?
+- Ist die Liste in Textbereich und Metabereich sinnvoll trennbar?
+- Gehört Foto/Anlagen fachlich zur Liste, zur Editbox oder als eigener Sonderbereich?
+- Welche Stellschrauben sind für den Nutzer wirklich verständlich?


### PR DESCRIPTION
### Motivation
- M8 soll die vorhandene Restarbeiten-Oberfläche fachlich als erste Pilot-Landkarte für den neuen UI‑Inspektor dokumentieren, ohne die App oder sichtbare UI zu verändern.

### Description
- Neue Datei `docs/ui-landkarten/RESTARBEITEN.md` angelegt und fachlich strukturiert (Zweck, Status, Bereichshierarchie, vorgeschlagene Landkarten‑IDs, Einstell‑Ebenen, denkbare Stellschrauben, harte Grenzen, offene Prüffragen). 
- `docs/UI_INSPEKTOR_AUFGABENHEFT.md` auf Status M8 aktualisiert und eine M8‑Abschlussnotiz mit geänderten Dateien und Prüfhinweisen ergänzt. 
- `docs/UI_INSPEKTOR_START_HIER.md` auf M8‑Stand gehoben und nächster Schritt auf M9 gesetzt. 
- Es wurden keine App-/UI-/CSS-/Router-/IPC-/Preload-/Datenbank-/Fachlogik‑Dateien geändert und keine DOM‑Markierungen, Overlays oder Panels eingeführt.

### Testing
- Zur Validierung wurden `git diff --stat` ausgeführt und die Änderungssumme geprüft, diese Prüfung war erfolgreich. 
- Zur Übersicht wurden `git diff --name-only` (ergab die geänderten/neu erstellten Dateien) und `git status --short --branch` ausgeführt und zeigten die erwarteten Änderungen auf Branch `docs/ui-inspector-restarbeiten-pilot-map`. 
- `npm test` wurde nicht ausgeführt, da M8 ausschließlich Dokumentation enthält; technische/Integrations‑Tests sind für spätere Meilensteine (z. B. M9) vorgesehen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10252727ac83229c8dc94f030fea89)