### PR TITLE
M9: Restarbeiten — add minimal data-ui-inspector-id DOM markers

### DIFF
--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -1,10 +1,10 @@
 # UI-Inspektor Aufgabenheft
 
 ## Projektstatus
-Status: M8 abgeschlossen (Restarbeiten-Pilot-Landkarte dokumentiert, ohne sichtbare UI-Funktion).
+Status: M9 abgeschlossen (Restarbeiten-DOM-Markierungen minimal eingeführt, ohne sichtbare UI-Funktion).
 
 Aktueller Stand:
-- M1 bis M8 abgeschlossen.
+- M1 bis M9 abgeschlossen.
 
 ## Haken-System
 - `[x]` erledigt
@@ -21,6 +21,7 @@ Aktueller Stand:
 - [x] M6 erster Code-Schritt: Modulgerüst
 - [x] M7 Layout-Landkarten-Format definieren
 - [x] M8 Restarbeiten als erste Pilot-Landkarte dokumentieren
+- [x] M9 Restarbeiten-DOM-Markierungen minimal einführen
 
 ## Definition of Done (DoD)
 Ein UI-Inspektor-Meilenstein gilt nur als erledigt, wenn:
@@ -67,7 +68,7 @@ Kein Codex-Auftrag gilt als fertig, wenn das Aufgabenheft nicht aktualisiert wur
 
 ## Nächster Schritt
 Als nächster Schritt folgt:
-- **M9 Restarbeiten-DOM-Markierungen minimal einführen**
+- **M10 Overlay nur anzeigen**
 
 Hinweis:
 - M6 hat nur ein Modulgerüst gebaut, ohne sichtbare UI-Funktion
@@ -161,3 +162,23 @@ Hinweis:
   - **M9 Restarbeiten-DOM-Markierungen minimal einführen**
 - Hinweis:
   - M8 hat nur dokumentiert, keine DOM-Markierungen eingebaut, kein Overlay gebaut und keine sichtbare UI-Funktion ergänzt.
+
+
+## M9 Abschlussnotiz
+- M9 hat in der bestehenden Restarbeiten-UI ausschließlich minimale `data-ui-inspector-id` DOM-Markierungen ergänzt.
+- Kein Overlay, kein Panel, keine sichtbare UI-Funktion, keine Layoutänderung, keine Fachlogik- oder Speicherlogik-Änderung.
+- Geänderte/neu angelegte Dateien:
+  - `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`
+  - `src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js`
+  - `scripts/tests/restarbeitenModule.test.cjs`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `docs/UI_INSPEKTOR_START_HIER.md`
+  - `docs/ui-landkarten/RESTARBEITEN.md`
+- Tests/Prüfung:
+  - `node scripts/tests/uiInspectorCore.test.cjs`
+  - `node scripts/tests/uiInspectorRegistry.test.cjs`
+  - `node scripts/tests/uiInspectorMapSchema.test.cjs`
+  - `node scripts/tests/restarbeitenModule.test.cjs`
+  - `npm test`
+- Nächster Schritt:
+  - **M10 Overlay nur anzeigen**

--- a/docs/UI_INSPEKTOR_START_HIER.md
+++ b/docs/UI_INSPEKTOR_START_HIER.md
@@ -30,16 +30,18 @@ Pflichtreihenfolge:
 - M6 Modulgerüst erledigt
 - M7 Layout-Landkarten-Format erledigt
 - M8 Restarbeiten-Pilot-Landkarte dokumentiert
+- M9 Restarbeiten-DOM-Markierungen minimal eingeführt
 - UI-Inspector-Modulgerüst und Layout-Landkarten-Format existieren
 - Noch kein Overlay
-- Noch keine Restarbeiten-DOM-Markierung
+- Restarbeiten-DOM-Markierungen vorhanden
 - Noch keine sichtbare App-Funktion
 
 ## 5. Nächster geplanter Schritt
-- Nächster Schritt: M9 Restarbeiten-DOM-Markierungen minimal einführen
-- M8 hat die Restarbeiten-Pilot-Landkarte dokumentiert
+- Nächster Schritt: M10 Overlay nur anzeigen
+- M9 hat minimale Restarbeiten-DOM-Markierungen eingeführt
 - Noch kein Overlay
-- Noch keine Restarbeiten-DOM-Markierung
+- Noch kein Panel
+- Noch keine Layoutänderung
 - Noch keine sichtbare UI-Funktion
 
 ## 6. Harte Stopps
@@ -53,4 +55,4 @@ Nicht fortführen:
 ## 7. Definition für neue Chats
 Ein neuer Chat soll mit dieser Zusammenfassung starten können:
 
-„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Das Modulgerüst und die erste Restarbeiten-Pilot-Landkarte sind dokumentiert. Nächster Schritt laut Aufgabenheft ist M9 (Restarbeiten-DOM-Markierungen minimal einführen, weiterhin ohne Overlay und ohne sichtbare App-Funktion).“
+„Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Das Modulgerüst und die erste Restarbeiten-Pilot-Landkarte sind dokumentiert. Nächster Schritt laut Aufgabenheft ist M10 (Overlay nur anzeigen; weiterhin ohne Panel und ohne sichtbare Fachfunktion).“

--- a/docs/ui-landkarten/RESTARBEITEN.md
+++ b/docs/ui-landkarten/RESTARBEITEN.md
@@ -6,8 +6,8 @@
 - Sie verändert die App nicht.
 
 ## 2. Status
-- M8 dokumentiert nur.
-- Noch keine DOM-Markierungen.
+- M9 DOM-Markierungen minimal eingeführt.
+- Marker-IDs sind technisch in der bestehenden Restarbeiten-UI verankert.
 - Noch kein Overlay.
 - Noch kein Panel.
 - Noch keine sichtbare UI-Funktion.
@@ -58,8 +58,8 @@ Restarbeiten
 - `restarbeiten.editbox.meta`
 
 Hinweis:
-- Die IDs sind fachliche Vorschläge für die spätere Landkarten-/Adapterarbeit.
-- In M8 werden keine App-Dateien markiert oder angebunden.
+- Die IDs wurden in M9 als `data-ui-inspector-id` in bestehende DOM-Struktur ergänzt.
+- Es wurden keine zusätzlichen sichtbaren Wrapper gebaut; Marker folgen der vorhandenen Struktur.
 
 ## 5. Einstell-Ebenen
 

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -445,6 +445,39 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(editbox, /event\.preventDefault\(\)/);
     assert.match(editbox, /input\.setAttribute\("list", datalist\.id\)/);
   });
+
+
+  await run("M9 UI-Inspektor: Restarbeiten DOM-Marker sind minimal vorhanden", () => {
+    const screen = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"), "utf8");
+    const editbox = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js"), "utf8");
+
+    [
+      "restarbeiten.root",
+      "restarbeiten.header",
+      "restarbeiten.filterleiste",
+      "restarbeiten.filterleiste.klassenfilter",
+      "restarbeiten.filterleiste.verortung",
+      "restarbeiten.filterleiste.meta",
+      "restarbeiten.filterleiste.meta.fertig_bis",
+      "restarbeiten.filterleiste.meta.status",
+      "restarbeiten.filterleiste.meta.verantwortlich",
+      "restarbeiten.filterleiste.meta.erledigt",
+      "restarbeiten.main",
+      "restarbeiten.liste",
+      "restarbeiten.liste.textbereich",
+      "restarbeiten.liste.metabereich",
+    ].forEach((id) => assert.equal(screen.includes(id), true));
+
+    [
+      "restarbeiten.editbox",
+      "restarbeiten.editbox.kurztext",
+      "restarbeiten.editbox.langtext",
+      "restarbeiten.editbox.meta",
+    ].forEach((id) => assert.equal(editbox.includes(id), true));
+
+    assert.doesNotMatch(screen, /data-ui-inspector-id\s*=\s*"restarbeiten\.overlay"/);
+    assert.doesNotMatch(screen, /ui-inspector-panel|inspector-panel/);
+  });
   await run("M5 Repo/IPC/Preload/DataSource: Create und Update sind verdrahtet", async () => {
     const repo = await importEsmFromFile(
       path.join(__dirname, "../../src/renderer/modules/restarbeiten/data/restarbeitenDataSource.js")

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -119,6 +119,7 @@ export default class RestarbeitenEditbox {
     const doc = this.document;
     const root = doc.createElement("section");
     root.className = "restarbeiten-editbox restarbeiten-editbox--compact";
+    root.setAttribute("data-ui-inspector-id", "restarbeiten.editbox");
     const form = doc.createElement("form");
     form.className = "restarbeiten-editbox__layout";
     const topBar = doc.createElement("div");
@@ -136,6 +137,7 @@ export default class RestarbeitenEditbox {
     rightGroup.className = "restarbeiten-editbox__rightGroup";
     const metaCol = doc.createElement("aside");
     metaCol.className = "restarbeiten-editbox__meta";
+    metaCol.setAttribute("data-ui-inspector-id", "restarbeiten.editbox.meta");
 
     const shortText = createInput(doc, "text");
     const longText = createInput(doc, "textarea");
@@ -144,9 +146,11 @@ export default class RestarbeitenEditbox {
     textColumn.className = "restarbeiten-editbox__textColumn";
     const shortField = doc.createElement("div");
     shortField.className = "restarbeiten-editbox__inputSlot restarbeiten-editbox__inputSlot--short";
+    shortField.setAttribute("data-ui-inspector-id", "restarbeiten.editbox.kurztext");
     shortField.append(shortText);
     const longField = doc.createElement("div");
     longField.className = "restarbeiten-editbox__inputSlot restarbeiten-editbox__inputSlot--long";
+    longField.setAttribute("data-ui-inspector-id", "restarbeiten.editbox.langtext");
     longField.append(longText);
 
     const shortRailRow = doc.createElement("div");

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -101,6 +101,7 @@ export default class RestarbeitenScreen {
 
     this.host = doc.createElement("div");
     this.host.setAttribute("data-bbm-restarbeiten-screen", "true");
+    this.host.setAttribute("data-ui-inspector-id", "restarbeiten.root");
 
     this._buildHeader(doc);
     this._buildSheetArea(doc);
@@ -121,6 +122,7 @@ export default class RestarbeitenScreen {
   _buildHeader(doc) {
     const header = doc.createElement("header");
     header.className = "restarbeiten-header restarbeiten-moduleHeader";
+    header.setAttribute("data-ui-inspector-id", "restarbeiten.header");
 
     const btnClose = doc.createElement("button");
     btnClose.type = "button";
@@ -134,12 +136,14 @@ export default class RestarbeitenScreen {
   _buildSheetArea(doc) {
     this.workArea = doc.createElement("div");
     this.workArea.className = "restarbeiten-workarea";
+    this.workArea.setAttribute("data-ui-inspector-id", "restarbeiten.main");
 
     this.contentArea = doc.createElement("div");
     this.contentArea.className = "restarbeiten-workarea__content";
 
     this.listHeaderHost = doc.createElement("div");
     this.listHeaderHost.className = "restarbeiten-listHeader";
+    this.listHeaderHost.setAttribute("data-ui-inspector-id", "restarbeiten.filterleiste");
     this.headerFiltersHost = this.listHeaderHost;
 
     this.sheetArea = doc.createElement("section");
@@ -153,6 +157,7 @@ export default class RestarbeitenScreen {
 
     const listHost = doc.createElement("div");
     listHost.className = "restarbeiten-sheet__list";
+    listHost.setAttribute("data-ui-inspector-id", "restarbeiten.liste");
 
     sheetPaper.append(listHost);
     sheetCanvas.append(sheetPaper);
@@ -204,6 +209,7 @@ export default class RestarbeitenScreen {
   _buildEditArea(doc) {
     this.editArea = doc.createElement("section");
     this.editArea.setAttribute("data-bbm-restarbeiten-screen-area", "edit");
+    this.editArea.setAttribute("data-ui-inspector-id", "restarbeiten.editbox");
 
     const editCanvas = doc.createElement("div");
     editCanvas.setAttribute("data-bbm-restarbeiten-screen-edit-canvas", "true");
@@ -314,6 +320,7 @@ export default class RestarbeitenScreen {
 
     const locationWrap = doc.createElement("div");
     locationWrap.className = "restarbeiten-filterleiste__locationFilters";
+    locationWrap.setAttribute("data-ui-inspector-id", "restarbeiten.filterleiste.verortung");
     const locationGroupA = doc.createElement("div");
     locationGroupA.className = "restarbeiten-filterleiste__locationGroupA";
     locationGroupA.append(this._buildSingleFilter(doc, "location_level_1", 1), this._buildSingleFilter(doc, "location_level_2", 2));
@@ -332,9 +339,11 @@ export default class RestarbeitenScreen {
       body: this._buildClassFilter(doc),
       className: "restarbeiten-listHeader__panel restarbeiten-listHeader__panel--class",
     });
+    classPanel.setAttribute("data-ui-inspector-id", "restarbeiten.filterleiste.klassenfilter");
 
     const metaWrap = doc.createElement("div");
     metaWrap.className = "restarbeiten-filterleiste__metaFilters";
+    metaWrap.setAttribute("data-ui-inspector-id", "restarbeiten.filterleiste.meta");
     metaWrap.append(
       this._buildMetaFilter(doc, {
         key: "due_date",
@@ -517,6 +526,14 @@ export default class RestarbeitenScreen {
   _buildMetaFilter(doc, { key, label, values = [], formatDisplay = null } = {}) {
     const wrap = doc.createElement("label");
     wrap.className = "restarbeiten-filterleiste__field";
+    const inspectorMap = {
+      due_date: "restarbeiten.filterleiste.meta.fertig_bis",
+      status: "restarbeiten.filterleiste.meta.status",
+      responsible_project_firm_id: "restarbeiten.filterleiste.meta.verantwortlich",
+      completed_state: "restarbeiten.filterleiste.meta.erledigt",
+    };
+    const inspectorId = inspectorMap[key];
+    if (inspectorId) wrap.setAttribute("data-ui-inspector-id", inspectorId);
     const caption = doc.createElement("span");
     caption.className = "restarbeiten-filterleiste__fieldLabel";
     caption.textContent = label;
@@ -680,6 +697,7 @@ export default class RestarbeitenScreen {
   _renderTextColumn(doc, item) {
     const col = doc.createElement("div");
     col.className = "restarbeiten-list__textCol";
+    col.setAttribute("data-ui-inspector-id", "restarbeiten.liste.textbereich");
 
     const location = doc.createElement("div");
     location.className = "restarbeiten-list__locationCompact";
@@ -704,6 +722,7 @@ export default class RestarbeitenScreen {
   _renderMetaColumn(doc, item) {
     const col = doc.createElement("div");
     col.className = "restarbeiten-list__metaCol";
+    col.setAttribute("data-ui-inspector-id", "restarbeiten.liste.metabereich");
 
     const statusLine = doc.createElement("div");
     statusLine.className = "restarbeiten-list__ampelLine";


### PR DESCRIPTION
### Motivation
- Provide stable, non-visual DOM markers so the future UI-Inspektor can reliably find Restarbeiten areas without changing behavior or layout. 
- Changes must be minimal: no overlay/panel, no CSS/class/layout/functional changes, only inert `data-ui-inspector-id` attributes.

### Description
- Added `data-ui-inspector-id` attributes to the Restarbeiten UI in `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js` for `restarbeiten.root`, `restarbeiten.header`, `restarbeiten.filterleiste`, `restarbeiten.filterleiste.klassenfilter`, `restarbeiten.filterleiste.verortung`, `restarbeiten.filterleiste.meta`, `restarbeiten.main`, `restarbeiten.liste`, `restarbeiten.liste.textbereich`, and `restarbeiten.liste.metabereich`.
- Added `data-ui-inspector-id` attributes to the edit area in `src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js` for `restarbeiten.editbox`, `restarbeiten.editbox.kurztext`, `restarbeiten.editbox.langtext` and `restarbeiten.editbox.meta` and kept existing DOM structure unchanged.
- Hooked meta-filter creation to set field-level inspector IDs by mapping meta keys to `restarbeiten.filterleiste.meta.*` inside `_buildMetaFilter` without adding new visible wrappers or styles.
- Updated test `scripts/tests/restarbeitenModule.test.cjs` to assert the new marker IDs and updated UI-Inspektor docs: `docs/UI_INSPEKTOR_AUFGABENHEFT.md`, `docs/UI_INSPEKTOR_START_HIER.md`, and `docs/ui-landkarten/RESTARBEITEN.md` to record M9 completion and next step M10.

### Testing
- Ran `node scripts/tests/uiInspectorCore.test.cjs` — passed. 
- Ran `node scripts/tests/uiInspectorRegistry.test.cjs` — passed. 
- Ran `node scripts/tests/uiInspectorMapSchema.test.cjs` — passed. 
- Ran `node scripts/tests/restarbeitenModule.test.cjs` — passed (includes new M9 marker assertions).
- Ran `npm test` in this environment — failed due to missing Electron system library (`libatk-1.0.so.0`); local `npm test` should be run in a full Electron-capable environment to validate the full test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10266e9ff083229ef2b35899c54aca)