### PR TITLE
M10: UI-Inspector — Overlay-only display for Restarbeiten markers

### DIFF
--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -1,10 +1,10 @@
 # UI-Inspektor Aufgabenheft
 
 ## Projektstatus
-Status: M9 abgeschlossen (Restarbeiten-DOM-Markierungen minimal eingeführt, ohne sichtbare UI-Funktion).
+Status: M10 abgeschlossen (Overlay nur anzeigen).
 
 Aktueller Stand:
-- M1 bis M9 abgeschlossen.
+- M1 bis M10 abgeschlossen.
 
 ## Haken-System
 - `[x]` erledigt
@@ -22,6 +22,7 @@ Aktueller Stand:
 - [x] M7 Layout-Landkarten-Format definieren
 - [x] M8 Restarbeiten als erste Pilot-Landkarte dokumentieren
 - [x] M9 Restarbeiten-DOM-Markierungen minimal einführen
+- [x] M10 Overlay nur anzeigen
 
 ## Definition of Done (DoD)
 Ein UI-Inspektor-Meilenstein gilt nur als erledigt, wenn:
@@ -68,7 +69,7 @@ Kein Codex-Auftrag gilt als fertig, wenn das Aufgabenheft nicht aktualisiert wur
 
 ## Nächster Schritt
 Als nächster Schritt folgt:
-- **M10 Overlay nur anzeigen**
+- **M11 Bereich anklicken und Auswahl anzeigen**
 
 Hinweis:
 - M6 hat nur ein Modulgerüst gebaut, ohne sichtbare UI-Funktion
@@ -182,3 +183,27 @@ Hinweis:
   - `npm test`
 - Nächster Schritt:
   - **M10 Overlay nur anzeigen**
+
+
+## M10 Abschlussnotiz
+- M10 hat ein reines Anzeige-Overlay für vorhandene `data-ui-inspector-id` Marker eingeführt.
+- Enthalten: Overlay-Rahmen + Inspector-ID-Label, aktivierbar im Restarbeiten-Screen über `Strg + Alt + I`.
+- Nicht enthalten: Panel, Klickauswahl, Layoutänderung, Speicherung.
+- Geänderte/neu angelegte Dateien:
+  - `src/renderer/uiInspector/UiInspectorOverlay.js`
+  - `src/renderer/uiInspector/UiInspectorRuntime.js`
+  - `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js`
+  - `scripts/tests/uiInspectorOverlay.test.cjs`
+  - `scripts/tests/restarbeitenModule.test.cjs`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `docs/UI_INSPEKTOR_START_HIER.md`
+  - `docs/ui-landkarten/RESTARBEITEN.md`
+- Tests/Prüfung:
+  - `node scripts/tests/uiInspectorCore.test.cjs`
+  - `node scripts/tests/uiInspectorRegistry.test.cjs`
+  - `node scripts/tests/uiInspectorMapSchema.test.cjs`
+  - `node scripts/tests/uiInspectorOverlay.test.cjs`
+  - `node scripts/tests/restarbeitenModule.test.cjs`
+  - `npm test`
+- Nächster Schritt:
+  - **M11 Bereich anklicken und Auswahl anzeigen**

--- a/docs/UI_INSPEKTOR_START_HIER.md
+++ b/docs/UI_INSPEKTOR_START_HIER.md
@@ -31,18 +31,19 @@ Pflichtreihenfolge:
 - M7 Layout-Landkarten-Format erledigt
 - M8 Restarbeiten-Pilot-Landkarte dokumentiert
 - M9 Restarbeiten-DOM-Markierungen minimal eingeführt
+- M10 Overlay nur anzeigen abgeschlossen
 - UI-Inspector-Modulgerüst und Layout-Landkarten-Format existieren
-- Noch kein Overlay
+- Overlay kann angezeigt werden
 - Restarbeiten-DOM-Markierungen vorhanden
 - Noch keine sichtbare App-Funktion
 
 ## 5. Nächster geplanter Schritt
-- Nächster Schritt: M10 Overlay nur anzeigen
-- M9 hat minimale Restarbeiten-DOM-Markierungen eingeführt
-- Noch kein Overlay
+- Nächster Schritt: M11 Bereich anklicken und Auswahl anzeigen
+- M10 zeigt nur Overlay-Rahmen über Marker
 - Noch kein Panel
+- Noch keine Klickauswahl
 - Noch keine Layoutänderung
-- Noch keine sichtbare UI-Funktion
+- Noch keine Speicherung
 
 ## 6. Harte Stopps
 Nicht fortführen:

--- a/docs/ui-landkarten/RESTARBEITEN.md
+++ b/docs/ui-landkarten/RESTARBEITEN.md
@@ -8,7 +8,7 @@
 ## 2. Status
 - M9 DOM-Markierungen minimal eingeführt.
 - Marker-IDs sind technisch in der bestehenden Restarbeiten-UI verankert.
-- Noch kein Overlay.
+- Ab M10 kann ein visuelles Overlay die Marker rahmen und die Inspector-ID anzeigen.
 - Noch kein Panel.
 - Noch keine sichtbare UI-Funktion.
 - Noch keine Layoutänderung.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -265,6 +265,19 @@ async function runRestarbeitenModuleTests(run) {
     assert.doesNotMatch(ipc, /restarbeiten:deleteItem/);
   });
 
+  await run("M10 UI-Inspector Overlay-Toggle ist klar begrenzt", () => {
+    const screenPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js");
+    const content = fs.readFileSync(screenPath, "utf8");
+
+    assert.match(content, /createUiInspectorRuntime/);
+    assert.match(content, /event\.ctrlKey\s*&&\s*event\.altKey/);
+    assert.match(content, /key\s*===\s*['"]i['"]/);
+    assert.match(content, /activateOverlay\(this\.host\)/);
+    assert.match(content, /deactivateOverlay\(\)/);
+    assert.doesNotMatch(content, /createUiInspectorPanel/);
+    assert.doesNotMatch(content, /save|speicher/i);
+  });
+
   await run("M14 Screen-UI: Header, Blattstruktur, Verortung 1-4, Fotos einklappbar, Editbox unten", () => {
     const screenPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js");
     const stylePath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/restarbeitenListStyle.js");

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -273,15 +273,18 @@ async function runRestarbeitenModuleTests(run) {
     const indexPath = path.join(__dirname, "../../src/renderer/uiInspector/index.js");
     const screenPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js");
 
-    for (const source of [
-      fs.readFileSync(overlayPath, "utf8"),
-      fs.readFileSync(runtimePath, "utf8"),
-      fs.readFileSync(panelPath, "utf8"),
-      fs.readFileSync(indexPath, "utf8"),
-    ]) {
+    const overlayContent = fs.readFileSync(overlayPath, "utf8");
+    const runtimeContent = fs.readFileSync(runtimePath, "utf8");
+    const panelContent = fs.readFileSync(panelPath, "utf8");
+    const indexContent = fs.readFileSync(indexPath, "utf8");
+
+    for (const source of [overlayContent, runtimeContent, panelContent, indexContent]) {
       assert.doesNotMatch(source, /module\.exports/);
       assert.doesNotMatch(source, /require\s*\(/);
     }
+
+    assert.doesNotMatch(runtimeContent, /\.\.\/\.\.\/shared\/uiInspector\/index\.js/);
+    assert.doesNotMatch(runtimeContent, /createUiInspectorCore|createUiInspectorRegistry|createMemoryUiInspectorStore/);
 
     const screenContent = fs.readFileSync(screenPath, "utf8");
     assert.match(screenContent, /import\s*\{\s*createUiInspectorRuntime\s*\}\s*from\s*["']\.\.\.\/\.\.\.\/uiInspector\/index\.js["']/);

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -265,6 +265,30 @@ async function runRestarbeitenModuleTests(run) {
     assert.doesNotMatch(ipc, /restarbeiten:deleteItem/);
   });
 
+
+  await run("M10 Renderer-UI-Inspector ist ESM-kompatibel", () => {
+    const overlayPath = path.join(__dirname, "../../src/renderer/uiInspector/UiInspectorOverlay.js");
+    const runtimePath = path.join(__dirname, "../../src/renderer/uiInspector/UiInspectorRuntime.js");
+    const panelPath = path.join(__dirname, "../../src/renderer/uiInspector/UiInspectorPanel.js");
+    const indexPath = path.join(__dirname, "../../src/renderer/uiInspector/index.js");
+    const screenPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js");
+
+    for (const source of [
+      fs.readFileSync(overlayPath, "utf8"),
+      fs.readFileSync(runtimePath, "utf8"),
+      fs.readFileSync(panelPath, "utf8"),
+      fs.readFileSync(indexPath, "utf8"),
+    ]) {
+      assert.doesNotMatch(source, /module\.exports/);
+      assert.doesNotMatch(source, /require\s*\(/);
+    }
+
+    const screenContent = fs.readFileSync(screenPath, "utf8");
+    assert.match(screenContent, /import\s*\{\s*createUiInspectorRuntime\s*\}\s*from\s*["']\.\.\.\/\.\.\.\/uiInspector\/index\.js["']/);
+    assert.doesNotMatch(screenContent, /createUiInspectorPanel/);
+    assert.doesNotMatch(screenContent, /save|speicher/i);
+  });
+
   await run("M10 UI-Inspector Overlay-Toggle ist klar begrenzt", () => {
     const screenPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js");
     const content = fs.readFileSync(screenPath, "utf8");

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -269,11 +269,15 @@ async function runRestarbeitenModuleTests(run) {
     const screenPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js");
     const content = fs.readFileSync(screenPath, "utf8");
 
-    assert.match(content, /createUiInspectorRuntime/);
+    assert.match(content, /this\.uiInspectorRuntime\s*=\s*createUiInspectorRuntime\(\)/);
+    assert.match(content, /this\.uiInspectorOverlayActive\s*=\s*false/);
+    assert.match(content, /this\.uiInspectorKeydownHandler\s*=\s*null/);
     assert.match(content, /event\.ctrlKey\s*&&\s*event\.altKey/);
     assert.match(content, /key\s*===\s*['"]i['"]/);
-    assert.match(content, /activateOverlay\(this\.host\)/);
-    assert.match(content, /deactivateOverlay\(\)/);
+    assert.match(content, /this\.uiInspectorRuntime\.activateOverlay\(this\.host\)/);
+    assert.match(content, /this\.uiInspectorRuntime\.deactivateOverlay\(\)/);
+    assert.match(content, /dispose\(\)/);
+    assert.match(content, /removeEventListener\('keydown',\s*this\.uiInspectorKeydownHandler\)/);
     assert.doesNotMatch(content, /createUiInspectorPanel/);
     assert.doesNotMatch(content, /save|speicher/i);
   });

--- a/scripts/tests/uiInspectorOverlay.test.cjs
+++ b/scripts/tests/uiInspectorOverlay.test.cjs
@@ -1,0 +1,115 @@
+const assert = require('node:assert/strict');
+const { createUiInspectorOverlay } = require('../../src/renderer/uiInspector/UiInspectorOverlay');
+
+function createFakeDom() {
+  const bodyChildren = [];
+  const nodes = [];
+
+  function createElement(tagName) {
+    const node = {
+      tagName: String(tagName || '').toUpperCase(),
+      children: [],
+      style: {},
+      attributes: {},
+      isConnected: false,
+      parentElement: null,
+      textContent: '',
+      append(...items) {
+        for (const child of items) {
+          child.parentElement = this;
+          child.isConnected = this.isConnected;
+          this.children.push(child);
+        }
+      },
+      replaceChildren(...items) {
+        this.children = [];
+        this.append(...items);
+      },
+      setAttribute(name, value) {
+        this.attributes[name] = String(value);
+      },
+      getAttribute(name) {
+        return this.attributes[name];
+      },
+      removeChild(child) {
+        this.children = this.children.filter((entry) => entry !== child);
+        child.parentElement = null;
+        child.isConnected = false;
+      },
+    };
+    nodes.push(node);
+    return node;
+  }
+
+  const document = {
+    body: createElement('body'),
+    createElement,
+  };
+  document.body.isConnected = true;
+  document.body.append = (...items) => {
+    for (const item of items) {
+      item.parentElement = document.body;
+      item.isConnected = true;
+      bodyChildren.push(item);
+      document.body.children.push(item);
+    }
+  };
+
+  return { document, nodes, bodyChildren };
+}
+
+function createInspectableRoot(document) {
+  const nodeA = {
+    ownerDocument: document,
+    getAttribute(name) {
+      if (name === 'data-ui-inspector-id') return 'restarbeiten.header';
+      return null;
+    },
+    getBoundingClientRect() {
+      return { left: 10, top: 20, width: 100, height: 40 };
+    },
+  };
+  const nodeB = {
+    ownerDocument: document,
+    getAttribute(name) {
+      if (name === 'data-ui-inspector-id') return 'restarbeiten.liste';
+      return null;
+    },
+    getBoundingClientRect() {
+      return { left: 30, top: 80, width: 200, height: 120 };
+    },
+  };
+  return {
+    ownerDocument: document,
+    classList: { add() {}, remove() {} },
+    querySelectorAll(selector) {
+      if (selector === '[data-ui-inspector-id]') return [nodeA, nodeB];
+      return [];
+    },
+  };
+}
+
+(function run() {
+  assert.equal(typeof createUiInspectorOverlay, 'function');
+
+  const { document } = createFakeDom();
+  const overlay = createUiInspectorOverlay();
+  const root = createInspectableRoot(document);
+
+  assert.equal(overlay.mount(root), true);
+  const overlayRoot = document.body.children[0];
+  assert.equal(overlayRoot.style.pointerEvents, 'none');
+  assert.equal(overlayRoot.children.length, 2);
+
+  const frame = overlayRoot.children[0];
+  assert.equal(frame.attributes['data-ui-inspector-overlay-frame'], 'restarbeiten.header');
+  assert.equal(frame.children[0].textContent, 'restarbeiten.header');
+
+  assert.equal(overlay.refresh(), true);
+  assert.equal(overlayRoot.children.length, 2);
+
+  assert.equal(overlay.unmount(), true);
+  assert.equal(document.body.children.length, 0);
+
+  console.log('ok - uiInspectorOverlay.test');
+})();

--- a/scripts/tests/uiInspectorOverlay.test.cjs
+++ b/scripts/tests/uiInspectorOverlay.test.cjs
@@ -1,115 +1,47 @@
 const assert = require('node:assert/strict');
-const { createUiInspectorOverlay } = require('../../src/renderer/uiInspector/UiInspectorOverlay');
+const path = require('node:path');
+const { importEsmFromFile } = require('./_esmLoader.cjs');
 
 function createFakeDom() {
   const bodyChildren = [];
-  const nodes = [];
-
   function createElement(tagName) {
-    const node = {
+    return {
       tagName: String(tagName || '').toUpperCase(),
-      children: [],
-      style: {},
-      attributes: {},
-      isConnected: false,
-      parentElement: null,
-      textContent: '',
-      append(...items) {
-        for (const child of items) {
-          child.parentElement = this;
-          child.isConnected = this.isConnected;
-          this.children.push(child);
-        }
-      },
-      replaceChildren(...items) {
-        this.children = [];
-        this.append(...items);
-      },
-      setAttribute(name, value) {
-        this.attributes[name] = String(value);
-      },
-      getAttribute(name) {
-        return this.attributes[name];
-      },
-      removeChild(child) {
-        this.children = this.children.filter((entry) => entry !== child);
-        child.parentElement = null;
-        child.isConnected = false;
-      },
+      children: [], style: {}, attributes: {}, isConnected: false, parentElement: null, textContent: '',
+      append(...items) { for (const child of items) { child.parentElement = this; child.isConnected = this.isConnected; this.children.push(child); } },
+      replaceChildren(...items) { this.children = []; this.append(...items); },
+      setAttribute(name, value) { this.attributes[name] = String(value); },
+      getAttribute(name) { return this.attributes[name]; },
+      removeChild(child) { this.children = this.children.filter((e) => e !== child); child.parentElement = null; child.isConnected = false; },
     };
-    nodes.push(node);
-    return node;
   }
-
-  const document = {
-    body: createElement('body'),
-    createElement,
-  };
+  const document = { body: createElement('body'), createElement };
   document.body.isConnected = true;
-  document.body.append = (...items) => {
-    for (const item of items) {
-      item.parentElement = document.body;
-      item.isConnected = true;
-      bodyChildren.push(item);
-      document.body.children.push(item);
-    }
-  };
-
-  return { document, nodes, bodyChildren };
+  document.body.append = (...items) => { for (const item of items) { item.parentElement = document.body; item.isConnected = true; bodyChildren.push(item); document.body.children.push(item);} };
+  return { document };
 }
 
 function createInspectableRoot(document) {
-  const nodeA = {
-    ownerDocument: document,
-    getAttribute(name) {
-      if (name === 'data-ui-inspector-id') return 'restarbeiten.header';
-      return null;
-    },
-    getBoundingClientRect() {
-      return { left: 10, top: 20, width: 100, height: 40 };
-    },
-  };
-  const nodeB = {
-    ownerDocument: document,
-    getAttribute(name) {
-      if (name === 'data-ui-inspector-id') return 'restarbeiten.liste';
-      return null;
-    },
-    getBoundingClientRect() {
-      return { left: 30, top: 80, width: 200, height: 120 };
-    },
-  };
-  return {
-    ownerDocument: document,
-    classList: { add() {}, remove() {} },
-    querySelectorAll(selector) {
-      if (selector === '[data-ui-inspector-id]') return [nodeA, nodeB];
-      return [];
-    },
-  };
+  const mk = (id, rect) => ({ ownerDocument: document, getAttribute: (n)=> n==='data-ui-inspector-id'?id:null, getBoundingClientRect: ()=>rect });
+  const nodeA = mk('restarbeiten.header', { left: 10, top: 20, width: 100, height: 40 });
+  const nodeB = mk('restarbeiten.liste', { left: 30, top: 80, width: 200, height: 120 });
+  return { ownerDocument: document, querySelectorAll: (sel)=> sel==='[data-ui-inspector-id]'?[nodeA,nodeB]:[] };
 }
 
-(function run() {
+(async function run() {
+  const { createUiInspectorOverlay } = await importEsmFromFile(path.join(__dirname, '../../src/renderer/uiInspector/UiInspectorOverlay.js'));
   assert.equal(typeof createUiInspectorOverlay, 'function');
-
   const { document } = createFakeDom();
   const overlay = createUiInspectorOverlay();
   const root = createInspectableRoot(document);
-
   assert.equal(overlay.mount(root), true);
   const overlayRoot = document.body.children[0];
   assert.equal(overlayRoot.style.pointerEvents, 'none');
   assert.equal(overlayRoot.children.length, 2);
-
-  const frame = overlayRoot.children[0];
-  assert.equal(frame.attributes['data-ui-inspector-overlay-frame'], 'restarbeiten.header');
-  assert.equal(frame.children[0].textContent, 'restarbeiten.header');
-
+  assert.equal(overlayRoot.children[0].attributes['data-ui-inspector-overlay-frame'], 'restarbeiten.header');
+  assert.equal(overlayRoot.children[0].children[0].textContent, 'restarbeiten.header');
   assert.equal(overlay.refresh(), true);
-  assert.equal(overlayRoot.children.length, 2);
-
   assert.equal(overlay.unmount(), true);
   assert.equal(document.body.children.length, 0);
-
   console.log('ok - uiInspectorOverlay.test');
 })();

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -11,6 +11,7 @@ import { mapRestarbeitenStatusLabel, toRestarbeitenListItems } from "../viewMode
 import RestarbeitenEditbox from "./RestarbeitenEditbox.js";
 import RestarbeitenQuicklane from "./RestarbeitenQuicklane.js";
 import { ensureRestarbeitenListStyle } from "./restarbeitenListStyle.js";
+import { createUiInspectorRuntime } from "../../../uiInspector/index.js";
 
 const LOCATION_KEYS = ["location_level_1", "location_level_2", "location_level_3", "location_level_4"];
 const LOCATION_LABEL_FALLBACKS = ["Ebene 1", "Ebene 2", "Ebene 3", "Ebene 4"];
@@ -115,8 +116,27 @@ export default class RestarbeitenScreen {
     this._renderHeaderFilters();
     this._renderList();
     this._renderEditbox();
+    this._bindUiInspectorToggleShortcut(doc);
 
     return this.host;
+  }
+
+
+  _bindUiInspectorToggleShortcut(doc) {
+    if (!doc || this.uiInspectorKeydownHandler) return;
+    this.uiInspectorKeydownHandler = (event) => {
+      if (!event || event.repeat) return;
+      const key = String(event.key || '').toLowerCase();
+      if (!(event.ctrlKey && event.altKey && key === 'i')) return;
+      event.preventDefault?.();
+      if (this.uiInspectorOverlayActive) {
+        this.uiInspectorRuntime.deactivateOverlay();
+        this.uiInspectorOverlayActive = false;
+      } else if (this.host) {
+        this.uiInspectorOverlayActive = this.uiInspectorRuntime.activateOverlay(this.host) === true;
+      }
+    };
+    doc.addEventListener('keydown', this.uiInspectorKeydownHandler);
   }
 
   _buildHeader(doc) {

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -94,6 +94,10 @@ export default class RestarbeitenScreen {
     this.listHost = null;
     this.editHost = null;
     this.createScrollPending = false;
+    this.uiInspectorRuntime = createUiInspectorRuntime();
+    this.uiInspectorOverlayActive = false;
+    this.uiInspectorKeydownHandler = null;
+    this.uiInspectorKeydownHost = null;
   }
 
   render() {
@@ -137,6 +141,18 @@ export default class RestarbeitenScreen {
       }
     };
     doc.addEventListener('keydown', this.uiInspectorKeydownHandler);
+    this.uiInspectorKeydownHost = doc;
+  }
+
+
+  dispose() {
+    if (this.uiInspectorKeydownHost && this.uiInspectorKeydownHandler) {
+      this.uiInspectorKeydownHost.removeEventListener('keydown', this.uiInspectorKeydownHandler);
+    }
+    this.uiInspectorRuntime?.deactivateOverlay?.();
+    this.uiInspectorOverlayActive = false;
+    this.uiInspectorKeydownHandler = null;
+    this.uiInspectorKeydownHost = null;
   }
 
   _buildHeader(doc) {

--- a/src/renderer/uiInspector/UiInspectorOverlay.js
+++ b/src/renderer/uiInspector/UiInspectorOverlay.js
@@ -1,4 +1,4 @@
-function createUiInspectorOverlay(options = {}) {
+export function createUiInspectorOverlay(options = {}) {
   const defaultSelector = '[data-ui-inspector-id]';
   const selector = typeof options.selector === 'string' && options.selector.trim() ? options.selector : defaultSelector;
   const zIndex = Number.isFinite(options.zIndex) ? String(options.zIndex) : '2147483000';
@@ -58,7 +58,6 @@ function createUiInspectorOverlay(options = {}) {
 
   function refresh() {
     if (!rootElement || !overlayRoot) return false;
-    const doc = rootElement.ownerDocument || globalThis.document;
     clearOverlayChildren();
 
     const nodes = rootElement.querySelectorAll(selector);
@@ -68,7 +67,7 @@ function createUiInspectorOverlay(options = {}) {
       if (!id) continue;
       const rect = node.getBoundingClientRect();
       if (!rect || rect.width <= 0 || rect.height <= 0) continue;
-      overlayRoot.append(createFrame(doc, id, rect));
+      overlayRoot.append(createFrame(rootElement.ownerDocument || globalThis.document, id, rect));
     }
     return true;
   }
@@ -91,13 +90,5 @@ function createUiInspectorOverlay(options = {}) {
     return true;
   }
 
-  return {
-    mount,
-    unmount,
-    refresh,
-  };
+  return { mount, unmount, refresh };
 }
-
-module.exports = {
-  createUiInspectorOverlay,
-};

--- a/src/renderer/uiInspector/UiInspectorOverlay.js
+++ b/src/renderer/uiInspector/UiInspectorOverlay.js
@@ -1,11 +1,100 @@
-function createUiInspectorOverlay() {
+function createUiInspectorOverlay(options = {}) {
+  const defaultSelector = '[data-ui-inspector-id]';
+  const selector = typeof options.selector === 'string' && options.selector.trim() ? options.selector : defaultSelector;
+  const zIndex = Number.isFinite(options.zIndex) ? String(options.zIndex) : '2147483000';
+
+  let rootElement = null;
+  let overlayRoot = null;
+
+  function clearOverlayChildren() {
+    if (!overlayRoot) return;
+    overlayRoot.replaceChildren();
+  }
+
+  function ensureOverlayRoot(doc) {
+    if (overlayRoot?.isConnected) return overlayRoot;
+    overlayRoot = doc.createElement('div');
+    overlayRoot.setAttribute('data-ui-inspector-overlay-root', 'true');
+    overlayRoot.style.position = 'fixed';
+    overlayRoot.style.inset = '0';
+    overlayRoot.style.pointerEvents = 'none';
+    overlayRoot.style.zIndex = zIndex;
+    overlayRoot.style.overflow = 'hidden';
+    return overlayRoot;
+  }
+
+  function createFrame(doc, id, rect) {
+    const frame = doc.createElement('div');
+    frame.setAttribute('data-ui-inspector-overlay-frame', id);
+    frame.style.position = 'fixed';
+    frame.style.left = `${rect.left}px`;
+    frame.style.top = `${rect.top}px`;
+    frame.style.width = `${rect.width}px`;
+    frame.style.height = `${rect.height}px`;
+    frame.style.boxSizing = 'border-box';
+    frame.style.border = '1px solid rgba(43, 157, 255, 0.95)';
+    frame.style.background = 'rgba(43, 157, 255, 0.08)';
+    frame.style.pointerEvents = 'none';
+
+    const label = doc.createElement('div');
+    label.setAttribute('data-ui-inspector-overlay-label', id);
+    label.textContent = id;
+    label.style.position = 'absolute';
+    label.style.left = '0';
+    label.style.top = '-16px';
+    label.style.maxWidth = '320px';
+    label.style.whiteSpace = 'nowrap';
+    label.style.overflow = 'hidden';
+    label.style.textOverflow = 'ellipsis';
+    label.style.background = 'rgba(43, 157, 255, 0.95)';
+    label.style.color = '#ffffff';
+    label.style.font = '11px/1.2 monospace';
+    label.style.padding = '2px 4px';
+    label.style.pointerEvents = 'none';
+
+    frame.append(label);
+    return frame;
+  }
+
+  function refresh() {
+    if (!rootElement || !overlayRoot) return false;
+    const doc = rootElement.ownerDocument || globalThis.document;
+    clearOverlayChildren();
+
+    const nodes = rootElement.querySelectorAll(selector);
+    for (const node of nodes) {
+      if (!node || typeof node.getBoundingClientRect !== 'function') continue;
+      const id = String(node.getAttribute('data-ui-inspector-id') || '').trim();
+      if (!id) continue;
+      const rect = node.getBoundingClientRect();
+      if (!rect || rect.width <= 0 || rect.height <= 0) continue;
+      overlayRoot.append(createFrame(doc, id, rect));
+    }
+    return true;
+  }
+
+  function mount(nextRootElement) {
+    if (!nextRootElement || typeof nextRootElement.querySelectorAll !== 'function') return false;
+    rootElement = nextRootElement;
+    const doc = rootElement.ownerDocument || globalThis.document;
+    const nextOverlayRoot = ensureOverlayRoot(doc);
+    const mountHost = doc.body || rootElement;
+    if (!nextOverlayRoot.isConnected) mountHost.append(nextOverlayRoot);
+    refresh();
+    return true;
+  }
+
+  function unmount() {
+    clearOverlayChildren();
+    if (overlayRoot?.parentElement) overlayRoot.parentElement.removeChild(overlayRoot);
+    rootElement = null;
+    return true;
+  }
+
   return {
-    mount() {
-      return false;
-    },
-    unmount() {
-      return false;
-    },
+    mount,
+    unmount,
+    refresh,
   };
 }
 

--- a/src/renderer/uiInspector/UiInspectorPanel.js
+++ b/src/renderer/uiInspector/UiInspectorPanel.js
@@ -1,4 +1,4 @@
-function createUiInspectorPanel() {
+export function createUiInspectorPanel() {
   return {
     mount() {
       return false;
@@ -8,7 +8,3 @@ function createUiInspectorPanel() {
     },
   };
 }
-
-module.exports = {
-  createUiInspectorPanel,
-};

--- a/src/renderer/uiInspector/UiInspectorRuntime.js
+++ b/src/renderer/uiInspector/UiInspectorRuntime.js
@@ -1,14 +1,7 @@
-import sharedUiInspector from '../../shared/uiInspector/index.js';
 import { createUiInspectorOverlay } from './UiInspectorOverlay.js';
 
-const { createUiInspectorCore, createUiInspectorRegistry, createMemoryUiInspectorStore } = sharedUiInspector;
-
-export function createUiInspectorRuntime({ registry, store, core, overlay } = {}) {
-  const resolvedRegistry = registry || createUiInspectorRegistry();
-  const resolvedStore = store || createMemoryUiInspectorStore();
-  const resolvedCore = core || createUiInspectorCore({ registry: resolvedRegistry, store: resolvedStore });
+export function createUiInspectorRuntime({ overlay } = {}) {
   const resolvedOverlay = overlay || createUiInspectorOverlay();
-
   let overlayActive = false;
 
   function activateOverlay(rootElement) {
@@ -28,9 +21,6 @@ export function createUiInspectorRuntime({ registry, store, core, overlay } = {}
   }
 
   return {
-    registry: resolvedRegistry,
-    store: resolvedStore,
-    core: resolvedCore,
     overlay: resolvedOverlay,
     activateOverlay,
     deactivateOverlay,

--- a/src/renderer/uiInspector/UiInspectorRuntime.js
+++ b/src/renderer/uiInspector/UiInspectorRuntime.js
@@ -3,17 +3,44 @@ const {
   createUiInspectorRegistry,
   createMemoryUiInspectorStore,
 } = require('../../shared/uiInspector');
+const { createUiInspectorOverlay } = require('./UiInspectorOverlay');
 
-function createUiInspectorRuntime({ registry, store, core } = {}) {
+function createUiInspectorRuntime({ registry, store, core, overlay } = {}) {
   const resolvedRegistry = registry || createUiInspectorRegistry();
   const resolvedStore = store || createMemoryUiInspectorStore();
   const resolvedCore =
     core || createUiInspectorCore({ registry: resolvedRegistry, store: resolvedStore });
+  const resolvedOverlay = overlay || createUiInspectorOverlay();
+
+  let overlayActive = false;
+
+  function activateOverlay(rootElement) {
+    overlayActive = resolvedOverlay.mount(rootElement) === true;
+    return overlayActive;
+  }
+
+  function deactivateOverlay() {
+    resolvedOverlay.unmount();
+    overlayActive = false;
+    return true;
+  }
+
+  function refreshOverlay() {
+    if (!overlayActive) return false;
+    return resolvedOverlay.refresh() === true;
+  }
 
   return {
     registry: resolvedRegistry,
     store: resolvedStore,
     core: resolvedCore,
+    overlay: resolvedOverlay,
+    activateOverlay,
+    deactivateOverlay,
+    refreshOverlay,
+    isOverlayActive() {
+      return overlayActive;
+    },
   };
 }
 

--- a/src/renderer/uiInspector/UiInspectorRuntime.js
+++ b/src/renderer/uiInspector/UiInspectorRuntime.js
@@ -1,15 +1,12 @@
-const {
-  createUiInspectorCore,
-  createUiInspectorRegistry,
-  createMemoryUiInspectorStore,
-} = require('../../shared/uiInspector');
-const { createUiInspectorOverlay } = require('./UiInspectorOverlay');
+import sharedUiInspector from '../../shared/uiInspector/index.js';
+import { createUiInspectorOverlay } from './UiInspectorOverlay.js';
 
-function createUiInspectorRuntime({ registry, store, core, overlay } = {}) {
+const { createUiInspectorCore, createUiInspectorRegistry, createMemoryUiInspectorStore } = sharedUiInspector;
+
+export function createUiInspectorRuntime({ registry, store, core, overlay } = {}) {
   const resolvedRegistry = registry || createUiInspectorRegistry();
   const resolvedStore = store || createMemoryUiInspectorStore();
-  const resolvedCore =
-    core || createUiInspectorCore({ registry: resolvedRegistry, store: resolvedStore });
+  const resolvedCore = core || createUiInspectorCore({ registry: resolvedRegistry, store: resolvedStore });
   const resolvedOverlay = overlay || createUiInspectorOverlay();
 
   let overlayActive = false;
@@ -43,7 +40,3 @@ function createUiInspectorRuntime({ registry, store, core, overlay } = {}) {
     },
   };
 }
-
-module.exports = {
-  createUiInspectorRuntime,
-};

--- a/src/renderer/uiInspector/index.js
+++ b/src/renderer/uiInspector/index.js
@@ -1,9 +1,3 @@
-const { createUiInspectorRuntime } = require('./UiInspectorRuntime');
-const { createUiInspectorOverlay } = require('./UiInspectorOverlay');
-const { createUiInspectorPanel } = require('./UiInspectorPanel');
-
-module.exports = {
-  createUiInspectorRuntime,
-  createUiInspectorOverlay,
-  createUiInspectorPanel,
-};
+export { createUiInspectorRuntime } from './UiInspectorRuntime.js';
+export { createUiInspectorOverlay } from './UiInspectorOverlay.js';
+export { createUiInspectorPanel } from './UiInspectorPanel.js';


### PR DESCRIPTION
### Motivation
- Provide a minimal, non-invasive visual UI-Inspector overlay (M10) that uses the existing `data-ui-inspector-id` markers to highlight Restarbeiten areas without changing app behavior. 
- Keep the Inspector strictly display-only: no panel, no click-selection, no layout or persistence changes, and no BBM fachlogic injected into the core.

### Description
- Implemented `src/renderer/uiInspector/UiInspectorOverlay.js` with `createUiInspectorOverlay(options)` exposing `mount(root)`, `refresh()`, and `unmount()` and rendering fixed-position frames and small ID labels for every `[data-ui-inspector-id]` inside the given root, using `pointer-events: none` and an isolated overlay root. 
- Extended `src/renderer/uiInspector/UiInspectorRuntime.js` to include an overlay instance and lifecycle helpers `activateOverlay(rootElement)`, `deactivateOverlay()`, and `refreshOverlay()` while keeping core/registry/store separation. 
- Added a minimal Restarbeiten integration in `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js` that imports the runtime and binds a dev-only keyboard toggle (`Ctrl + Alt + I`) to activate/deactivate the overlay for the Restarbeiten screen; the toggle only shows/hides the overlay and performs no selection, saving or fachlogic. 
- Added tests: new `scripts/tests/uiInspectorOverlay.test.cjs` (overlay import/mount/refresh/unmount and pointer-events checks) and extended `scripts/tests/restarbeitenModule.test.cjs` with a focused M10 assertion that the overlay toggle exists and that no panel/save logic was introduced. 
- Updated documentation: `docs/UI_INSPEKTOR_AUFGABENHEFT.md`, `docs/UI_INSPEKTOR_START_HIER.md`, and `docs/ui-landkarten/RESTARBEITEN.md` to mark M10 as completed and describe scope and next step (M11). 

### Testing
- Ran `node scripts/tests/uiInspectorCore.test.cjs` and it passed. 
- Ran `node scripts/tests/uiInspectorRegistry.test.cjs` and it passed. 
- Ran `node scripts/tests/uiInspectorMapSchema.test.cjs` and it passed. 
- Ran the new `node scripts/tests/uiInspectorOverlay.test.cjs` and it passed. 
- Ran the updated `node scripts/tests/restarbeitenModule.test.cjs` and it passed. 
- Ran `npm test` in this environment which failed due to missing Electron native system libraries (`libatk-1.0.so.0`), so full `npm test` should be executed locally in a proper Electron-enabled environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1028c6f84c8322ad4b876ba6b6f539)