### PR TITLE
M10.1: guard UI-Inspector doc listeners and fix Restarbeiten tests

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -287,9 +287,15 @@ async function runRestarbeitenModuleTests(run) {
     assert.doesNotMatch(runtimeContent, /createUiInspectorCore|createUiInspectorRegistry|createMemoryUiInspectorStore/);
 
     const screenContent = fs.readFileSync(screenPath, "utf8");
-    assert.match(screenContent, /import\s*\{\s*createUiInspectorRuntime\s*\}\s*from\s*["']\.\.\.\/\.\.\.\/uiInspector\/index\.js["']/);
+    assert.match(screenContent, /createUiInspectorRuntime/);
+    assert.match(screenContent, /from\s+["']\.\.\/\.\.\/\.\.\/uiInspector\/index\.js["']/);
     assert.doesNotMatch(screenContent, /createUiInspectorPanel/);
-    assert.doesNotMatch(screenContent, /save|speicher/i);
+    assert.doesNotMatch(screenContent, /uiInspectorStore/);
+    assert.doesNotMatch(screenContent, /saveInspector/);
+    assert.doesNotMatch(screenContent, /saveUiInspector/);
+    assert.doesNotMatch(screenContent, /localStorage/);
+    assert.doesNotMatch(screenContent, /ui-inspector:save/);
+    assert.doesNotMatch(screenContent, /inspector:save/);
   });
 
   await run("M10 UI-Inspector Overlay-Toggle ist klar begrenzt", () => {
@@ -303,10 +309,18 @@ async function runRestarbeitenModuleTests(run) {
     assert.match(content, /key\s*===\s*['"]i['"]/);
     assert.match(content, /this\.uiInspectorRuntime\.activateOverlay\(this\.host\)/);
     assert.match(content, /this\.uiInspectorRuntime\.deactivateOverlay\(\)/);
+    assert.match(content, /if \(!doc \|\| this\.uiInspectorKeydownHandler\) return;/);
+    assert.match(content, /typeof doc\.addEventListener !== ["']function["']/);
     assert.match(content, /dispose\(\)/);
+    assert.match(content, /typeof this\.uiInspectorKeydownHost\.removeEventListener === ["']function["']/);
     assert.match(content, /removeEventListener\('keydown',\s*this\.uiInspectorKeydownHandler\)/);
     assert.doesNotMatch(content, /createUiInspectorPanel/);
-    assert.doesNotMatch(content, /save|speicher/i);
+    assert.doesNotMatch(content, /uiInspectorStore/);
+    assert.doesNotMatch(content, /saveInspector/);
+    assert.doesNotMatch(content, /saveUiInspector/);
+    assert.doesNotMatch(content, /localStorage/);
+    assert.doesNotMatch(content, /ui-inspector:save/);
+    assert.doesNotMatch(content, /inspector:save/);
   });
 
   await run("M14 Screen-UI: Header, Blattstruktur, Verortung 1-4, Fotos einklappbar, Editbox unten", () => {

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -128,6 +128,7 @@ export default class RestarbeitenScreen {
 
   _bindUiInspectorToggleShortcut(doc) {
     if (!doc || this.uiInspectorKeydownHandler) return;
+    if (typeof doc.addEventListener !== "function") return;
     this.uiInspectorKeydownHandler = (event) => {
       if (!event || event.repeat) return;
       const key = String(event.key || '').toLowerCase();
@@ -146,7 +147,11 @@ export default class RestarbeitenScreen {
 
 
   dispose() {
-    if (this.uiInspectorKeydownHost && this.uiInspectorKeydownHandler) {
+    if (
+      this.uiInspectorKeydownHost &&
+      typeof this.uiInspectorKeydownHost.removeEventListener === "function" &&
+      this.uiInspectorKeydownHandler
+    ) {
       this.uiInspectorKeydownHost.removeEventListener('keydown', this.uiInspectorKeydownHandler);
     }
     this.uiInspectorRuntime?.deactivateOverlay?.();


### PR DESCRIPTION
### Motivation
- Local tests started failing after M10 merge because `RestarbeitenScreen._bindUiInspectorToggleShortcut` assumed a real DOM `doc` with `addEventListener`, which test fakes lack. 
- Some test assertions were too fragile (overly strict import RegEx) or incorrect (banned `save|speicher` globally), so tests needed adjustment to reflect M10 intent (overlay-only, no panel/saving). 

### Description
- Made `src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js` resilient to fake documents by adding a guard in `_bindUiInspectorToggleShortcut(doc)` that returns if `!doc` or `typeof doc.addEventListener !== 'function'`, and by only calling `removeEventListener` in `dispose()` when `removeEventListener` is a function; overlay deactivation and state reset remain unchanged. 
- Updated `scripts/tests/restarbeitenModule.test.cjs` to replace the fragile import RegEx with robust `assert.match` checks for `createUiInspectorRuntime` and the `from "../../../uiInspector/index.js"` import, removed the global `save|speicher` negative check, and added targeted negative checks against `createUiInspectorPanel`, `uiInspectorStore`, `saveInspector`, `saveUiInspector`, `localStorage`, and IPC event names; tests also assert presence of the new guard-strings. 
- No UI/CSS/layout/DB/IPC/preload/fachlogic changes were made and no new features (panel, selection, saving) were introduced. 

### Testing
- Ran `node scripts/tests/uiInspectorCore.test.cjs` — passed. 
- Ran `node scripts/tests/uiInspectorRegistry.test.cjs` — passed. 
- Ran `node scripts/tests/uiInspectorMapSchema.test.cjs` — passed. 
- Ran `node scripts/tests/uiInspectorOverlay.test.cjs` — passed. 
- Ran `node scripts/tests/restarbeitenModule.test.cjs` (updated) — passed. 
- Ran `npm test` in this environment — failed due to missing system library `libatk-1.0.so.0` required by Electron, so full `npm test` should be re-run in CI or a local environment with the native dependency available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1036404a408322805766adcb70ee4f)