### PR TITLE
M11 neu: UI-Inspektor Auswahl über Trefferliste am Klickpunkt

### DIFF
--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -207,3 +207,12 @@ Hinweis:
   - `npm test`
 - Nächster Schritt:
   - **M11 Bereich anklicken und Auswahl anzeigen**
+
+
+## M11 Abschluss (neu)
+- Status: erledigt.
+- Auswahl erfolgt jetzt über eine temporäre Trefferliste am Klickpunkt (statt Handle-Ansatz aus PR #152).
+- Keine Panels, keine Werteanzeige, keine Speicherung, keine Layoutänderung.
+- Geänderte Dateien: `src/renderer/uiInspector/UiInspectorOverlay.js`, `src/renderer/uiInspector/UiInspectorRuntime.js`, `scripts/tests/uiInspectorOverlay.test.cjs`, `scripts/tests/restarbeitenModule.test.cjs`, `docs/UI_INSPEKTOR_AUFGABENHEFT.md`, `docs/UI_INSPEKTOR_START_HIER.md`, `docs/ui-landkarten/RESTARBEITEN.md`, `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`.
+- Tests: `node scripts/tests/uiInspectorCore.test.cjs`, `node scripts/tests/uiInspectorRegistry.test.cjs`, `node scripts/tests/uiInspectorMapSchema.test.cjs`, `node scripts/tests/uiInspectorOverlay.test.cjs`, `node scripts/tests/restarbeitenModule.test.cjs`, `npm test`.
+- Nächster Schritt: M12 – Panel zeigt erlaubte Stellschrauben.

--- a/docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md
+++ b/docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md
@@ -47,3 +47,11 @@
 **Beschluss:** Der UI-Inspektor wird schrittweise ab M6 über ein Modulgerüst, Landkartenformat, Pilot-Landkarte, Markierungen, Overlay, Auswahl, Panel, temporäre Anwendung und Speicherung aufgebaut.
 
 **Begründung:** Der Inspektor darf nicht als Großpaket entstehen. Die schrittweise Umsetzung verhindert Nebenwirkungen und hält das Modul exportierbar.
+
+
+## Entscheidung 010
+**Beschluss:** M11 nutzt eine Trefferliste am Klickpunkt statt klickbarer Rahmen/Handles.
+
+**Begründung:** Bei verschachtelten UI-Bereichen ist Handle-/Rahmenklick für Laien nicht zuverlässig und unübersichtlich.
+
+**Auswirkung:** Die Trefferliste trennt Auswahl von Rahmenanzeige und bleibt in komplexen UIs bedienbar.

--- a/docs/UI_INSPEKTOR_START_HIER.md
+++ b/docs/UI_INSPEKTOR_START_HIER.md
@@ -57,3 +57,11 @@ Nicht fortführen:
 Ein neuer Chat soll mit dieser Zusammenfassung starten können:
 
 „Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Das Modulgerüst und die erste Restarbeiten-Pilot-Landkarte sind dokumentiert. Nächster Schritt laut Aufgabenheft ist M10 (Overlay nur anzeigen; weiterhin ohne Panel und ohne sichtbare Fachfunktion).“
+
+
+## Statusupdate M11 (neu)
+- M11 ist erledigt.
+- Overlay zeigt Bereiche weiterhin als Rahmen.
+- Auswahl erfolgt über Trefferliste am Klickpunkt.
+- Noch kein Panel, keine Werte, keine Speicherung, keine Layoutänderung.
+- Nächster Meilenstein: M12 (Panel zeigt erlaubte Stellschrauben).

--- a/docs/ui-landkarten/RESTARBEITEN.md
+++ b/docs/ui-landkarten/RESTARBEITEN.md
@@ -42,7 +42,9 @@ Restarbeiten
 - `restarbeiten.header`
 - `restarbeiten.filterleiste`
 - `restarbeiten.filterleiste.klassenfilter`
+- `restarbeiten.filterleiste.klassenfilter.feld`
 - `restarbeiten.filterleiste.verortung`
+- `restarbeiten.filterleiste.verortung.feld`
 - `restarbeiten.filterleiste.meta`
 - `restarbeiten.filterleiste.meta.fertig_bis`
 - `restarbeiten.filterleiste.meta.status`
@@ -53,8 +55,14 @@ Restarbeiten
 - `restarbeiten.liste.textbereich`
 - `restarbeiten.liste.metabereich`
 - `restarbeiten.editbox`
+- `restarbeiten.editbox.header`
+- `restarbeiten.editbox.verortung`
 - `restarbeiten.editbox.kurztext`
+- `restarbeiten.editbox.kurztext.label`
+- `restarbeiten.editbox.kurztext.restzeichen`
 - `restarbeiten.editbox.langtext`
+- `restarbeiten.editbox.langtext.label`
+- `restarbeiten.editbox.langtext.restzeichen`
 - `restarbeiten.editbox.meta`
 
 Hinweis:

--- a/docs/ui-landkarten/RESTARBEITEN.md
+++ b/docs/ui-landkarten/RESTARBEITEN.md
@@ -144,3 +144,9 @@ Editbox:
 - Ist die Liste in Textbereich und Metabereich sinnvoll trennbar?
 - Gehört Foto/Anlagen fachlich zur Liste, zur Editbox oder als eigener Sonderbereich?
 - Welche Stellschrauben sind für den Nutzer wirklich verständlich?
+
+
+## M11 Hinweis
+- Ab M11 erfolgt die Bereichsauswahl über eine temporäre Trefferliste am Klickpunkt.
+- Keine Handles pro Rahmen als primärer Auswahlweg.
+- Keine Einstellfunktion in M11.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -283,6 +283,13 @@ async function runRestarbeitenModuleTests(run) {
       assert.doesNotMatch(source, /require\s*\(/);
     }
 
+
+    assert.match(overlayContent, /data-ui-inspector-hit-list/);
+    assert.match(overlayContent, /data-ui-inspector-hit-option/);
+    assert.match(overlayContent, /getHitsAtPoint/);
+    assert.match(overlayContent, /showHitListAtPoint/);
+    assert.doesNotMatch(overlayContent, /data-ui-inspector-overlay-handle/);
+
     assert.doesNotMatch(runtimeContent, /\.\.\/\.\.\/shared\/uiInspector\/index\.js/);
     assert.doesNotMatch(runtimeContent, /createUiInspectorCore|createUiInspectorRegistry|createMemoryUiInspectorStore/);
 

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -521,7 +521,9 @@ async function runRestarbeitenModuleTests(run) {
       "restarbeiten.header",
       "restarbeiten.filterleiste",
       "restarbeiten.filterleiste.klassenfilter",
+      "restarbeiten.filterleiste.klassenfilter.feld",
       "restarbeiten.filterleiste.verortung",
+      "restarbeiten.filterleiste.verortung.feld",
       "restarbeiten.filterleiste.meta",
       "restarbeiten.filterleiste.meta.fertig_bis",
       "restarbeiten.filterleiste.meta.status",
@@ -535,8 +537,14 @@ async function runRestarbeitenModuleTests(run) {
 
     [
       "restarbeiten.editbox",
+      "restarbeiten.editbox.header",
+      "restarbeiten.editbox.verortung",
       "restarbeiten.editbox.kurztext",
+      "restarbeiten.editbox.kurztext.label",
+      "restarbeiten.editbox.kurztext.restzeichen",
       "restarbeiten.editbox.langtext",
+      "restarbeiten.editbox.langtext.label",
+      "restarbeiten.editbox.langtext.restzeichen",
       "restarbeiten.editbox.meta",
     ].forEach((id) => assert.equal(editbox.includes(id), true));
 

--- a/scripts/tests/uiInspectorOverlay.test.cjs
+++ b/scripts/tests/uiInspectorOverlay.test.cjs
@@ -44,6 +44,10 @@ function createInspectableRoot(document) {
 
 (async function run() {
   const { createUiInspectorOverlay } = await importEsmFromFile(path.join(__dirname, '../../src/renderer/uiInspector/UiInspectorOverlay.js'));
+
+  const overlaySource = require('node:fs').readFileSync(path.join(__dirname, '../../src/renderer/uiInspector/UiInspectorOverlay.js'), 'utf8');
+  assert.equal(overlaySource.includes('overlayRoot.children ='), false);
+
   const { document } = createFakeDom();
   const overlay = createUiInspectorOverlay();
   const root = createInspectableRoot(document);

--- a/scripts/tests/uiInspectorOverlay.test.cjs
+++ b/scripts/tests/uiInspectorOverlay.test.cjs
@@ -3,45 +3,95 @@ const path = require('node:path');
 const { importEsmFromFile } = require('./_esmLoader.cjs');
 
 function createFakeDom() {
-  const bodyChildren = [];
+  const listeners = new Map();
   function createElement(tagName) {
-    return {
+    const node = {
       tagName: String(tagName || '').toUpperCase(),
-      children: [], style: {}, attributes: {}, isConnected: false, parentElement: null, textContent: '',
+      children: [], style: {}, attributes: {}, isConnected: false, parentElement: null, textContent: '', onclick: null,
       append(...items) { for (const child of items) { child.parentElement = this; child.isConnected = this.isConnected; this.children.push(child); } },
       replaceChildren(...items) { this.children = []; this.append(...items); },
       setAttribute(name, value) { this.attributes[name] = String(value); },
       getAttribute(name) { return this.attributes[name]; },
       removeChild(child) { this.children = this.children.filter((e) => e !== child); child.parentElement = null; child.isConnected = false; },
+      click() { this.onclick?.({ preventDefault() {}, stopPropagation() {}, stopImmediatePropagation() {} }); },
     };
+    return node;
   }
-  const document = { body: createElement('body'), createElement };
+  const document = {
+    body: createElement('body'),
+    createElement,
+    addEventListener(type, handler) { if (!listeners.has(type)) listeners.set(type, []); listeners.get(type).push(handler); },
+    removeEventListener(type, handler) { listeners.set(type, (listeners.get(type) || []).filter((h) => h !== handler)); },
+    dispatch(type, event) { for (const h of listeners.get(type) || []) h(event); },
+    listenerCount(type) { return (listeners.get(type) || []).length; },
+  };
   document.body.isConnected = true;
-  document.body.append = (...items) => { for (const item of items) { item.parentElement = document.body; item.isConnected = true; bodyChildren.push(item); document.body.children.push(item);} };
+  document.body.append = (...items) => { for (const item of items) { item.parentElement = document.body; item.isConnected = true; document.body.children.push(item);} };
   return { document };
 }
 
 function createInspectableRoot(document) {
-  const mk = (id, rect) => ({ ownerDocument: document, getAttribute: (n)=> n==='data-ui-inspector-id'?id:null, getBoundingClientRect: ()=>rect });
-  const nodeA = mk('restarbeiten.header', { left: 10, top: 20, width: 100, height: 40 });
-  const nodeB = mk('restarbeiten.liste', { left: 30, top: 80, width: 200, height: 120 });
-  return { ownerDocument: document, querySelectorAll: (sel)=> sel==='[data-ui-inspector-id]'?[nodeA,nodeB]:[] };
+  const mk = (id, rect) => ({ ownerDocument: document, className:'', getAttribute: (n)=> n==='data-ui-inspector-id'?id:null, getBoundingClientRect: ()=>rect });
+  const nodes = [
+    mk('restarbeiten.root', { left: 0, top: 0, width: 500, height: 400 }),
+    mk('restarbeiten.main', { left: 10, top: 20, width: 450, height: 300 }),
+    mk('restarbeiten.filterleiste', { left: 20, top: 30, width: 300, height: 80 }),
+    mk('restarbeiten.filterleiste.meta', { left: 40, top: 40, width: 180, height: 50 }),
+    mk('restarbeiten.filterleiste.meta.status', { left: 60, top: 50, width: 70, height: 20 }),
+  ];
+  return { ownerDocument: document, querySelectorAll: (sel)=> sel==='[data-ui-inspector-id]'?nodes:[] };
 }
 
 (async function run() {
   const { createUiInspectorOverlay } = await importEsmFromFile(path.join(__dirname, '../../src/renderer/uiInspector/UiInspectorOverlay.js'));
-  assert.equal(typeof createUiInspectorOverlay, 'function');
   const { document } = createFakeDom();
   const overlay = createUiInspectorOverlay();
   const root = createInspectableRoot(document);
+
   assert.equal(overlay.mount(root), true);
   const overlayRoot = document.body.children[0];
   assert.equal(overlayRoot.style.pointerEvents, 'none');
-  assert.equal(overlayRoot.children.length, 2);
-  assert.equal(overlayRoot.children[0].attributes['data-ui-inspector-overlay-frame'], 'restarbeiten.header');
-  assert.equal(overlayRoot.children[0].children[0].textContent, 'restarbeiten.header');
-  assert.equal(overlay.refresh(), true);
+  assert.equal(overlayRoot.children.some((c) => c.attributes['data-ui-inspector-overlay-frame'] === 'restarbeiten.main'), true);
+  assert.equal(document.listenerCount('pointerdown'), 1);
+
+  const hits = overlay.getHitsAtPoint(65, 55).map((h) => h.id);
+  assert.deepEqual(hits.slice(0, 5), [
+    'restarbeiten.filterleiste.meta.status',
+    'restarbeiten.filterleiste.meta',
+    'restarbeiten.filterleiste',
+    'restarbeiten.main',
+    'restarbeiten.root',
+  ]);
+
+  const prevented = { value: false };
+  document.dispatch('pointerdown', { clientX: 65, clientY: 55, preventDefault() { prevented.value = true; }, stopPropagation() {}, stopImmediatePropagation() {} });
+  assert.equal(prevented.value, true);
+
+  const hitList = overlayRoot.children.find((c) => c.attributes['data-ui-inspector-hit-list'] === 'true');
+  assert.ok(hitList);
+  assert.equal(hitList.style.pointerEvents, 'auto');
+  const firstOption = hitList.children[0];
+  assert.equal(firstOption.attributes['data-ui-inspector-hit-option'], 'restarbeiten.filterleiste.meta.status');
+  firstOption.click();
+
+  assert.equal(overlay.getSelectedId(), 'restarbeiten.filterleiste.meta.status');
+  const selectedFrame = overlayRoot.children.find((c) => c.attributes['data-ui-inspector-selected'] === 'true');
+  assert.equal(selectedFrame.attributes['data-ui-inspector-overlay-frame'], 'restarbeiten.filterleiste.meta.status');
+  const badge = overlayRoot.children.find((c) => c.attributes['data-ui-inspector-selection-badge'] === 'true');
+  assert.equal(badge.textContent, 'Auswahl: restarbeiten.filterleiste.meta.status');
+  assert.equal(overlayRoot.children.some((c) => c.attributes['data-ui-inspector-hit-list'] === 'true'), false);
+
+  overlay.clearSelection();
+  const badgeAfterClear = overlayRoot.children.find((c) => c.attributes['data-ui-inspector-selection-badge'] === 'true');
+  assert.equal(badgeAfterClear.textContent, 'Auswahl: -');
+
   assert.equal(overlay.unmount(), true);
-  assert.equal(document.body.children.length, 0);
+  assert.equal(document.listenerCount('pointerdown'), 0);
+
+  const noEventsDoc = { ...document, addEventListener: undefined, removeEventListener: undefined, body: document.body, createElement: document.createElement };
+  const root2 = createInspectableRoot(noEventsDoc);
+  const overlay2 = createUiInspectorOverlay();
+  assert.equal(overlay2.mount(root2), true);
+  assert.equal(overlay2.unmount(), true);
   console.log('ok - uiInspectorOverlay.test');
 })();

--- a/scripts/tests/uiInspectorOverlay.test.cjs
+++ b/scripts/tests/uiInspectorOverlay.test.cjs
@@ -72,6 +72,21 @@ function createInspectableRoot(document) {
   assert.equal(hitList.style.pointerEvents, 'auto');
   const firstOption = hitList.children[0];
   assert.equal(firstOption.attributes['data-ui-inspector-hit-option'], 'restarbeiten.filterleiste.meta.status');
+
+  const firstHitListRef = hitList;
+  const preventedHitOption = { value: false };
+  document.dispatch('pointerdown', {
+    clientX: 66,
+    clientY: 56,
+    target: firstOption,
+    preventDefault() { preventedHitOption.value = true; },
+    stopPropagation() {},
+    stopImmediatePropagation() {},
+  });
+  assert.equal(preventedHitOption.value, false);
+  const hitListAfterOptionPointerdown = overlayRoot.children.find((c) => c.attributes['data-ui-inspector-hit-list'] === 'true');
+  assert.equal(hitListAfterOptionPointerdown, firstHitListRef);
+
   firstOption.click();
 
   assert.equal(overlay.getSelectedId(), 'restarbeiten.filterleiste.meta.status');

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenEditbox.js
@@ -124,6 +124,7 @@ export default class RestarbeitenEditbox {
     form.className = "restarbeiten-editbox__layout";
     const topBar = doc.createElement("div");
     topBar.className = "restarbeiten-editbox__topBar";
+    topBar.setAttribute("data-ui-inspector-id", "restarbeiten.editbox.header");
     const titleEl = doc.createElement("div");
     titleEl.className = "restarbeiten-editbox__title";
     titleEl.textContent = "R der Liste bearbeiten";
@@ -157,18 +158,22 @@ export default class RestarbeitenEditbox {
     shortRailRow.className = "restarbeiten-editbox__railRow restarbeiten-editbox__railRow--short";
     const shortRailLabel = doc.createElement("span");
     shortRailLabel.className = "restarbeiten-editbox__railLabel";
+    shortRailLabel.setAttribute("data-ui-inspector-id", "restarbeiten.editbox.kurztext.label");
     shortRailLabel.textContent = "Kurztext";
     const shortCounter = doc.createElement("span");
     shortCounter.className = "restarbeiten-editbox__railCounter";
+    shortCounter.setAttribute("data-ui-inspector-id", "restarbeiten.editbox.kurztext.restzeichen");
     shortRailRow.append(shortRailLabel, shortCounter);
 
     const longRailRow = doc.createElement("div");
     longRailRow.className = "restarbeiten-editbox__railRow restarbeiten-editbox__railRow--long";
     const longRailLabel = doc.createElement("span");
     longRailLabel.className = "restarbeiten-editbox__railLabel";
+    longRailLabel.setAttribute("data-ui-inspector-id", "restarbeiten.editbox.langtext.label");
     longRailLabel.textContent = "Langtext";
     const longCounter = doc.createElement("span");
     longCounter.className = "restarbeiten-editbox__railCounter";
+    longCounter.setAttribute("data-ui-inspector-id", "restarbeiten.editbox.langtext.restzeichen");
     longRailRow.append(longRailLabel, longCounter);
 
     textRail.append(shortRailRow, longRailRow);
@@ -181,6 +186,7 @@ export default class RestarbeitenEditbox {
 
     const locationGrid = doc.createElement("div");
     locationGrid.className = "restarbeiten-editbox__locationGrid";
+    locationGrid.setAttribute("data-ui-inspector-id", "restarbeiten.editbox.verortung");
     const loc1Field = createField(doc, this._getLocationLabel(1), level1, "restarbeiten-editbox__locationField");
     const loc2Field = createField(doc, this._getLocationLabel(2), level2, "restarbeiten-editbox__locationField");
     const loc3Field = createField(doc, this._getLocationLabel(3), level3, "restarbeiten-editbox__locationField");

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -453,6 +453,7 @@ export default class RestarbeitenScreen {
   _buildClassFilter(doc) {
     const wrap = doc.createElement("div");
     wrap.className = "restarbeiten-filterleiste__classFilter";
+    wrap.setAttribute("data-ui-inspector-id", "restarbeiten.filterleiste.klassenfilter.feld");
     const values = [
       { value: "", label: "Alle" },
       { value: "mangel", label: "Mangel" },
@@ -477,6 +478,7 @@ export default class RestarbeitenScreen {
   _buildSingleFilter(doc, key, levelIndex) {
     const wrap = doc.createElement("label");
     wrap.className = "restarbeiten-filterleiste__field";
+    wrap.setAttribute("data-ui-inspector-id", "restarbeiten.filterleiste.verortung.feld");
 
     const caption = doc.createElement("span");
     caption.className = "restarbeiten-filterleiste__fieldLabel";

--- a/src/renderer/uiInspector/UiInspectorOverlay.js
+++ b/src/renderer/uiInspector/UiInspectorOverlay.js
@@ -98,11 +98,10 @@ export function createUiInspectorOverlay(options = {}) {
 
   function removeHitList() {
     if (!overlayRoot) return;
-    overlayRoot.children = overlayRoot.children; // noop for fake dom safety
-    const children = Array.isArray(overlayRoot.children) ? [...overlayRoot.children] : [];
+    const children = Array.from(overlayRoot.children || []);
     for (const child of children) {
       if (child?.getAttribute?.('data-ui-inspector-hit-list') === 'true') {
-        overlayRoot.removeChild(child);
+        child.parentElement?.removeChild?.(child);
       }
     }
   }

--- a/src/renderer/uiInspector/UiInspectorOverlay.js
+++ b/src/renderer/uiInspector/UiInspectorOverlay.js
@@ -5,6 +5,10 @@ export function createUiInspectorOverlay(options = {}) {
 
   let rootElement = null;
   let overlayRoot = null;
+  let selectedId = '';
+  let captureHost = null;
+  let captureHandler = null;
+  let domSequence = 0;
 
   function clearOverlayChildren() {
     if (!overlayRoot) return;
@@ -23,6 +27,22 @@ export function createUiInspectorOverlay(options = {}) {
     return overlayRoot;
   }
 
+  function createBadge(doc) {
+    const badge = doc.createElement('div');
+    badge.setAttribute('data-ui-inspector-selection-badge', 'true');
+    badge.style.position = 'fixed';
+    badge.style.right = '12px';
+    badge.style.top = '12px';
+    badge.style.background = 'rgba(30, 35, 45, 0.92)';
+    badge.style.color = '#ffffff';
+    badge.style.font = '12px/1.3 monospace';
+    badge.style.padding = '6px 8px';
+    badge.style.borderRadius = '4px';
+    badge.style.pointerEvents = 'none';
+    badge.textContent = `Auswahl: ${selectedId || '-'}`;
+    return badge;
+  }
+
   function createFrame(doc, id, rect) {
     const frame = doc.createElement('div');
     frame.setAttribute('data-ui-inspector-overlay-frame', id);
@@ -32,9 +52,10 @@ export function createUiInspectorOverlay(options = {}) {
     frame.style.width = `${rect.width}px`;
     frame.style.height = `${rect.height}px`;
     frame.style.boxSizing = 'border-box';
-    frame.style.border = '1px solid rgba(43, 157, 255, 0.95)';
-    frame.style.background = 'rgba(43, 157, 255, 0.08)';
+    frame.style.border = selectedId === id ? '2px solid rgba(255, 168, 42, 0.98)' : '1px solid rgba(43, 157, 255, 0.95)';
+    frame.style.background = selectedId === id ? 'rgba(255, 168, 42, 0.16)' : 'rgba(43, 157, 255, 0.08)';
     frame.style.pointerEvents = 'none';
+    if (selectedId === id) frame.setAttribute('data-ui-inspector-selected', 'true');
 
     const label = doc.createElement('div');
     label.setAttribute('data-ui-inspector-overlay-label', id);
@@ -46,7 +67,7 @@ export function createUiInspectorOverlay(options = {}) {
     label.style.whiteSpace = 'nowrap';
     label.style.overflow = 'hidden';
     label.style.textOverflow = 'ellipsis';
-    label.style.background = 'rgba(43, 157, 255, 0.95)';
+    label.style.background = selectedId === id ? 'rgba(255, 168, 42, 0.98)' : 'rgba(43, 157, 255, 0.95)';
     label.style.color = '#ffffff';
     label.style.font = '11px/1.2 monospace';
     label.style.padding = '2px 4px';
@@ -54,6 +75,92 @@ export function createUiInspectorOverlay(options = {}) {
 
     frame.append(label);
     return frame;
+  }
+
+  function getHitsAtPoint(x, y) {
+    if (!rootElement) return [];
+    const nodes = rootElement.querySelectorAll(selector);
+    const hits = [];
+    domSequence = 0;
+    for (const node of nodes) {
+      domSequence += 1;
+      if (!node || typeof node.getBoundingClientRect !== 'function') continue;
+      const id = String(node.getAttribute('data-ui-inspector-id') || '').trim();
+      if (!id) continue;
+      const rect = node.getBoundingClientRect();
+      if (!rect || rect.width <= 0 || rect.height <= 0) continue;
+      if (x < rect.left || x > rect.left + rect.width || y < rect.top || y > rect.top + rect.height) continue;
+      hits.push({ id, rect, area: rect.width * rect.height, depth: id.split('.').length, index: domSequence });
+    }
+    hits.sort((a, b) => a.area - b.area || b.depth - a.depth || a.index - b.index);
+    return hits;
+  }
+
+  function removeHitList() {
+    if (!overlayRoot) return;
+    overlayRoot.children = overlayRoot.children; // noop for fake dom safety
+    const children = Array.isArray(overlayRoot.children) ? [...overlayRoot.children] : [];
+    for (const child of children) {
+      if (child?.getAttribute?.('data-ui-inspector-hit-list') === 'true') {
+        overlayRoot.removeChild(child);
+      }
+    }
+  }
+
+  function select(id) {
+    selectedId = String(id || '').trim();
+    removeHitList();
+    return refresh();
+  }
+
+  function clearSelection() {
+    selectedId = '';
+    removeHitList();
+    return refresh();
+  }
+
+  function showHitListAtPoint(x, y) {
+    if (!overlayRoot || !rootElement) return false;
+    removeHitList();
+    const hits = getHitsAtPoint(x, y);
+    if (!hits.length) {
+      clearSelection();
+      return false;
+    }
+
+    const doc = rootElement.ownerDocument || globalThis.document;
+    const list = doc.createElement('div');
+    list.setAttribute('data-ui-inspector-hit-list', 'true');
+    list.style.position = 'fixed';
+    list.style.left = `${x}px`;
+    list.style.top = `${y}px`;
+    list.style.maxWidth = '380px';
+    list.style.background = 'rgba(24, 29, 38, 0.97)';
+    list.style.border = '1px solid rgba(255,255,255,0.2)';
+    list.style.borderRadius = '6px';
+    list.style.padding = '6px';
+    list.style.display = 'flex';
+    list.style.flexDirection = 'column';
+    list.style.gap = '4px';
+    list.style.pointerEvents = 'auto';
+
+    for (const hit of hits) {
+      const option = doc.createElement('button');
+      option.type = 'button';
+      option.setAttribute('data-ui-inspector-hit-option', hit.id);
+      option.textContent = hit.id;
+      option.style.pointerEvents = 'auto';
+      option.style.textAlign = 'left';
+      option.onclick = (event) => {
+        event?.preventDefault?.();
+        event?.stopPropagation?.();
+        event?.stopImmediatePropagation?.();
+        select(hit.id);
+      };
+      list.append(option);
+    }
+    overlayRoot.append(list);
+    return true;
   }
 
   function refresh() {
@@ -69,7 +176,32 @@ export function createUiInspectorOverlay(options = {}) {
       if (!rect || rect.width <= 0 || rect.height <= 0) continue;
       overlayRoot.append(createFrame(rootElement.ownerDocument || globalThis.document, id, rect));
     }
+    overlayRoot.append(createBadge(rootElement.ownerDocument || globalThis.document));
     return true;
+  }
+
+  function bindCaptureListener(doc) {
+    if (!doc || captureHandler || typeof doc.addEventListener !== 'function') return;
+    captureHandler = (event) => {
+      const x = Number(event?.clientX);
+      const y = Number(event?.clientY);
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      event.stopImmediatePropagation?.();
+      showHitListAtPoint(x, y);
+    };
+    doc.addEventListener('pointerdown', captureHandler, true);
+    captureHost = doc;
+  }
+
+  function unbindCaptureListener() {
+    if (!captureHost || !captureHandler) return;
+    if (typeof captureHost.removeEventListener === 'function') {
+      captureHost.removeEventListener('pointerdown', captureHandler, true);
+    }
+    captureHost = null;
+    captureHandler = null;
   }
 
   function mount(nextRootElement) {
@@ -79,16 +211,19 @@ export function createUiInspectorOverlay(options = {}) {
     const nextOverlayRoot = ensureOverlayRoot(doc);
     const mountHost = doc.body || rootElement;
     if (!nextOverlayRoot.isConnected) mountHost.append(nextOverlayRoot);
+    bindCaptureListener(doc);
     refresh();
     return true;
   }
 
   function unmount() {
+    clearSelection();
+    unbindCaptureListener();
     clearOverlayChildren();
     if (overlayRoot?.parentElement) overlayRoot.parentElement.removeChild(overlayRoot);
     rootElement = null;
     return true;
   }
 
-  return { mount, unmount, refresh };
+  return { mount, unmount, refresh, getSelectedId: () => selectedId, select, clearSelection, getHitsAtPoint, showHitListAtPoint };
 }

--- a/src/renderer/uiInspector/UiInspectorOverlay.js
+++ b/src/renderer/uiInspector/UiInspectorOverlay.js
@@ -180,9 +180,21 @@ export function createUiInspectorOverlay(options = {}) {
     return true;
   }
 
+
+  function isInsideHitList(target) {
+    let node = target;
+    while (node) {
+      if (node.getAttribute?.('data-ui-inspector-hit-list') === 'true') return true;
+      if (node.getAttribute?.('data-ui-inspector-hit-option')) return true;
+      node = node.parentElement;
+    }
+    return false;
+  }
+
   function bindCaptureListener(doc) {
     if (!doc || captureHandler || typeof doc.addEventListener !== 'function') return;
     captureHandler = (event) => {
+      if (isInsideHitList(event?.target)) return;
       const x = Number(event?.clientX);
       const y = Number(event?.clientY);
       if (!Number.isFinite(x) || !Number.isFinite(y)) return;

--- a/src/renderer/uiInspector/UiInspectorRuntime.js
+++ b/src/renderer/uiInspector/UiInspectorRuntime.js
@@ -20,11 +20,21 @@ export function createUiInspectorRuntime({ overlay } = {}) {
     return resolvedOverlay.refresh() === true;
   }
 
+  function getSelectedElementId() {
+    return resolvedOverlay.getSelectedId?.() || '';
+  }
+
+  function clearSelection() {
+    return resolvedOverlay.clearSelection?.() === true;
+  }
+
   return {
     overlay: resolvedOverlay,
     activateOverlay,
     deactivateOverlay,
     refreshOverlay,
+    getSelectedElementId,
+    clearSelection,
     isOverlayActive() {
       return overlayActive;
     },


### PR DESCRIPTION
### Motivation
- Die vorherige Handle-/Label-Lösung (PR #152) ist ungeeignet für verschachtelte UI-Bereiche, deshalb wird die Auswahl vom Klickpunkt getrennt und laientauglicher gemacht. 
- Ziel ist eine temporäre, punktbasierte Trefferliste zur Auswahl eines Bereichs, während Overlay-Rahmen weiterhin nur Anzeige sind.

### Description
- Implementiert hit-basierte Trefferermittlung in `src/renderer/uiInspector/UiInspectorOverlay.js` mit `getHitsAtPoint`, `showHitListAtPoint`, temporärer Hit-Liste (`data-ui-inspector-hit-list=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1081a57c0c83228f5b89e8e2475f9a)