### PR TITLE
M12: read-only UI‑Inspector panel showing allowed controls

### DIFF
--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -23,6 +23,7 @@ Aktueller Stand:
 - [x] M8 Restarbeiten als erste Pilot-Landkarte dokumentieren
 - [x] M9 Restarbeiten-DOM-Markierungen minimal einführen
 - [x] M10 Overlay nur anzeigen
+- [x] M12 Panel zeigt erlaubte Stellschrauben
 
 ## Definition of Done (DoD)
 Ein UI-Inspektor-Meilenstein gilt nur als erledigt, wenn:
@@ -216,3 +217,12 @@ Hinweis:
 - Geänderte Dateien: `src/renderer/uiInspector/UiInspectorOverlay.js`, `src/renderer/uiInspector/UiInspectorRuntime.js`, `scripts/tests/uiInspectorOverlay.test.cjs`, `scripts/tests/restarbeitenModule.test.cjs`, `docs/UI_INSPEKTOR_AUFGABENHEFT.md`, `docs/UI_INSPEKTOR_START_HIER.md`, `docs/ui-landkarten/RESTARBEITEN.md`, `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`.
 - Tests: `node scripts/tests/uiInspectorCore.test.cjs`, `node scripts/tests/uiInspectorRegistry.test.cjs`, `node scripts/tests/uiInspectorMapSchema.test.cjs`, `node scripts/tests/uiInspectorOverlay.test.cjs`, `node scripts/tests/restarbeitenModule.test.cjs`, `npm test`.
 - Nächster Schritt: M12 – Panel zeigt erlaubte Stellschrauben.
+
+
+## M12 Abschluss
+- Status: erledigt.
+- Panel zeigt nur ausgewählten Bereich und erlaubte Stellschrauben (read-only).
+- Keine Werteänderung, keine Speicherung, keine Layoutänderung.
+- Geänderte Dateien: `src/renderer/uiInspector/UiInspectorPanel.js`, `src/renderer/uiInspector/UiInspectorRuntime.js`, `src/renderer/uiInspector/UiInspectorOverlay.js`, `scripts/tests/uiInspectorPanel.test.cjs`, `scripts/tests/restarbeitenModule.test.cjs`, `docs/UI_INSPEKTOR_AUFGABENHEFT.md`, `docs/UI_INSPEKTOR_START_HIER.md`, `docs/ui-landkarten/RESTARBEITEN.md`, `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`.
+- Tests: `node scripts/tests/uiInspectorCore.test.cjs`, `node scripts/tests/uiInspectorRegistry.test.cjs`, `node scripts/tests/uiInspectorMapSchema.test.cjs`, `node scripts/tests/uiInspectorOverlay.test.cjs`, `node scripts/tests/restarbeitenModule.test.cjs`, `node scripts/tests/uiInspectorPanel.test.cjs`, `npm test`.
+- Nächster Schritt: M13 – Werte temporär anwenden, aber noch nicht speichern.

--- a/docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md
+++ b/docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md
@@ -55,3 +55,9 @@
 **Begründung:** Bei verschachtelten UI-Bereichen ist Handle-/Rahmenklick für Laien nicht zuverlässig und unübersichtlich.
 
 **Auswirkung:** Die Trefferliste trennt Auswahl von Rahmenanzeige und bleibt in komplexen UIs bedienbar.
+
+
+## Entscheidung 011
+**Beschluss:** Das M12-Panel bleibt rein lesend und zeigt nur erlaubte Stellschrauben.
+
+**Begründung:** Anwendung und Speicherung werden bewusst getrennt in M13/M14 umgesetzt.

--- a/docs/UI_INSPEKTOR_START_HIER.md
+++ b/docs/UI_INSPEKTOR_START_HIER.md
@@ -59,9 +59,9 @@ Ein neuer Chat soll mit dieser Zusammenfassung starten können:
 „Wir bauen ein neues exportierbares UI-Inspector-Modul. Projektauftrag, Architektur, Arbeitsvertrag, Aufgabenheft und Entscheidungslog liegen im Repo. Das Modulgerüst und die erste Restarbeiten-Pilot-Landkarte sind dokumentiert. Nächster Schritt laut Aufgabenheft ist M10 (Overlay nur anzeigen; weiterhin ohne Panel und ohne sichtbare Fachfunktion).“
 
 
-## Statusupdate M11 (neu)
-- M11 ist erledigt.
-- Overlay zeigt Bereiche weiterhin als Rahmen.
-- Auswahl erfolgt über Trefferliste am Klickpunkt.
-- Noch kein Panel, keine Werte, keine Speicherung, keine Layoutänderung.
-- Nächster Meilenstein: M12 (Panel zeigt erlaubte Stellschrauben).
+## Statusupdate M12
+- M12 ist erledigt.
+- Auswahl läuft weiterhin über Trefferliste am Klickpunkt.
+- Panel zeigt den ausgewählten Bereich und die erlaubten Stellschrauben.
+- Noch keine Anwendung, noch keine Speicherung, noch keine Layoutänderung.
+- Nächster Meilenstein: M13 (Werte temporär anwenden, noch nicht speichern).

--- a/docs/ui-landkarten/RESTARBEITEN.md
+++ b/docs/ui-landkarten/RESTARBEITEN.md
@@ -9,8 +9,9 @@
 - M9 DOM-Markierungen minimal eingeführt.
 - Marker-IDs sind technisch in der bestehenden Restarbeiten-UI verankert.
 - Ab M10 kann ein visuelles Overlay die Marker rahmen und die Inspector-ID anzeigen.
-- Noch kein Panel.
-- Noch keine sichtbare UI-Funktion.
+- Ab M12 zeigt ein Inspector-Panel die für den gewählten Bereich erlaubten Stellschrauben.
+- Noch keine Anwendung.
+- Noch keine Speicherung.
 - Noch keine Layoutänderung.
 
 ## 3. Fachliche Bereichsstruktur

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -325,6 +325,10 @@ async function runRestarbeitenModuleTests(run) {
     assert.doesNotMatch(panelContent, /<input|\btype\s*=\s*['"](range|text|number)['"]/i);
 
     assert.match(runtimeContent, /getAllowedControlsForSelectedId/);
+    assert.match(runtimeContent, /restarbeiten\.filterleiste\.meta/);
+    assert.match(runtimeContent, /restarbeiten\.editbox\.header/);
+    assert.match(runtimeContent, /restarbeiten\.editbox\.verortung/);
+    assert.match(runtimeContent, /restarbeiten\.editbox\.meta/);
     assert.doesNotMatch(runtimeContent, /localStorage/);
     assert.doesNotMatch(runtimeContent, /ui-inspector:save/);
     assert.doesNotMatch(runtimeContent, /inspector:save/);

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -305,6 +305,30 @@ async function runRestarbeitenModuleTests(run) {
     assert.doesNotMatch(screenContent, /inspector:save/);
   });
 
+
+  await run("M12 UI-Inspector Panel ist read-only und ESM-kompatibel", () => {
+    const panelPath = path.join(__dirname, "../../src/renderer/uiInspector/UiInspectorPanel.js");
+    const runtimePath = path.join(__dirname, "../../src/renderer/uiInspector/UiInspectorRuntime.js");
+    const panelContent = fs.readFileSync(panelPath, "utf8");
+    const runtimeContent = fs.readFileSync(runtimePath, "utf8");
+
+    assert.match(panelContent, /data-ui-inspector-panel/);
+    assert.match(panelContent, /UI-Inspektor/);
+    assert.match(panelContent, /Nur Anzeige/);
+    assert.doesNotMatch(panelContent, /module\.exports/);
+    assert.doesNotMatch(panelContent, /require\s*\(/);
+    assert.doesNotMatch(panelContent, /localStorage/);
+    assert.doesNotMatch(panelContent, /ipc/i);
+    assert.doesNotMatch(panelContent, /store/i);
+    assert.doesNotMatch(panelContent, /Speichern/);
+    assert.doesNotMatch(panelContent, /Anwenden/);
+    assert.doesNotMatch(panelContent, /<input|\btype\s*=\s*['"](range|text|number)['"]/i);
+
+    assert.match(runtimeContent, /getAllowedControlsForSelectedId/);
+    assert.doesNotMatch(runtimeContent, /localStorage/);
+    assert.doesNotMatch(runtimeContent, /ui-inspector:save/);
+    assert.doesNotMatch(runtimeContent, /inspector:save/);
+  });
   await run("M10 UI-Inspector Overlay-Toggle ist klar begrenzt", () => {
     const screenPath = path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js");
     const content = fs.readFileSync(screenPath, "utf8");

--- a/scripts/tests/uiInspectorOverlay.test.cjs
+++ b/scripts/tests/uiInspectorOverlay.test.cjs
@@ -91,6 +91,23 @@ function createInspectableRoot(document) {
   const hitListAfterOptionPointerdown = overlayRoot.children.find((c) => c.attributes['data-ui-inspector-hit-list'] === 'true');
   assert.equal(hitListAfterOptionPointerdown, firstHitListRef);
 
+  const panelNode = document.createElement('div');
+  panelNode.setAttribute('data-ui-inspector-panel', 'true');
+  overlayRoot.append(panelNode);
+  const panelChild = document.createElement('button');
+  panelNode.append(panelChild);
+  const preventedPanelPointerdown = { value: false };
+  document.dispatch('pointerdown', {
+    clientX: 200,
+    clientY: 200,
+    target: panelChild,
+    preventDefault() { preventedPanelPointerdown.value = true; },
+    stopPropagation() {},
+    stopImmediatePropagation() {},
+  });
+  assert.equal(preventedPanelPointerdown.value, false);
+  assert.equal(overlayRoot.children.find((c) => c.attributes['data-ui-inspector-hit-list'] === 'true'), firstHitListRef);
+
   firstOption.click();
 
   assert.equal(overlay.getSelectedId(), 'restarbeiten.filterleiste.meta.status');

--- a/scripts/tests/uiInspectorPanel.test.cjs
+++ b/scripts/tests/uiInspectorPanel.test.cjs
@@ -30,6 +30,39 @@ function collectText(node) {
   return [String(node.textContent || ''), ...(node.children || []).map(collectText)].join(' ');
 }
 
+function createFakeDomForRuntime() {
+  const listeners = new Map();
+  function createElement(tagName) {
+    return {
+      tagName: String(tagName || '').toUpperCase(),
+      children: [],
+      style: {},
+      attributes: {},
+      parentElement: null,
+      textContent: '',
+      isConnected: false,
+      onclick: null,
+      ownerDocument: null,
+      append(...items) { for (const child of items) { child.parentElement = this; child.ownerDocument = this.ownerDocument; child.isConnected = this.isConnected; this.children.push(child); } },
+      replaceChildren(...items) { this.children = []; this.append(...items); },
+      removeChild(child) { this.children = this.children.filter((e) => e !== child); child.parentElement = null; child.isConnected = false; },
+      setAttribute(name, value) { this.attributes[name] = String(value); },
+      getAttribute(name) { return this.attributes[name]; },
+      click() { this.onclick?.({ preventDefault() {}, stopPropagation() {}, stopImmediatePropagation() {} }); },
+    };
+  }
+  const document = {
+    createElement(tag) { const node = createElement(tag); node.ownerDocument = document; return node; },
+    body: null,
+    addEventListener(type, handler) { if (!listeners.has(type)) listeners.set(type, []); listeners.get(type).push(handler); },
+    removeEventListener(type, handler) { listeners.set(type, (listeners.get(type) || []).filter((h) => h !== handler)); },
+  };
+  document.body = document.createElement('body');
+  document.body.isConnected = true;
+  document.body.append = (...items) => { for (const item of items) { item.parentElement = document.body; item.ownerDocument = document; item.isConnected = true; document.body.children.push(item); } };
+  return document;
+}
+
 (async function run() {
   const { createUiInspectorPanel } = await importEsmFromFile(path.join(__dirname, '../../src/renderer/uiInspector/UiInspectorPanel.js'));
   assert.equal(typeof createUiInspectorPanel, 'function');
@@ -57,5 +90,25 @@ function collectText(node) {
 
   assert.equal(panel.unmount(), true);
   assert.equal(document.body.children.some((c) => c.attributes['data-ui-inspector-panel'] === 'true'), false);
+
+  const runtimeDocument = createFakeDomForRuntime();
+  global.document = runtimeDocument;
+  const { createUiInspectorRuntime } = await importEsmFromFile(path.join(__dirname, '../../src/renderer/uiInspector/UiInspectorRuntime.js'));
+  const runtime = createUiInspectorRuntime();
+  const rootNodes = [
+    { getAttribute: (n) => n === 'data-ui-inspector-id' ? 'restarbeiten.main' : null, getBoundingClientRect: () => ({ left: 0, top: 0, width: 300, height: 200 }) },
+    { getAttribute: (n) => n === 'data-ui-inspector-id' ? 'restarbeiten.editbox.meta' : null, getBoundingClientRect: () => ({ left: 20, top: 20, width: 100, height: 40 }) },
+  ];
+  const root = { ownerDocument: runtimeDocument, querySelectorAll: (sel) => sel === '[data-ui-inspector-id]' ? rootNodes : [] };
+  assert.equal(runtime.activateOverlay(root), true);
+  assert.equal(runtime.overlay.select('restarbeiten.editbox.meta'), true);
+  assert.equal(runtime.refreshOverlay(), true);
+  const mountedPanel = runtimeDocument.body.children.find((c) => c.attributes['data-ui-inspector-panel'] === 'true');
+  assert.ok(mountedPanel);
+  assert.match(collectText(mountedPanel), /restarbeiten\.editbox\.meta/);
+  assert.match(collectText(mountedPanel), /Breite/);
+  assert.equal(runtime.deactivateOverlay(), true);
+  assert.equal(runtimeDocument.body.children.some((c) => c.attributes['data-ui-inspector-panel'] === 'true'), false);
+
   console.log('ok - uiInspectorPanel.test');
 })();

--- a/scripts/tests/uiInspectorPanel.test.cjs
+++ b/scripts/tests/uiInspectorPanel.test.cjs
@@ -1,0 +1,61 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { importEsmFromFile } = require('./_esmLoader.cjs');
+
+function createFakeDocument() {
+  function createElement(tagName) {
+    return {
+      tagName: String(tagName || '').toUpperCase(),
+      children: [],
+      style: {},
+      attributes: {},
+      parentElement: null,
+      textContent: '',
+      isConnected: false,
+      append(...items) { for (const child of items) { child.parentElement = this; child.isConnected = this.isConnected; this.children.push(child); } },
+      replaceChildren(...items) { this.children = []; this.append(...items); },
+      removeChild(child) { this.children = this.children.filter((e) => e !== child); child.parentElement = null; child.isConnected = false; },
+      setAttribute(name, value) { this.attributes[name] = String(value); },
+      getAttribute(name) { return this.attributes[name]; },
+    };
+  }
+  const document = { createElement, body: createElement('body') };
+  document.body.isConnected = true;
+  document.body.append = (...items) => { for (const item of items) { item.parentElement = document.body; item.isConnected = true; document.body.children.push(item); } };
+  return document;
+}
+
+function collectText(node) {
+  if (!node) return '';
+  return [String(node.textContent || ''), ...(node.children || []).map(collectText)].join(' ');
+}
+
+(async function run() {
+  const { createUiInspectorPanel } = await importEsmFromFile(path.join(__dirname, '../../src/renderer/uiInspector/UiInspectorPanel.js'));
+  assert.equal(typeof createUiInspectorPanel, 'function');
+
+  const document = createFakeDocument();
+  global.document = document;
+
+  const panel = createUiInspectorPanel();
+  assert.equal(panel.mount(document.body), true);
+
+  const panelNode = document.body.children.find((c) => c.attributes['data-ui-inspector-panel'] === 'true');
+  assert.ok(panelNode);
+  assert.equal(panelNode.style.pointerEvents, 'auto');
+
+  assert.equal(panel.render({ selectedId: 'restarbeiten.editbox.kurztext', controls: ['Breite', 'Höhe', 'Sichtbarkeit'] }), true);
+  const text = collectText(panelNode);
+  assert.match(text, /UI-Inspektor/);
+  assert.match(text, /restarbeiten\.editbox\.kurztext/);
+  assert.match(text, /Breite/);
+  assert.match(text, /Höhe/);
+  assert.match(text, /Sichtbarkeit/);
+  assert.match(text, /Nur Anzeige/);
+  assert.doesNotMatch(text, /Speichern/);
+  assert.doesNotMatch(text, /Anwenden/);
+
+  assert.equal(panel.unmount(), true);
+  assert.equal(document.body.children.some((c) => c.attributes['data-ui-inspector-panel'] === 'true'), false);
+  console.log('ok - uiInspectorPanel.test');
+})();

--- a/src/renderer/uiInspector/UiInspectorOverlay.js
+++ b/src/renderer/uiInspector/UiInspectorOverlay.js
@@ -109,12 +109,14 @@ export function createUiInspectorOverlay(options = {}) {
   function select(id) {
     selectedId = String(id || '').trim();
     removeHitList();
+    options.onSelect?.(selectedId);
     return refresh();
   }
 
   function clearSelection() {
     selectedId = '';
     removeHitList();
+    options.onClearSelection?.();
     return refresh();
   }
 
@@ -215,7 +217,11 @@ export function createUiInspectorOverlay(options = {}) {
     captureHandler = null;
   }
 
-  function mount(nextRootElement) {
+  function mount(nextRootElement, runtimeOptions = {}) {
+    if (runtimeOptions && typeof runtimeOptions === 'object') {
+      options.onSelect = runtimeOptions.onSelect || options.onSelect;
+      options.onClearSelection = runtimeOptions.onClearSelection || options.onClearSelection;
+    }
     if (!nextRootElement || typeof nextRootElement.querySelectorAll !== 'function') return false;
     rootElement = nextRootElement;
     const doc = rootElement.ownerDocument || globalThis.document;
@@ -236,5 +242,5 @@ export function createUiInspectorOverlay(options = {}) {
     return true;
   }
 
-  return { mount, unmount, refresh, getSelectedId: () => selectedId, select, clearSelection, getHitsAtPoint, showHitListAtPoint };
+  return { mount, unmount, refresh, getSelectedId: () => selectedId, getOverlayRoot: () => overlayRoot, select, clearSelection, getHitsAtPoint, showHitListAtPoint };
 }

--- a/src/renderer/uiInspector/UiInspectorOverlay.js
+++ b/src/renderer/uiInspector/UiInspectorOverlay.js
@@ -182,11 +182,12 @@ export function createUiInspectorOverlay(options = {}) {
   }
 
 
-  function isInsideHitList(target) {
+  function isInsideInspectorUi(target) {
     let node = target;
     while (node) {
       if (node.getAttribute?.('data-ui-inspector-hit-list') === 'true') return true;
       if (node.getAttribute?.('data-ui-inspector-hit-option')) return true;
+      if (node.getAttribute?.('data-ui-inspector-panel') === 'true') return true;
       node = node.parentElement;
     }
     return false;
@@ -195,7 +196,7 @@ export function createUiInspectorOverlay(options = {}) {
   function bindCaptureListener(doc) {
     if (!doc || captureHandler || typeof doc.addEventListener !== 'function') return;
     captureHandler = (event) => {
-      if (isInsideHitList(event?.target)) return;
+      if (isInsideInspectorUi(event?.target)) return;
       const x = Number(event?.clientX);
       const y = Number(event?.clientY);
       if (!Number.isFinite(x) || !Number.isFinite(y)) return;

--- a/src/renderer/uiInspector/UiInspectorPanel.js
+++ b/src/renderer/uiInspector/UiInspectorPanel.js
@@ -1,10 +1,104 @@
-export function createUiInspectorPanel() {
-  return {
-    mount() {
-      return false;
-    },
-    unmount() {
-      return false;
-    },
-  };
+function createPanelRoot(doc) {
+  const panel = doc.createElement('div');
+  panel.setAttribute('data-ui-inspector-panel', 'true');
+  panel.style.position = 'fixed';
+  panel.style.right = '12px';
+  panel.style.bottom = '12px';
+  panel.style.width = '340px';
+  panel.style.maxWidth = 'calc(100vw - 24px)';
+  panel.style.background = 'rgba(20, 25, 35, 0.96)';
+  panel.style.color = '#ffffff';
+  panel.style.border = '1px solid rgba(255,255,255,0.2)';
+  panel.style.borderRadius = '6px';
+  panel.style.padding = '10px';
+  panel.style.font = '12px/1.4 sans-serif';
+  panel.style.zIndex = '2147483001';
+  panel.style.pointerEvents = 'auto';
+  panel.style.boxSizing = 'border-box';
+  return panel;
+}
+
+function renderPanelContent(panelRoot, { selectedId = '', controls = [], note = '' } = {}) {
+  panelRoot.replaceChildren();
+
+  const doc = panelRoot.ownerDocument || globalThis.document;
+  const title = doc.createElement('div');
+  title.textContent = 'UI-Inspektor';
+  title.style.fontWeight = '700';
+  title.style.marginBottom = '8px';
+
+  const selectedLabel = doc.createElement('div');
+  selectedLabel.textContent = selectedId ? `Ausgewählter Bereich: ${selectedId}` : 'Kein Bereich ausgewählt';
+  selectedLabel.style.marginBottom = '8px';
+
+  const controlsTitle = doc.createElement('div');
+  controlsTitle.textContent = 'Erlaubte Stellschrauben:';
+  controlsTitle.style.marginBottom = '4px';
+
+  const controlsList = doc.createElement('ul');
+  controlsList.style.margin = '0 0 8px 16px';
+  controlsList.style.padding = '0';
+
+  if (Array.isArray(controls) && controls.length > 0) {
+    for (const control of controls) {
+      const item = doc.createElement('li');
+      item.textContent = String(control);
+      controlsList.append(item);
+    }
+  } else {
+    const item = doc.createElement('li');
+    item.textContent = note || 'Für diesen Bereich sind noch keine Stellschrauben definiert.';
+    controlsList.append(item);
+  }
+
+  const hint = doc.createElement('div');
+  hint.textContent = 'Nur Anzeige – Änderungen folgen erst in M13.';
+  hint.style.opacity = '0.9';
+
+  panelRoot.append(title, selectedLabel, controlsTitle, controlsList, hint);
+}
+
+export function createUiInspectorPanel(options = {}) {
+  let panelRoot = null;
+  let mountHost = null;
+
+  function ensurePanel(doc) {
+    if (panelRoot?.isConnected) return panelRoot;
+    panelRoot = createPanelRoot(doc);
+    return panelRoot;
+  }
+
+  function mount(target) {
+    const doc = target?.ownerDocument || globalThis.document;
+    if (!doc || typeof doc.createElement !== 'function') return false;
+
+    const host = target || doc.body;
+    if (!host || typeof host.append !== 'function') return false;
+
+    mountHost = host;
+    const node = ensurePanel(doc);
+    if (!node.isConnected) mountHost.append(node);
+    renderPanelContent(node, options.initialState || {});
+    return true;
+  }
+
+  function unmount() {
+    if (panelRoot?.parentElement) panelRoot.parentElement.removeChild(panelRoot);
+    mountHost = null;
+    return true;
+  }
+
+  function render(nextState = {}) {
+    if (!panelRoot) return false;
+    renderPanelContent(panelRoot, nextState);
+    return true;
+  }
+
+  function clear() {
+    if (!panelRoot) return false;
+    renderPanelContent(panelRoot, { selectedId: '', controls: [] });
+    return true;
+  }
+
+  return { mount, unmount, render, clear };
 }

--- a/src/renderer/uiInspector/UiInspectorRuntime.js
+++ b/src/renderer/uiInspector/UiInspectorRuntime.js
@@ -10,9 +10,14 @@ function getAllowedControlsForSelectedId(selectedId) {
 
   const containerIds = new Set([
     'restarbeiten.root',
+    'restarbeiten.header',
     'restarbeiten.main',
     'restarbeiten.filterleiste',
+    'restarbeiten.filterleiste.meta',
     'restarbeiten.editbox',
+    'restarbeiten.editbox.header',
+    'restarbeiten.editbox.verortung',
+    'restarbeiten.editbox.meta',
     'restarbeiten.liste',
   ]);
   if (containerIds.has(normalizedId)) return [...CONTAINER_CONTROLS];

--- a/src/renderer/uiInspector/UiInspectorRuntime.js
+++ b/src/renderer/uiInspector/UiInspectorRuntime.js
@@ -1,16 +1,70 @@
 import { createUiInspectorOverlay } from './UiInspectorOverlay.js';
+import { createUiInspectorPanel } from './UiInspectorPanel.js';
 
-export function createUiInspectorRuntime({ overlay } = {}) {
+const CONTAINER_CONTROLS = ['Breite', 'Höhe', 'Abstand außen', 'Abstand innen', 'Sichtbarkeit'];
+const FIELD_CONTROLS = ['Breite', 'Höhe', 'Abstand links', 'Abstand oben', 'Schriftgröße', 'Sichtbarkeit'];
+
+function getAllowedControlsForSelectedId(selectedId) {
+  const normalizedId = String(selectedId || '').trim();
+  if (!normalizedId) return [];
+
+  const containerIds = new Set([
+    'restarbeiten.root',
+    'restarbeiten.main',
+    'restarbeiten.filterleiste',
+    'restarbeiten.editbox',
+    'restarbeiten.liste',
+  ]);
+  if (containerIds.has(normalizedId)) return [...CONTAINER_CONTROLS];
+
+  const fieldSuffixes = ['.feld', '.kurztext', '.langtext', '.fertig_bis', '.status', '.verantwortlich', '.label', '.restzeichen'];
+  if (fieldSuffixes.some((suffix) => normalizedId.endsWith(suffix))) return [...FIELD_CONTROLS];
+
+  return [];
+}
+
+export function createUiInspectorRuntime({ overlay, panel } = {}) {
   const resolvedOverlay = overlay || createUiInspectorOverlay();
+  const resolvedPanel = panel || createUiInspectorPanel();
   let overlayActive = false;
 
+  function renderPanelForSelection(selectedId) {
+    const controls = getAllowedControlsForSelectedId(selectedId);
+    resolvedPanel.render({
+      selectedId,
+      controls,
+      note: controls.length ? '' : 'Für diesen Bereich sind noch keine Stellschrauben definiert.',
+    });
+  }
+
   function activateOverlay(rootElement) {
-    overlayActive = resolvedOverlay.mount(rootElement) === true;
+    const overlayMounted = resolvedOverlay.mount(rootElement, {
+      onSelect: (id) => {
+        renderPanelForSelection(id);
+      },
+      onClearSelection: () => {
+        resolvedPanel.clear();
+      },
+    }) === true;
+
+    if (!overlayMounted) {
+      overlayActive = false;
+      return false;
+    }
+
+    const panelMounted = resolvedPanel.mount(resolvedOverlay.getOverlayRoot?.() || rootElement?.ownerDocument?.body || globalThis.document?.body) === true;
+    overlayActive = panelMounted;
+
+    if (overlayActive) {
+      renderPanelForSelection(resolvedOverlay.getSelectedId?.() || '');
+    }
+
     return overlayActive;
   }
 
   function deactivateOverlay() {
     resolvedOverlay.unmount();
+    resolvedPanel.unmount();
     overlayActive = false;
     return true;
   }
@@ -25,16 +79,20 @@ export function createUiInspectorRuntime({ overlay } = {}) {
   }
 
   function clearSelection() {
-    return resolvedOverlay.clearSelection?.() === true;
+    const result = resolvedOverlay.clearSelection?.() === true;
+    resolvedPanel.clear();
+    return result;
   }
 
   return {
     overlay: resolvedOverlay,
+    panel: resolvedPanel,
     activateOverlay,
     deactivateOverlay,
     refreshOverlay,
     getSelectedElementId,
     clearSelection,
+    getAllowedControlsForSelectedId,
     isOverlayActive() {
       return overlayActive;
     },

--- a/src/renderer/uiInspector/UiInspectorRuntime.js
+++ b/src/renderer/uiInspector/UiInspectorRuntime.js
@@ -57,7 +57,7 @@ export function createUiInspectorRuntime({ overlay, panel } = {}) {
       return false;
     }
 
-    const panelMounted = resolvedPanel.mount(resolvedOverlay.getOverlayRoot?.() || rootElement?.ownerDocument?.body || globalThis.document?.body) === true;
+    const panelMounted = resolvedPanel.mount(rootElement?.ownerDocument?.body || globalThis.document?.body) === true;
     overlayActive = panelMounted;
 
     if (overlayActive) {


### PR DESCRIPTION
### Motivation
- Implement M12: when a UI-Inspector selection exists the renderer must display a small read-only panel that shows which "Stellschrauben" (allowed controls) are available for the selected area, building on the M11 hit-list selection flow. 
- The panel must be purely informational and must not change/apply/save values or touch IPC/preload/DB/CSS/Store or app business logic.

### Description
- Added a lightweight ESM panel component `createUiInspectorPanel` with `mount`, `unmount`, `render` and `clear` that sets `data-ui-inspector-panel="true"`, is fixed-positioned, uses inline styles and is read-only (`src/renderer/uiInspector/UiInspectorPanel.js`).
- Implemented `getAllowedControlsForSelectedId(selectedId)` and connected the panel to the runtime so selection updates render the allowed control list, and the panel is mounted next to the overlay (`src/renderer/uiInspector/UiInspectorRuntime.js`).
- Extended the overlay minimal runtime contract to accept runtime callbacks (`onSelect` / `onClearSelection`) and exposed `getOverlayRoot` so the panel can be mounted without modifying app DOM structure (`src/renderer/uiInspector/UiInspectorOverlay.js`).
- Added a dedicated panel unit test `scripts/tests/uiInspectorPanel.test.cjs` and a M12 guard in `scripts/tests/restarbeitenModule.test.cjs`, and updated task documentation to mark M12 done in `docs/UI_INSPEKTOR_AUFGABENHEFT.md`, `docs/UI_INSPEKTOR_START_HIER.md`, `docs/ui-landkarten/RESTARBEITEN.md` and decision log `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`.
- No CSS files, Store, IPC, Preload, DB, tables-calibrator, app business logic or layout files were modified and no value-apply/save behavior was added.

### Testing
- Ran unit tests: `node scripts/tests/uiInspectorCore.test.cjs`, `node scripts/tests/uiInspectorRegistry.test.cjs`, `node scripts/tests/uiInspectorMapSchema.test.cjs`, `node scripts/tests/uiInspectorOverlay.test.cjs`, `node scripts/tests/restarbeitenModule.test.cjs`, and the new `node scripts/tests/uiInspectorPanel.test.cjs`; all of these individual tests passed in the environment. 
- `npm test` could not complete in the Cloud environment due to missing Electron system libraries (`libatk-1.0.so.0`), so full `npm test` should be run locally where Electron deps are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a65172a483229003a0923d1fd825)