### PR TITLE
M13.1.2 – UI-Inspector Clear/Refresh-Stabilisierung auf sauberem Auswahlmodell

### DIFF
--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -226,3 +226,11 @@ Hinweis:
 - Geänderte Dateien: `src/renderer/uiInspector/UiInspectorPanel.js`, `src/renderer/uiInspector/UiInspectorRuntime.js`, `src/renderer/uiInspector/UiInspectorOverlay.js`, `scripts/tests/uiInspectorPanel.test.cjs`, `scripts/tests/restarbeitenModule.test.cjs`, `docs/UI_INSPEKTOR_AUFGABENHEFT.md`, `docs/UI_INSPEKTOR_START_HIER.md`, `docs/ui-landkarten/RESTARBEITEN.md`, `docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md`.
 - Tests: `node scripts/tests/uiInspectorCore.test.cjs`, `node scripts/tests/uiInspectorRegistry.test.cjs`, `node scripts/tests/uiInspectorMapSchema.test.cjs`, `node scripts/tests/uiInspectorOverlay.test.cjs`, `node scripts/tests/restarbeitenModule.test.cjs`, `node scripts/tests/uiInspectorPanel.test.cjs`, `npm test`.
 - Nächster Schritt: M13 – Werte temporär anwenden, aber noch nicht speichern.
+
+
+## M13.1.2 Zwischenstand (lokale Abnahme offen)
+- Clear behält die Target-Liste im Panel.
+- Refresh aktualisiert Targets.
+- Panel bleibt read-only.
+- Keine Layoutänderung.
+- Keine Speicherung.

--- a/docs/UI_INSPEKTOR_START_HIER.md
+++ b/docs/UI_INSPEKTOR_START_HIER.md
@@ -65,3 +65,10 @@ Ein neuer Chat soll mit dieser Zusammenfassung starten können:
 - Panel zeigt den ausgewählten Bereich und die erlaubten Stellschrauben.
 - Noch keine Anwendung, noch keine Speicherung, noch keine Layoutänderung.
 - Nächster Meilenstein: M13 (Werte temporär anwenden, noch nicht speichern).
+
+
+## Statusupdate M13.1.2 (PR-Zwischenstand)
+- M13.1.2 ist als PR-Zwischenstand in Arbeit (lokale Abnahme offen).
+- Clear behält die Target-Liste sichtbar.
+- Refresh aktualisiert Targets nach DOM-Änderungen.
+- Panel bleibt read-only (keine Layoutänderung, keine Speicherung).

--- a/scripts/tests/uiInspectorOverlay.test.cjs
+++ b/scripts/tests/uiInspectorOverlay.test.cjs
@@ -75,7 +75,7 @@ function createInspectableRoot(document) {
   assert.ok(hitList);
   assert.equal(hitList.style.pointerEvents, 'auto');
   const firstOption = hitList.children[0];
-  assert.equal(firstOption.attributes['data-ui-inspector-hit-option'], 'restarbeiten.filterleiste.meta.status');
+  assert.equal(firstOption.attributes['data-ui-inspector-hit-option'], 'restarbeiten.filterleiste.meta.status::1');
 
   const firstHitListRef = hitList;
   const preventedHitOption = { value: false };
@@ -111,6 +111,7 @@ function createInspectableRoot(document) {
   firstOption.click();
 
   assert.equal(overlay.getSelectedId(), 'restarbeiten.filterleiste.meta.status');
+  assert.equal(overlay.getSelectedTargetKey(), 'restarbeiten.filterleiste.meta.status::1');
   const selectedFrame = overlayRoot.children.find((c) => c.attributes['data-ui-inspector-selected'] === 'true');
   assert.equal(selectedFrame.attributes['data-ui-inspector-overlay-frame'], 'restarbeiten.filterleiste.meta.status');
   const badge = overlayRoot.children.find((c) => c.attributes['data-ui-inspector-selection-badge'] === 'true');

--- a/scripts/tests/uiInspectorPanel.test.cjs
+++ b/scripts/tests/uiInspectorPanel.test.cjs
@@ -101,7 +101,7 @@ function createFakeDomForRuntime() {
   ];
   const root = { ownerDocument: runtimeDocument, querySelectorAll: (sel) => sel === '[data-ui-inspector-id]' ? rootNodes : [] };
   assert.equal(runtime.activateOverlay(root), true);
-  assert.equal(runtime.overlay.select('restarbeiten.editbox.meta'), true);
+  assert.equal(runtime.overlay.select('restarbeiten.editbox.meta::1'), true);
   assert.equal(runtime.refreshOverlay(), true);
   const mountedPanel = runtimeDocument.body.children.find((c) => c.attributes['data-ui-inspector-panel'] === 'true');
   assert.ok(mountedPanel);

--- a/scripts/tests/uiInspectorPanel.test.cjs
+++ b/scripts/tests/uiInspectorPanel.test.cjs
@@ -84,7 +84,7 @@ function createFakeDomForRuntime() {
   assert.match(text, /Breite/);
   assert.match(text, /Höhe/);
   assert.match(text, /Sichtbarkeit/);
-  assert.match(text, /Nur Anzeige/);
+  assert.match(text, /Auswahlmodell/);
   assert.doesNotMatch(text, /Speichern/);
   assert.doesNotMatch(text, /Anwenden/);
 

--- a/scripts/tests/uiInspectorRuntime.test.cjs
+++ b/scripts/tests/uiInspectorRuntime.test.cjs
@@ -1,0 +1,20 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { importEsmFromFile } = require('./_esmLoader.cjs');
+
+(async function run() {
+  const { createUiInspectorRuntime, buildTargets } = await importEsmFromFile(path.join(__dirname, '../../src/renderer/uiInspector/UiInspectorRuntime.js'));
+  const raw = [
+    { id:'restarbeiten.filterleiste.verortung.feld', key:'restarbeiten.filterleiste.verortung.feld::2', instance:2, element:{} },
+    { id:'restarbeiten.main', key:'restarbeiten.main::1', instance:1, element:{} },
+    { id:'restarbeiten.filterleiste', key:'restarbeiten.filterleiste::1', instance:1, element:{} },
+    { id:'restarbeiten.filterleiste.verortung', key:'restarbeiten.filterleiste.verortung::1', instance:1, element:{} },
+    { id:'restarbeiten.filterleiste.verortung.feld', key:'restarbeiten.filterleiste.verortung.feld::1', instance:1, element:{} },
+  ];
+  const built = buildTargets(raw);
+  assert.equal(built.find((x)=>x.id==='restarbeiten.filterleiste').parentId, 'restarbeiten.main');
+  assert.equal(built.find((x)=>x.key.endsWith('::1') && x.id.endsWith('.feld')).label, 'Feld #1');
+  assert.equal(built.find((x)=>x.key.endsWith('::2') && x.id.endsWith('.feld')).label, 'Feld #2');
+  assert.equal(built.find((x)=>x.id==='restarbeiten.filterleiste.verortung').parentId, 'restarbeiten.filterleiste');
+  console.log('ok - uiInspectorRuntime.test');
+})();

--- a/scripts/tests/uiInspectorRuntime.test.cjs
+++ b/scripts/tests/uiInspectorRuntime.test.cjs
@@ -16,5 +16,54 @@ const { importEsmFromFile } = require('./_esmLoader.cjs');
   assert.equal(built.find((x)=>x.key.endsWith('::1') && x.id.endsWith('.feld')).label, 'Feld #1');
   assert.equal(built.find((x)=>x.key.endsWith('::2') && x.id.endsWith('.feld')).label, 'Feld #2');
   assert.equal(built.find((x)=>x.id==='restarbeiten.filterleiste.verortung').parentId, 'restarbeiten.filterleiste');
+
+  const panelStates = [];
+  const fakePanel = {
+    mount: () => true,
+    unmount: () => true,
+    render(state) { panelStates.push({ kind: 'render', state }); return true; },
+    clear(state) { panelStates.push({ kind: 'clear', state }); return true; },
+  };
+  const markers = [{ id: 'restarbeiten.main', key: 'restarbeiten.main::1', instance: 1, element: {} }];
+  let selected = '';
+  let selectedKey = '';
+  const fakeOverlay = {
+    mount: () => true,
+    unmount: () => true,
+    refresh: () => true,
+    getTargets: () => markers,
+    getSelectedId: () => selected,
+    getSelectedTargetKey: () => selectedKey,
+    select(key) {
+      const match = markers.find((target) => target.key === key);
+      if (!match) return false;
+      selected = match.id;
+      selectedKey = match.key;
+      return true;
+    },
+    clearSelection() {
+      selected = '';
+      selectedKey = '';
+      return true;
+    },
+  };
+  const runtime = createUiInspectorRuntime({ overlay: fakeOverlay, panel: fakePanel });
+  assert.equal(runtime.activateOverlay({ ownerDocument: { body: {} } }), true);
+
+  runtime.overlay.select('restarbeiten.main::1');
+  assert.equal(runtime.refreshOverlay(), true);
+  assert.equal(panelStates.at(-1).kind, 'render');
+  assert.ok(Array.isArray(panelStates.at(-1).state.targets));
+  assert.equal(panelStates.at(-1).state.targets.length > 0, true);
+
+  assert.equal(runtime.clearSelection(), true);
+  assert.equal(panelStates.at(-1).kind, 'clear');
+  assert.equal(Array.isArray(panelStates.at(-1).state.targets), true);
+  assert.equal(panelStates.at(-1).state.targets.length > 0, true);
+
+  markers.push({ id: 'restarbeiten.filterleiste', key: 'restarbeiten.filterleiste::1', instance: 1, element: {} });
+  assert.equal(runtime.refreshOverlay(), true);
+  const latestTargets = panelStates.at(-1).state.targets;
+  assert.equal(latestTargets.some((target) => target.id === 'restarbeiten.filterleiste'), true);
   console.log('ok - uiInspectorRuntime.test');
 })();

--- a/src/renderer/uiInspector/UiInspectorOverlay.js
+++ b/src/renderer/uiInspector/UiInspectorOverlay.js
@@ -6,242 +6,100 @@ export function createUiInspectorOverlay(options = {}) {
   let rootElement = null;
   let overlayRoot = null;
   let selectedId = '';
+  let selectedTargetKey = '';
   let captureHost = null;
   let captureHandler = null;
   let domSequence = 0;
+  let targets = [];
 
-  function clearOverlayChildren() {
-    if (!overlayRoot) return;
-    overlayRoot.replaceChildren();
-  }
-
+  function clearOverlayChildren() { if (overlayRoot) overlayRoot.replaceChildren(); }
   function ensureOverlayRoot(doc) {
     if (overlayRoot?.isConnected) return overlayRoot;
     overlayRoot = doc.createElement('div');
     overlayRoot.setAttribute('data-ui-inspector-overlay-root', 'true');
-    overlayRoot.style.position = 'fixed';
-    overlayRoot.style.inset = '0';
-    overlayRoot.style.pointerEvents = 'none';
-    overlayRoot.style.zIndex = zIndex;
-    overlayRoot.style.overflow = 'hidden';
+    Object.assign(overlayRoot.style, { position:'fixed', inset:'0', pointerEvents:'none', zIndex, overflow:'hidden' });
     return overlayRoot;
   }
 
   function createBadge(doc) {
     const badge = doc.createElement('div');
     badge.setAttribute('data-ui-inspector-selection-badge', 'true');
-    badge.style.position = 'fixed';
-    badge.style.right = '12px';
-    badge.style.top = '12px';
-    badge.style.background = 'rgba(30, 35, 45, 0.92)';
-    badge.style.color = '#ffffff';
-    badge.style.font = '12px/1.3 monospace';
-    badge.style.padding = '6px 8px';
-    badge.style.borderRadius = '4px';
-    badge.style.pointerEvents = 'none';
+    Object.assign(badge.style, { position:'fixed', right:'12px', top:'12px', background:'rgba(30, 35, 45, 0.92)', color:'#ffffff', font:'12px/1.3 monospace', padding:'6px 8px', borderRadius:'4px', pointerEvents:'none' });
     badge.textContent = `Auswahl: ${selectedId || '-'}`;
     return badge;
   }
 
-  function createFrame(doc, id, rect) {
+  function createFrame(doc, target, rect) {
     const frame = doc.createElement('div');
-    frame.setAttribute('data-ui-inspector-overlay-frame', id);
-    frame.style.position = 'fixed';
-    frame.style.left = `${rect.left}px`;
-    frame.style.top = `${rect.top}px`;
-    frame.style.width = `${rect.width}px`;
-    frame.style.height = `${rect.height}px`;
-    frame.style.boxSizing = 'border-box';
-    frame.style.border = selectedId === id ? '2px solid rgba(255, 168, 42, 0.98)' : '1px solid rgba(43, 157, 255, 0.95)';
-    frame.style.background = selectedId === id ? 'rgba(255, 168, 42, 0.16)' : 'rgba(43, 157, 255, 0.08)';
-    frame.style.pointerEvents = 'none';
-    if (selectedId === id) frame.setAttribute('data-ui-inspector-selected', 'true');
-
+    frame.setAttribute('data-ui-inspector-overlay-frame', target.id);
+    Object.assign(frame.style, { position:'fixed', left:`${rect.left}px`, top:`${rect.top}px`, width:`${rect.width}px`, height:`${rect.height}px`, boxSizing:'border-box', border: selectedTargetKey===target.key?'2px solid rgba(255, 168, 42, 0.98)':'1px solid rgba(43, 157, 255, 0.95)', background:selectedTargetKey===target.key?'rgba(255, 168, 42, 0.16)':'rgba(43, 157, 255, 0.08)', pointerEvents:'none' });
+    if (selectedTargetKey === target.key) frame.setAttribute('data-ui-inspector-selected', 'true');
     const label = doc.createElement('div');
-    label.setAttribute('data-ui-inspector-overlay-label', id);
-    label.textContent = id;
-    label.style.position = 'absolute';
-    label.style.left = '0';
-    label.style.top = '-16px';
-    label.style.maxWidth = '320px';
-    label.style.whiteSpace = 'nowrap';
-    label.style.overflow = 'hidden';
-    label.style.textOverflow = 'ellipsis';
-    label.style.background = selectedId === id ? 'rgba(255, 168, 42, 0.98)' : 'rgba(43, 157, 255, 0.95)';
-    label.style.color = '#ffffff';
-    label.style.font = '11px/1.2 monospace';
-    label.style.padding = '2px 4px';
-    label.style.pointerEvents = 'none';
-
+    label.setAttribute('data-ui-inspector-overlay-label', target.key || target.id);
+    label.textContent = target.id;
+    Object.assign(label.style, { position:'absolute', left:'0', top:'-16px', maxWidth:'320px', whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis', background:selectedTargetKey===target.key?'rgba(255, 168, 42, 0.98)':'rgba(43, 157, 255, 0.95)', color:'#ffffff', font:'11px/1.2 monospace', padding:'2px 4px', pointerEvents:'none' });
     frame.append(label);
     return frame;
   }
 
-  function getHitsAtPoint(x, y) {
-    if (!rootElement) return [];
+  function rebuildTargets() {
+    if (!rootElement) { targets=[]; return; }
     const nodes = rootElement.querySelectorAll(selector);
-    const hits = [];
-    domSequence = 0;
+    const counts = new Map();
+    const next = [];
     for (const node of nodes) {
-      domSequence += 1;
-      if (!node || typeof node.getBoundingClientRect !== 'function') continue;
-      const id = String(node.getAttribute('data-ui-inspector-id') || '').trim();
+      const id = String(node?.getAttribute?.('data-ui-inspector-id') || '').trim();
       if (!id) continue;
-      const rect = node.getBoundingClientRect();
-      if (!rect || rect.width <= 0 || rect.height <= 0) continue;
-      if (x < rect.left || x > rect.left + rect.width || y < rect.top || y > rect.top + rect.height) continue;
-      hits.push({ id, rect, area: rect.width * rect.height, depth: id.split('.').length, index: domSequence });
+      const instance = (counts.get(id) || 0) + 1; counts.set(id, instance);
+      next.push({ id, key: `${id}::${instance}`, element: node, instance });
     }
-    hits.sort((a, b) => a.area - b.area || b.depth - a.depth || a.index - b.index);
+    targets = next;
+  }
+
+  function getHitsAtPoint(x,y){
+    if(!rootElement) return [];
+    const hits=[]; domSequence=0;
+    for(const target of targets){
+      const node=target.element; domSequence+=1;
+      if(!node||typeof node.getBoundingClientRect!=='function') continue;
+      const rect=node.getBoundingClientRect();
+      if(!rect||rect.width<=0||rect.height<=0) continue;
+      if(x<rect.left||x>rect.left+rect.width||y<rect.top||y>rect.top+rect.height) continue;
+      hits.push({ ...target, rect, area:rect.width*rect.height, depth:target.id.split('.').length, index:domSequence });
+    }
+    hits.sort((a,b)=>a.area-b.area||b.depth-a.depth||a.instance-b.instance||a.index-b.index);
     return hits;
   }
+  function removeHitList(){ if(!overlayRoot)return; for(const child of Array.from(overlayRoot.children||[])){ if(child?.getAttribute?.('data-ui-inspector-hit-list')==='true') child.parentElement?.removeChild?.(child);} }
+  function select(targetKey){
+    const match = targets.find((t)=>t.key===String(targetKey||'').trim());
+    if(!match) return false;
+    selectedTargetKey = match.key; selectedId = match.id; removeHitList(); options.onSelect?.(selectedId, match); return refresh();
+  }
+  function clearSelection(){ selectedId=''; selectedTargetKey=''; removeHitList(); options.onClearSelection?.(); return refresh(); }
 
-  function removeHitList() {
-    if (!overlayRoot) return;
-    const children = Array.from(overlayRoot.children || []);
-    for (const child of children) {
-      if (child?.getAttribute?.('data-ui-inspector-hit-list') === 'true') {
-        child.parentElement?.removeChild?.(child);
-      }
-    }
+  function showHitListAtPoint(x,y){
+    if(!overlayRoot||!rootElement) return false; removeHitList(); const hits=getHitsAtPoint(x,y); if(!hits.length){ clearSelection(); return false; }
+    const doc=rootElement.ownerDocument||globalThis.document; const list=doc.createElement('div'); list.setAttribute('data-ui-inspector-hit-list','true');
+    Object.assign(list.style,{ position:'fixed', left:`${x}px`, top:`${y}px`, maxWidth:'380px', background:'rgba(24, 29, 38, 0.97)', border:'1px solid rgba(255,255,255,0.2)', borderRadius:'6px', padding:'6px', display:'flex', flexDirection:'column', gap:'4px', pointerEvents:'auto' });
+    for(const hit of hits){ const option=doc.createElement('button'); option.type='button'; option.setAttribute('data-ui-inspector-hit-option', hit.key); option.textContent=hit.id; option.style.pointerEvents='auto'; option.style.textAlign='left'; option.onclick=(event)=>{ event?.preventDefault?.(); event?.stopPropagation?.(); event?.stopImmediatePropagation?.(); select(hit.key); }; list.append(option);} overlayRoot.append(list); return true;
   }
 
-  function select(id) {
-    selectedId = String(id || '').trim();
-    removeHitList();
-    options.onSelect?.(selectedId);
-    return refresh();
-  }
-
-  function clearSelection() {
-    selectedId = '';
-    removeHitList();
-    options.onClearSelection?.();
-    return refresh();
-  }
-
-  function showHitListAtPoint(x, y) {
-    if (!overlayRoot || !rootElement) return false;
-    removeHitList();
-    const hits = getHitsAtPoint(x, y);
-    if (!hits.length) {
-      clearSelection();
-      return false;
-    }
-
-    const doc = rootElement.ownerDocument || globalThis.document;
-    const list = doc.createElement('div');
-    list.setAttribute('data-ui-inspector-hit-list', 'true');
-    list.style.position = 'fixed';
-    list.style.left = `${x}px`;
-    list.style.top = `${y}px`;
-    list.style.maxWidth = '380px';
-    list.style.background = 'rgba(24, 29, 38, 0.97)';
-    list.style.border = '1px solid rgba(255,255,255,0.2)';
-    list.style.borderRadius = '6px';
-    list.style.padding = '6px';
-    list.style.display = 'flex';
-    list.style.flexDirection = 'column';
-    list.style.gap = '4px';
-    list.style.pointerEvents = 'auto';
-
-    for (const hit of hits) {
-      const option = doc.createElement('button');
-      option.type = 'button';
-      option.setAttribute('data-ui-inspector-hit-option', hit.id);
-      option.textContent = hit.id;
-      option.style.pointerEvents = 'auto';
-      option.style.textAlign = 'left';
-      option.onclick = (event) => {
-        event?.preventDefault?.();
-        event?.stopPropagation?.();
-        event?.stopImmediatePropagation?.();
-        select(hit.id);
-      };
-      list.append(option);
-    }
-    overlayRoot.append(list);
+  function refresh(){
+    if(!rootElement||!overlayRoot) return false;
+    rebuildTargets(); clearOverlayChildren();
+    for(const target of targets){ const rect=target.element?.getBoundingClientRect?.(); if(!rect||rect.width<=0||rect.height<=0) continue; overlayRoot.append(createFrame(rootElement.ownerDocument||globalThis.document,target,rect)); }
+    overlayRoot.append(createBadge(rootElement.ownerDocument||globalThis.document));
     return true;
   }
 
-  function refresh() {
-    if (!rootElement || !overlayRoot) return false;
-    clearOverlayChildren();
+  function isInsideInspectorUi(target){ let node=target; while(node){ if(node.getAttribute?.('data-ui-inspector-hit-list')==='true'||node.getAttribute?.('data-ui-inspector-hit-option')||node.getAttribute?.('data-ui-inspector-panel')==='true') return true; node=node.parentElement; } return false; }
+  function bindCaptureListener(doc){ if(!doc||captureHandler||typeof doc.addEventListener!=='function') return; captureHandler=(event)=>{ if(isInsideInspectorUi(event?.target)) return; const x=Number(event?.clientX); const y=Number(event?.clientY); if(!Number.isFinite(x)||!Number.isFinite(y)) return; event.preventDefault?.(); event.stopPropagation?.(); event.stopImmediatePropagation?.(); showHitListAtPoint(x,y);}; doc.addEventListener('pointerdown',captureHandler,true); captureHost=doc; }
+  function unbindCaptureListener(){ if(captureHost&&captureHandler&&typeof captureHost.removeEventListener==='function') captureHost.removeEventListener('pointerdown',captureHandler,true); captureHost=null; captureHandler=null; }
 
-    const nodes = rootElement.querySelectorAll(selector);
-    for (const node of nodes) {
-      if (!node || typeof node.getBoundingClientRect !== 'function') continue;
-      const id = String(node.getAttribute('data-ui-inspector-id') || '').trim();
-      if (!id) continue;
-      const rect = node.getBoundingClientRect();
-      if (!rect || rect.width <= 0 || rect.height <= 0) continue;
-      overlayRoot.append(createFrame(rootElement.ownerDocument || globalThis.document, id, rect));
-    }
-    overlayRoot.append(createBadge(rootElement.ownerDocument || globalThis.document));
-    return true;
-  }
+  function mount(nextRootElement, runtimeOptions={}){ if(runtimeOptions&&typeof runtimeOptions==='object'){ options.onSelect=runtimeOptions.onSelect||options.onSelect; options.onClearSelection=runtimeOptions.onClearSelection||options.onClearSelection; }
+    if(!nextRootElement||typeof nextRootElement.querySelectorAll!=='function') return false; rootElement=nextRootElement; const doc=rootElement.ownerDocument||globalThis.document; const nextOverlayRoot=ensureOverlayRoot(doc); const mountHost=doc.body||rootElement; if(!nextOverlayRoot.isConnected) mountHost.append(nextOverlayRoot); bindCaptureListener(doc); refresh(); return true; }
+  function unmount(){ clearSelection(); unbindCaptureListener(); clearOverlayChildren(); if(overlayRoot?.parentElement) overlayRoot.parentElement.removeChild(overlayRoot); rootElement=null; targets=[]; return true; }
 
-
-  function isInsideInspectorUi(target) {
-    let node = target;
-    while (node) {
-      if (node.getAttribute?.('data-ui-inspector-hit-list') === 'true') return true;
-      if (node.getAttribute?.('data-ui-inspector-hit-option')) return true;
-      if (node.getAttribute?.('data-ui-inspector-panel') === 'true') return true;
-      node = node.parentElement;
-    }
-    return false;
-  }
-
-  function bindCaptureListener(doc) {
-    if (!doc || captureHandler || typeof doc.addEventListener !== 'function') return;
-    captureHandler = (event) => {
-      if (isInsideInspectorUi(event?.target)) return;
-      const x = Number(event?.clientX);
-      const y = Number(event?.clientY);
-      if (!Number.isFinite(x) || !Number.isFinite(y)) return;
-      event.preventDefault?.();
-      event.stopPropagation?.();
-      event.stopImmediatePropagation?.();
-      showHitListAtPoint(x, y);
-    };
-    doc.addEventListener('pointerdown', captureHandler, true);
-    captureHost = doc;
-  }
-
-  function unbindCaptureListener() {
-    if (!captureHost || !captureHandler) return;
-    if (typeof captureHost.removeEventListener === 'function') {
-      captureHost.removeEventListener('pointerdown', captureHandler, true);
-    }
-    captureHost = null;
-    captureHandler = null;
-  }
-
-  function mount(nextRootElement, runtimeOptions = {}) {
-    if (runtimeOptions && typeof runtimeOptions === 'object') {
-      options.onSelect = runtimeOptions.onSelect || options.onSelect;
-      options.onClearSelection = runtimeOptions.onClearSelection || options.onClearSelection;
-    }
-    if (!nextRootElement || typeof nextRootElement.querySelectorAll !== 'function') return false;
-    rootElement = nextRootElement;
-    const doc = rootElement.ownerDocument || globalThis.document;
-    const nextOverlayRoot = ensureOverlayRoot(doc);
-    const mountHost = doc.body || rootElement;
-    if (!nextOverlayRoot.isConnected) mountHost.append(nextOverlayRoot);
-    bindCaptureListener(doc);
-    refresh();
-    return true;
-  }
-
-  function unmount() {
-    clearSelection();
-    unbindCaptureListener();
-    clearOverlayChildren();
-    if (overlayRoot?.parentElement) overlayRoot.parentElement.removeChild(overlayRoot);
-    rootElement = null;
-    return true;
-  }
-
-  return { mount, unmount, refresh, getSelectedId: () => selectedId, getOverlayRoot: () => overlayRoot, select, clearSelection, getHitsAtPoint, showHitListAtPoint };
+  return { mount, unmount, refresh, getSelectedId:()=>selectedId, getSelectedTargetKey:()=>selectedTargetKey, getTargets:()=>[...targets], getOverlayRoot:()=>overlayRoot, select, clearSelection, getHitsAtPoint, showHitListAtPoint };
 }

--- a/src/renderer/uiInspector/UiInspectorOverlay.js
+++ b/src/renderer/uiInspector/UiInspectorOverlay.js
@@ -12,7 +12,10 @@ export function createUiInspectorOverlay(options = {}) {
   let domSequence = 0;
   let targets = [];
 
-  function clearOverlayChildren() { if (overlayRoot) overlayRoot.replaceChildren(); }
+  function clearOverlayChildren() {
+    if (!overlayRoot) return;
+    overlayRoot.replaceChildren();
+  }
   function ensureOverlayRoot(doc) {
     if (overlayRoot?.isConnected) return overlayRoot;
     overlayRoot = doc.createElement('div');
@@ -56,50 +59,170 @@ export function createUiInspectorOverlay(options = {}) {
     targets = next;
   }
 
-  function getHitsAtPoint(x,y){
-    if(!rootElement) return [];
-    const hits=[]; domSequence=0;
-    for(const target of targets){
-      const node=target.element; domSequence+=1;
-      if(!node||typeof node.getBoundingClientRect!=='function') continue;
-      const rect=node.getBoundingClientRect();
-      if(!rect||rect.width<=0||rect.height<=0) continue;
-      if(x<rect.left||x>rect.left+rect.width||y<rect.top||y>rect.top+rect.height) continue;
-      hits.push({ ...target, rect, area:rect.width*rect.height, depth:target.id.split('.').length, index:domSequence });
+  function getHitsAtPoint(x, y) {
+    if (!rootElement) return [];
+
+    const hits = [];
+    domSequence = 0;
+
+    for (const target of targets) {
+      const node = target.element;
+      domSequence += 1;
+
+      if (!node || typeof node.getBoundingClientRect !== 'function') continue;
+
+      const rect = node.getBoundingClientRect();
+      if (!rect || rect.width <= 0 || rect.height <= 0) continue;
+      if (x < rect.left || x > rect.left + rect.width || y < rect.top || y > rect.top + rect.height) continue;
+
+      hits.push({
+        ...target,
+        rect,
+        area: rect.width * rect.height,
+        depth: target.id.split('.').length,
+        index: domSequence,
+      });
     }
-    hits.sort((a,b)=>a.area-b.area||b.depth-a.depth||a.instance-b.instance||a.index-b.index);
+
+    hits.sort((a, b) => a.area - b.area || b.depth - a.depth || a.instance - b.instance || a.index - b.index);
     return hits;
   }
-  function removeHitList(){ if(!overlayRoot)return; for(const child of Array.from(overlayRoot.children||[])){ if(child?.getAttribute?.('data-ui-inspector-hit-list')==='true') child.parentElement?.removeChild?.(child);} }
-  function select(targetKey){
-    const match = targets.find((t)=>t.key===String(targetKey||'').trim());
-    if(!match) return false;
-    selectedTargetKey = match.key; selectedId = match.id; removeHitList(); options.onSelect?.(selectedId, match); return refresh();
-  }
-  function clearSelection(){ selectedId=''; selectedTargetKey=''; removeHitList(); options.onClearSelection?.(); return refresh(); }
+  function removeHitList() {
+    if (!overlayRoot) return;
 
-  function showHitListAtPoint(x,y){
-    if(!overlayRoot||!rootElement) return false; removeHitList(); const hits=getHitsAtPoint(x,y); if(!hits.length){ clearSelection(); return false; }
-    const doc=rootElement.ownerDocument||globalThis.document; const list=doc.createElement('div'); list.setAttribute('data-ui-inspector-hit-list','true');
-    Object.assign(list.style,{ position:'fixed', left:`${x}px`, top:`${y}px`, maxWidth:'380px', background:'rgba(24, 29, 38, 0.97)', border:'1px solid rgba(255,255,255,0.2)', borderRadius:'6px', padding:'6px', display:'flex', flexDirection:'column', gap:'4px', pointerEvents:'auto' });
-    for(const hit of hits){ const option=doc.createElement('button'); option.type='button'; option.setAttribute('data-ui-inspector-hit-option', hit.key); option.textContent=hit.id; option.style.pointerEvents='auto'; option.style.textAlign='left'; option.onclick=(event)=>{ event?.preventDefault?.(); event?.stopPropagation?.(); event?.stopImmediatePropagation?.(); select(hit.key); }; list.append(option);} overlayRoot.append(list); return true;
+    const children = Array.from(overlayRoot.children || []);
+    for (const child of children) {
+      if (child?.getAttribute?.('data-ui-inspector-hit-list') !== 'true') continue;
+      child.parentElement?.removeChild?.(child);
+    }
+  }
+  function select(targetKey) {
+    const match = targets.find((t) => t.key === String(targetKey || '').trim());
+    if (!match) return false;
+
+    selectedTargetKey = match.key;
+    selectedId = match.id;
+    removeHitList();
+    options.onSelect?.(selectedId, match);
+    return refresh();
+  }
+  function clearSelection() {
+    selectedId = '';
+    selectedTargetKey = '';
+    removeHitList();
+    options.onClearSelection?.();
+    return refresh();
   }
 
-  function refresh(){
-    if(!rootElement||!overlayRoot) return false;
-    rebuildTargets(); clearOverlayChildren();
-    for(const target of targets){ const rect=target.element?.getBoundingClientRect?.(); if(!rect||rect.width<=0||rect.height<=0) continue; overlayRoot.append(createFrame(rootElement.ownerDocument||globalThis.document,target,rect)); }
+  function showHitListAtPoint(x, y) {
+    if (!overlayRoot || !rootElement) return false;
+
+    removeHitList();
+    const hits = getHitsAtPoint(x, y);
+    if (!hits.length) {
+      clearSelection();
+      return false;
+    }
+
+    const doc = rootElement.ownerDocument || globalThis.document;
+    const list = doc.createElement('div');
+    list.setAttribute('data-ui-inspector-hit-list', 'true');
+    Object.assign(list.style, { position:'fixed', left:`${x}px`, top:`${y}px`, maxWidth:'380px', background:'rgba(24, 29, 38, 0.97)', border:'1px solid rgba(255,255,255,0.2)', borderRadius:'6px', padding:'6px', display:'flex', flexDirection:'column', gap:'4px', pointerEvents:'auto' });
+
+    for (const hit of hits) {
+      const option = doc.createElement('button');
+      option.type = 'button';
+      option.setAttribute('data-ui-inspector-hit-option', hit.key);
+      option.textContent = hit.id;
+      option.style.pointerEvents = 'auto';
+      option.style.textAlign = 'left';
+      option.onclick = (event) => {
+        event?.preventDefault?.();
+        event?.stopPropagation?.();
+        event?.stopImmediatePropagation?.();
+        select(hit.key);
+      };
+      list.append(option);
+    }
+
+    overlayRoot.append(list);
+    return true;
+  }
+
+  function refresh() {
+    if (!rootElement || !overlayRoot) return false;
+
+    rebuildTargets();
+    clearOverlayChildren();
+
+    for (const target of targets) {
+      const rect = target.element?.getBoundingClientRect?.();
+      if (!rect || rect.width <= 0 || rect.height <= 0) continue;
+      overlayRoot.append(createFrame(rootElement.ownerDocument || globalThis.document, target, rect));
+    }
+
     overlayRoot.append(createBadge(rootElement.ownerDocument||globalThis.document));
     return true;
   }
 
-  function isInsideInspectorUi(target){ let node=target; while(node){ if(node.getAttribute?.('data-ui-inspector-hit-list')==='true'||node.getAttribute?.('data-ui-inspector-hit-option')||node.getAttribute?.('data-ui-inspector-panel')==='true') return true; node=node.parentElement; } return false; }
-  function bindCaptureListener(doc){ if(!doc||captureHandler||typeof doc.addEventListener!=='function') return; captureHandler=(event)=>{ if(isInsideInspectorUi(event?.target)) return; const x=Number(event?.clientX); const y=Number(event?.clientY); if(!Number.isFinite(x)||!Number.isFinite(y)) return; event.preventDefault?.(); event.stopPropagation?.(); event.stopImmediatePropagation?.(); showHitListAtPoint(x,y);}; doc.addEventListener('pointerdown',captureHandler,true); captureHost=doc; }
+  function isInsideInspectorUi(target) {
+    let node = target;
+    while (node) {
+      if (
+        node.getAttribute?.('data-ui-inspector-hit-list') === 'true' ||
+        node.getAttribute?.('data-ui-inspector-hit-option') ||
+        node.getAttribute?.('data-ui-inspector-panel') === 'true'
+      ) return true;
+      node = node.parentElement;
+    }
+    return false;
+  }
+  function bindCaptureListener(doc) {
+    if (!doc || captureHandler || typeof doc.addEventListener !== 'function') return;
+
+    captureHandler = (event) => {
+      if (isInsideInspectorUi(event?.target)) return;
+      const x = Number(event?.clientX);
+      const y = Number(event?.clientY);
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      event.stopImmediatePropagation?.();
+      showHitListAtPoint(x, y);
+    };
+
+    doc.addEventListener('pointerdown', captureHandler, true);
+    captureHost = doc;
+  }
   function unbindCaptureListener(){ if(captureHost&&captureHandler&&typeof captureHost.removeEventListener==='function') captureHost.removeEventListener('pointerdown',captureHandler,true); captureHost=null; captureHandler=null; }
 
-  function mount(nextRootElement, runtimeOptions={}){ if(runtimeOptions&&typeof runtimeOptions==='object'){ options.onSelect=runtimeOptions.onSelect||options.onSelect; options.onClearSelection=runtimeOptions.onClearSelection||options.onClearSelection; }
-    if(!nextRootElement||typeof nextRootElement.querySelectorAll!=='function') return false; rootElement=nextRootElement; const doc=rootElement.ownerDocument||globalThis.document; const nextOverlayRoot=ensureOverlayRoot(doc); const mountHost=doc.body||rootElement; if(!nextOverlayRoot.isConnected) mountHost.append(nextOverlayRoot); bindCaptureListener(doc); refresh(); return true; }
-  function unmount(){ clearSelection(); unbindCaptureListener(); clearOverlayChildren(); if(overlayRoot?.parentElement) overlayRoot.parentElement.removeChild(overlayRoot); rootElement=null; targets=[]; return true; }
+  function mount(nextRootElement, runtimeOptions = {}) {
+    if (runtimeOptions && typeof runtimeOptions === 'object') {
+      options.onSelect = runtimeOptions.onSelect || options.onSelect;
+      options.onClearSelection = runtimeOptions.onClearSelection || options.onClearSelection;
+    }
+
+    if (!nextRootElement || typeof nextRootElement.querySelectorAll !== 'function') return false;
+
+    rootElement = nextRootElement;
+    const doc = rootElement.ownerDocument || globalThis.document;
+    const nextOverlayRoot = ensureOverlayRoot(doc);
+    const mountHost = doc.body || rootElement;
+
+    if (!nextOverlayRoot.isConnected) mountHost.append(nextOverlayRoot);
+    bindCaptureListener(doc);
+    refresh();
+    return true;
+  }
+  function unmount() {
+    clearSelection();
+    unbindCaptureListener();
+    clearOverlayChildren();
+    if (overlayRoot?.parentElement) overlayRoot.parentElement.removeChild(overlayRoot);
+    rootElement = null;
+    targets = [];
+    return true;
+  }
 
   return { mount, unmount, refresh, getSelectedId:()=>selectedId, getSelectedTargetKey:()=>selectedTargetKey, getTargets:()=>[...targets], getOverlayRoot:()=>overlayRoot, select, clearSelection, getHitsAtPoint, showHitListAtPoint };
 }

--- a/src/renderer/uiInspector/UiInspectorPanel.js
+++ b/src/renderer/uiInspector/UiInspectorPanel.js
@@ -18,7 +18,7 @@ function createPanelRoot(doc) {
   return panel;
 }
 
-function renderPanelContent(panelRoot, { selectedId = '', controls = [], note = '' } = {}) {
+function renderPanelContent(panelRoot, { selectedId = '', controls = [], targets = [], note = '' } = {}) {
   panelRoot.replaceChildren();
 
   const doc = panelRoot.ownerDocument || globalThis.document;
@@ -30,6 +30,35 @@ function renderPanelContent(panelRoot, { selectedId = '', controls = [], note = 
   const selectedLabel = doc.createElement('div');
   selectedLabel.textContent = selectedId ? `Ausgewählter Bereich: ${selectedId}` : 'Kein Bereich ausgewählt';
   selectedLabel.style.marginBottom = '8px';
+
+
+  const targetLabel = doc.createElement('div');
+  targetLabel.textContent = 'Bereich auswählen:';
+  targetLabel.style.marginBottom = '4px';
+
+  const targetSelect = doc.createElement('select');
+  targetSelect.setAttribute('data-ui-inspector-target-select', 'true');
+  targetSelect.style.width = '100%';
+  targetSelect.style.marginBottom = '8px';
+
+  const empty = doc.createElement('option');
+  empty.value = '';
+  empty.textContent = '— Bereich wählen —';
+  targetSelect.append(empty);
+
+  for (const target of Array.isArray(targets) ? targets : []) {
+    const option = doc.createElement('option');
+    option.value = String(target?.key || '');
+    const level = Number(target?.level || 0);
+    const indent = '  '.repeat(Math.max(0, level));
+    option.textContent = `${indent}${String(target?.label || target?.id || '')}`;
+    if (selectedId && String(target?.id || '') === String(selectedId)) option.selected = true;
+    targetSelect.append(option);
+  }
+
+  if (typeof panelRoot.__onSelectTarget === 'function') {
+    targetSelect.onchange = () => panelRoot.__onSelectTarget(targetSelect.value);
+  }
 
   const controlsTitle = doc.createElement('div');
   controlsTitle.textContent = 'Erlaubte Stellschrauben:';
@@ -55,12 +84,14 @@ function renderPanelContent(panelRoot, { selectedId = '', controls = [], note = 
   hint.textContent = 'Nur Anzeige – Änderungen folgen erst in M13.';
   hint.style.opacity = '0.9';
 
-  panelRoot.append(title, selectedLabel, controlsTitle, controlsList, hint);
+  panelRoot.append(title, selectedLabel, targetLabel, targetSelect, controlsTitle, controlsList, hint);
 }
 
 export function createUiInspectorPanel(options = {}) {
   let panelRoot = null;
   let mountHost = null;
+  let latestState = options.initialState || {};
+  const onSelectTarget = typeof options.onSelectTarget === 'function' ? options.onSelectTarget : null;
 
   function ensurePanel(doc) {
     if (panelRoot?.isConnected) return panelRoot;
@@ -78,7 +109,8 @@ export function createUiInspectorPanel(options = {}) {
     mountHost = host;
     const node = ensurePanel(doc);
     if (!node.isConnected) mountHost.append(node);
-    renderPanelContent(node, options.initialState || {});
+    node.__onSelectTarget = onSelectTarget;
+    renderPanelContent(node, latestState);
     return true;
   }
 
@@ -90,13 +122,15 @@ export function createUiInspectorPanel(options = {}) {
 
   function render(nextState = {}) {
     if (!panelRoot) return false;
-    renderPanelContent(panelRoot, nextState);
+    latestState = { ...latestState, ...nextState };
+    renderPanelContent(panelRoot, latestState);
     return true;
   }
 
-  function clear() {
+  function clear(nextState = {}) {
     if (!panelRoot) return false;
-    renderPanelContent(panelRoot, { selectedId: '', controls: [] });
+    latestState = { ...latestState, ...nextState, selectedId: '', controls: [] };
+    renderPanelContent(panelRoot, latestState);
     return true;
   }
 

--- a/src/renderer/uiInspector/UiInspectorPanel.js
+++ b/src/renderer/uiInspector/UiInspectorPanel.js
@@ -18,7 +18,7 @@ function createPanelRoot(doc) {
   return panel;
 }
 
-function renderPanelContent(panelRoot, { selectedId = '', controls = [], targets = [], note = '' } = {}) {
+function renderPanelContent(panelRoot, { selectedId = '', selectedTargetKey = '', controls = [], targets = [], note = '' } = {}) {
   panelRoot.replaceChildren();
 
   const doc = panelRoot.ownerDocument || globalThis.document;
@@ -52,7 +52,7 @@ function renderPanelContent(panelRoot, { selectedId = '', controls = [], targets
     const level = Number(target?.level || 0);
     const indent = '  '.repeat(Math.max(0, level));
     option.textContent = `${indent}${String(target?.label || target?.id || '')}`;
-    if (selectedId && String(target?.id || '') === String(selectedId)) option.selected = true;
+    if (selectedTargetKey && String(target?.key || '') === String(selectedTargetKey)) option.selected = true;
     targetSelect.append(option);
   }
 
@@ -81,7 +81,7 @@ function renderPanelContent(panelRoot, { selectedId = '', controls = [], targets
   }
 
   const hint = doc.createElement('div');
-  hint.textContent = 'Nur Anzeige – Änderungen folgen erst in M13.';
+  hint.textContent = 'Auswahlmodell – noch keine Layoutänderung.';
   hint.style.opacity = '0.9';
 
   panelRoot.append(title, selectedLabel, targetLabel, targetSelect, controlsTitle, controlsList, hint);

--- a/src/renderer/uiInspector/UiInspectorRuntime.js
+++ b/src/renderer/uiInspector/UiInspectorRuntime.js
@@ -30,14 +30,14 @@ export function buildTargets(rawTargets = []) {
   }
   return out;
 }
-function getAllowedControlsForSelectedId(selectedId) { const normalizedId = String(selectedId || '').trim(); if (!normalizedId) return []; const containerIds = new Set(['restarbeiten.root','restarbeiten.header','restarbeiten.main','restarbeiten.filterleiste','restarbeiten.filterleiste.meta','restarbeiten.editbox','restarbeiten.editbox.header','restarbeiten.editbox.verortung','restarbeiten.editbox.meta','restarbeiten.liste']); if (containerIds.has(normalizedId)) return [...CONTAINER_CONTROLS]; const fieldSuffixes = ['.feld', '.kurztext', '.langtext', '.fertig_bis', '.status', '.verantwortlich', '.label', '.restzeichen']; if (fieldSuffixes.some((suffix) => normalizedId.endsWith(suffix))) return [...FIELD_CONTROLS]; return []; }
+function getAllowedControlsForSelectedId(selectedId) { const normalizedId = String(selectedId || '').trim(); if (!normalizedId) return []; const containerIds = new Set(['restarbeiten.root','restarbeiten.header','restarbeiten.main','restarbeiten.filterleiste','restarbeiten.filterleiste.klassenfilter','restarbeiten.filterleiste.verortung','restarbeiten.filterleiste.meta','restarbeiten.editbox','restarbeiten.editbox.header','restarbeiten.editbox.verortung','restarbeiten.editbox.meta','restarbeiten.liste','restarbeiten.liste.textbereich','restarbeiten.liste.metabereich']); if (containerIds.has(normalizedId)) return [...CONTAINER_CONTROLS]; const fieldSuffixes = ['.feld', '.kurztext', '.langtext', '.fertig_bis', '.status', '.verantwortlich', '.label', '.restzeichen']; if (fieldSuffixes.some((suffix) => normalizedId.endsWith(suffix))) return [...FIELD_CONTROLS]; return []; }
 
 export function createUiInspectorRuntime({ overlay, panel } = {}) {
   const resolvedOverlay = overlay || createUiInspectorOverlay();
   const resolvedPanel = panel || createUiInspectorPanel({ onSelectTarget: (key) => { if (key) resolvedOverlay.select?.(key); } });
   let overlayActive = false;
   const targets = () => buildTargets(resolvedOverlay.getTargets?.() || []);
-  function renderPanelForSelection(selectedId) { const controls = getAllowedControlsForSelectedId(selectedId); resolvedPanel.render({ selectedId, controls, targets: targets(), note: controls.length ? '' : 'Für diesen Bereich sind noch keine Stellschrauben definiert.' }); }
+  function renderPanelForSelection(selectedId) { const controls = getAllowedControlsForSelectedId(selectedId); resolvedPanel.render({ selectedId, selectedTargetKey: resolvedOverlay.getSelectedTargetKey?.() || '', controls, targets: targets(), note: controls.length ? '' : 'Für diesen Bereich sind noch keine Stellschrauben definiert.' }); }
   function activateOverlay(rootElement) {
     const overlayMounted = resolvedOverlay.mount(rootElement, { onSelect: (id) => renderPanelForSelection(id), onClearSelection: () => resolvedPanel.clear({ targets: targets() }) }) === true;
     if (!overlayMounted) { overlayActive = false; return false; }

--- a/src/renderer/uiInspector/UiInspectorRuntime.js
+++ b/src/renderer/uiInspector/UiInspectorRuntime.js
@@ -3,103 +3,48 @@ import { createUiInspectorPanel } from './UiInspectorPanel.js';
 
 const CONTAINER_CONTROLS = ['Breite', 'Höhe', 'Abstand außen', 'Abstand innen', 'Sichtbarkeit'];
 const FIELD_CONTROLS = ['Breite', 'Höhe', 'Abstand links', 'Abstand oben', 'Schriftgröße', 'Sichtbarkeit'];
+const PARENT_MAP = new Map([
+  ['restarbeiten.filterleiste', 'restarbeiten.main'], ['restarbeiten.liste', 'restarbeiten.main'],
+  ['restarbeiten.filterleiste.klassenfilter', 'restarbeiten.filterleiste'], ['restarbeiten.filterleiste.verortung', 'restarbeiten.filterleiste'], ['restarbeiten.filterleiste.meta', 'restarbeiten.filterleiste'],
+  ['restarbeiten.filterleiste.klassenfilter.feld', 'restarbeiten.filterleiste.klassenfilter'], ['restarbeiten.filterleiste.verortung.feld', 'restarbeiten.filterleiste.verortung'],
+  ['restarbeiten.liste.textbereich', 'restarbeiten.liste'], ['restarbeiten.liste.metabereich', 'restarbeiten.liste'],
+  ['restarbeiten.editbox.header', 'restarbeiten.editbox'], ['restarbeiten.editbox.verortung', 'restarbeiten.editbox'], ['restarbeiten.editbox.kurztext', 'restarbeiten.editbox'], ['restarbeiten.editbox.langtext', 'restarbeiten.editbox'], ['restarbeiten.editbox.meta', 'restarbeiten.editbox'],
+  ['restarbeiten.editbox.kurztext.label', 'restarbeiten.editbox.kurztext'], ['restarbeiten.editbox.kurztext.restzeichen', 'restarbeiten.editbox.kurztext'], ['restarbeiten.editbox.langtext.label', 'restarbeiten.editbox.langtext'], ['restarbeiten.editbox.langtext.restzeichen', 'restarbeiten.editbox.langtext'],
+]);
+const TOP_ORDER = ['restarbeiten.header', 'restarbeiten.main', 'restarbeiten.editbox'];
 
-function getAllowedControlsForSelectedId(selectedId) {
-  const normalizedId = String(selectedId || '').trim();
-  if (!normalizedId) return [];
-
-  const containerIds = new Set([
-    'restarbeiten.root',
-    'restarbeiten.header',
-    'restarbeiten.main',
-    'restarbeiten.filterleiste',
-    'restarbeiten.filterleiste.meta',
-    'restarbeiten.editbox',
-    'restarbeiten.editbox.header',
-    'restarbeiten.editbox.verortung',
-    'restarbeiten.editbox.meta',
-    'restarbeiten.liste',
-  ]);
-  if (containerIds.has(normalizedId)) return [...CONTAINER_CONTROLS];
-
-  const fieldSuffixes = ['.feld', '.kurztext', '.langtext', '.fertig_bis', '.status', '.verantwortlich', '.label', '.restzeichen'];
-  if (fieldSuffixes.some((suffix) => normalizedId.endsWith(suffix))) return [...FIELD_CONTROLS];
-
-  return [];
+function getLabel(id, instance) { const leaf = String(id || '').split('.').pop() || id; const base = leaf.charAt(0).toUpperCase() + leaf.slice(1).replaceAll('_', ' '); return leaf === 'feld' ? `Feld #${instance}` : base; }
+function getParentId(id, existing) { let cursor = PARENT_MAP.get(id) || ''; while (cursor && !existing.has(cursor)) cursor = PARENT_MAP.get(cursor) || ''; if (cursor) return cursor; const parts = String(id).split('.'); while (parts.length > 2) { parts.pop(); const c = parts.join('.'); if (existing.has(c)) return c; } return ''; }
+export function buildTargets(rawTargets = []) {
+  const existing = new Set(rawTargets.map((t) => t.id));
+  const byId = new Map();
+  for (const t of rawTargets) { if (!byId.has(t.id)) byId.set(t.id, []); byId.get(t.id).push(t); }
+  const ids = Array.from(byId.keys());
+  const idOrder = (id) => { const i = TOP_ORDER.indexOf(id); return i >= 0 ? i : 100 + id.split('.').length; };
+  ids.sort((a,b)=>idOrder(a)-idOrder(b)||a.localeCompare(b));
+  const out=[];
+  for (const id of ids) {
+    const parentId = getParentId(id, existing); const parent = out.find((x)=>x.id===parentId); const level = parent ? parent.level + 1 : (TOP_ORDER.includes(id)?0:1);
+    const rows = byId.get(id).slice().sort((a,b)=>a.instance-b.instance);
+    for (const row of rows) out.push({ ...row, parentId, level, label: getLabel(id, row.instance) });
+  }
+  return out;
 }
+function getAllowedControlsForSelectedId(selectedId) { const normalizedId = String(selectedId || '').trim(); if (!normalizedId) return []; const containerIds = new Set(['restarbeiten.root','restarbeiten.header','restarbeiten.main','restarbeiten.filterleiste','restarbeiten.filterleiste.meta','restarbeiten.editbox','restarbeiten.editbox.header','restarbeiten.editbox.verortung','restarbeiten.editbox.meta','restarbeiten.liste']); if (containerIds.has(normalizedId)) return [...CONTAINER_CONTROLS]; const fieldSuffixes = ['.feld', '.kurztext', '.langtext', '.fertig_bis', '.status', '.verantwortlich', '.label', '.restzeichen']; if (fieldSuffixes.some((suffix) => normalizedId.endsWith(suffix))) return [...FIELD_CONTROLS]; return []; }
 
 export function createUiInspectorRuntime({ overlay, panel } = {}) {
   const resolvedOverlay = overlay || createUiInspectorOverlay();
-  const resolvedPanel = panel || createUiInspectorPanel();
+  const resolvedPanel = panel || createUiInspectorPanel({ onSelectTarget: (key) => { if (key) resolvedOverlay.select?.(key); } });
   let overlayActive = false;
-
-  function renderPanelForSelection(selectedId) {
-    const controls = getAllowedControlsForSelectedId(selectedId);
-    resolvedPanel.render({
-      selectedId,
-      controls,
-      note: controls.length ? '' : 'Für diesen Bereich sind noch keine Stellschrauben definiert.',
-    });
-  }
-
+  const targets = () => buildTargets(resolvedOverlay.getTargets?.() || []);
+  function renderPanelForSelection(selectedId) { const controls = getAllowedControlsForSelectedId(selectedId); resolvedPanel.render({ selectedId, controls, targets: targets(), note: controls.length ? '' : 'Für diesen Bereich sind noch keine Stellschrauben definiert.' }); }
   function activateOverlay(rootElement) {
-    const overlayMounted = resolvedOverlay.mount(rootElement, {
-      onSelect: (id) => {
-        renderPanelForSelection(id);
-      },
-      onClearSelection: () => {
-        resolvedPanel.clear();
-      },
-    }) === true;
-
-    if (!overlayMounted) {
-      overlayActive = false;
-      return false;
-    }
-
-    const panelMounted = resolvedPanel.mount(rootElement?.ownerDocument?.body || globalThis.document?.body) === true;
-    overlayActive = panelMounted;
-
-    if (overlayActive) {
-      renderPanelForSelection(resolvedOverlay.getSelectedId?.() || '');
-    }
-
-    return overlayActive;
+    const overlayMounted = resolvedOverlay.mount(rootElement, { onSelect: (id) => renderPanelForSelection(id), onClearSelection: () => resolvedPanel.clear({ targets: targets() }) }) === true;
+    if (!overlayMounted) { overlayActive = false; return false; }
+    const panelMounted = resolvedPanel.mount(rootElement?.ownerDocument?.body || globalThis.document?.body) === true; overlayActive = panelMounted; if (overlayActive) renderPanelForSelection(resolvedOverlay.getSelectedId?.() || ''); return overlayActive;
   }
-
-  function deactivateOverlay() {
-    resolvedOverlay.unmount();
-    resolvedPanel.unmount();
-    overlayActive = false;
-    return true;
-  }
-
-  function refreshOverlay() {
-    if (!overlayActive) return false;
-    return resolvedOverlay.refresh() === true;
-  }
-
-  function getSelectedElementId() {
-    return resolvedOverlay.getSelectedId?.() || '';
-  }
-
-  function clearSelection() {
-    const result = resolvedOverlay.clearSelection?.() === true;
-    resolvedPanel.clear();
-    return result;
-  }
-
-  return {
-    overlay: resolvedOverlay,
-    panel: resolvedPanel,
-    activateOverlay,
-    deactivateOverlay,
-    refreshOverlay,
-    getSelectedElementId,
-    clearSelection,
-    getAllowedControlsForSelectedId,
-    isOverlayActive() {
-      return overlayActive;
-    },
-  };
+  function deactivateOverlay() { resolvedOverlay.unmount(); resolvedPanel.unmount(); overlayActive = false; return true; }
+  function refreshOverlay() { if (!overlayActive) return false; const ok = resolvedOverlay.refresh() === true; if (ok) renderPanelForSelection(resolvedOverlay.getSelectedId?.() || ''); return ok; }
+  function clearSelection() { const result = resolvedOverlay.clearSelection?.() === true; resolvedPanel.clear({ targets: targets() }); return result; }
+  return { overlay: resolvedOverlay, panel: resolvedPanel, activateOverlay, deactivateOverlay, refreshOverlay, getSelectedElementId() { return resolvedOverlay.getSelectedId?.() || ''; }, clearSelection, getAllowedControlsForSelectedId, buildTargets, isOverlayActive() { return overlayActive; } };
 }


### PR DESCRIPTION
### Motivation
- Stabilize the UI-Inspector read-only selection model so selection is instance-precise and robust across clear/refresh cycles.
- Ensure clearing the selection leaves the panel and the hierarchical target list visible so users can re-select immediately.
- Make refresh rebuild targets from the live DOM so newly added markers appear without remounting.
- Keep the scope minimal and read-only: no layout application, no saving, no IPC/DB/CSS changes.

### Description
- Overlay: rebuilds a targets list from `[data-ui-inspector-id]` nodes, assigns instance keys (`id::n`), exposes `getTargets()`, `getSelectedTargetKey()` and selects by target-key so identical IDs are distinguishable by instance.
- Runtime: adds `buildTargets()` with a domain `PARENT_MAP` and `TOP_ORDER`, computes `parentId`, `level` and human labels (e.g., `Feld #1`), and wires panel rendering to use the hierarchical targets.
- Panel: renders a read-only hierarchical `select` of targets, keeps the list visible on `clear`, and supports an `onSelectTarget` callback that invokes overlay selection by key; panel remains strictly read-only (no apply/save controls).
- Sync/behavior: `clearSelection()` resets selection but preserves targets in the panel, `refreshOverlay()` rebuilds targets from current DOM and re-renders panel/overlay state, and overlay frames highlight an exact target instance via `selectedTargetKey`.
- Docs/tests: updated `docs/UI_INSPEKTOR_START_HIER.md` and `docs/UI_INSPEKTOR_AUFGABENHEFT.md` with M13.1.2 interim notes, added `scripts/tests/uiInspectorRuntime.test.cjs`, and adjusted overlay/panel tests to assert instance-key behavior.

### Testing
- Ran unit tests: `node scripts/tests/uiInspectorCore.test.cjs`, `node scripts/tests/uiInspectorRegistry.test.cjs`, and `node scripts/tests/uiInspectorMapSchema.test.cjs`, all passed.
- Ran overlay/panel/runtime tests: `node scripts/tests/uiInspectorOverlay.test.cjs`, `node scripts/tests/uiInspectorPanel.test.cjs`, `node scripts/tests/uiInspectorRuntime.test.cjs`, and `node scripts/tests/restarbeitenModule.test.cjs`, all passed in this environment.
- Attempted `npm test` (full runner) but it failed in this environment because Electron cannot start due to a missing system library (`libatk-1.0.so.0`), so full npm run was not completed here.
- Summary: targeted unit tests for the changed components passed; full Electron-based test-suite must be executed in an environment with required system libs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a121651f3e88322a591eb1a6aa44f8d)