### PR TITLE
K19.1: zentrale BBM UI-Editor-Registry hinzufügen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,10 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- K19.1 BBM zentrale UI-Editor-Registry eingefuehrt:
+  - Der offizielle Einstieg fuer spaetere Editor-Anbindung ist `src/renderer/uiEditor/bbmUiEditorRegistry.js`.
+  - Keine Editor-Integration, keine Speicherung und keine produktive Aenderung.
+
 - K19.0 BBM liefert erste explizite UI-Elementliste fuer das Protokoll-Modul:
   - Feste, explizit klassifizierte UI-Strukturliste fuer `protokoll.root`, `protokoll.header`, `protokoll.toolbar`, `protokoll.list`, `protokoll.detail` und `protokoll.footer` ergaenzt.
   - Keine Editor-Integration, kein DOM-Scan, keine Speicherung und keine produktive UI-Aenderung.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -18,6 +18,7 @@ const { runTopServiceHierarchyTests } = require("./tests/topServiceHierarchy.tes
 const { runProtokollRouterFallbackTests } = require("./tests/protokollRouterFallback.test.cjs");
 const { runProtokollProjectEntryRoutingTests } = require("./tests/protokollProjectEntryRouting.test.cjs");
 const { runProtokollUiEditorElementsTests } = require("./tests/protokollUiEditorElements.test.cjs");
+const { runBbmUiEditorRegistryTests } = require("./tests/bbmUiEditorRegistry.test.cjs");
 const { runProjektverwaltungModuleTests } = require("./tests/projektverwaltungModule.test.cjs");
 const { runRestarbeitenModuleTests } = require("./tests/restarbeitenModule.test.cjs");
 const { runRestarbeitenDataModelTests } = require("./tests/restarbeitenDataModel.test.cjs");
@@ -138,6 +139,7 @@ async function main() {
   await runProtokollRouterFallbackTests(run);
   await runProtokollProjectEntryRoutingTests(run);
   await runProtokollUiEditorElementsTests(run);
+  await runBbmUiEditorRegistryTests(run);
   await runProjektverwaltungModuleTests(run);
   await runRestarbeitenModuleTests(run);
   await runRestarbeitenDataModelTests(run);

--- a/scripts/tests/bbmUiEditorRegistry.test.cjs
+++ b/scripts/tests/bbmUiEditorRegistry.test.cjs
@@ -1,0 +1,175 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const REGISTRY_PATH = path.join(
+  __dirname,
+  "../../src/renderer/uiEditor/bbmUiEditorRegistry.js"
+);
+
+const FORBIDDEN_DATA_FIELDS = [
+  "projectId",
+  "project",
+  "meetingId",
+  "meeting",
+  "topId",
+  "top",
+  "databaseId",
+  "database",
+  "personId",
+  "person",
+  "date",
+  "deadline",
+  "value",
+  "text",
+  "content",
+];
+
+const FORBIDDEN_LOGIC_SNIPPETS = [
+  "document.",
+  "window.",
+  "querySelector",
+  "querySelectorAll",
+  "getElementById",
+  "getElementsBy",
+  "addEventListener",
+  "MutationObserver",
+  "localStorage",
+  "sessionStorage",
+  "indexedDB",
+  "fetch(",
+  "XMLHttpRequest",
+  "ipcRenderer",
+  "ipcMain",
+  "better-sqlite3",
+  "sqlite",
+  "db.",
+  "database.",
+  "execute(",
+  "eval(",
+  "new Function",
+  "writeFile",
+  "readFile",
+];
+
+function assertNoForbiddenFields(value, pathParts = []) {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertNoForbiddenFields(entry, [...pathParts, String(index)]));
+    return;
+  }
+
+  if (!value || typeof value !== "object") return;
+
+  for (const key of Object.keys(value)) {
+    assert.equal(
+      FORBIDDEN_DATA_FIELDS.includes(key),
+      false,
+      `forbidden data field ${key} at ${pathParts.concat(key).join(".")}`
+    );
+    assertNoForbiddenFields(value[key], [...pathParts, key]);
+  }
+}
+
+async function loadRegistryModule() {
+  const mod = await importEsmFromFile(REGISTRY_PATH);
+  assert.equal(typeof mod.getBbmUiEditorTargetInfo, "function");
+  assert.equal(typeof mod.getAvailableUiScopes, "function");
+  assert.equal(typeof mod.getActiveUiScope, "function");
+  assert.equal(typeof mod.getBbmUiEditorRegistry, "function");
+  return mod;
+}
+
+async function runBbmUiEditorRegistryTests(run) {
+  await run("BBM UI-Editor-Registry: exportiert die zentralen Einstiegfunktionen", async () => {
+    await loadRegistryModule();
+  });
+
+  await run("BBM UI-Editor-Registry: liefert feste Ziel-App-Informationen", async () => {
+    const mod = await loadRegistryModule();
+    assert.deepEqual(mod.getBbmUiEditorTargetInfo(), {
+      targetAppId: "bbm-produktiv",
+      targetAppName: "BBM-Produktiv",
+      registryVersion: "1.0.0",
+    });
+  });
+
+  await run("BBM UI-Editor-Registry: listet den Protokoll-Scope als verfuegbar", async () => {
+    const mod = await loadRegistryModule();
+    assert.deepEqual(mod.getAvailableUiScopes(), [
+      {
+        uiScope: "protokoll.topsScreen",
+        moduleId: "protokoll",
+        label: "Protokoll",
+        status: "available",
+      },
+    ]);
+  });
+
+  await run("BBM UI-Editor-Registry: aktiver Scope ist Protokoll-Tops", async () => {
+    const mod = await loadRegistryModule();
+    assert.equal(mod.getActiveUiScope(), "protokoll.topsScreen");
+  });
+
+  await run("BBM UI-Editor-Registry: liefert Protokoll-Elemente ueber den zentralen Einstieg", async () => {
+    const mod = await loadRegistryModule();
+    const registry = mod.getBbmUiEditorRegistry("protokoll.topsScreen");
+    assert.equal(registry.targetAppId, "bbm-produktiv");
+    assert.equal(registry.uiScope, "protokoll.topsScreen");
+    assert.equal(registry.moduleId, "protokoll");
+    assert.equal(Array.isArray(registry.elements), true);
+    assert.equal(
+      registry.elements.some((element) => element.id === "protokoll.root"),
+      true,
+      "missing protokoll.root"
+    );
+  });
+
+  await run("BBM UI-Editor-Registry: unbekannter Scope wird sauber abgefangen", async () => {
+    const mod = await loadRegistryModule();
+    const registry = mod.getBbmUiEditorRegistry("unbekannt.scope");
+    assert.equal(registry.ok, false);
+    assert.equal(registry.targetAppId, "bbm-produktiv");
+    assert.equal(registry.uiScope, "unbekannt.scope");
+    assert.deepEqual(registry.elements, []);
+    assert.equal(typeof registry.reason, "string");
+    assert.equal(registry.reason.length > 0, true);
+  });
+
+  await run("BBM UI-Editor-Registry: enthaelt keine Fachdatenfelder", async () => {
+    const mod = await loadRegistryModule();
+    assertNoForbiddenFields(mod.getBbmUiEditorTargetInfo());
+    assertNoForbiddenFields(mod.getAvailableUiScopes());
+    assertNoForbiddenFields(mod.getBbmUiEditorRegistry("protokoll.topsScreen"));
+    assertNoForbiddenFields(mod.getBbmUiEditorRegistry("unbekannt.scope"));
+  });
+
+  await run("BBM UI-Editor-Registry: enthaelt keine Datenbank-, Speicher-, Ausfuehrungs- oder DOM-Scanlogik", () => {
+    const source = fs.readFileSync(REGISTRY_PATH, "utf8");
+    for (const snippet of FORBIDDEN_LOGIC_SNIPPETS) {
+      assert.equal(source.includes(snippet), false, `forbidden logic snippet: ${snippet}`);
+    }
+  });
+}
+
+if (require.main === module) {
+  const run = async (name, fn) => {
+    try {
+      const out = fn();
+      if (out && typeof out.then === "function") {
+        await out;
+      }
+      console.log(`ok - ${name}`);
+    } catch (err) {
+      console.error(`not ok - ${name}`);
+      console.error(err?.stack || err?.message || err);
+      process.exitCode = 1;
+    }
+  };
+
+  runBbmUiEditorRegistryTests(run).then(() => {
+    if (!process.exitCode) console.log("bbmUiEditorRegistry.test.cjs passed");
+  });
+}
+
+module.exports = { runBbmUiEditorRegistryTests };

--- a/src/renderer/uiEditor/bbmUiEditorRegistry.js
+++ b/src/renderer/uiEditor/bbmUiEditorRegistry.js
@@ -1,0 +1,52 @@
+import { getProtokollUiEditorElements } from "../modules/protokoll/uiEditor/protokollUiElements.js";
+
+const TARGET_INFO = Object.freeze({
+  targetAppId: "bbm-produktiv",
+  targetAppName: "BBM-Produktiv",
+  registryVersion: "1.0.0",
+});
+
+const PROTOKOLL_TOPS_SCOPE = Object.freeze({
+  uiScope: "protokoll.topsScreen",
+  moduleId: "protokoll",
+  label: "Protokoll",
+  status: "available",
+});
+
+const AVAILABLE_UI_SCOPES = Object.freeze([PROTOKOLL_TOPS_SCOPE]);
+const ACTIVE_UI_SCOPE = "protokoll.topsScreen";
+
+function cloneScope(scope) {
+  return { ...scope };
+}
+
+export function getBbmUiEditorTargetInfo() {
+  return { ...TARGET_INFO };
+}
+
+export function getAvailableUiScopes() {
+  return AVAILABLE_UI_SCOPES.map(cloneScope);
+}
+
+export function getActiveUiScope() {
+  return ACTIVE_UI_SCOPE;
+}
+
+export function getBbmUiEditorRegistry(uiScope = getActiveUiScope()) {
+  if (uiScope !== PROTOKOLL_TOPS_SCOPE.uiScope) {
+    return {
+      ok: false,
+      targetAppId: TARGET_INFO.targetAppId,
+      uiScope,
+      elements: [],
+      reason: `Unknown UI scope: ${String(uiScope)}`,
+    };
+  }
+
+  return {
+    targetAppId: TARGET_INFO.targetAppId,
+    uiScope: PROTOKOLL_TOPS_SCOPE.uiScope,
+    moduleId: PROTOKOLL_TOPS_SCOPE.moduleId,
+    elements: getProtokollUiEditorElements(),
+  };
+}


### PR DESCRIPTION
### Motivation
- Zentrales, stabilisiertes Einstiegspunkt für spätere UI-Editor-Anbindungen bereitstellen, damit Module nicht direkt UI-Listen lesen. 
- Minimaler, risikofreier Einbau ohne Editor-Integration, Speicherung oder fachliche Logik.

### Description
- Neue Datei `src/renderer/uiEditor/bbmUiEditorRegistry.js` ergänzt, die `getBbmUiEditorTargetInfo()`, `getAvailableUiScopes()`, `getActiveUiScope()` und `getBbmUiEditorRegistry(uiScope)` exportiert und aktuell den Scope `protokoll.topsScreen` liefert. 
- Registry liefert für `protokoll.topsScreen` die Elemente aus `getProtokollUiEditorElements()` und fängt unbekannte `uiScope`-Werte mit `{ ok: false, elements: [], reason }` sauber ab. 
- Neuer Test `scripts/tests/bbmUiEditorRegistry.test.cjs` hinzugefügt und in die vorhandene Testkette (`scripts/test.cjs`) aufgenommen. 
- `STATUS.md` um den Eintrag K19.1 ergänzt.

### Testing
- `node scripts/tests/bbmUiEditorRegistry.test.cjs` ausgeführt und bestanden. 
- Kombinationstest `node scripts/tests/protokollUiEditorElements.test.cjs && node scripts/tests/bbmUiEditorRegistry.test.cjs` ausgeführt und bestanden. 
- `npm run test:node` (`node scripts/test.cjs`) ausgeführt; die Testkette lief und die neuen Registry-Tests wurden im Einzel- und kombinierten Lauf grün ausgeführt (umfangreiche Teilmenge der Node-Tests erfolgreich). 
- `npm test` konnte in dieser Umgebung nicht komplett grün laufen, da Electron beim Start an Systembibliothek `libatk-1.0.so.0` scheiterte (Umgebungsbeschränkung), daher kein vollständiger grüner Lauf der electron-angelehnten Testkette möglich.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df137e8748322a8d5492d4249edab)