### PR TITLE
K19.7: Connect uiEditor installed registry to BBM registry

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,11 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- K19.7 installierte UI-Editor-Grundstruktur mit echter BBM-Registry verbunden:
+  - `uiEditor/` ist nicht mehr nur Beispielstruktur, sondern verweist auf den offiziellen BBM-Registry-Einstieg `src/renderer/uiEditor/bbmUiEditorRegistry.js`.
+  - Der Beispiel-Scope ist kein aktiver Registry-Inhalt mehr.
+  - Kein Editor-Panel, kein Header-Button, keine produktive Aenderung, keine Speicherung und keine Fachlogik/Fachdaten.
+
 - K19.1 BBM zentrale UI-Editor-Registry eingefuehrt:
   - Der offizielle Einstieg fuer spaetere Editor-Anbindung ist `src/renderer/uiEditor/bbmUiEditorRegistry.js`.
   - Keine Editor-Integration, keine Speicherung und keine produktive Aenderung.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -1,11 +1,12 @@
 # UI-Inspektor Aufgabenheft
 
 ## Projektstatus
-Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.0 abgeschlossen (BBM liefert explizite Protokoll-UI-Elementliste ohne Integration).
+Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.7 abgeschlossen (installierte UI-Editor-Grundstruktur verweist auf die echte BBM-Registry).
 
 Aktueller Stand:
 - M1 bis M13.6a abgeschlossen.
 - K19.0 abgeschlossen: erste explizite UI-Elementliste fuer das Protokoll-Modul, ohne Editor-Integration und ohne produktive UI-Aenderung.
+- K19.7 abgeschlossen: installierter Einstieg unter `uiEditor/` ist mit dem offiziellen BBM-Registry-Einstieg verbunden, ohne produktive UI-Aenderung.
 
 ## Haken-System
 - `[x]` erledigt
@@ -40,6 +41,14 @@ Aktueller Stand:
 - [x] M13.6 UI-Editor: Rahmenmodus nur für editorfähige Rahmenziele
 - [x] M13.6a UI-Editor-Panel aus Header lösen und verschiebbar halten
 - [x] K19.0 BBM liefert explizite Protokoll-UI-Elementliste ohne Scan/Integration
+- [x] K19.7 Installierte UI-Editor-Grundstruktur mit echter BBM-Registry verbinden
+
+## Statusupdate K19.7
+- Der installierte Einstieg `uiEditor/uiEditorRegistry.js` verweist jetzt auf den offiziellen BBM-Registry-Einstieg `src/renderer/uiEditor/bbmUiEditorRegistry.js`.
+- `uiEditor/` bleibt als installierter Einstieg bestehen, erzeugt aber keine zweite aktive Beispiel-Registry.
+- Der Beispiel-Scope ist kein aktiver Registry-Inhalt mehr.
+- Keine Editor-Integration, kein Panel, kein Header-Button, kein DOM-Scan, keine Speicherung und keine produktive UI-Aenderung.
+- Abgesichert durch `uiEditor/tests/uiEditorRegistry.test.cjs`; der Test ist in `scripts/test.cjs` eingebunden.
 
 ## Statusupdate K19.0
 - BBM liefert fuer das Protokoll-Modul erstmals eine feste, explizit klassifizierte UI-Elementliste als Code-Artefakt.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -19,6 +19,7 @@ const { runProtokollRouterFallbackTests } = require("./tests/protokollRouterFall
 const { runProtokollProjectEntryRoutingTests } = require("./tests/protokollProjectEntryRouting.test.cjs");
 const { runProtokollUiEditorElementsTests } = require("./tests/protokollUiEditorElements.test.cjs");
 const { runBbmUiEditorRegistryTests } = require("./tests/bbmUiEditorRegistry.test.cjs");
+const { runInstalledUiEditorRegistryTests } = require("../uiEditor/tests/uiEditorRegistry.test.cjs");
 const { runProjektverwaltungModuleTests } = require("./tests/projektverwaltungModule.test.cjs");
 const { runRestarbeitenModuleTests } = require("./tests/restarbeitenModule.test.cjs");
 const { runRestarbeitenDataModelTests } = require("./tests/restarbeitenDataModel.test.cjs");
@@ -140,6 +141,7 @@ async function main() {
   await runProtokollProjectEntryRoutingTests(run);
   await runProtokollUiEditorElementsTests(run);
   await runBbmUiEditorRegistryTests(run);
+  await runInstalledUiEditorRegistryTests(run);
   await runProjektverwaltungModuleTests(run);
   await runRestarbeitenModuleTests(run);
   await runRestarbeitenDataModelTests(run);

--- a/uiEditor/tests/uiEditorRegistry.test.cjs
+++ b/uiEditor/tests/uiEditorRegistry.test.cjs
@@ -1,15 +1,183 @@
 #!/usr/bin/env node
 
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
 const path = require("node:path");
+const { importEsmFromFile } = require("../../scripts/tests/_esmLoader.cjs");
 
-const { uiEditorRegistry } = require(path.resolve(__dirname, "../uiEditorRegistry.js"));
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const INSTALLED_REGISTRY_PATH = path.resolve(__dirname, "../uiEditorRegistry.js");
+const OFFICIAL_BBM_REGISTRY_RELATIVE_PATH = "src/renderer/uiEditor/bbmUiEditorRegistry.js";
+const OFFICIAL_BBM_REGISTRY_PATH = path.resolve(
+  REPO_ROOT,
+  OFFICIAL_BBM_REGISTRY_RELATIVE_PATH
+);
 
-assert.equal(Boolean(uiEditorRegistry), true);
-assert.equal(Array.isArray(uiEditorRegistry.uiScopes), true);
-assert.equal(uiEditorRegistry.uiScopes.length, 1);
-assert.equal(uiEditorRegistry.uiScopes[0].uiScopeId, "example-ui-scope");
-assert.equal(Array.isArray(uiEditorRegistry.uiScopes[0].elements), true);
-assert.equal(uiEditorRegistry.uiScopes[0].elements.length, 0);
+const FORBIDDEN_DATA_FIELDS = [
+  "projectId",
+  "project",
+  "meetingId",
+  "meeting",
+  "topId",
+  "top",
+  "databaseId",
+  "database",
+  "personId",
+  "person",
+  "date",
+  "deadline",
+  "value",
+  "text",
+  "content",
+];
 
-console.log("TESTS OK: uiEditorRegistry contract");
+const FORBIDDEN_LOGIC_SNIPPETS = [
+  "document.",
+  "window.",
+  "querySelector",
+  "querySelectorAll",
+  "getElementById",
+  "getElementsBy",
+  "addEventListener",
+  "MutationObserver",
+  "localStorage",
+  "sessionStorage",
+  "indexedDB",
+  "fetch(",
+  "XMLHttpRequest",
+  "ipcRenderer",
+  "ipcMain",
+  "better-sqlite3",
+  "sqlite",
+  "db.",
+  "database.",
+  "execute(",
+  "eval(",
+  "new Function",
+  "writeFile",
+];
+
+function assertNoForbiddenFields(value, pathParts = []) {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertNoForbiddenFields(entry, [...pathParts, String(index)]));
+    return;
+  }
+
+  if (!value || typeof value !== "object") return;
+
+  for (const key of Object.keys(value)) {
+    assert.equal(
+      FORBIDDEN_DATA_FIELDS.includes(key),
+      false,
+      `forbidden data field ${key} at ${pathParts.concat(key).join(".")}`
+    );
+    assertNoForbiddenFields(value[key], [...pathParts, key]);
+  }
+}
+
+async function loadInstalledRegistry() {
+  const installed = require(INSTALLED_REGISTRY_PATH);
+  assert.equal(typeof installed.getInstalledUiEditorRegistryInfo, "function");
+  assert.equal(typeof installed.getOfficialBbmUiEditorRegistryPath, "function");
+  assert.equal(typeof installed.loadBbmUiEditorRegistry, "function");
+  assert.equal(Boolean(installed.uiEditorRegistry), true);
+  return installed;
+}
+
+async function loadOfficialBbmRegistry() {
+  return importEsmFromFile(OFFICIAL_BBM_REGISTRY_PATH);
+}
+
+async function runInstalledUiEditorRegistryTests(run) {
+  await run("Installierte UI-Editor-Registry: Einstieg existiert", () => {
+    assert.equal(fs.existsSync(INSTALLED_REGISTRY_PATH), true);
+  });
+
+  await run("Installierte UI-Editor-Registry: verweist auf den offiziellen BBM-Registry-Pfad", async () => {
+    const installed = await loadInstalledRegistry();
+    const info = installed.getInstalledUiEditorRegistryInfo();
+    assert.equal(info.officialBbmRegistryPath, OFFICIAL_BBM_REGISTRY_RELATIVE_PATH);
+    assert.equal(installed.BBM_UI_EDITOR_REGISTRY_RELATIVE_PATH, OFFICIAL_BBM_REGISTRY_RELATIVE_PATH);
+    assert.equal(installed.getOfficialBbmUiEditorRegistryPath(REPO_ROOT), OFFICIAL_BBM_REGISTRY_PATH);
+    assert.equal(fs.existsSync(installed.getOfficialBbmUiEditorRegistryPath(REPO_ROOT)), true);
+  });
+
+  await run("Installierte UI-Editor-Registry: erzeugt keine doppelte aktive Beispiel-Registry", async () => {
+    const installed = await loadInstalledRegistry();
+    const info = installed.getInstalledUiEditorRegistryInfo();
+    assert.equal(info.createsOwnRegistry, false);
+    assert.equal(info.activeExampleScope, false);
+    assert.equal(Array.isArray(installed.uiEditorRegistry.uiScopes), true);
+    assert.equal(
+      installed.uiEditorRegistry.uiScopes.some((scope) => scope.uiScopeId === "example-ui-scope"),
+      false
+    );
+  });
+
+  await run("Installierte UI-Editor-Registry: Quelltext nutzt keinen aktiven example-ui-scope", () => {
+    const source = fs.readFileSync(INSTALLED_REGISTRY_PATH, "utf8");
+    assert.equal(source.includes("example-ui-scope"), false);
+    assert.equal(source.includes(OFFICIAL_BBM_REGISTRY_RELATIVE_PATH), true);
+  });
+
+  await run("Installierte UI-Editor-Registry: echte BBM-Registry ist erreichbar", async () => {
+    const installed = await loadInstalledRegistry();
+    const registry = await installed.loadBbmUiEditorRegistry(importEsmFromFile, { repoRoot: REPO_ROOT });
+    assert.equal(typeof registry.getAvailableUiScopes, "function");
+    assert.equal(typeof registry.getBbmUiEditorRegistry, "function");
+  });
+
+  await run("BBM UI-Editor-Registry: getAvailableUiScopes enthaelt protokoll.topsScreen", async () => {
+    const registry = await loadOfficialBbmRegistry();
+    const scopes = registry.getAvailableUiScopes();
+    assert.equal(scopes.some((scope) => scope.uiScope === "protokoll.topsScreen"), true);
+  });
+
+  await run("BBM UI-Editor-Registry: getBbmUiEditorRegistry liefert Protokoll-Elemente", async () => {
+    const registry = await loadOfficialBbmRegistry();
+    const result = registry.getBbmUiEditorRegistry("protokoll.topsScreen");
+    assert.equal(Array.isArray(result.elements), true);
+    assert.equal(result.elements.length > 0, true);
+    assert.equal(result.elements.some((element) => element.id === "protokoll.root"), true);
+  });
+
+  await run("UI-Editor-Registry: enthaelt keine Fachdatenfelder", async () => {
+    const installed = await loadInstalledRegistry();
+    const registry = await loadOfficialBbmRegistry();
+    assertNoForbiddenFields(installed.getInstalledUiEditorRegistryInfo());
+    assertNoForbiddenFields(installed.uiEditorRegistry);
+    assertNoForbiddenFields(registry.getAvailableUiScopes());
+    assertNoForbiddenFields(registry.getBbmUiEditorRegistry("protokoll.topsScreen"));
+  });
+
+  await run("UI-Editor-Registry: enthaelt keine Datenbank-, Speicher-, Ausfuehrungs- oder DOM-Scanlogik", () => {
+    const installedSource = fs.readFileSync(INSTALLED_REGISTRY_PATH, "utf8");
+    const officialSource = fs.readFileSync(OFFICIAL_BBM_REGISTRY_PATH, "utf8");
+    for (const snippet of FORBIDDEN_LOGIC_SNIPPETS) {
+      assert.equal(installedSource.includes(snippet), false, `installed forbidden logic snippet: ${snippet}`);
+      assert.equal(officialSource.includes(snippet), false, `official forbidden logic snippet: ${snippet}`);
+    }
+  });
+}
+
+if (require.main === module) {
+  const run = async (name, fn) => {
+    try {
+      const out = fn();
+      if (out && typeof out.then === "function") {
+        await out;
+      }
+      console.log(`ok - ${name}`);
+    } catch (err) {
+      console.error(`not ok - ${name}`);
+      console.error(err?.stack || err?.message || err);
+      process.exitCode = 1;
+    }
+  };
+
+  runInstalledUiEditorRegistryTests(run).then(() => {
+    if (!process.exitCode) console.log("uiEditorRegistry.test.cjs passed");
+  });
+}
+
+module.exports = { runInstalledUiEditorRegistryTests };

--- a/uiEditor/uiEditorRegistry.js
+++ b/uiEditor/uiEditorRegistry.js
@@ -1,13 +1,45 @@
 "use strict";
 
-const uiEditorRegistry = Object.freeze({
-  uiScopes: Object.freeze([
-    Object.freeze({
-      uiScopeId: "example-ui-scope",
-      label: "Example UI scope",
-      elements: Object.freeze([]),
-    }),
-  ]),
+const path = require("node:path");
+
+const BBM_UI_EDITOR_REGISTRY_RELATIVE_PATH =
+  "src/renderer/uiEditor/bbmUiEditorRegistry.js";
+
+const INSTALLED_UI_EDITOR_REGISTRY_INFO = Object.freeze({
+  installedEntry: "uiEditor/uiEditorRegistry.js",
+  targetApp: "BBM-Produktiv",
+  registryMode: "target-app-registry-reference",
+  officialBbmRegistryPath: BBM_UI_EDITOR_REGISTRY_RELATIVE_PATH,
+  createsOwnRegistry: false,
+  activeExampleScope: false,
 });
 
-module.exports = { uiEditorRegistry };
+function getInstalledUiEditorRegistryInfo() {
+  return { ...INSTALLED_UI_EDITOR_REGISTRY_INFO };
+}
+
+function getOfficialBbmUiEditorRegistryPath(repoRoot = path.resolve(__dirname, "..")) {
+  return path.resolve(repoRoot, BBM_UI_EDITOR_REGISTRY_RELATIVE_PATH);
+}
+
+async function loadBbmUiEditorRegistry(importEsmFromFile, options = {}) {
+  if (typeof importEsmFromFile !== "function") {
+    throw new TypeError("loadBbmUiEditorRegistry needs an ESM file importer function");
+  }
+
+  const registryPath = getOfficialBbmUiEditorRegistryPath(options.repoRoot);
+  return importEsmFromFile(registryPath);
+}
+
+const uiEditorRegistry = Object.freeze({
+  ...INSTALLED_UI_EDITOR_REGISTRY_INFO,
+  uiScopes: Object.freeze([]),
+});
+
+module.exports = {
+  BBM_UI_EDITOR_REGISTRY_RELATIVE_PATH,
+  getInstalledUiEditorRegistryInfo,
+  getOfficialBbmUiEditorRegistryPath,
+  loadBbmUiEditorRegistry,
+  uiEditorRegistry,
+};


### PR DESCRIPTION
### Motivation
- The installed example registry under `uiEditor/` must not remain a live example and should reference the official BBM registry entrypoint.  
- Avoid having a duplicate/active example scope (`example-ui-scope`) while allowing the installed entry to remain as a safe, documented launcher.  
- Add guardrail tests to prove the installed entry points at `src/renderer/uiEditor/bbmUiEditorRegistry.js` and that the real registry exposes `protokoll.topsScreen` and `protokoll.root` without introducing UI, storage or domain logic.

### Description
- Updated `uiEditor/uiEditorRegistry.js` to be a lightweight installer/bridge that documents the official BBM registry path and exposes `getInstalledUiEditorRegistryInfo()`, `getOfficialBbmUiEditorRegistryPath()` and `loadBbmUiEditorRegistry()` (ESM loader callback), and removed the active `example-ui-scope` content.  
- Added/extended tests in `uiEditor/tests/uiEditorRegistry.test.cjs` to validate the installed entry, ensure it does not create an example registry, verify reachability of the official registry, and assert absence of forbidden fachdaten/storage/DOM logic.  
- Integrated the new registry test into the central test runner by adding it to `scripts/test.cjs`.  
- Updated documentation/status: `STATUS.md` and `docs/UI_INSPEKTOR_AUFGABENHEFT.md` to record K19.7 and note that no UI/persistence/fachlogic changes were made.

### Testing
- Ran the dedicated installed-registry test: `node uiEditor/tests/uiEditorRegistry.test.cjs` — succeeded.  
- Ran combined registry-related checks: `node scripts/tests/protokollUiEditorElements.test.cjs && node scripts/tests/bbmUiEditorRegistry.test.cjs && node uiEditor/tests/uiEditorRegistry.test.cjs` — all succeeded.  
- Executed targeted node test runner: `node scripts/test.cjs`/`npm run test:node` in this environment and observed many tests passing; the full `npm test` (Electron-backed run) failed here due to the environment missing system library `libatk-1.0.so.0`, so a complete `npm test` must be re-run in an Electron-capable environment.  
- Verified `git diff --check` produced no issues and modified files are limited to `uiEditor/uiEditorRegistry.js`, `uiEditor/tests/uiEditorRegistry.test.cjs`, `scripts/test.cjs`, `STATUS.md`, and `docs/UI_INSPEKTOR_AUFGABENHEFT.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eea02ab54832297f8c73188d44bb6)