### PR TITLE
K19.9a: Trenne installierte UI-Editor-Artefakt-Tests und füge BBM-eigenen Test hinzu

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,9 +17,16 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
-- K19.7 installierte UI-Editor-Grundstruktur mit echter BBM-Registry verbunden:
-  - `uiEditor/` ist nicht mehr nur Beispielstruktur, sondern verweist auf den offiziellen BBM-Registry-Einstieg `src/renderer/uiEditor/bbmUiEditorRegistry.js`.
-  - Der Beispiel-Scope ist kein aktiver Registry-Inhalt mehr.
+- K19.9a BBM-Testeinbindung nach Neuinstallation der UI-Editor-Artefakte sauber repariert:
+  - Installierte Artefakt-Tests unter `uiEditor/tests/` bleiben generisch und werden nicht mehr direkt als BBM-Testmodul in `scripts/test.cjs` importiert.
+  - BBM prueft installierte UI-Editor-Artefakte ueber den eigenen Test `scripts/tests/bbmUiEditorInstalledArtifacts.test.cjs`.
+  - Die echte BBM-Registry bleibt separat unter `src/renderer/uiEditor/bbmUiEditorRegistry.js` abgesichert.
+  - Naechster offener Schritt: fachliche/technische Abnahme auf dem Branch mit den neu installierten UI-Editor-Artefakten.
+  - Risiken/Hinweise: `uiEditor/` selbst bleibt installierter Artefaktbereich und wurde nicht mit BBM-Fachlogik erweitert.
+
+- K19.7 installierte UI-Editor-Grundstruktur mit echter BBM-Registry verbunden (historischer Stand, durch K19.9a testseitig getrennt):
+  - `uiEditor/` war als installierter Einstieg mit Verweis auf den offiziellen BBM-Registry-Einstieg `src/renderer/uiEditor/bbmUiEditorRegistry.js` abgesichert.
+  - K19.9a trennt die installierten Artefakte und die echte BBM-Registry wieder sauber in zwei Testbereiche.
   - Kein Editor-Panel, kein Header-Button, keine produktive Aenderung, keine Speicherung und keine Fachlogik/Fachdaten.
 
 - K19.1 BBM zentrale UI-Editor-Registry eingefuehrt:

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -1,12 +1,13 @@
 # UI-Inspektor Aufgabenheft
 
 ## Projektstatus
-Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.7 abgeschlossen (installierte UI-Editor-Grundstruktur verweist auf die echte BBM-Registry).
+Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.9a abgeschlossen (BBM-Testeinbindung fuer installierte UI-Editor-Artefakte ist von generischen Artefakt-Tests getrennt).
 
 Aktueller Stand:
 - M1 bis M13.6a abgeschlossen.
 - K19.0 abgeschlossen: erste explizite UI-Elementliste fuer das Protokoll-Modul, ohne Editor-Integration und ohne produktive UI-Aenderung.
-- K19.7 abgeschlossen: installierter Einstieg unter `uiEditor/` ist mit dem offiziellen BBM-Registry-Einstieg verbunden, ohne produktive UI-Aenderung.
+- K19.7 abgeschlossen: installierter Einstieg unter `uiEditor/` war mit dem offiziellen BBM-Registry-Einstieg verbunden, ohne produktive UI-Aenderung.
+- K19.9a abgeschlossen: `uiEditor/` enthaelt installierte UI-Editor-Artefakte; die echte BBM-Registry bleibt separat unter `src/renderer/uiEditor/bbmUiEditorRegistry.js`; `scripts/test.cjs` ist nicht direkt an installierte Artefakt-Testdateien gekoppelt.
 
 ## Haken-System
 - `[x]` erledigt
@@ -42,13 +43,21 @@ Aktueller Stand:
 - [x] M13.6a UI-Editor-Panel aus Header lösen und verschiebbar halten
 - [x] K19.0 BBM liefert explizite Protokoll-UI-Elementliste ohne Scan/Integration
 - [x] K19.7 Installierte UI-Editor-Grundstruktur mit echter BBM-Registry verbinden
+- [x] K19.9a BBM-Testeinbindung nach Neuinstallation der UI-Editor-Artefakte trennen
+
+## Statusupdate K19.9a
+- `uiEditor/` enthaelt installierte UI-Editor-Artefakte.
+- Die BBM-Registry bleibt separat unter `src/renderer/uiEditor/bbmUiEditorRegistry.js`.
+- `scripts/test.cjs` ist nicht direkt an installierte Artefakt-Testdateien unter `uiEditor/tests/` gekoppelt.
+- BBM prueft installierte UI-Editor-Artefakte ueber `scripts/tests/bbmUiEditorInstalledArtifacts.test.cjs`.
+- Keine Editor-Integration, kein Panel, kein Hover-Rahmen, kein DOM-Scan, keine Speicherung und keine Fachlogik.
 
 ## Statusupdate K19.7
 - Der installierte Einstieg `uiEditor/uiEditorRegistry.js` verweist jetzt auf den offiziellen BBM-Registry-Einstieg `src/renderer/uiEditor/bbmUiEditorRegistry.js`.
 - `uiEditor/` bleibt als installierter Einstieg bestehen, erzeugt aber keine zweite aktive Beispiel-Registry.
 - Der Beispiel-Scope ist kein aktiver Registry-Inhalt mehr.
 - Keine Editor-Integration, kein Panel, kein Header-Button, kein DOM-Scan, keine Speicherung und keine produktive UI-Aenderung.
-- Abgesichert durch `uiEditor/tests/uiEditorRegistry.test.cjs`; der Test ist in `scripts/test.cjs` eingebunden.
+- Historische Absicherung: `uiEditor/tests/uiEditorRegistry.test.cjs`. Seit K19.9a ist `scripts/test.cjs` nicht mehr direkt an diese installierte Artefakt-Testdatei gekoppelt.
 
 ## Statusupdate K19.0
 - BBM liefert fuer das Protokoll-Modul erstmals eine feste, explizit klassifizierte UI-Elementliste als Code-Artefakt.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -19,7 +19,7 @@ const { runProtokollRouterFallbackTests } = require("./tests/protokollRouterFall
 const { runProtokollProjectEntryRoutingTests } = require("./tests/protokollProjectEntryRouting.test.cjs");
 const { runProtokollUiEditorElementsTests } = require("./tests/protokollUiEditorElements.test.cjs");
 const { runBbmUiEditorRegistryTests } = require("./tests/bbmUiEditorRegistry.test.cjs");
-const { runInstalledUiEditorRegistryTests } = require("../uiEditor/tests/uiEditorRegistry.test.cjs");
+const { runBbmUiEditorInstalledArtifactsTests } = require("./tests/bbmUiEditorInstalledArtifacts.test.cjs");
 const { runProjektverwaltungModuleTests } = require("./tests/projektverwaltungModule.test.cjs");
 const { runRestarbeitenModuleTests } = require("./tests/restarbeitenModule.test.cjs");
 const { runRestarbeitenDataModelTests } = require("./tests/restarbeitenDataModel.test.cjs");
@@ -141,7 +141,7 @@ async function main() {
   await runProtokollProjectEntryRoutingTests(run);
   await runProtokollUiEditorElementsTests(run);
   await runBbmUiEditorRegistryTests(run);
-  await runInstalledUiEditorRegistryTests(run);
+  await runBbmUiEditorInstalledArtifactsTests(run);
   await runProjektverwaltungModuleTests(run);
   await runRestarbeitenModuleTests(run);
   await runRestarbeitenDataModelTests(run);

--- a/scripts/tests/bbmUiEditorInstalledArtifacts.test.cjs
+++ b/scripts/tests/bbmUiEditorInstalledArtifacts.test.cjs
@@ -1,0 +1,157 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const UI_EDITOR_DIR = path.join(REPO_ROOT, "uiEditor");
+const INSTALLED_REGISTRY_PATH = path.join(UI_EDITOR_DIR, "uiEditorRegistry.js");
+const OFFICIAL_BBM_REGISTRY_PATH = path.join(
+  REPO_ROOT,
+  "src/renderer/uiEditor/bbmUiEditorRegistry.js"
+);
+
+const REQUIRED_INSTALLED_ARTIFACTS = [
+  "uiEditor/README.md",
+  "uiEditor/uiEditorRegistry.js",
+  "uiEditor/uiEditorRules.md",
+  "uiEditor/uiEditorLauncherButton.js",
+  "uiEditor/uiEditorLauncherButton.css",
+  "uiEditor/tests/uiEditorRegistry.test.cjs",
+];
+
+const LAUNCHER_ARTIFACTS = [
+  "uiEditor/uiEditorRegistry.js",
+  "uiEditor/uiEditorLauncherButton.js",
+  "uiEditor/uiEditorLauncherButton.css",
+];
+
+const FORBIDDEN_NEUTRALITY_SNIPPETS = [
+  "BBM",
+  "bbm",
+  "projectId",
+  "meetingId",
+  "topId",
+  "databaseId",
+  "personId",
+  "restarbeit",
+  "protokoll",
+  "querySelector",
+  "querySelectorAll",
+  "MutationObserver",
+  "detectElements",
+  "autoRegister",
+  "writeFile",
+  "localStorage",
+  "sessionStorage",
+  "indexedDB",
+  "better-sqlite3",
+  "ipcRenderer",
+  "ipcMain",
+];
+
+function resolveRepoPath(relativePath) {
+  return path.join(REPO_ROOT, relativePath);
+}
+
+function loadInstalledRegistry() {
+  delete require.cache[require.resolve(INSTALLED_REGISTRY_PATH)];
+  const installed = require(INSTALLED_REGISTRY_PATH);
+  assert.equal(Boolean(installed.uiEditorRegistry), true);
+  return installed.uiEditorRegistry;
+}
+
+function findLauncherScope(registry) {
+  assert.equal(Array.isArray(registry.uiScopes), true, "uiScopes must be an array");
+  return registry.uiScopes.find((scope) => scope.id === "uiEditor.global" || scope.uiScope === "uiEditor.global");
+}
+
+function getScopeElements(scope) {
+  const elements = scope?.elements;
+  if (Array.isArray(elements)) return elements;
+  if (elements && typeof elements === "object") return Object.values(elements);
+  return [];
+}
+
+async function loadBbmRegistry() {
+  const mod = await importEsmFromFile(OFFICIAL_BBM_REGISTRY_PATH);
+  assert.equal(typeof mod.getAvailableUiScopes, "function");
+  assert.equal(typeof mod.getBbmUiEditorRegistry, "function");
+  return mod;
+}
+
+async function runBbmUiEditorInstalledArtifactsTests(run) {
+  await run("BBM UI-Editor-Artefakte: installierte Dateien existieren", () => {
+    for (const relativePath of REQUIRED_INSTALLED_ARTIFACTS) {
+      assert.equal(fs.existsSync(resolveRepoPath(relativePath)), true, `missing artifact: ${relativePath}`);
+    }
+  });
+
+  await run("BBM UI-Editor-Artefakte: installierte Registry enthaelt globalen Launcher", () => {
+    const registry = loadInstalledRegistry();
+    const scope = findLauncherScope(registry);
+    assert.equal(Boolean(scope), true, "missing uiEditor.global scope");
+
+    const launcher = getScopeElements(scope).find(
+      (element) => element.id === "uiEditor.launcherButton" || element.elementId === "uiEditor.launcherButton"
+    );
+    assert.equal(Boolean(launcher), true, "missing uiEditor.launcherButton element");
+    assert.equal(launcher.type, "button");
+    assert.equal(launcher.role, "editor-launcher");
+    assert.equal(launcher.area, "overlay");
+    assert.equal(launcher.position?.x, 24);
+    assert.equal(launcher.position?.y, 24);
+    assert.equal(launcher.editable, true);
+
+    for (const op of ["move", "hide", "show"]) {
+      assert.equal(launcher.allowedOps?.includes(op), true, `missing allowed op: ${op}`);
+    }
+
+    for (const op of ["delete", "executeTargetAction", "modifyDomainData"]) {
+      assert.equal(launcher.lockedOps?.includes(op), true, `missing locked op: ${op}`);
+    }
+  });
+
+  await run("BBM UI-Editor-Artefakte: Launcher-Artefakte bleiben neutral", () => {
+    for (const relativePath of LAUNCHER_ARTIFACTS) {
+      const source = fs.readFileSync(resolveRepoPath(relativePath), "utf8");
+      for (const snippet of FORBIDDEN_NEUTRALITY_SNIPPETS) {
+        assert.equal(source.includes(snippet), false, `${relativePath} contains forbidden snippet: ${snippet}`);
+      }
+    }
+  });
+
+  await run("BBM UI-Editor-Artefakte: echte BBM-Registry bleibt separat erreichbar", async () => {
+    assert.equal(fs.existsSync(OFFICIAL_BBM_REGISTRY_PATH), true);
+    const registry = await loadBbmRegistry();
+    const scopes = registry.getAvailableUiScopes();
+    assert.equal(scopes.some((scope) => scope.uiScope === "protokoll.topsScreen"), true);
+
+    const result = registry.getBbmUiEditorRegistry("protokoll.topsScreen");
+    assert.equal(Array.isArray(result.elements), true);
+    assert.equal(result.elements.length > 0, true);
+    assert.equal(result.elements.some((element) => element.id === "protokoll.root"), true);
+  });
+}
+
+if (require.main === module) {
+  const run = async (name, fn) => {
+    try {
+      const out = fn();
+      if (out && typeof out.then === "function") {
+        await out;
+      }
+      console.log(`ok - ${name}`);
+    } catch (err) {
+      console.error(`not ok - ${name}`);
+      console.error(err?.stack || err?.message || err);
+      process.exitCode = 1;
+    }
+  };
+
+  runBbmUiEditorInstalledArtifactsTests(run).then(() => {
+    if (!process.exitCode) console.log("bbmUiEditorInstalledArtifacts.test.cjs passed");
+  });
+}
+
+module.exports = { runBbmUiEditorInstalledArtifactsTests };

--- a/uiEditor/tests/uiEditorRegistry.test.cjs
+++ b/uiEditor/tests/uiEditorRegistry.test.cjs
@@ -1,183 +1,42 @@
 #!/usr/bin/env node
 
 const assert = require("node:assert/strict");
-const fs = require("node:fs");
 const path = require("node:path");
-const { importEsmFromFile } = require("../../scripts/tests/_esmLoader.cjs");
 
-const REPO_ROOT = path.resolve(__dirname, "../..");
-const INSTALLED_REGISTRY_PATH = path.resolve(__dirname, "../uiEditorRegistry.js");
-const OFFICIAL_BBM_REGISTRY_RELATIVE_PATH = "src/renderer/uiEditor/bbmUiEditorRegistry.js";
-const OFFICIAL_BBM_REGISTRY_PATH = path.resolve(
-  REPO_ROOT,
-  OFFICIAL_BBM_REGISTRY_RELATIVE_PATH
-);
+const REGISTRY_PATH = path.resolve(__dirname, "../uiEditorRegistry.js");
 
-const FORBIDDEN_DATA_FIELDS = [
-  "projectId",
-  "project",
-  "meetingId",
-  "meeting",
-  "topId",
-  "top",
-  "databaseId",
-  "database",
-  "personId",
-  "person",
-  "date",
-  "deadline",
-  "value",
-  "text",
-  "content",
-];
+function runUiEditorRegistryArtifactTests() {
+  const { uiEditorRegistry } = require(REGISTRY_PATH);
+  assert.equal(Array.isArray(uiEditorRegistry.uiScopes), true);
 
-const FORBIDDEN_LOGIC_SNIPPETS = [
-  "document.",
-  "window.",
-  "querySelector",
-  "querySelectorAll",
-  "getElementById",
-  "getElementsBy",
-  "addEventListener",
-  "MutationObserver",
-  "localStorage",
-  "sessionStorage",
-  "indexedDB",
-  "fetch(",
-  "XMLHttpRequest",
-  "ipcRenderer",
-  "ipcMain",
-  "better-sqlite3",
-  "sqlite",
-  "db.",
-  "database.",
-  "execute(",
-  "eval(",
-  "new Function",
-  "writeFile",
-];
+  const globalScope = uiEditorRegistry.uiScopes.find((scope) => scope.uiScope === "uiEditor.global");
+  assert.equal(Boolean(globalScope), true, "missing uiEditor.global scope");
+  assert.equal(Array.isArray(globalScope.elements), true);
 
-function assertNoForbiddenFields(value, pathParts = []) {
-  if (Array.isArray(value)) {
-    value.forEach((entry, index) => assertNoForbiddenFields(entry, [...pathParts, String(index)]));
-    return;
+  const launcher = globalScope.elements.find((element) => element.id === "uiEditor.launcherButton");
+  assert.equal(Boolean(launcher), true, "missing uiEditor.launcherButton");
+  assert.equal(launcher.type, "button");
+  assert.equal(launcher.role, "editor-launcher");
+  assert.equal(launcher.area, "overlay");
+  assert.equal(launcher.position?.x, 24);
+  assert.equal(launcher.position?.y, 24);
+  assert.equal(launcher.editable, true);
+
+  for (const op of ["move", "hide", "show"]) {
+    assert.equal(launcher.allowedOps.includes(op), true, `missing allowed op: ${op}`);
   }
 
-  if (!value || typeof value !== "object") return;
-
-  for (const key of Object.keys(value)) {
-    assert.equal(
-      FORBIDDEN_DATA_FIELDS.includes(key),
-      false,
-      `forbidden data field ${key} at ${pathParts.concat(key).join(".")}`
-    );
-    assertNoForbiddenFields(value[key], [...pathParts, key]);
+  for (const op of ["delete", "executeTargetAction", "modifyDomainData"]) {
+    assert.equal(launcher.lockedOps.includes(op), true, `missing locked op: ${op}`);
   }
-}
-
-async function loadInstalledRegistry() {
-  const installed = require(INSTALLED_REGISTRY_PATH);
-  assert.equal(typeof installed.getInstalledUiEditorRegistryInfo, "function");
-  assert.equal(typeof installed.getOfficialBbmUiEditorRegistryPath, "function");
-  assert.equal(typeof installed.loadBbmUiEditorRegistry, "function");
-  assert.equal(Boolean(installed.uiEditorRegistry), true);
-  return installed;
-}
-
-async function loadOfficialBbmRegistry() {
-  return importEsmFromFile(OFFICIAL_BBM_REGISTRY_PATH);
-}
-
-async function runInstalledUiEditorRegistryTests(run) {
-  await run("Installierte UI-Editor-Registry: Einstieg existiert", () => {
-    assert.equal(fs.existsSync(INSTALLED_REGISTRY_PATH), true);
-  });
-
-  await run("Installierte UI-Editor-Registry: verweist auf den offiziellen BBM-Registry-Pfad", async () => {
-    const installed = await loadInstalledRegistry();
-    const info = installed.getInstalledUiEditorRegistryInfo();
-    assert.equal(info.officialBbmRegistryPath, OFFICIAL_BBM_REGISTRY_RELATIVE_PATH);
-    assert.equal(installed.BBM_UI_EDITOR_REGISTRY_RELATIVE_PATH, OFFICIAL_BBM_REGISTRY_RELATIVE_PATH);
-    assert.equal(installed.getOfficialBbmUiEditorRegistryPath(REPO_ROOT), OFFICIAL_BBM_REGISTRY_PATH);
-    assert.equal(fs.existsSync(installed.getOfficialBbmUiEditorRegistryPath(REPO_ROOT)), true);
-  });
-
-  await run("Installierte UI-Editor-Registry: erzeugt keine doppelte aktive Beispiel-Registry", async () => {
-    const installed = await loadInstalledRegistry();
-    const info = installed.getInstalledUiEditorRegistryInfo();
-    assert.equal(info.createsOwnRegistry, false);
-    assert.equal(info.activeExampleScope, false);
-    assert.equal(Array.isArray(installed.uiEditorRegistry.uiScopes), true);
-    assert.equal(
-      installed.uiEditorRegistry.uiScopes.some((scope) => scope.uiScopeId === "example-ui-scope"),
-      false
-    );
-  });
-
-  await run("Installierte UI-Editor-Registry: Quelltext nutzt keinen aktiven example-ui-scope", () => {
-    const source = fs.readFileSync(INSTALLED_REGISTRY_PATH, "utf8");
-    assert.equal(source.includes("example-ui-scope"), false);
-    assert.equal(source.includes(OFFICIAL_BBM_REGISTRY_RELATIVE_PATH), true);
-  });
-
-  await run("Installierte UI-Editor-Registry: echte BBM-Registry ist erreichbar", async () => {
-    const installed = await loadInstalledRegistry();
-    const registry = await installed.loadBbmUiEditorRegistry(importEsmFromFile, { repoRoot: REPO_ROOT });
-    assert.equal(typeof registry.getAvailableUiScopes, "function");
-    assert.equal(typeof registry.getBbmUiEditorRegistry, "function");
-  });
-
-  await run("BBM UI-Editor-Registry: getAvailableUiScopes enthaelt protokoll.topsScreen", async () => {
-    const registry = await loadOfficialBbmRegistry();
-    const scopes = registry.getAvailableUiScopes();
-    assert.equal(scopes.some((scope) => scope.uiScope === "protokoll.topsScreen"), true);
-  });
-
-  await run("BBM UI-Editor-Registry: getBbmUiEditorRegistry liefert Protokoll-Elemente", async () => {
-    const registry = await loadOfficialBbmRegistry();
-    const result = registry.getBbmUiEditorRegistry("protokoll.topsScreen");
-    assert.equal(Array.isArray(result.elements), true);
-    assert.equal(result.elements.length > 0, true);
-    assert.equal(result.elements.some((element) => element.id === "protokoll.root"), true);
-  });
-
-  await run("UI-Editor-Registry: enthaelt keine Fachdatenfelder", async () => {
-    const installed = await loadInstalledRegistry();
-    const registry = await loadOfficialBbmRegistry();
-    assertNoForbiddenFields(installed.getInstalledUiEditorRegistryInfo());
-    assertNoForbiddenFields(installed.uiEditorRegistry);
-    assertNoForbiddenFields(registry.getAvailableUiScopes());
-    assertNoForbiddenFields(registry.getBbmUiEditorRegistry("protokoll.topsScreen"));
-  });
-
-  await run("UI-Editor-Registry: enthaelt keine Datenbank-, Speicher-, Ausfuehrungs- oder DOM-Scanlogik", () => {
-    const installedSource = fs.readFileSync(INSTALLED_REGISTRY_PATH, "utf8");
-    const officialSource = fs.readFileSync(OFFICIAL_BBM_REGISTRY_PATH, "utf8");
-    for (const snippet of FORBIDDEN_LOGIC_SNIPPETS) {
-      assert.equal(installedSource.includes(snippet), false, `installed forbidden logic snippet: ${snippet}`);
-      assert.equal(officialSource.includes(snippet), false, `official forbidden logic snippet: ${snippet}`);
-    }
-  });
 }
 
 if (require.main === module) {
-  const run = async (name, fn) => {
-    try {
-      const out = fn();
-      if (out && typeof out.then === "function") {
-        await out;
-      }
-      console.log(`ok - ${name}`);
-    } catch (err) {
-      console.error(`not ok - ${name}`);
-      console.error(err?.stack || err?.message || err);
-      process.exitCode = 1;
-    }
-  };
-
-  runInstalledUiEditorRegistryTests(run).then(() => {
-    if (!process.exitCode) console.log("uiEditorRegistry.test.cjs passed");
-  });
+  try {
+    runUiEditorRegistryArtifactTests();
+    console.log("uiEditorRegistry.test.cjs passed");
+  } catch (err) {
+    console.error(err?.stack || err?.message || err);
+    process.exitCode = 1;
+  }
 }
-
-module.exports = { runInstalledUiEditorRegistryTests };

--- a/uiEditor/uiEditorLauncherButton.css
+++ b/uiEditor/uiEditorLauncherButton.css
@@ -1,0 +1,13 @@
+.ui-editor-launcher-button {
+  position: fixed;
+  inset-inline-start: 24px;
+  inset-block-start: 24px;
+  z-index: 1000;
+  min-inline-size: 44px;
+  min-block-size: 44px;
+  border: 1px solid #516070;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #1f2933;
+  font: inherit;
+}

--- a/uiEditor/uiEditorLauncherButton.js
+++ b/uiEditor/uiEditorLauncherButton.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const uiEditorLauncherButton = Object.freeze({
+  id: "uiEditor.launcherButton",
+  type: "button",
+  role: "editor-launcher",
+  area: "overlay",
+  position: Object.freeze({
+    x: 24,
+    y: 24,
+  }),
+  editable: true,
+  allowedOps: Object.freeze(["move", "hide", "show"]),
+  lockedOps: Object.freeze(["delete", "executeTargetAction", "modifyDomainData"]),
+});
+
+module.exports = {
+  uiEditorLauncherButton,
+};

--- a/uiEditor/uiEditorRegistry.js
+++ b/uiEditor/uiEditorRegistry.js
@@ -1,45 +1,32 @@
 "use strict";
 
-const path = require("node:path");
-
-const BBM_UI_EDITOR_REGISTRY_RELATIVE_PATH =
-  "src/renderer/uiEditor/bbmUiEditorRegistry.js";
-
-const INSTALLED_UI_EDITOR_REGISTRY_INFO = Object.freeze({
-  installedEntry: "uiEditor/uiEditorRegistry.js",
-  targetApp: "BBM-Produktiv",
-  registryMode: "target-app-registry-reference",
-  officialBbmRegistryPath: BBM_UI_EDITOR_REGISTRY_RELATIVE_PATH,
-  createsOwnRegistry: false,
-  activeExampleScope: false,
+const launcherButton = Object.freeze({
+  id: "uiEditor.launcherButton",
+  type: "button",
+  role: "editor-launcher",
+  area: "overlay",
+  position: Object.freeze({
+    x: 24,
+    y: 24,
+  }),
+  editable: true,
+  allowedOps: Object.freeze(["move", "hide", "show"]),
+  lockedOps: Object.freeze(["delete", "executeTargetAction", "modifyDomainData"]),
 });
 
-function getInstalledUiEditorRegistryInfo() {
-  return { ...INSTALLED_UI_EDITOR_REGISTRY_INFO };
-}
-
-function getOfficialBbmUiEditorRegistryPath(repoRoot = path.resolve(__dirname, "..")) {
-  return path.resolve(repoRoot, BBM_UI_EDITOR_REGISTRY_RELATIVE_PATH);
-}
-
-async function loadBbmUiEditorRegistry(importEsmFromFile, options = {}) {
-  if (typeof importEsmFromFile !== "function") {
-    throw new TypeError("loadBbmUiEditorRegistry needs an ESM file importer function");
-  }
-
-  const registryPath = getOfficialBbmUiEditorRegistryPath(options.repoRoot);
-  return importEsmFromFile(registryPath);
-}
+const globalScope = Object.freeze({
+  id: "uiEditor.global",
+  uiScope: "uiEditor.global",
+  label: "UI-Editor",
+  elements: Object.freeze([launcherButton]),
+});
 
 const uiEditorRegistry = Object.freeze({
-  ...INSTALLED_UI_EDITOR_REGISTRY_INFO,
-  uiScopes: Object.freeze([]),
+  registryId: "uiEditor.installedArtifacts",
+  registryVersion: "1.0.0",
+  uiScopes: Object.freeze([globalScope]),
 });
 
 module.exports = {
-  BBM_UI_EDITOR_REGISTRY_RELATIVE_PATH,
-  getInstalledUiEditorRegistryInfo,
-  getOfficialBbmUiEditorRegistryPath,
-  loadBbmUiEditorRegistry,
   uiEditorRegistry,
 };


### PR DESCRIPTION
### Motivation
- `npm test` schlug fehl mit `runInstalledUiEditorRegistryTests is not a function`, weil `uiEditor/tests/uiEditorRegistry.test.cjs` nach Neuinstallation ein generisches Artefakt ist und keine BBM-Testfunktion exportiert. 
- Ziel war, die installierten Artefakt-Tests generisch zu belassen und BBM-seitig eine eigene, stabile Prüfungsbrücke bereitzustellen.

### Description
- `scripts/test.cjs` wurde angepasst, so dass es nicht mehr die installierte Artefakt-Testdatei importiert, sondern den neuen BBM-Test `scripts/tests/bbmUiEditorInstalledArtifacts.test.cjs` aufruft.
- Neuer Test `scripts/tests/bbmUiEditorInstalledArtifacts.test.cjs` wurde hinzugefügt und prüft Anwesenheit der installierten Artefakte, die Launcher-Scope-/Elementstruktur, Neutralitäts-Guardrails (verbotene Snippets) und die separat erreichbare BBM-Registry (`protokoll.topsScreen` / `protokoll.root`).
- Die installierten Artefakte wurden als neutraler Launcher ergänzt: `uiEditor/uiEditorRegistry.js`, `uiEditor/uiEditorLauncherButton.js` und `uiEditor/uiEditorLauncherButton.css` (Artefakt-Registry + Launcher), und der Artefakt-Test `uiEditor/tests/uiEditorRegistry.test.cjs` wurde auf ein reines Artefakt-Checkskript reduziert.
- Dokumentation/Status wurde aktualisiert: `STATUS.md` und `docs/UI_INSPEKTOR_AUFGABENHEFT.md` um K19.9a ergänzt.

### Testing
- `node uiEditor/tests/uiEditorRegistry.test.cjs` ausgeführt und bestand erfolgreich.
- `node scripts/tests/bbmUiEditorInstalledArtifacts.test.cjs` ausgeführt und bestand erfolgreich.
- `npm run test:node` (Node-only testlauf: `node scripts/test.cjs`) ausgeführt und alle Node-Tests liefen grün in dieser Umgebung.
- `npm test` konnte in der CI-/lokalen Umgebung nicht vollständig ausgeführt werden, weil Electron die Systembibliothek `libatk-1.0.so.0` nicht laden konnte (Umgebungsgrenze), daher ist der volle `npm test`-Durchlauf an dieser Stelle nicht grün gelaufen; die relevanten Node-Tests für diese Änderung sind jedoch grün.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f1fcef700832298de5937d1958451)