### PR TITLE
K19.14: Installierten UI-Editor-Launcher zur Laufzeit sichtbar machen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2370,3 +2370,29 @@ Wichtig:
   - fachliche Abnahme des installierten UI-Editor-Artefaktvertrags im Ziel-Branch.
 - Risiken/Hinweise:
   - Das neue Pflichtartefakt bleibt neutral und enthaelt keine BBM-Fachlogik.
+
+### K19.14 – Installierten UI-Editor-Launcher zur Laufzeit sichtbar machen
+- Status: erledigt
+- Beschreibung:
+  - Der installierte UI-Editor-Launcher wird in BBM zur Laufzeit im DEV-Kontext sichtbar gemacht.
+  - Der Button stammt aus dem installierten Artefaktbestand unter `uiEditor/` (`uiEditorLauncherButton.js` und `uiEditorLauncherButton.css`).
+  - Der Klick toggelt nur einen neutralen Launcher-State (`uiEditorLauncherActive` / `data-ui-editor-launcher-active`).
+  - `activeUiScope` ist strukturell vorbereitet und bleibt in K19.14 neutral auf `null`.
+  - Kein Editor-Panel, kein Hover-Rahmen, keine Speicherung, keine Fachlogik, kein DOM-Scan und keine automatische UI-Erkennung.
+- Betroffene Dateien:
+  - `uiEditor/uiEditorLauncherButton.js`
+  - `src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js`
+  - `src/renderer/app/CoreShell.js`
+  - `src/renderer/ui/MainHeader.js`
+  - `scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`
+  - `scripts/tests/projektverwaltungModule.test.cjs`
+  - `scripts/test.cjs`
+  - `STATUS.md`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+- Commit:
+  - `aktueller Branch-HEAD / PR`
+- Naechster offener Schritt:
+  - Sichtpruefung im lokalen Electron-DEV-Kontext: Launcher sichtbar und Toggle-State am Button nachvollziehbar.
+- Risiken/Hinweise:
+  - Die produktive Scope-Auswertung, Editor-Panel, Hover-/Auswahlmodus und Speicherung bleiben ausdruecklich nicht umgesetzt.
+  - `npm test` ist in dieser Umgebung durch fehlendes Electron-Systempaket `libatk-1.0.so.0` blockiert; gezielte Launcher-/Artefaktpruefungen liefen gruen.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -388,3 +388,15 @@ Hinweis:
 - DEV-Header scannt den aktuellen Screen nur lesend.
 - Keine Auswahl, keine Bearbeitung, keine Speicherung.
 - Nächster Schritt: M13.4b UI-Editor-Scan weiter verfeinern, ohne Bearbeitung.
+
+## K19.14 Abschlussnotiz
+- Der installierte UI-Editor-Launcher wird in BBM im DEV-Kontext als eigenständiger Runtime-Launcher sichtbar.
+- Der Launcher lädt den Button aus `uiEditor/uiEditorLauncherButton.js` und die Styles aus `uiEditor/uiEditorLauncherButton.css`.
+- Der Klick toggelt nur den neutralen Launcher-State; `activeUiScope` bleibt als vorbereiteter Platzhalter `null`.
+- Der alte DEV-Header-Scan bleibt deaktiviert und ist nicht Grundlage des K19.14-Launchers.
+- Kein Editor-Panel, kein Hover-Rahmen, kein Editmodus, keine Speicherung, keine Fachlogik, kein DOM-Scan und keine automatische UI-Erkennung.
+- Tests:
+  - `node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`
+  - `npm test`
+- Nächster Schritt:
+  - Lokale Sichtprüfung im Electron-DEV-Kontext.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -20,6 +20,7 @@ const { runProtokollProjectEntryRoutingTests } = require("./tests/protokollProje
 const { runProtokollUiEditorElementsTests } = require("./tests/protokollUiEditorElements.test.cjs");
 const { runBbmUiEditorRegistryTests } = require("./tests/bbmUiEditorRegistry.test.cjs");
 const { runBbmUiEditorInstalledArtifactsTests } = require("./tests/bbmUiEditorInstalledArtifacts.test.cjs");
+const { runBbmUiEditorRuntimeLauncherTests } = require("./tests/bbmUiEditorRuntimeLauncher.test.cjs");
 const { runProjektverwaltungModuleTests } = require("./tests/projektverwaltungModule.test.cjs");
 const { runRestarbeitenModuleTests } = require("./tests/restarbeitenModule.test.cjs");
 const { runRestarbeitenDataModelTests } = require("./tests/restarbeitenDataModel.test.cjs");
@@ -142,6 +143,7 @@ async function main() {
   await runProtokollUiEditorElementsTests(run);
   await runBbmUiEditorRegistryTests(run);
   await runBbmUiEditorInstalledArtifactsTests(run);
+  await runBbmUiEditorRuntimeLauncherTests(run);
   await runProjektverwaltungModuleTests(run);
   await runRestarbeitenModuleTests(run);
   await runRestarbeitenDataModelTests(run);

--- a/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+++ b/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
@@ -1,0 +1,236 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const RUNTIME_PATH = path.join(__dirname, "../../src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js");
+const CORE_SHELL_PATH = path.join(__dirname, "../../src/renderer/app/CoreShell.js");
+const MAIN_HEADER_PATH = path.join(__dirname, "../../src/renderer/ui/MainHeader.js");
+
+function createFakeDocument() {
+  const createNode = (tag, doc) => {
+    const listeners = {};
+    const node = {
+      tagName: String(tag || "").toUpperCase(),
+      ownerDocument: doc,
+      children: [],
+      parentNode: null,
+      parentElement: null,
+      attributes: {},
+      dataset: {},
+      style: {},
+      className: "",
+      textContent: "",
+      disabled: false,
+      appendChild(child) {
+        if (child) {
+          child.parentNode = this;
+          child.parentElement = this;
+          this.children.push(child);
+        }
+        return child;
+      },
+      append(...children) {
+        children.forEach((child) => this.appendChild(child));
+      },
+      removeChild(child) {
+        this.children = this.children.filter((entry) => entry !== child);
+        if (child) {
+          child.parentNode = null;
+          child.parentElement = null;
+        }
+        return child;
+      },
+      remove() {
+        this.parentElement?.removeChild?.(this);
+      },
+      setAttribute(name, value) {
+        const normalizedName = String(name);
+        const normalizedValue = String(value);
+        this.attributes[normalizedName] = normalizedValue;
+        if (normalizedName.startsWith("data-")) {
+          const key = normalizedName
+            .slice(5)
+            .replace(/-([a-z])/g, (_match, char) => char.toUpperCase());
+          this.dataset[key] = normalizedValue;
+        }
+      },
+      getAttribute(name) {
+        return Object.hasOwn(this.attributes, String(name)) ? this.attributes[String(name)] : null;
+      },
+      addEventListener(type, handler) {
+        listeners[type] ||= [];
+        listeners[type].push(handler);
+      },
+      click() {
+        const event = {
+          type: "click",
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+          stopPropagation() {
+            this.stopped = true;
+          },
+        };
+        for (const handler of listeners.click || []) handler.call(this, event);
+      },
+      querySelector(selector) {
+        return findNode(this, (child) => matchesSelector(child, selector));
+      },
+      querySelectorAll(selector) {
+        const matches = [];
+        walk(this, (child) => {
+          if (matchesSelector(child, selector)) matches.push(child);
+        });
+        return matches;
+      },
+    };
+    return node;
+  };
+
+  const doc = {
+    createElement(tag) {
+      return createNode(tag, doc);
+    },
+    querySelector(selector) {
+      return this.documentElement.querySelector(selector);
+    },
+    querySelectorAll(selector) {
+      return this.documentElement.querySelectorAll(selector);
+    },
+  };
+  doc.documentElement = createNode("html", doc);
+  doc.head = createNode("head", doc);
+  doc.body = createNode("body", doc);
+  doc.documentElement.append(doc.head, doc.body);
+  return doc;
+}
+
+function walk(node, visit) {
+  for (const child of node?.children || []) {
+    visit(child);
+    walk(child, visit);
+  }
+}
+
+function findNode(node, predicate) {
+  let found = null;
+  walk(node, (child) => {
+    if (!found && predicate(child)) found = child;
+  });
+  return found;
+}
+
+function matchesSelector(node, selector) {
+  const raw = String(selector || "");
+  if (raw === "button") return node.tagName === "BUTTON";
+  if (raw.startsWith("link[")) {
+    return node.tagName === "LINK" && node.getAttribute("data-ui-editor-launcher-css") === "true";
+  }
+  if (raw === "[data-ui-editor-launcher-host=\"true\"]") {
+    return node.getAttribute("data-ui-editor-launcher-host") === "true";
+  }
+  if (raw === "[data-ui-inspector-panel=\"true\"]") {
+    return node.getAttribute("data-ui-inspector-panel") === "true";
+  }
+  return false;
+}
+
+async function loadRuntime() {
+  const mod = await importEsmFromFile(RUNTIME_PATH);
+  assert.equal(typeof mod.installBbmUiEditorRuntimeLauncher, "function");
+  return mod;
+}
+
+async function runBbmUiEditorRuntimeLauncherTests(run) {
+  await run("BBM UI-Editor-Runtime: bindet installierte Launcher-Artefakte ein", async () => {
+    const mod = await loadRuntime();
+    assert.equal(mod.INSTALLED_LAUNCHER_SCRIPT_PATH, "../../uiEditor/uiEditorLauncherButton.js");
+    assert.equal(mod.INSTALLED_LAUNCHER_CSS_PATH, "../../uiEditor/uiEditorLauncherButton.css");
+
+    const source = fs.readFileSync(RUNTIME_PATH, "utf8");
+    assert.equal(source.includes("uiEditor/uiEditorLauncherButton.js"), true);
+    assert.equal(source.includes("uiEditor/uiEditorLauncherButton.css"), true);
+    assert.equal(source.includes("scanUiInspectorTargets"), false);
+    assert.equal(source.includes("createUiInspectorPanel"), false);
+    assert.equal(source.includes("localStorage"), false);
+    assert.equal(source.includes("sessionStorage"), false);
+    assert.equal(source.includes("MutationObserver"), false);
+    assert.equal(source.includes("querySelectorAll"), false);
+  });
+
+  await run("BBM UI-Editor-Runtime: Launcher ist nur im DEV-Kontext sichtbar", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const win = {
+      uiEditorLauncherButtonArtifact: require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js")),
+    };
+
+    const hidden = await mod.installBbmUiEditorRuntimeLauncher({ devEnabled: false, doc, win });
+    assert.equal(hidden, null);
+    assert.equal(Boolean(doc.querySelector('[data-ui-editor-launcher-host="true"]')), false);
+
+    const button = await mod.installBbmUiEditorRuntimeLauncher({ devEnabled: true, doc, win, activeUiScope: null });
+    assert.equal(Boolean(button), true);
+    assert.equal(button.id, "uiEditor.launcherButton");
+    assert.equal(button.className, "ui-editor-launcher-button");
+    assert.equal(button.getAttribute("data-ui-editor-installed-artifact"), "uiEditor/uiEditorLauncherButton.js");
+    assert.equal(button.getAttribute("data-ui-editor-active-ui-scope"), "");
+    assert.equal(doc.querySelector('link[data-ui-editor-launcher-css="true"]').href, "../../uiEditor/uiEditorLauncherButton.css");
+  });
+
+  await run("BBM UI-Editor-Runtime: Klick toggelt nur neutralen Launcher-State", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const win = {
+      uiEditorLauncherButtonArtifact: require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js")),
+    };
+    const toggles = [];
+    const button = await mod.installBbmUiEditorRuntimeLauncher({
+      devEnabled: true,
+      doc,
+      win,
+      activeUiScope: null,
+      onToggle: (event) => toggles.push(event),
+    });
+
+    assert.equal(button.dataset.uiEditorLauncherActive, "false");
+    button.click();
+    assert.equal(button.dataset.uiEditorLauncherActive, "true");
+    assert.equal(button.getAttribute("data-ui-editor-launcher-active"), "true");
+    button.click();
+    assert.equal(button.dataset.uiEditorLauncherActive, "false");
+    assert.deepEqual(toggles.map((event) => event.uiEditorLauncherActive), [true, false]);
+    assert.deepEqual(toggles.map((event) => event.activeUiScope), [null, null]);
+    assert.equal(Boolean(doc.querySelector('[data-ui-inspector-panel="true"]')), false);
+  });
+
+  await run("BBM UI-Editor-Runtime: CoreShell nutzt Runtime-Launcher statt alter Scanstatus-Grundlage", () => {
+    const coreShellSource = fs.readFileSync(CORE_SHELL_PATH, "utf8");
+    const mainHeaderSource = fs.readFileSync(MAIN_HEADER_PATH, "utf8");
+    assert.equal(coreShellSource.includes("installBbmUiEditorRuntimeLauncher"), true);
+    assert.equal(coreShellSource.includes("activeUiScope: null"), true);
+    assert.equal(mainHeaderSource.includes("_isUiEditorRuntimeLauncherEnabled"), true);
+    assert.equal(mainHeaderSource.includes("_isUiEditorEnabled() {\n    return false;\n  }"), true);
+  });
+}
+
+if (require.main === module) {
+  const run = async (name, fn) => {
+    try {
+      const out = fn();
+      if (out && typeof out.then === "function") await out;
+      console.log(`ok - ${name}`);
+    } catch (err) {
+      console.error(`not ok - ${name}`);
+      console.error(err?.stack || err?.message || err);
+      process.exitCode = 1;
+    }
+  };
+
+  runBbmUiEditorRuntimeLauncherTests(run).then(() => {
+    if (!process.exitCode) console.log("bbmUiEditorRuntimeLauncher.test.cjs passed");
+  });
+}
+
+module.exports = { runBbmUiEditorRuntimeLauncherTests };

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -1058,7 +1058,7 @@ async function runProjektverwaltungModuleTests(run) {
     }
   });
 
-  await run("Projektverwaltung: MainHeader zeigt im DEV-Header den UI-Editor-Button und Scanstatus", async () => {
+  await run("Projektverwaltung: alter UI-Editor-Scan bleibt im DEV-Header deaktiviert", async () => {
     const previousDocument = global.document;
     const previousWindow = global.window;
     const fakeDocument = createFakeDocumentWithBubbling();
@@ -1083,64 +1083,15 @@ async function runProjektverwaltungModuleTests(run) {
       path.join(__dirname, "../../src/renderer/ui/MainHeader.js")
     );
 
-    const completeIds = [
-      "restarbeiten.root",
-      "restarbeiten.header",
-      "restarbeiten.main",
-      "restarbeiten.filterleiste",
-      "restarbeiten.filterleiste.klassenfilter",
-      "restarbeiten.filterleiste.verortung",
-      "restarbeiten.filterleiste.meta",
-      "restarbeiten.liste",
-      "restarbeiten.liste.nummernbereich",
-      "restarbeiten.liste.textbereich",
-      "restarbeiten.liste.metabereich",
-      "restarbeiten.editbox",
-      "restarbeiten.editbox.header",
-      "restarbeiten.editbox.verortung",
-      "restarbeiten.editbox.kurztext",
-      "restarbeiten.editbox.langtext",
-      "restarbeiten.editbox.meta",
-      "restarbeiten.filterleiste.klassenfilter.feld",
-      "restarbeiten.filterleiste.verortung.feld",
-      "restarbeiten.liste.kurztext",
-      "restarbeiten.liste.langtext",
-      "restarbeiten.filterleiste.meta.fertig_bis",
-      "restarbeiten.filterleiste.meta.status",
-      "restarbeiten.filterleiste.meta.verantwortlich",
-      "restarbeiten.filterleiste.meta.erledigt",
-      "restarbeiten.editbox.kurztext.label",
-      "restarbeiten.editbox.kurztext.restzeichen",
-      "restarbeiten.editbox.langtext.label",
-      "restarbeiten.editbox.langtext.restzeichen",
-    ];
-    const warningIds = completeIds.filter(
-      (id) =>
-        ![
-          "restarbeiten.filterleiste.verortung",
-        ].includes(id)
-    );
-
-    const mkRoot = (ids) => ({
-      querySelectorAll(selector) {
-        if (selector !== "[data-ui-inspector-id]") return [];
-        return ids.map((id) => ({
-          getAttribute(name) {
-            return name === "data-ui-inspector-id" ? id : null;
-          },
-          style: { cssText: "" },
-          getBoundingClientRect() {
-            return { left: 0, top: 0, width: 10, height: 10 };
-          },
-        }));
-      },
-    });
-
     try {
       const router = {
         currentProjectId: "17",
         currentMeetingId: null,
-        contentRoot: mkRoot(completeIds),
+        contentRoot: {
+          querySelectorAll() {
+            throw new Error("alter UI-Editor-Scan darf nicht laufen");
+          },
+        },
         activeSection: "projectWorkspace",
         context: {
           ui: { pageTitle: "", activeModuleLabel: "Protokoll", isTopsView: false },
@@ -1156,66 +1107,14 @@ async function runProjektverwaltungModuleTests(run) {
       const header = new MainHeader({ router, version: "1.5.0" });
       header.render();
       header.refresh();
-      const headerChildCountBefore = header.root.children.length;
 
       const editorButton = findNode(header.root, (node) => node?.tagName === "BUTTON" && node?.textContent === "Editor");
       assert.ok(editorButton);
       assert.equal(editorButton.dataset.uiEditorState, "off");
-      assert.equal(editorButton.disabled, false);
-
-      assert.equal(header.toggleUiEditorScan(), true);
-      assert.equal(editorButton.dataset.uiEditorState, "scan-ok");
-      assert.equal(editorButton.dataset.uiEditorSeverity, "ok");
-      assert.match(editorButton.title, /vollständig/);
-      const panelRoot = header.elUiEditorPanel?.getPanelRoot?.();
-      assert.ok(panelRoot);
-      assert.equal(panelRoot.parentElement || panelRoot.parentNode, fakeDocument.body);
-      assert.equal(panelRoot.style.position, "fixed");
-      assert.equal(
-        panelRoot.getAttribute?.("data-ui-editor-mode") || panelRoot["data-ui-editor-mode"],
-        "frame"
-      );
-      const panelText = collectText(panelRoot);
-      assert.match(panelText, /UI-Editor Scan/);
-      assert.match(panelText, /Status: vollständig/);
-      assert.match(panelText, /Marker: \d+/);
-      assert.match(panelText, /Rahmen: \d+/);
-      assert.match(panelText, /Felder: \d+/);
-      assert.match(panelText, /Einzelelemente: \d+/);
-      assert.equal(Boolean(findNode(panelRoot, (node) => node?.tagName === "BUTTON" && node?.textContent === "Rahmen")), true);
-      assert.equal(Boolean(findNode(panelRoot, (node) => node?.tagName === "BUTTON" && node?.textContent === "Feld")), true);
-      assert.equal(Boolean(findNode(panelRoot, (node) => node?.tagName === "BUTTON" && node?.textContent === "Einzelelement")), true);
-
-      const fieldButton = findNode(panelRoot, (node) => node?.tagName === "BUTTON" && node?.textContent === "Feld");
-      fieldButton.click();
-      const updatedPanelRoot = header.elUiEditorPanel?.getPanelRoot?.();
-      assert.equal(
-        updatedPanelRoot.getAttribute?.("data-ui-editor-mode") || updatedPanelRoot["data-ui-editor-mode"],
-        "field"
-      );
-      assert.equal(editorButton.dataset.uiEditorState, "scan-ok");
-      assert.equal(header.elUiEditorStatus.style.display, "none");
-      assert.equal(header.root.children.length, headerChildCountBefore);
-      assert.equal(Boolean(findNode(header.root, (node) => node?.attributes?.["data-ui-inspector-panel"] === "true")), false);
-
-      router.contentRoot = mkRoot(warningIds);
-      header.refresh();
-      assert.equal(editorButton.dataset.uiEditorState, "scan-warning");
-      assert.equal(header.elUiEditorStatus.style.display, "none");
-      const warningPanelText = collectText(header.elUiEditorPanel?.getPanelRoot?.());
-      assert.match(warningPanelText, /Status: unvollständig/);
-      assert.match(warningPanelText, /Fehlt Pflicht:/);
-      assert.match(warningPanelText, /restarbeiten\.filterleiste\.verortung/);
-      assert.equal(
-        header.elUiEditorPanel?.getPanelRoot?.().getAttribute?.("data-ui-editor-mode") ||
-          header.elUiEditorPanel?.getPanelRoot?.()["data-ui-editor-mode"],
-        "field"
-      );
-
+      assert.equal(editorButton.disabled, true);
+      assert.equal(header.elUiEditorWrap.style.display, "none");
       assert.equal(header.toggleUiEditorScan(), false);
-      assert.equal(editorButton.dataset.uiEditorState, "off");
-      assert.equal(header.elUiEditorStatus.style.display, "none");
-      assert.equal(String(header.elUiEditorStatus?.textContent || ""), "");
+      assert.equal(header.elUiEditorPanel, null);
       assert.equal(Boolean(findNode(fakeDocument.body, (node) => node?.attributes?.["data-ui-inspector-panel"] === "true")), false);
     } finally {
       global.document = previousDocument;

--- a/src/renderer/app/CoreShell.js
+++ b/src/renderer/app/CoreShell.js
@@ -20,6 +20,7 @@ import { registerCoreShellHeaderBridge } from "./coreShellHeaderBridge.js";
 import { registerCoreShellContextControls } from "./coreShellContextControls.js";
 import { registerCoreShellKeyboardHandling } from "./coreShellKeyboard.js";
 import { createCoreShellNavigationRuntime } from "./coreShellNavigationRuntime.js";
+import { installBbmUiEditorRuntimeLauncher } from "../uiEditor/BbmUiEditorRuntimeLauncher.js";
 
 export default class CoreShell {
   constructor({ router, version } = {}) {
@@ -100,6 +101,11 @@ export default class CoreShell {
 
     router.showHome();
     header.refresh();
+    installBbmUiEditorRuntimeLauncher({
+      header,
+      devEnabled: header._isUiEditorRuntimeLauncherEnabled?.() === true,
+      activeUiScope: null,
+    });
     if (typeof updateContextButtons === "function") {
       updateContextButtons();
     }

--- a/src/renderer/ui/MainHeader.js
+++ b/src/renderer/ui/MainHeader.js
@@ -1705,6 +1705,10 @@ export default class MainHeader {
   }
 
   _isUiEditorEnabled() {
+    return false;
+  }
+
+  _isUiEditorRuntimeLauncherEnabled() {
     return this._isNewUi;
   }
 

--- a/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
+++ b/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
@@ -1,0 +1,152 @@
+const INSTALLED_LAUNCHER_SCRIPT_PATH = "../../uiEditor/uiEditorLauncherButton.js";
+const INSTALLED_LAUNCHER_CSS_PATH = "../../uiEditor/uiEditorLauncherButton.css";
+const LAUNCHER_HOST_ATTRIBUTE = "data-ui-editor-launcher-host";
+const LAUNCHER_CSS_ATTRIBUTE = "data-ui-editor-launcher-css";
+
+function getDocument(explicitDocument = null) {
+  return explicitDocument || (typeof document === "object" ? document : null);
+}
+
+function getWindow(explicitWindow = null) {
+  return explicitWindow || (typeof window === "object" ? window : null);
+}
+
+function getInstalledLauncherArtifact(explicitWindow = null) {
+  const win = getWindow(explicitWindow);
+  return win?.uiEditorLauncherButtonArtifact?.uiEditorLauncherButton || null;
+}
+
+function getLauncherHost(doc, host = null) {
+  if (host) return host;
+  return doc?.body || null;
+}
+
+function createLauncherState({ activeUiScope = null } = {}) {
+  return {
+    uiEditorLauncherActive: false,
+    activeUiScope,
+  };
+}
+
+function ensureInstalledLauncherCss(doc = getDocument()) {
+  if (!doc?.createElement) return null;
+  const existing = doc.querySelector?.(`link[${LAUNCHER_CSS_ATTRIBUTE}="true"]`);
+  if (existing) return existing;
+
+  const link = doc.createElement("link");
+  link.rel = "stylesheet";
+  link.href = INSTALLED_LAUNCHER_CSS_PATH;
+  link.setAttribute(LAUNCHER_CSS_ATTRIBUTE, "true");
+  link.setAttribute("data-ui-editor-installed-css", INSTALLED_LAUNCHER_CSS_PATH);
+  const target = doc.head || doc.body || doc.documentElement;
+  target?.appendChild?.(link);
+  return link;
+}
+
+function loadInstalledLauncherButton({ doc = getDocument(), win = getWindow() } = {}) {
+  const existing = getInstalledLauncherArtifact(win);
+  if (existing) return Promise.resolve(existing);
+  if (!doc?.createElement) return Promise.resolve(null);
+
+  return new Promise((resolve) => {
+    const script = doc.createElement("script");
+    script.src = INSTALLED_LAUNCHER_SCRIPT_PATH;
+    script.async = true;
+    script.setAttribute("data-ui-editor-installed-script", INSTALLED_LAUNCHER_SCRIPT_PATH);
+    script.onload = () => resolve(getInstalledLauncherArtifact(win));
+    script.onerror = () => resolve(null);
+    const target = doc.body || doc.head || doc.documentElement;
+    target?.appendChild?.(script);
+  });
+}
+
+function removeExistingLauncher(doc = getDocument()) {
+  const existing = doc?.querySelector?.(`[${LAUNCHER_HOST_ATTRIBUTE}="true"]`);
+  if (existing?.parentElement?.removeChild) {
+    existing.parentElement.removeChild(existing);
+  } else if (existing?.remove) {
+    existing.remove();
+  }
+}
+
+function syncLauncherButtonState(button, state) {
+  const active = !!state?.uiEditorLauncherActive;
+  button.dataset.uiEditorLauncherActive = active ? "true" : "false";
+  button.setAttribute("data-ui-editor-launcher-active", active ? "true" : "false");
+  button.setAttribute("aria-pressed", active ? "true" : "false");
+}
+
+function renderLauncherButton({ artifact, doc, host, state, onToggle = null }) {
+  if (!artifact?.id || !doc?.createElement || !host?.appendChild) return null;
+
+  removeExistingLauncher(doc);
+
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.id = artifact.id;
+  button.className = "ui-editor-launcher-button";
+  button.textContent = "UI";
+  button.title = "UI-Editor Launcher";
+  button.setAttribute(LAUNCHER_HOST_ATTRIBUTE, "true");
+  button.setAttribute("data-ui-editor-installed-artifact", "uiEditor/uiEditorLauncherButton.js");
+  button.setAttribute("data-ui-editor-launcher-id", artifact.id);
+  button.setAttribute("data-ui-editor-launcher-role", artifact.role || "editor-launcher");
+  button.setAttribute("data-ui-editor-active-ui-scope", state.activeUiScope == null ? "" : String(state.activeUiScope));
+  button.setAttribute("aria-label", "UI-Editor Launcher");
+  syncLauncherButtonState(button, state);
+
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    state.uiEditorLauncherActive = !state.uiEditorLauncherActive;
+    syncLauncherButtonState(button, state);
+    if (typeof onToggle === "function") {
+      onToggle({
+        uiEditorLauncherActive: state.uiEditorLauncherActive,
+        activeUiScope: state.activeUiScope,
+        launcherId: artifact.id,
+      });
+    }
+  });
+
+  host.appendChild(button);
+  return button;
+}
+
+function isRuntimeLauncherDevEnabled({ header = null, devEnabled = null } = {}) {
+  if (typeof devEnabled === "boolean") return devEnabled;
+  if (typeof header?._isUiEditorEnabled === "function") return header._isUiEditorEnabled() === true;
+  return false;
+}
+
+export async function installBbmUiEditorRuntimeLauncher({
+  header = null,
+  devEnabled = null,
+  activeUiScope = null,
+  doc = getDocument(),
+  win = getWindow(),
+  host = null,
+  onToggle = null,
+} = {}) {
+  if (!isRuntimeLauncherDevEnabled({ header, devEnabled })) {
+    removeExistingLauncher(doc);
+    return null;
+  }
+
+  ensureInstalledLauncherCss(doc);
+  const artifact = await loadInstalledLauncherButton({ doc, win });
+  const launcherHost = getLauncherHost(doc, host);
+  const state = createLauncherState({ activeUiScope });
+  return renderLauncherButton({ artifact, doc, host: launcherHost, state, onToggle });
+}
+
+export {
+  INSTALLED_LAUNCHER_SCRIPT_PATH,
+  INSTALLED_LAUNCHER_CSS_PATH,
+  createLauncherState,
+  ensureInstalledLauncherCss,
+  getInstalledLauncherArtifact,
+  isRuntimeLauncherDevEnabled,
+  loadInstalledLauncherButton,
+  renderLauncherButton,
+};

--- a/uiEditor/uiEditorLauncherButton.js
+++ b/uiEditor/uiEditorLauncherButton.js
@@ -1,19 +1,29 @@
 "use strict";
 
-const uiEditorLauncherButton = Object.freeze({
-  id: "uiEditor.launcherButton",
-  type: "button",
-  role: "editor-launcher",
-  area: "overlay",
-  position: Object.freeze({
-    x: 24,
-    y: 24,
-  }),
-  editable: true,
-  allowedOps: Object.freeze(["move", "hide", "show"]),
-  lockedOps: Object.freeze(["delete", "executeTargetAction", "modifyDomainData"]),
-});
+(function registerUiEditorLauncherButton(root, factory) {
+  const artifact = factory();
+  if (typeof module === "object" && module && typeof module.exports === "object") {
+    module.exports = artifact;
+  }
+  if (root && typeof root === "object") {
+    root.uiEditorLauncherButtonArtifact = artifact;
+  }
+})(typeof globalThis === "object" ? globalThis : undefined, function createUiEditorLauncherButtonArtifact() {
+  const uiEditorLauncherButton = Object.freeze({
+    id: "uiEditor.launcherButton",
+    type: "button",
+    role: "editor-launcher",
+    area: "overlay",
+    position: Object.freeze({
+      x: 24,
+      y: 24,
+    }),
+    editable: true,
+    allowedOps: Object.freeze(["move", "hide", "show"]),
+    lockedOps: Object.freeze(["delete", "executeTargetAction", "modifyDomainData"]),
+  });
 
-module.exports = {
-  uiEditorLauncherButton,
-};
+  return {
+    uiEditorLauncherButton,
+  };
+});


### PR DESCRIPTION
### Motivation
- BBM soll den bereits installierten UI-Editor-Launcher aus dem `uiEditor/` Artefaktbestand zur Laufzeit im DEV-Kontext anzeigen, ohne eine BBM-eigene Button-Implementierung oder alte Scanstatus-Logik zu verwenden. 
- Der Launcher darf keine fachliche Logik, kein DOM-Scan und kein Editor-Panel starten, sondern nur einen neutralen, testbaren Toggle-State bereitstellen. 

### Description
- Neues Runtime-Modul `src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js` hinzugefügt, das das installierte Launcher-Skript und die CSS-Datei lädt, den Button rendert und nur einen neutralen `uiEditorLauncherActive`-State toggelt. 
- Installiertes Artefakt `uiEditor/uiEditorLauncherButton.js` browser-loadable gemacht (erhält weiterhin CommonJS-Export und setzt zusätzlich `globalThis.uiEditorLauncherButtonArtifact`) damit das Runtime-Modul das vorhandene Button-Artefakt wiederverwenden kann. 
- Shell-Startpunkt eingebunden: `src/renderer/app/CoreShell.js` ruft `installBbmUiEditorRuntimeLauncher` nach `header.refresh()` auf und übergibt konservativ `activeUiScope: null`. 
- Alte Header-Scan-Einstiege deaktiviert/entkoppelt: `src/renderer/ui/MainHeader.js` passt die DEV-Flags an, so dass der neue Runtime-Launcher nicht auf der alten Scanstatus-Logik beruht. 
- Tests und Test-Registrierung ergänzt: `scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs` hinzugefügt und das Test-Suite-Register `scripts/test.cjs` aktualisiert; `STATUS.md` und `docs/UI_INSPEKTOR_AUFGABENHEFT.md` mit K19.14-Notiz aktualisiert. 

### Testing
- `node uiEditor/tests/uiEditorRegistry.test.cjs` ausgeführt und bestanden. 
- `node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs` ausgeführt und bestanden (Prüfungen: Pfade zu installierten Artefakten, DEV-Only Sichtbarkeit, CSS-Einbindung, Button-ID und neutraler Toggle-Verhalten, kein Panel/Scan). 
- `node scripts/tests/bbmUiEditorInstalledArtifacts.test.cjs` ausgeführt und bestanden (installierte Artefakte vorhanden und neutral). 
- `npm test` / vollständige CI-Run (`node scripts/runElectronNodeTest.cjs`) ist in dieser Umgebung am Electron-Systempaket `libatk-1.0.so.0` gescheitert; gezielte Launcher- und Artefakttests liefen jedoch grün.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a202154e77083229369d5e663365fb7)