### PR TITLE
K19.14 / K19.14a: Add runtime UI-Editor launcher and remove old EditorLab header button

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2370,3 +2370,51 @@ Wichtig:
   - fachliche Abnahme des installierten UI-Editor-Artefaktvertrags im Ziel-Branch.
 - Risiken/Hinweise:
   - Das neue Pflichtartefakt bleibt neutral und enthaelt keine BBM-Fachlogik.
+
+### K19.14 – Installierten UI-Editor-Launcher zur Laufzeit sichtbar machen
+- Status: erledigt
+- Beschreibung:
+  - Der installierte UI-Editor-Launcher wird in BBM zur Laufzeit im DEV-Kontext sichtbar gemacht.
+  - Der Button stammt aus dem installierten Artefaktbestand unter `uiEditor/` (`uiEditorLauncherButton.js` und `uiEditorLauncherButton.css`).
+  - Der Klick toggelt nur einen neutralen Launcher-State (`uiEditorLauncherActive` / `data-ui-editor-launcher-active`).
+  - `activeUiScope` ist strukturell vorbereitet und bleibt in K19.14 neutral auf `null`.
+  - Kein Editor-Panel, kein Hover-Rahmen, keine Speicherung, keine Fachlogik, kein DOM-Scan und keine automatische UI-Erkennung.
+- Betroffene Dateien:
+  - `uiEditor/uiEditorLauncherButton.js`
+  - `src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js`
+  - `src/renderer/app/CoreShell.js`
+  - `src/renderer/ui/MainHeader.js`
+  - `scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`
+  - `scripts/tests/projektverwaltungModule.test.cjs`
+  - `scripts/test.cjs`
+  - `STATUS.md`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+- Commit:
+  - `aktueller Branch-HEAD / PR`
+- Naechster offener Schritt:
+  - Sichtpruefung im lokalen Electron-DEV-Kontext: Launcher sichtbar und Toggle-State am Button nachvollziehbar.
+- Risiken/Hinweise:
+  - Die produktive Scope-Auswertung, Editor-Panel, Hover-/Auswahlmodus und Speicherung bleiben ausdruecklich nicht umgesetzt.
+  - `npm test` ist in dieser Umgebung durch fehlendes Electron-Systempaket `libatk-1.0.so.0` blockiert; gezielte Launcher-/Artefaktpruefungen liefen gruen.
+
+### K19.14a – Alten EditorLab-DEV-Headerbutton entfernen
+- Status: erledigt
+- Beschreibung:
+  - Der alte sichtbare EditorLab-/Scanstatus-/UI-Editor-Headerbutton wird nicht mehr in den Header eingehängt.
+  - Der sichtbare UI-Editor-Launcher ist eindeutig der installierte Runtime-Launcher aus `uiEditor/`.
+  - Der echte Launcher behält `id="uiEditor.launcherButton"`, setzt `data-ui-editor-installed-artifact="uiEditor/uiEditorLauncherButton.js"` und ist sichtbar als `UI-Editor` beschriftet.
+  - Klick toggelt nur den neutralen Launcher-State; kein Editor-Panel, kein Hover-Rahmen, kein Editmodus, keine Speicherung, keine Fachlogik, kein DOM-Scan und keine automatische UI-Erkennung.
+- Betroffene Dateien:
+  - `src/renderer/ui/MainHeader.js`
+  - `src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js`
+  - `scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`
+  - `scripts/tests/projektverwaltungModule.test.cjs`
+  - `scripts/tests/editorLabV2Access.test.cjs`
+  - `STATUS.md`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+- Commit:
+  - `aktueller Branch-HEAD / PR`
+- Naechster offener Schritt:
+  - Lokale Sichtpruefung im Electron-DEV-Kontext: `EditorLab V2` ist nicht sichtbar, `UI-Editor`-Launcher ist sichtbar und toggelt neutral.
+- Risiken/Hinweise:
+  - Produktive Scope-Auswertung, Panel, Hover-/Auswahlmodus, Speicherung und automatische Registry-Befuellung bleiben ausdruecklich nicht umgesetzt.

--- a/STATUS.md
+++ b/STATUS.md
@@ -2460,3 +2460,25 @@ Wichtig:
   - Lokale Electron-Sichtpruefung: Restarbeiten V2 sichtbar, EditorLab V2 nicht sichtbar, UI-Editor sichtbar und Toggle-State nachvollziehbar.
 - Risiken/Hinweise:
   - `npm test` ist in dieser Umgebung weiterhin durch fehlendes Electron-Systempaket `libatk-1.0.so.0` blockiert; gezielte Header-/Launcher-Pruefungen liefen gruen.
+
+### K19.14b – Globalen DEV-Header bereinigt
+- Status: erledigt
+- Beschreibung:
+  - Der globale Header rendert keinen Restarbeiten-V2-DEV-Shortcut mehr.
+  - Restarbeiten V2 als Modul/Route bleibt unberuehrt und weiterhin separat testbar.
+  - EditorLab V2, alter Scanstatus und UI-Inspector-Altbuttons bleiben nicht sichtbar.
+  - Der einzige sichtbare UI-Werkzeug-Launcher ist der installierte UI-Editor-Launcher aus `uiEditor/`.
+  - Kein Editor-Panel, kein Hover-Rahmen, kein Editmodus, keine Speicherung, kein DOM-Scan und keine automatische UI-Erkennung.
+- Betroffene Dateien:
+  - `src/renderer/ui/MainHeader.js`
+  - `scripts/tests/projektverwaltungModule.test.cjs`
+  - `scripts/tests/restarbeitenV2DevAccess.test.cjs`
+  - `STATUS.md`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+- Commit:
+  - `aktueller Branch-HEAD / PR`
+- Naechster offener Schritt:
+  - Lokale Electron-Sichtpruefung: UI-Editor sichtbar, EditorLab V2 nicht sichtbar, Restarbeiten V2 nicht sichtbar, kein weißer Bildschirm.
+- Risiken/Hinweise:
+  - Restarbeiten-Moduldateien und Restarbeiten-Fachlogik wurden nicht geaendert.
+  - `npm test` ist in dieser Umgebung weiterhin durch fehlendes Electron-Systempaket `libatk-1.0.so.0` blockiert.

--- a/STATUS.md
+++ b/STATUS.md
@@ -2418,3 +2418,23 @@ Wichtig:
   - Lokale Sichtpruefung im Electron-DEV-Kontext: `EditorLab V2` ist nicht sichtbar, `UI-Editor`-Launcher ist sichtbar und toggelt neutral.
 - Risiken/Hinweise:
   - Produktive Scope-Auswertung, Panel, Hover-/Auswahlmodus, Speicherung und automatische Registry-Befuellung bleiben ausdruecklich nicht umgesetzt.
+
+### K19.14a-Fix – MainHeader-Restarbeiten-V2-State repariert
+- Status: erledigt
+- Beschreibung:
+  - Der weiße Bildschirm durch den fehlenden MainHeader-Methodenpfad wurde behoben.
+  - `_applyRestarbeitenV2ButtonState()` ist wieder vorhanden und steuert nur den fachlich richtigen Restarbeiten-V2-Headerbutton.
+  - Restarbeiten V2 bleibt im DEV-/New-UI-Kontext sichtbar und klickbar.
+  - Alter EditorLab-/Scanstatus-/UI-Inspector-Headerbutton bleibt entfernt.
+  - Der installierte UI-Editor-Launcher aus `uiEditor/` bleibt unverändert der sichtbare `UI-Editor`-Launcher; kein Panel, kein DOM-Scan, keine Speicherung.
+- Betroffene Dateien:
+  - `src/renderer/ui/MainHeader.js`
+  - `scripts/tests/projektverwaltungModule.test.cjs`
+  - `STATUS.md`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+- Commit:
+  - `aktueller Branch-HEAD / PR`
+- Naechster offener Schritt:
+  - Lokale Electron-Sichtpruefung: App startet ohne weißen Bildschirm, Restarbeiten V2 ist sichtbar/funktionsfähig, EditorLab V2 bleibt unsichtbar.
+- Risiken/Hinweise:
+  - `npm test` ist in dieser Umgebung weiterhin durch fehlendes Electron-Systempaket `libatk-1.0.so.0` blockiert; gezielte Header-/Launcher-Pruefungen liefen gruen.

--- a/STATUS.md
+++ b/STATUS.md
@@ -2438,3 +2438,25 @@ Wichtig:
   - Lokale Electron-Sichtpruefung: App startet ohne weißen Bildschirm, Restarbeiten V2 ist sichtbar/funktionsfähig, EditorLab V2 bleibt unsichtbar.
 - Risiken/Hinweise:
   - `npm test` ist in dieser Umgebung weiterhin durch fehlendes Electron-Systempaket `libatk-1.0.so.0` blockiert; gezielte Header-/Launcher-Pruefungen liefen gruen.
+
+### K19.14a-Fix 2 – UI-Editor-Launcher sichtbar gemacht
+- Status: erledigt
+- Beschreibung:
+  - Der installierte UI-Editor-Launcher wird vor dem Renderer-Start als installiertes Artefakt in `index.html` geladen, damit der Runtime-Mount ihn sofort finden kann.
+  - Das installierte Launcher-CSS hebt den Button über den Header, sodass `UI-Editor` sichtbar ist.
+  - Restarbeiten V2 bleibt sichtbar und klickbar; der Test wartet den Klick nun korrekt ab.
+  - EditorLab V2 und alter Scanstatus-/UI-Inspector-Headerbutton bleiben nicht sichtbar.
+  - Der Launcher behält `id="uiEditor.launcherButton"`, `data-ui-editor-installed-artifact="uiEditor/uiEditorLauncherButton.js"` und toggelt nur neutralen State.
+- Betroffene Dateien:
+  - `src/renderer/index.html`
+  - `uiEditor/uiEditorLauncherButton.css`
+  - `scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`
+  - `scripts/tests/projektverwaltungModule.test.cjs`
+  - `STATUS.md`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+- Commit:
+  - `aktueller Branch-HEAD / PR`
+- Naechster offener Schritt:
+  - Lokale Electron-Sichtpruefung: Restarbeiten V2 sichtbar, EditorLab V2 nicht sichtbar, UI-Editor sichtbar und Toggle-State nachvollziehbar.
+- Risiken/Hinweise:
+  - `npm test` ist in dieser Umgebung weiterhin durch fehlendes Electron-Systempaket `libatk-1.0.so.0` blockiert; gezielte Header-/Launcher-Pruefungen liefen gruen.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -407,3 +407,10 @@ Hinweis:
 - Die sichtbare Beschriftung lautet `UI-Editor`; `EditorLab V2` wird nicht mehr als Headerbutton gerendert.
 - Der Klick toggelt nur neutralen Launcher-State.
 - Kein Editor-Panel, kein Hover-Rahmen, kein Editmodus, keine Speicherung, keine Fachlogik, kein DOM-Scan und keine automatische UI-Erkennung.
+
+## K19.14a-Fix Abschlussnotiz
+- Der MainHeader-Fehler durch fehlende `_applyRestarbeitenV2ButtonState()` ist behoben.
+- Restarbeiten V2 bleibt als fachlich richtiger DEV-/New-UI-Headerbutton sichtbar und klickbar.
+- EditorLab V2, alter Scanstatus und UI-Inspector-Headerbutton bleiben nicht sichtbar.
+- Der installierte UI-Editor-Launcher aus `uiEditor/` bleibt der einzige sichtbare UI-Editor-Launcher und toggelt nur neutralen State.
+- Kein Editor-Panel, kein Hover-Rahmen, kein Editmodus, keine Speicherung, kein DOM-Scan und keine automatische UI-Erkennung.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -388,3 +388,22 @@ Hinweis:
 - DEV-Header scannt den aktuellen Screen nur lesend.
 - Keine Auswahl, keine Bearbeitung, keine Speicherung.
 - Nächster Schritt: M13.4b UI-Editor-Scan weiter verfeinern, ohne Bearbeitung.
+
+## K19.14 Abschlussnotiz
+- Der installierte UI-Editor-Launcher wird in BBM im DEV-Kontext als eigenständiger Runtime-Launcher sichtbar.
+- Der Launcher lädt den Button aus `uiEditor/uiEditorLauncherButton.js` und die Styles aus `uiEditor/uiEditorLauncherButton.css`.
+- Der Klick toggelt nur den neutralen Launcher-State; `activeUiScope` bleibt als vorbereiteter Platzhalter `null`.
+- Der alte DEV-Header-Scan bleibt deaktiviert und ist nicht Grundlage des K19.14-Launchers.
+- Kein Editor-Panel, kein Hover-Rahmen, kein Editmodus, keine Speicherung, keine Fachlogik, kein DOM-Scan und keine automatische UI-Erkennung.
+- Tests:
+  - `node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`
+  - `npm test`
+- Nächster Schritt:
+  - Lokale Sichtprüfung im Electron-DEV-Kontext.
+
+## K19.14a Abschlussnotiz
+- Der alte EditorLab-/Scanstatus-/UI-Editor-Headerbutton wird nicht mehr in den Header eingehängt.
+- Der sichtbare Launcher ist eindeutig der installierte UI-Editor-Launcher aus `uiEditor/uiEditorLauncherButton.js` mit CSS aus `uiEditor/uiEditorLauncherButton.css`.
+- Die sichtbare Beschriftung lautet `UI-Editor`; `EditorLab V2` wird nicht mehr als Headerbutton gerendert.
+- Der Klick toggelt nur neutralen Launcher-State.
+- Kein Editor-Panel, kein Hover-Rahmen, kein Editmodus, keine Speicherung, keine Fachlogik, kein DOM-Scan und keine automatische UI-Erkennung.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -421,3 +421,10 @@ Hinweis:
 - Sichtbares Soll: `UI-Editor` sichtbar, `Restarbeiten V2` sichtbar, `EditorLab V2` nicht sichtbar.
 - Klick auf `UI-Editor` toggelt nur neutralen Launcher-State; `activeUiScope` bleibt neutral vorbereitet.
 - Kein Editor-Panel, kein Hover-Rahmen, kein Editmodus, keine Speicherung, kein DOM-Scan und keine automatische UI-Erkennung.
+
+## K19.14b Abschlussnotiz
+- Der globale Header rendert keinen Restarbeiten-V2-DEV-Shortcut mehr.
+- Restarbeiten V2 als Modul/Route bleibt unberührt und separat testbar.
+- Sichtbares Soll: `UI-Editor` sichtbar, `EditorLab V2` nicht sichtbar, `Restarbeiten V2` nicht sichtbar.
+- Der einzige sichtbare UI-Werkzeug-Launcher ist der installierte UI-Editor-Launcher aus `uiEditor/`.
+- Kein Editor-Panel, kein Hover-Rahmen, kein Editmodus, keine Speicherung, kein DOM-Scan und keine automatische UI-Erkennung.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -414,3 +414,10 @@ Hinweis:
 - EditorLab V2, alter Scanstatus und UI-Inspector-Headerbutton bleiben nicht sichtbar.
 - Der installierte UI-Editor-Launcher aus `uiEditor/` bleibt der einzige sichtbare UI-Editor-Launcher und toggelt nur neutralen State.
 - Kein Editor-Panel, kein Hover-Rahmen, kein Editmodus, keine Speicherung, kein DOM-Scan und keine automatische UI-Erkennung.
+
+## K19.14a-Fix 2 Abschlussnotiz
+- Der installierte UI-Editor-Launcher wird vor dem Renderer-Start als Artefakt geladen und vom Runtime-Mount sichtbar gemacht.
+- Die Launcher-CSS liegt weiter im installierten Artefaktbestand und hebt den Button über den Header.
+- Sichtbares Soll: `UI-Editor` sichtbar, `Restarbeiten V2` sichtbar, `EditorLab V2` nicht sichtbar.
+- Klick auf `UI-Editor` toggelt nur neutralen Launcher-State; `activeUiScope` bleibt neutral vorbereitet.
+- Kein Editor-Panel, kein Hover-Rahmen, kein Editmodus, keine Speicherung, kein DOM-Scan und keine automatische UI-Erkennung.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -20,6 +20,7 @@ const { runProtokollProjectEntryRoutingTests } = require("./tests/protokollProje
 const { runProtokollUiEditorElementsTests } = require("./tests/protokollUiEditorElements.test.cjs");
 const { runBbmUiEditorRegistryTests } = require("./tests/bbmUiEditorRegistry.test.cjs");
 const { runBbmUiEditorInstalledArtifactsTests } = require("./tests/bbmUiEditorInstalledArtifacts.test.cjs");
+const { runBbmUiEditorRuntimeLauncherTests } = require("./tests/bbmUiEditorRuntimeLauncher.test.cjs");
 const { runProjektverwaltungModuleTests } = require("./tests/projektverwaltungModule.test.cjs");
 const { runRestarbeitenModuleTests } = require("./tests/restarbeitenModule.test.cjs");
 const { runRestarbeitenDataModelTests } = require("./tests/restarbeitenDataModel.test.cjs");
@@ -142,6 +143,7 @@ async function main() {
   await runProtokollUiEditorElementsTests(run);
   await runBbmUiEditorRegistryTests(run);
   await runBbmUiEditorInstalledArtifactsTests(run);
+  await runBbmUiEditorRuntimeLauncherTests(run);
   await runProjektverwaltungModuleTests(run);
   await runRestarbeitenModuleTests(run);
   await runRestarbeitenDataModelTests(run);

--- a/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+++ b/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
@@ -6,6 +6,8 @@ const { importEsmFromFile } = require("./_esmLoader.cjs");
 const RUNTIME_PATH = path.join(__dirname, "../../src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js");
 const CORE_SHELL_PATH = path.join(__dirname, "../../src/renderer/app/CoreShell.js");
 const MAIN_HEADER_PATH = path.join(__dirname, "../../src/renderer/ui/MainHeader.js");
+const INDEX_PATH = path.join(__dirname, "../../src/renderer/index.html");
+const LAUNCHER_CSS_PATH = path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.css");
 
 function createFakeDocument() {
   const createNode = (tag, doc) => {
@@ -157,6 +159,11 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(source.includes("sessionStorage"), false);
     assert.equal(source.includes("MutationObserver"), false);
     assert.equal(source.includes("querySelectorAll"), false);
+
+    const indexSource = fs.readFileSync(INDEX_PATH, "utf8");
+    assert.equal(indexSource.includes("../../uiEditor/uiEditorLauncherButton.js"), true);
+    const cssSource = fs.readFileSync(LAUNCHER_CSS_PATH, "utf8");
+    assert.equal(cssSource.includes("z-index: 13050"), true);
   });
 
   await run("BBM UI-Editor-Runtime: Launcher ist nur im DEV-Kontext sichtbar", async () => {

--- a/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+++ b/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
@@ -1,0 +1,238 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const RUNTIME_PATH = path.join(__dirname, "../../src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js");
+const CORE_SHELL_PATH = path.join(__dirname, "../../src/renderer/app/CoreShell.js");
+const MAIN_HEADER_PATH = path.join(__dirname, "../../src/renderer/ui/MainHeader.js");
+
+function createFakeDocument() {
+  const createNode = (tag, doc) => {
+    const listeners = {};
+    const node = {
+      tagName: String(tag || "").toUpperCase(),
+      ownerDocument: doc,
+      children: [],
+      parentNode: null,
+      parentElement: null,
+      attributes: {},
+      dataset: {},
+      style: {},
+      className: "",
+      textContent: "",
+      disabled: false,
+      appendChild(child) {
+        if (child) {
+          child.parentNode = this;
+          child.parentElement = this;
+          this.children.push(child);
+        }
+        return child;
+      },
+      append(...children) {
+        children.forEach((child) => this.appendChild(child));
+      },
+      removeChild(child) {
+        this.children = this.children.filter((entry) => entry !== child);
+        if (child) {
+          child.parentNode = null;
+          child.parentElement = null;
+        }
+        return child;
+      },
+      remove() {
+        this.parentElement?.removeChild?.(this);
+      },
+      setAttribute(name, value) {
+        const normalizedName = String(name);
+        const normalizedValue = String(value);
+        this.attributes[normalizedName] = normalizedValue;
+        if (normalizedName.startsWith("data-")) {
+          const key = normalizedName
+            .slice(5)
+            .replace(/-([a-z])/g, (_match, char) => char.toUpperCase());
+          this.dataset[key] = normalizedValue;
+        }
+      },
+      getAttribute(name) {
+        return Object.hasOwn(this.attributes, String(name)) ? this.attributes[String(name)] : null;
+      },
+      addEventListener(type, handler) {
+        listeners[type] ||= [];
+        listeners[type].push(handler);
+      },
+      click() {
+        const event = {
+          type: "click",
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+          stopPropagation() {
+            this.stopped = true;
+          },
+        };
+        for (const handler of listeners.click || []) handler.call(this, event);
+      },
+      querySelector(selector) {
+        return findNode(this, (child) => matchesSelector(child, selector));
+      },
+      querySelectorAll(selector) {
+        const matches = [];
+        walk(this, (child) => {
+          if (matchesSelector(child, selector)) matches.push(child);
+        });
+        return matches;
+      },
+    };
+    return node;
+  };
+
+  const doc = {
+    createElement(tag) {
+      return createNode(tag, doc);
+    },
+    querySelector(selector) {
+      return this.documentElement.querySelector(selector);
+    },
+    querySelectorAll(selector) {
+      return this.documentElement.querySelectorAll(selector);
+    },
+  };
+  doc.documentElement = createNode("html", doc);
+  doc.head = createNode("head", doc);
+  doc.body = createNode("body", doc);
+  doc.documentElement.append(doc.head, doc.body);
+  return doc;
+}
+
+function walk(node, visit) {
+  for (const child of node?.children || []) {
+    visit(child);
+    walk(child, visit);
+  }
+}
+
+function findNode(node, predicate) {
+  let found = null;
+  walk(node, (child) => {
+    if (!found && predicate(child)) found = child;
+  });
+  return found;
+}
+
+function matchesSelector(node, selector) {
+  const raw = String(selector || "");
+  if (raw === "button") return node.tagName === "BUTTON";
+  if (raw.startsWith("link[")) {
+    return node.tagName === "LINK" && node.getAttribute("data-ui-editor-launcher-css") === "true";
+  }
+  if (raw === "[data-ui-editor-launcher-host=\"true\"]") {
+    return node.getAttribute("data-ui-editor-launcher-host") === "true";
+  }
+  if (raw === "[data-ui-inspector-panel=\"true\"]") {
+    return node.getAttribute("data-ui-inspector-panel") === "true";
+  }
+  return false;
+}
+
+async function loadRuntime() {
+  const mod = await importEsmFromFile(RUNTIME_PATH);
+  assert.equal(typeof mod.installBbmUiEditorRuntimeLauncher, "function");
+  return mod;
+}
+
+async function runBbmUiEditorRuntimeLauncherTests(run) {
+  await run("BBM UI-Editor-Runtime: bindet installierte Launcher-Artefakte ein", async () => {
+    const mod = await loadRuntime();
+    assert.equal(mod.INSTALLED_LAUNCHER_SCRIPT_PATH, "../../uiEditor/uiEditorLauncherButton.js");
+    assert.equal(mod.INSTALLED_LAUNCHER_CSS_PATH, "../../uiEditor/uiEditorLauncherButton.css");
+
+    const source = fs.readFileSync(RUNTIME_PATH, "utf8");
+    assert.equal(source.includes("uiEditor/uiEditorLauncherButton.js"), true);
+    assert.equal(source.includes("uiEditor/uiEditorLauncherButton.css"), true);
+    assert.equal(source.includes("scanUiInspectorTargets"), false);
+    assert.equal(source.includes("createUiInspectorPanel"), false);
+    assert.equal(source.includes("localStorage"), false);
+    assert.equal(source.includes("sessionStorage"), false);
+    assert.equal(source.includes("MutationObserver"), false);
+    assert.equal(source.includes("querySelectorAll"), false);
+  });
+
+  await run("BBM UI-Editor-Runtime: Launcher ist nur im DEV-Kontext sichtbar", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const win = {
+      uiEditorLauncherButtonArtifact: require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js")),
+    };
+
+    const hidden = await mod.installBbmUiEditorRuntimeLauncher({ devEnabled: false, doc, win });
+    assert.equal(hidden, null);
+    assert.equal(Boolean(doc.querySelector('[data-ui-editor-launcher-host="true"]')), false);
+
+    const button = await mod.installBbmUiEditorRuntimeLauncher({ devEnabled: true, doc, win, activeUiScope: null });
+    assert.equal(Boolean(button), true);
+    assert.equal(button.id, "uiEditor.launcherButton");
+    assert.equal(button.className, "ui-editor-launcher-button");
+    assert.equal(button.textContent, "UI-Editor");
+    assert.equal(button.textContent.includes("EditorLab V2"), false);
+    assert.equal(button.getAttribute("data-ui-editor-installed-artifact"), "uiEditor/uiEditorLauncherButton.js");
+    assert.equal(button.getAttribute("data-ui-editor-active-ui-scope"), "");
+    assert.equal(doc.querySelector('link[data-ui-editor-launcher-css="true"]').href, "../../uiEditor/uiEditorLauncherButton.css");
+  });
+
+  await run("BBM UI-Editor-Runtime: Klick toggelt nur neutralen Launcher-State", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const win = {
+      uiEditorLauncherButtonArtifact: require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js")),
+    };
+    const toggles = [];
+    const button = await mod.installBbmUiEditorRuntimeLauncher({
+      devEnabled: true,
+      doc,
+      win,
+      activeUiScope: null,
+      onToggle: (event) => toggles.push(event),
+    });
+
+    assert.equal(button.dataset.uiEditorLauncherActive, "false");
+    button.click();
+    assert.equal(button.dataset.uiEditorLauncherActive, "true");
+    assert.equal(button.getAttribute("data-ui-editor-launcher-active"), "true");
+    button.click();
+    assert.equal(button.dataset.uiEditorLauncherActive, "false");
+    assert.deepEqual(toggles.map((event) => event.uiEditorLauncherActive), [true, false]);
+    assert.deepEqual(toggles.map((event) => event.activeUiScope), [null, null]);
+    assert.equal(Boolean(doc.querySelector('[data-ui-inspector-panel="true"]')), false);
+  });
+
+  await run("BBM UI-Editor-Runtime: CoreShell nutzt Runtime-Launcher statt alter Scanstatus-Grundlage", () => {
+    const coreShellSource = fs.readFileSync(CORE_SHELL_PATH, "utf8");
+    const mainHeaderSource = fs.readFileSync(MAIN_HEADER_PATH, "utf8");
+    assert.equal(coreShellSource.includes("installBbmUiEditorRuntimeLauncher"), true);
+    assert.equal(coreShellSource.includes("activeUiScope: null"), true);
+    assert.equal(mainHeaderSource.includes("_isUiEditorRuntimeLauncherEnabled"), true);
+    assert.equal(mainHeaderSource.includes("_isUiEditorEnabled() {\n    return false;\n  }"), true);
+  });
+}
+
+if (require.main === module) {
+  const run = async (name, fn) => {
+    try {
+      const out = fn();
+      if (out && typeof out.then === "function") await out;
+      console.log(`ok - ${name}`);
+    } catch (err) {
+      console.error(`not ok - ${name}`);
+      console.error(err?.stack || err?.message || err);
+      process.exitCode = 1;
+    }
+  };
+
+  runBbmUiEditorRuntimeLauncherTests(run).then(() => {
+    if (!process.exitCode) console.log("bbmUiEditorRuntimeLauncher.test.cjs passed");
+  });
+}
+
+module.exports = { runBbmUiEditorRuntimeLauncherTests };

--- a/scripts/tests/editorLabV2Access.test.cjs
+++ b/scripts/tests/editorLabV2Access.test.cjs
@@ -154,9 +154,8 @@ async function runEditorLabV2AccessTests(run) {
   const headerSource = fs.readFileSync(headerPath, "utf8");
 
   assert.equal(routerSource.includes("showEditorLabV2"), true);
-  assert.equal(headerSource.includes("EditorLab V2"), true);
-  assert.equal(headerSource.includes("showEditorLabV2"), true);
-  assert.equal(headerSource.includes("uiInspector"), true);
+  assert.equal(headerSource.includes("EditorLab V2"), false);
+  assert.equal(headerSource.includes("showEditorLabV2"), false);
 
   const [{ default: Router }, { default: MainHeader }, { getActiveProjectModuleNavigation }] = await Promise.all([
     importEsmFromFile(routerPath),
@@ -207,8 +206,7 @@ async function runEditorLabV2AccessTests(run) {
     header.refresh();
 
     const button = getNodeById(header.root, "editorlabv2.button") || collectNodes(header.root, (node) => node?.tagName === "BUTTON" && node?.textContent === "EditorLab V2")[0];
-    assert.ok(button);
-    assert.equal(button.disabled, false);
+    assert.equal(Boolean(button), false);
 
     await router.showEditorLabV2();
     assert.equal(router.currentProjectId, null);
@@ -229,7 +227,7 @@ async function runEditorLabV2AccessTests(run) {
     header = null;
   }
 
-  await run("EditorLab V2 ist als DEV-Testzugang sichtbar", () => undefined);
+  await run("EditorLab V2 bleibt per Router testbar, aber ohne sichtbaren Header-Button", () => undefined);
 }
 
 if (require.main === module) {

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -1084,9 +1084,13 @@ async function runProjektverwaltungModuleTests(run) {
     );
 
     try {
+      let restarbeitenV2OpenCount = 0;
       const router = {
         currentProjectId: "17",
         currentMeetingId: null,
+        showRestarbeitenV2Dev() {
+          restarbeitenV2OpenCount += 1;
+        },
         contentRoot: {
           querySelectorAll() {
             throw new Error("alter UI-Editor-Scan darf nicht laufen");
@@ -1108,10 +1112,17 @@ async function runProjektverwaltungModuleTests(run) {
       header.render();
       header.refresh();
 
+      assert.equal(typeof header._applyRestarbeitenV2ButtonState, "function");
       const editorButton = findNode(header.root, (node) => node?.tagName === "BUTTON" && node?.textContent === "Editor");
       const editorLabButton = findNode(header.root, (node) => node?.tagName === "BUTTON" && node?.textContent === "EditorLab V2");
+      const restarbeitenV2Button = findNode(header.root, (node) => node?.tagName === "BUTTON" && node?.textContent === "Restarbeiten V2");
       assert.equal(Boolean(editorButton), false);
       assert.equal(Boolean(editorLabButton), false);
+      assert.ok(restarbeitenV2Button);
+      assert.equal(restarbeitenV2Button.disabled, false);
+      assert.equal(header.elRestarbeitenV2Wrap.style.display, "inline-flex");
+      restarbeitenV2Button.click();
+      assert.equal(restarbeitenV2OpenCount, 1);
       assert.equal(header.toggleUiEditorScan(), false);
       assert.equal(header.elUiEditorPanel, null);
       assert.equal(Boolean(findNode(fakeDocument.body, (node) => node?.attributes?.["data-ui-inspector-panel"] === "true")), false);

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -1058,7 +1058,7 @@ async function runProjektverwaltungModuleTests(run) {
     }
   });
 
-  await run("Projektverwaltung: MainHeader zeigt im DEV-Header den UI-Editor-Button und Scanstatus", async () => {
+  await run("Projektverwaltung: alter UI-Editor-Scan bleibt im DEV-Header deaktiviert", async () => {
     const previousDocument = global.document;
     const previousWindow = global.window;
     const fakeDocument = createFakeDocumentWithBubbling();
@@ -1083,64 +1083,15 @@ async function runProjektverwaltungModuleTests(run) {
       path.join(__dirname, "../../src/renderer/ui/MainHeader.js")
     );
 
-    const completeIds = [
-      "restarbeiten.root",
-      "restarbeiten.header",
-      "restarbeiten.main",
-      "restarbeiten.filterleiste",
-      "restarbeiten.filterleiste.klassenfilter",
-      "restarbeiten.filterleiste.verortung",
-      "restarbeiten.filterleiste.meta",
-      "restarbeiten.liste",
-      "restarbeiten.liste.nummernbereich",
-      "restarbeiten.liste.textbereich",
-      "restarbeiten.liste.metabereich",
-      "restarbeiten.editbox",
-      "restarbeiten.editbox.header",
-      "restarbeiten.editbox.verortung",
-      "restarbeiten.editbox.kurztext",
-      "restarbeiten.editbox.langtext",
-      "restarbeiten.editbox.meta",
-      "restarbeiten.filterleiste.klassenfilter.feld",
-      "restarbeiten.filterleiste.verortung.feld",
-      "restarbeiten.liste.kurztext",
-      "restarbeiten.liste.langtext",
-      "restarbeiten.filterleiste.meta.fertig_bis",
-      "restarbeiten.filterleiste.meta.status",
-      "restarbeiten.filterleiste.meta.verantwortlich",
-      "restarbeiten.filterleiste.meta.erledigt",
-      "restarbeiten.editbox.kurztext.label",
-      "restarbeiten.editbox.kurztext.restzeichen",
-      "restarbeiten.editbox.langtext.label",
-      "restarbeiten.editbox.langtext.restzeichen",
-    ];
-    const warningIds = completeIds.filter(
-      (id) =>
-        ![
-          "restarbeiten.filterleiste.verortung",
-        ].includes(id)
-    );
-
-    const mkRoot = (ids) => ({
-      querySelectorAll(selector) {
-        if (selector !== "[data-ui-inspector-id]") return [];
-        return ids.map((id) => ({
-          getAttribute(name) {
-            return name === "data-ui-inspector-id" ? id : null;
-          },
-          style: { cssText: "" },
-          getBoundingClientRect() {
-            return { left: 0, top: 0, width: 10, height: 10 };
-          },
-        }));
-      },
-    });
-
     try {
       const router = {
         currentProjectId: "17",
         currentMeetingId: null,
-        contentRoot: mkRoot(completeIds),
+        contentRoot: {
+          querySelectorAll() {
+            throw new Error("alter UI-Editor-Scan darf nicht laufen");
+          },
+        },
         activeSection: "projectWorkspace",
         context: {
           ui: { pageTitle: "", activeModuleLabel: "Protokoll", isTopsView: false },
@@ -1156,66 +1107,13 @@ async function runProjektverwaltungModuleTests(run) {
       const header = new MainHeader({ router, version: "1.5.0" });
       header.render();
       header.refresh();
-      const headerChildCountBefore = header.root.children.length;
 
       const editorButton = findNode(header.root, (node) => node?.tagName === "BUTTON" && node?.textContent === "Editor");
-      assert.ok(editorButton);
-      assert.equal(editorButton.dataset.uiEditorState, "off");
-      assert.equal(editorButton.disabled, false);
-
-      assert.equal(header.toggleUiEditorScan(), true);
-      assert.equal(editorButton.dataset.uiEditorState, "scan-ok");
-      assert.equal(editorButton.dataset.uiEditorSeverity, "ok");
-      assert.match(editorButton.title, /vollständig/);
-      const panelRoot = header.elUiEditorPanel?.getPanelRoot?.();
-      assert.ok(panelRoot);
-      assert.equal(panelRoot.parentElement || panelRoot.parentNode, fakeDocument.body);
-      assert.equal(panelRoot.style.position, "fixed");
-      assert.equal(
-        panelRoot.getAttribute?.("data-ui-editor-mode") || panelRoot["data-ui-editor-mode"],
-        "frame"
-      );
-      const panelText = collectText(panelRoot);
-      assert.match(panelText, /UI-Editor Scan/);
-      assert.match(panelText, /Status: vollständig/);
-      assert.match(panelText, /Marker: \d+/);
-      assert.match(panelText, /Rahmen: \d+/);
-      assert.match(panelText, /Felder: \d+/);
-      assert.match(panelText, /Einzelelemente: \d+/);
-      assert.equal(Boolean(findNode(panelRoot, (node) => node?.tagName === "BUTTON" && node?.textContent === "Rahmen")), true);
-      assert.equal(Boolean(findNode(panelRoot, (node) => node?.tagName === "BUTTON" && node?.textContent === "Feld")), true);
-      assert.equal(Boolean(findNode(panelRoot, (node) => node?.tagName === "BUTTON" && node?.textContent === "Einzelelement")), true);
-
-      const fieldButton = findNode(panelRoot, (node) => node?.tagName === "BUTTON" && node?.textContent === "Feld");
-      fieldButton.click();
-      const updatedPanelRoot = header.elUiEditorPanel?.getPanelRoot?.();
-      assert.equal(
-        updatedPanelRoot.getAttribute?.("data-ui-editor-mode") || updatedPanelRoot["data-ui-editor-mode"],
-        "field"
-      );
-      assert.equal(editorButton.dataset.uiEditorState, "scan-ok");
-      assert.equal(header.elUiEditorStatus.style.display, "none");
-      assert.equal(header.root.children.length, headerChildCountBefore);
-      assert.equal(Boolean(findNode(header.root, (node) => node?.attributes?.["data-ui-inspector-panel"] === "true")), false);
-
-      router.contentRoot = mkRoot(warningIds);
-      header.refresh();
-      assert.equal(editorButton.dataset.uiEditorState, "scan-warning");
-      assert.equal(header.elUiEditorStatus.style.display, "none");
-      const warningPanelText = collectText(header.elUiEditorPanel?.getPanelRoot?.());
-      assert.match(warningPanelText, /Status: unvollständig/);
-      assert.match(warningPanelText, /Fehlt Pflicht:/);
-      assert.match(warningPanelText, /restarbeiten\.filterleiste\.verortung/);
-      assert.equal(
-        header.elUiEditorPanel?.getPanelRoot?.().getAttribute?.("data-ui-editor-mode") ||
-          header.elUiEditorPanel?.getPanelRoot?.()["data-ui-editor-mode"],
-        "field"
-      );
-
+      const editorLabButton = findNode(header.root, (node) => node?.tagName === "BUTTON" && node?.textContent === "EditorLab V2");
+      assert.equal(Boolean(editorButton), false);
+      assert.equal(Boolean(editorLabButton), false);
       assert.equal(header.toggleUiEditorScan(), false);
-      assert.equal(editorButton.dataset.uiEditorState, "off");
-      assert.equal(header.elUiEditorStatus.style.display, "none");
-      assert.equal(String(header.elUiEditorStatus?.textContent || ""), "");
+      assert.equal(header.elUiEditorPanel, null);
       assert.equal(Boolean(findNode(fakeDocument.body, (node) => node?.attributes?.["data-ui-inspector-panel"] === "true")), false);
     } finally {
       global.document = previousDocument;

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -1085,13 +1085,9 @@ async function runProjektverwaltungModuleTests(run) {
     );
 
     try {
-      let restarbeitenV2OpenCount = 0;
       const router = {
         currentProjectId: "17",
         currentMeetingId: null,
-        showRestarbeitenV2Dev() {
-          restarbeitenV2OpenCount += 1;
-        },
         contentRoot: {
           querySelectorAll() {
             throw new Error("alter UI-Editor-Scan darf nicht laufen");
@@ -1119,11 +1115,9 @@ async function runProjektverwaltungModuleTests(run) {
       const restarbeitenV2Button = findNode(header.root, (node) => node?.tagName === "BUTTON" && node?.textContent === "Restarbeiten V2");
       assert.equal(Boolean(editorButton), false);
       assert.equal(Boolean(editorLabButton), false);
-      assert.ok(restarbeitenV2Button);
-      assert.equal(restarbeitenV2Button.disabled, false);
-      assert.equal(header.elRestarbeitenV2Wrap.style.display, "inline-flex");
-      await restarbeitenV2Button.click();
-      assert.equal(restarbeitenV2OpenCount, 1);
+      assert.equal(Boolean(restarbeitenV2Button), false);
+      assert.equal(header.elRestarbeitenV2Wrap, null);
+      assert.equal(header.elRestarbeitenV2Btn, null);
 
       global.window.uiEditorLauncherButtonArtifact = require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js"));
       const launcherButton = await installBbmUiEditorRuntimeLauncher({

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -997,9 +997,10 @@ async function runProjektverwaltungModuleTests(run) {
       bbmDb: {},
     };
 
-    const { default: MainHeader } = await importEsmFromFile(
-      path.join(__dirname, "../../src/renderer/ui/MainHeader.js")
-    );
+    const [{ default: MainHeader }, { installBbmUiEditorRuntimeLauncher }] = await Promise.all([
+      importEsmFromFile(path.join(__dirname, "../../src/renderer/ui/MainHeader.js")),
+      importEsmFromFile(path.join(__dirname, "../../src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js")),
+    ]);
 
     try {
       const router = {
@@ -1121,8 +1122,24 @@ async function runProjektverwaltungModuleTests(run) {
       assert.ok(restarbeitenV2Button);
       assert.equal(restarbeitenV2Button.disabled, false);
       assert.equal(header.elRestarbeitenV2Wrap.style.display, "inline-flex");
-      restarbeitenV2Button.click();
+      await restarbeitenV2Button.click();
       assert.equal(restarbeitenV2OpenCount, 1);
+
+      global.window.uiEditorLauncherButtonArtifact = require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js"));
+      const launcherButton = await installBbmUiEditorRuntimeLauncher({
+        header,
+        devEnabled: header._isUiEditorRuntimeLauncherEnabled?.() === true,
+        activeUiScope: null,
+        doc: fakeDocument,
+        win: global.window,
+      });
+      assert.ok(launcherButton);
+      assert.equal(launcherButton.id, "uiEditor.launcherButton");
+      assert.equal(launcherButton.textContent, "UI-Editor");
+      assert.equal(launcherButton.getAttribute("data-ui-editor-installed-artifact"), "uiEditor/uiEditorLauncherButton.js");
+      assert.equal(launcherButton.getAttribute("data-ui-editor-launcher-active"), "false");
+      await launcherButton.click();
+      assert.equal(launcherButton.getAttribute("data-ui-editor-launcher-active"), "true");
       assert.equal(header.toggleUiEditorScan(), false);
       assert.equal(header.elUiEditorPanel, null);
       assert.equal(Boolean(findNode(fakeDocument.body, (node) => node?.attributes?.["data-ui-inspector-panel"] === "true")), false);

--- a/scripts/tests/restarbeitenV2DevAccess.test.cjs
+++ b/scripts/tests/restarbeitenV2DevAccess.test.cjs
@@ -170,8 +170,8 @@ async function runRestarbeitenV2DevAccessTests(run) {
   assert.equal(readOnlyDecisionSource.includes("M19.0 Fachlicher Abnahmetest vor Aktivierung"), true);
   assert.equal(routerSource.includes("Restarbeiten V2 ReadOnly"), true);
   assert.equal(routerSource.includes("Restarbeiten V2 ist derzeit nicht freigegeben."), true);
-  assert.equal(headerSource.includes("Restarbeiten V2"), true);
-  assert.equal(headerSource.includes("showRestarbeitenV2Dev"), true);
+  assert.equal(headerSource.includes("Restarbeiten V2"), false);
+  assert.equal(headerSource.includes("showRestarbeitenV2Dev"), false);
 
   const methodSourceMatch = routerSource.match(/async showRestarbeitenV2Dev\(\) \{[\s\S]*?\n  \}\n\n  \/\/ Kern-Routing mit Projektkontext:/);
   assert.ok(methodSourceMatch, "showRestarbeitenV2Dev body not found");
@@ -411,19 +411,7 @@ async function runRestarbeitenV2DevAccessTests(run) {
     header.refresh();
 
     const button = getNodeById(header.root, "restarbeitenv2.button") || collectNodes(header.root, (node) => node?.tagName === "BUTTON" && node?.textContent === "Restarbeiten V2")[0];
-    assert.ok(button);
-    assert.equal(button.disabled, false);
-
-    let clicked = false;
-    router.showRestarbeitenV2Dev = async () => {
-      clicked = true;
-      return true;
-    };
-    button.onclick?.({
-      preventDefault() {},
-      stopPropagation() {},
-    });
-    assert.equal(clicked, true);
+    assert.equal(Boolean(button), false);
 
     router.showRestarbeitenV2Dev = originalShowRestarbeitenV2Dev;
     await router.showRestarbeitenV2Dev();
@@ -597,7 +585,7 @@ async function runRestarbeitenV2DevAccessTests(run) {
   assert.equal(diffFiles.some((file) => file.startsWith("src/renderer/modules/protokoll/")), false);
   assert.equal(diffFiles.some((file) => file.startsWith("src/renderer/uiInspector/")), false);
 
-  await run("Restarbeiten V2 ist als DEV-Testzugang sichtbar", () => undefined);
+  await run("Restarbeiten V2 bleibt per Route testbar, aber ohne globalen Headerbutton", () => undefined);
 }
 
 if (require.main === module) {

--- a/src/renderer/app/CoreShell.js
+++ b/src/renderer/app/CoreShell.js
@@ -20,6 +20,7 @@ import { registerCoreShellHeaderBridge } from "./coreShellHeaderBridge.js";
 import { registerCoreShellContextControls } from "./coreShellContextControls.js";
 import { registerCoreShellKeyboardHandling } from "./coreShellKeyboard.js";
 import { createCoreShellNavigationRuntime } from "./coreShellNavigationRuntime.js";
+import { installBbmUiEditorRuntimeLauncher } from "../uiEditor/BbmUiEditorRuntimeLauncher.js";
 
 export default class CoreShell {
   constructor({ router, version } = {}) {
@@ -100,6 +101,11 @@ export default class CoreShell {
 
     router.showHome();
     header.refresh();
+    installBbmUiEditorRuntimeLauncher({
+      header,
+      devEnabled: header._isUiEditorRuntimeLauncherEnabled?.() === true,
+      activeUiScope: null,
+    });
     if (typeof updateContextButtons === "function") {
       updateContextButtons();
     }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -15,6 +15,7 @@
 </head>
 <body>
 <main id="content"></main>
+<script src="../../uiEditor/uiEditorLauncherButton.js"></script>
 <script type="module" src="./main.js"></script>
 </body>
 </html>

--- a/src/renderer/ui/MainHeader.js
+++ b/src/renderer/ui/MainHeader.js
@@ -626,25 +626,9 @@ export default class MainHeader {
     const editorLabWrap = null;
     const editorLabBtn = null;
 
-    const restarbeitenV2Wrap = document.createElement("div");
-    restarbeitenV2Wrap.style.display = "inline-flex";
-    restarbeitenV2Wrap.style.flexDirection = "column";
-    restarbeitenV2Wrap.style.alignItems = "flex-start";
-    restarbeitenV2Wrap.style.gap = "4px";
-
-    const restarbeitenV2Btn = document.createElement("button");
-    restarbeitenV2Btn.type = "button";
-    restarbeitenV2Btn.textContent = "Restarbeiten V2";
-    applyUiEditorButtonStyle(restarbeitenV2Btn);
-    restarbeitenV2Btn.onclick = (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (restarbeitenV2Btn.disabled) return;
-      this.router?.showRestarbeitenV2Dev?.();
-    };
-    restarbeitenV2Btn.title = "Restarbeiten V2 oeffnen";
-    restarbeitenV2Wrap.append(restarbeitenV2Btn);
-
+    // K19.14b: interner Modul-DEV-Shortcut bleibt aus dem globalen Header entfernt.
+    const restarbeitenV2Wrap = null;
+    const restarbeitenV2Btn = null;
 
     const mailWrap = document.createElement("div");
     mailWrap.style.position = "relative";
@@ -810,7 +794,6 @@ export default class MainHeader {
     if (!this._isNewUi) {
       actionWrap.append(setupWrap);
     }
-    actionWrap.append(restarbeitenV2Wrap);
 
     const stickyNotice = document.createElement("div");
     stickyNotice.style.gridColumn = "1 / span 3";
@@ -1691,14 +1674,7 @@ export default class MainHeader {
   }
 
   _applyRestarbeitenV2ButtonState() {
-    if (!this.elRestarbeitenV2Wrap || !this.elRestarbeitenV2Btn) return;
-    const enabled = this._isRestarbeitenV2DevEnabled();
-    this.elRestarbeitenV2Wrap.style.display = enabled ? "inline-flex" : "none";
-    this.elRestarbeitenV2Btn.disabled = !enabled;
-    this.elRestarbeitenV2Btn.setAttribute("aria-disabled", enabled ? "false" : "true");
-    this.elRestarbeitenV2Btn.title = enabled
-      ? "Restarbeiten V2 oeffnen"
-      : "Restarbeiten V2 ist nur im DEV-Testzugang verfuegbar.";
+    // K19.14b: kein globaler Restarbeiten-V2-Headerbutton.
   }
 
   setUiEditorSelectionMode(_nextMode) {

--- a/src/renderer/ui/MainHeader.js
+++ b/src/renderer/ui/MainHeader.js
@@ -10,8 +10,6 @@ import { resolveProtocolsDir } from "../utils/pdfProtocolsDir.js";
 import { PROTOKOLL_MODULE_ID } from "../app/modules/index.js";
 import { isModuleActive, refreshCachedActiveModuleAccess } from "../app/modules/moduleAccessState.js";
 import { getVisiblePrintDialogActions } from "../../shared/print/printModes.mjs";
-import { createUiInspectorPanel } from "../uiInspector/UiInspectorPanel.js";
-import { createUiInspectorRuntime, formatUiInspectorScanSummary, scanUiInspectorTargets } from "../uiInspector/UiInspectorRuntime.js";
 
 const PROTOCOL_DISABLED_MESSAGE = "Modul Protokoll ist fuer diese Lizenz nicht freigeschaltet.";
 
@@ -72,7 +70,6 @@ export default class MainHeader {
     this._uiEditorScanActive = false;
     this._uiEditorScanSummary = null;
     this._uiEditorSelectionMode = "frame";
-    this.uiInspectorRuntime = createUiInspectorRuntime({ initialSelectionMode: "frame" });
 
     this.elPrintBtn = null;
     this.elPrintWrap = null;
@@ -622,50 +619,12 @@ export default class MainHeader {
     printMenu.append(itemPreview, itemFirms, itemTodo, itemTopList, itemMeetingsClosed);
     printWrap.append(printBtn, printMenu);
 
-    const uiEditorWrap = document.createElement("div");
-    uiEditorWrap.style.display = "inline-flex";
-    uiEditorWrap.style.flexDirection = "column";
-    uiEditorWrap.style.alignItems = "flex-start";
-    uiEditorWrap.style.gap = "4px";
-
-    const uiEditorBtn = document.createElement("button");
-    uiEditorBtn.type = "button";
-    uiEditorBtn.textContent = "Editor";
-    applyUiEditorButtonStyle(uiEditorBtn);
-    uiEditorBtn.onclick = (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (uiEditorBtn.disabled) return;
-      this.toggleUiEditorScan();
-    };
-
-    const uiEditorStatus = document.createElement("div");
-    uiEditorStatus.style.display = "none";
-    uiEditorStatus.style.maxWidth = "320px";
-    uiEditorStatus.style.whiteSpace = "normal";
-    uiEditorStatus.style.boxSizing = "border-box";
-    uiEditorStatus.style.userSelect = "text";
-
-    uiEditorWrap.append(uiEditorBtn, uiEditorStatus);
-
-    const editorLabWrap = document.createElement("div");
-    editorLabWrap.style.display = "inline-flex";
-    editorLabWrap.style.flexDirection = "column";
-    editorLabWrap.style.alignItems = "flex-start";
-    editorLabWrap.style.gap = "4px";
-
-    const editorLabBtn = document.createElement("button");
-    editorLabBtn.type = "button";
-    editorLabBtn.textContent = "EditorLab V2";
-    applyUiEditorButtonStyle(editorLabBtn);
-    editorLabBtn.onclick = (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (editorLabBtn.disabled) return;
-      this.router?.showEditorLabV2?.();
-    };
-    editorLabBtn.title = "EditorLab V2 oeffnen";
-    editorLabWrap.append(editorLabBtn);
+    // K19.14a: alte UI-Editor-/Scanstatus- und EditorLab-Headerbuttons werden nicht mehr gerendert.
+    const uiEditorWrap = null;
+    const uiEditorBtn = null;
+    const uiEditorStatus = null;
+    const editorLabWrap = null;
+    const editorLabBtn = null;
 
     const restarbeitenV2Wrap = document.createElement("div");
     restarbeitenV2Wrap.style.display = "inline-flex";
@@ -846,12 +805,11 @@ export default class MainHeader {
     };
 
     // Ausgabe bleibt intern vorbereitet; direkte Header-Hauptaktionen laufen vorerst nur ueber die Quicklane.
-    if (this._isNewUi) {
-      actionWrap.append(uiEditorWrap);
-    } else {
-      actionWrap.append(setupWrap, uiEditorWrap);
+    // K19.14a: alte UI-Editor-/Scanstatus-/EditorLab-Headerbuttons bleiben aus dem Header entfernt.
+    // Der sichtbare UI-Editor-Launcher wird separat aus dem installierten Artefaktbestand gemountet.
+    if (!this._isNewUi) {
+      actionWrap.append(setupWrap);
     }
-    actionWrap.append(editorLabWrap);
     actionWrap.append(restarbeitenV2Wrap);
 
     const stickyNotice = document.createElement("div");
@@ -1705,179 +1663,43 @@ export default class MainHeader {
   }
 
   _isUiEditorEnabled() {
+    return false;
+  }
+
+  _isUiEditorRuntimeLauncherEnabled() {
     return this._isNewUi;
   }
 
   _isEditorLabV2Enabled() {
-    return this._isNewUi;
+    return false;
   }
 
   _isRestarbeitenV2DevEnabled() {
     return this._isNewUi;
   }
 
-  _setUiEditorStatusContent(summary = null) {
-    if (!this.elUiEditorStatus) return;
-
-    if (!summary) {
-      this.uiInspectorRuntime?.clearScanSummary?.();
-      this.elUiEditorStatus.replaceChildren();
-      this.elUiEditorStatus.style.display = "none";
-      if (typeof this.elUiEditorStatus.removeAttribute === "function") {
-        this.elUiEditorStatus.removeAttribute("data-ui-editor-status");
-      }
-      this.elUiEditorPanel?.unmount?.();
-      return;
-    }
-
-    const scan = formatUiInspectorScanSummary(summary);
-    this.uiInspectorRuntime?.setScanSummary?.(summary);
-    this.elUiEditorStatus.style.display = "none";
-    this.elUiEditorStatus.dataset.uiEditorStatus = scan.status;
-    this.elUiEditorStatus.dataset.uiEditorState = scan.status;
-    this.elUiEditorStatus.dataset.uiEditorMode = this.uiInspectorRuntime?.getSelectionMode?.() || "frame";
-
-    if (!this.elUiEditorPanel) {
-      this.elUiEditorPanel = createUiInspectorPanel();
-    }
-    const panelHost = this.elUiEditorStatus.ownerDocument?.body || document.body || this.elUiEditorStatus;
-    this.elUiEditorPanel.mount(panelHost);
-
-    this.elUiEditorPanel.render({
-      scanSummary: summary,
-      selectionMode: this.uiInspectorRuntime?.getSelectionMode?.() || "frame",
-      selectionModeLabel: this.uiInspectorRuntime?.getSelectionModeLabel?.() || "Rahmen",
-      actions: {
-        setSelectionMode: (mode) => this.setUiEditorSelectionMode(mode),
-      },
-    });
+  _setUiEditorStatusContent(_summary = null) {
+    // K19.14a: alter Scanstatus-Headerpfad ist deaktiviert.
   }
 
   _applyUiEditorButtonState() {
-    if (!this.elUiEditorBtn) return;
-
-    const enabled = this._isUiEditorEnabled();
-    const active = !!this._uiEditorScanActive;
-    const summary = this._uiEditorScanSummary || null;
-    const state = !enabled || !active ? "off" : summary?.status === "ok" ? "scan-ok" : "scan-warning";
-    const severity = !enabled || !active ? "off" : summary?.status === "ok" ? "ok" : "warning";
-
-    this.elUiEditorBtn.disabled = !enabled;
-    this.elUiEditorBtn.dataset.uiEditorState = state;
-    this.elUiEditorBtn.dataset.uiEditorSeverity = severity;
-    this.elUiEditorBtn.setAttribute("aria-pressed", active ? "true" : "false");
-
-    if (!enabled) {
-      this.elUiEditorBtn.style.background = "#ececec";
-      this.elUiEditorBtn.style.borderColor = "#b8b8b8";
-      this.elUiEditorBtn.style.color = "#575757";
-      this.elUiEditorBtn.style.boxShadow = "none";
-      this.elUiEditorBtn.title = "UI-Editor ist nur im DEV-Header verfuegbar.";
-      this._setUiEditorStatusContent(null);
-      if (this.elUiEditorWrap) this.elUiEditorWrap.style.display = "none";
-      return;
-    }
-
-    if (this.elUiEditorWrap) this.elUiEditorWrap.style.display = "inline-flex";
-
-    if (!active) {
-      this.elUiEditorBtn.style.background = "#eef1f4";
-      this.elUiEditorBtn.style.borderColor = "#c8d0da";
-      this.elUiEditorBtn.style.color = "#4b5563";
-      this.elUiEditorBtn.style.boxShadow = "none";
-      this.elUiEditorBtn.title = "UI-Editor Scan einschalten";
-      this._setUiEditorStatusContent(null);
-      return;
-    }
-
-    if (summary?.status === "ok") {
-      this.elUiEditorBtn.style.background = "#e8f7eb";
-      this.elUiEditorBtn.style.borderColor = "#16a34a";
-      this.elUiEditorBtn.style.color = "#166534";
-      this.elUiEditorBtn.style.boxShadow = "0 0 0 1px rgba(22,163,74,0.22) inset";
-      this.elUiEditorBtn.title = "UI-Editor Scan: vollständig";
-    } else {
-      this.elUiEditorBtn.style.background = "#fff5db";
-      this.elUiEditorBtn.style.borderColor = "#d97706";
-      this.elUiEditorBtn.style.color = "#92400e";
-      this.elUiEditorBtn.style.boxShadow = "0 0 0 1px rgba(217,119,6,0.22) inset";
-      this.elUiEditorBtn.title = "UI-Editor Scan: unvollständig";
-    }
-
-    this._setUiEditorStatusContent(summary);
+    // K19.14a: kein alter UI-Editor-Headerbutton; Runtime-Launcher wird separat gemountet.
   }
 
   _applyEditorLabButtonState() {
-    if (!this.elEditorLabWrap || !this.elEditorLabBtn) return;
-    const enabled = this._isEditorLabV2Enabled();
-    this.elEditorLabWrap.style.display = enabled ? "inline-flex" : "none";
-    this.elEditorLabBtn.disabled = !enabled;
-    this.elEditorLabBtn.setAttribute("aria-disabled", enabled ? "false" : "true");
-    this.elEditorLabBtn.title = enabled
-      ? "EditorLab V2 oeffnen"
-      : "EditorLab V2 ist nur im DEV-Testzugang verfuegbar.";
+    // K19.14a: kein sichtbarer EditorLab-Headerbutton.
   }
 
-  _applyRestarbeitenV2ButtonState() {
-    if (!this.elRestarbeitenV2Wrap || !this.elRestarbeitenV2Btn) return;
-    const enabled = this._isRestarbeitenV2DevEnabled();
-    this.elRestarbeitenV2Wrap.style.display = enabled ? "inline-flex" : "none";
-    this.elRestarbeitenV2Btn.disabled = !enabled;
-    this.elRestarbeitenV2Btn.setAttribute("aria-disabled", enabled ? "false" : "true");
-    this.elRestarbeitenV2Btn.title = enabled
-      ? "Restarbeiten V2 oeffnen"
-      : "Restarbeiten V2 ist nur im DEV-Testzugang verfuegbar.";
-  }
-
-  setUiEditorSelectionMode(nextMode) {
-    const changed = this.uiInspectorRuntime?.setSelectionMode?.(nextMode) === true;
-    this._uiEditorSelectionMode = this.uiInspectorRuntime?.getSelectionMode?.() || "frame";
-    if (this._uiEditorScanActive && this._uiEditorScanSummary) {
-      this._setUiEditorStatusContent(this._uiEditorScanSummary);
-      this._applyUiEditorButtonState();
-    }
-    return changed;
+  setUiEditorSelectionMode(_nextMode) {
+    return false;
   }
 
   _scanUiEditorCurrentScreen() {
-    const root = this.router?.contentRoot || null;
-    if (!root) {
-      this._uiEditorScanSummary = {
-        schemaKey: "",
-        totalMarkers: 0,
-        frameCount: 0,
-        fieldCount: 0,
-        singleElementCount: 0,
-        unknownCount: 0,
-        missingImportantIds: [],
-        status: "warning",
-        statusLabel: "unvollständig",
-      };
-      this.uiInspectorRuntime?.setScanSummary?.(this._uiEditorScanSummary);
-      this._applyUiEditorButtonState();
-      return this._uiEditorScanSummary;
-    }
-
-    this._uiEditorScanSummary = scanUiInspectorTargets(root);
-    this.uiInspectorRuntime?.setScanSummary?.(this._uiEditorScanSummary);
-    this._applyUiEditorButtonState();
-    return this._uiEditorScanSummary;
+    return null;
   }
 
   toggleUiEditorScan() {
-    if (!this._isUiEditorEnabled()) return false;
-
-    this._uiEditorScanActive = !this._uiEditorScanActive;
-    if (this._uiEditorScanActive) {
-      this.uiInspectorRuntime?.setSelectionMode?.("frame");
-      this._uiEditorSelectionMode = this.uiInspectorRuntime?.getSelectionMode?.() || "frame";
-      this._scanUiEditorCurrentScreen();
-    } else {
-      this._uiEditorScanSummary = null;
-      this.uiInspectorRuntime?.clearScanSummary?.();
-      this._applyUiEditorButtonState();
-    }
-    return this._uiEditorScanActive;
+    return false;
   }
 
   _applyPrintButtonState() {

--- a/src/renderer/ui/MainHeader.js
+++ b/src/renderer/ui/MainHeader.js
@@ -1690,6 +1690,17 @@ export default class MainHeader {
     // K19.14a: kein sichtbarer EditorLab-Headerbutton.
   }
 
+  _applyRestarbeitenV2ButtonState() {
+    if (!this.elRestarbeitenV2Wrap || !this.elRestarbeitenV2Btn) return;
+    const enabled = this._isRestarbeitenV2DevEnabled();
+    this.elRestarbeitenV2Wrap.style.display = enabled ? "inline-flex" : "none";
+    this.elRestarbeitenV2Btn.disabled = !enabled;
+    this.elRestarbeitenV2Btn.setAttribute("aria-disabled", enabled ? "false" : "true");
+    this.elRestarbeitenV2Btn.title = enabled
+      ? "Restarbeiten V2 oeffnen"
+      : "Restarbeiten V2 ist nur im DEV-Testzugang verfuegbar.";
+  }
+
   setUiEditorSelectionMode(_nextMode) {
     return false;
   }

--- a/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
+++ b/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
@@ -1,0 +1,152 @@
+const INSTALLED_LAUNCHER_SCRIPT_PATH = "../../uiEditor/uiEditorLauncherButton.js";
+const INSTALLED_LAUNCHER_CSS_PATH = "../../uiEditor/uiEditorLauncherButton.css";
+const LAUNCHER_HOST_ATTRIBUTE = "data-ui-editor-launcher-host";
+const LAUNCHER_CSS_ATTRIBUTE = "data-ui-editor-launcher-css";
+
+function getDocument(explicitDocument = null) {
+  return explicitDocument || (typeof document === "object" ? document : null);
+}
+
+function getWindow(explicitWindow = null) {
+  return explicitWindow || (typeof window === "object" ? window : null);
+}
+
+function getInstalledLauncherArtifact(explicitWindow = null) {
+  const win = getWindow(explicitWindow);
+  return win?.uiEditorLauncherButtonArtifact?.uiEditorLauncherButton || null;
+}
+
+function getLauncherHost(doc, host = null) {
+  if (host) return host;
+  return doc?.body || null;
+}
+
+function createLauncherState({ activeUiScope = null } = {}) {
+  return {
+    uiEditorLauncherActive: false,
+    activeUiScope,
+  };
+}
+
+function ensureInstalledLauncherCss(doc = getDocument()) {
+  if (!doc?.createElement) return null;
+  const existing = doc.querySelector?.(`link[${LAUNCHER_CSS_ATTRIBUTE}="true"]`);
+  if (existing) return existing;
+
+  const link = doc.createElement("link");
+  link.rel = "stylesheet";
+  link.href = INSTALLED_LAUNCHER_CSS_PATH;
+  link.setAttribute(LAUNCHER_CSS_ATTRIBUTE, "true");
+  link.setAttribute("data-ui-editor-installed-css", INSTALLED_LAUNCHER_CSS_PATH);
+  const target = doc.head || doc.body || doc.documentElement;
+  target?.appendChild?.(link);
+  return link;
+}
+
+function loadInstalledLauncherButton({ doc = getDocument(), win = getWindow() } = {}) {
+  const existing = getInstalledLauncherArtifact(win);
+  if (existing) return Promise.resolve(existing);
+  if (!doc?.createElement) return Promise.resolve(null);
+
+  return new Promise((resolve) => {
+    const script = doc.createElement("script");
+    script.src = INSTALLED_LAUNCHER_SCRIPT_PATH;
+    script.async = true;
+    script.setAttribute("data-ui-editor-installed-script", INSTALLED_LAUNCHER_SCRIPT_PATH);
+    script.onload = () => resolve(getInstalledLauncherArtifact(win));
+    script.onerror = () => resolve(null);
+    const target = doc.body || doc.head || doc.documentElement;
+    target?.appendChild?.(script);
+  });
+}
+
+function removeExistingLauncher(doc = getDocument()) {
+  const existing = doc?.querySelector?.(`[${LAUNCHER_HOST_ATTRIBUTE}="true"]`);
+  if (existing?.parentElement?.removeChild) {
+    existing.parentElement.removeChild(existing);
+  } else if (existing?.remove) {
+    existing.remove();
+  }
+}
+
+function syncLauncherButtonState(button, state) {
+  const active = !!state?.uiEditorLauncherActive;
+  button.dataset.uiEditorLauncherActive = active ? "true" : "false";
+  button.setAttribute("data-ui-editor-launcher-active", active ? "true" : "false");
+  button.setAttribute("aria-pressed", active ? "true" : "false");
+}
+
+function renderLauncherButton({ artifact, doc, host, state, onToggle = null }) {
+  if (!artifact?.id || !doc?.createElement || !host?.appendChild) return null;
+
+  removeExistingLauncher(doc);
+
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.id = artifact.id;
+  button.className = "ui-editor-launcher-button";
+  button.textContent = "UI-Editor";
+  button.title = "UI-Editor Launcher";
+  button.setAttribute(LAUNCHER_HOST_ATTRIBUTE, "true");
+  button.setAttribute("data-ui-editor-installed-artifact", "uiEditor/uiEditorLauncherButton.js");
+  button.setAttribute("data-ui-editor-launcher-id", artifact.id);
+  button.setAttribute("data-ui-editor-launcher-role", artifact.role || "editor-launcher");
+  button.setAttribute("data-ui-editor-active-ui-scope", state.activeUiScope == null ? "" : String(state.activeUiScope));
+  button.setAttribute("aria-label", "UI-Editor Launcher");
+  syncLauncherButtonState(button, state);
+
+  button.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    state.uiEditorLauncherActive = !state.uiEditorLauncherActive;
+    syncLauncherButtonState(button, state);
+    if (typeof onToggle === "function") {
+      onToggle({
+        uiEditorLauncherActive: state.uiEditorLauncherActive,
+        activeUiScope: state.activeUiScope,
+        launcherId: artifact.id,
+      });
+    }
+  });
+
+  host.appendChild(button);
+  return button;
+}
+
+function isRuntimeLauncherDevEnabled({ header = null, devEnabled = null } = {}) {
+  if (typeof devEnabled === "boolean") return devEnabled;
+  if (typeof header?._isUiEditorEnabled === "function") return header._isUiEditorEnabled() === true;
+  return false;
+}
+
+export async function installBbmUiEditorRuntimeLauncher({
+  header = null,
+  devEnabled = null,
+  activeUiScope = null,
+  doc = getDocument(),
+  win = getWindow(),
+  host = null,
+  onToggle = null,
+} = {}) {
+  if (!isRuntimeLauncherDevEnabled({ header, devEnabled })) {
+    removeExistingLauncher(doc);
+    return null;
+  }
+
+  ensureInstalledLauncherCss(doc);
+  const artifact = await loadInstalledLauncherButton({ doc, win });
+  const launcherHost = getLauncherHost(doc, host);
+  const state = createLauncherState({ activeUiScope });
+  return renderLauncherButton({ artifact, doc, host: launcherHost, state, onToggle });
+}
+
+export {
+  INSTALLED_LAUNCHER_SCRIPT_PATH,
+  INSTALLED_LAUNCHER_CSS_PATH,
+  createLauncherState,
+  ensureInstalledLauncherCss,
+  getInstalledLauncherArtifact,
+  isRuntimeLauncherDevEnabled,
+  loadInstalledLauncherButton,
+  renderLauncherButton,
+};

--- a/uiEditor/uiEditorLauncherButton.css
+++ b/uiEditor/uiEditorLauncherButton.css
@@ -2,9 +2,10 @@
   position: fixed;
   inset-inline-start: 24px;
   inset-block-start: 24px;
-  z-index: 1000;
+  z-index: 13050;
   min-inline-size: 44px;
   min-block-size: 44px;
+  padding: 0 14px;
   border: 1px solid #516070;
   border-radius: 999px;
   background: #ffffff;

--- a/uiEditor/uiEditorLauncherButton.js
+++ b/uiEditor/uiEditorLauncherButton.js
@@ -1,19 +1,29 @@
 "use strict";
 
-const uiEditorLauncherButton = Object.freeze({
-  id: "uiEditor.launcherButton",
-  type: "button",
-  role: "editor-launcher",
-  area: "overlay",
-  position: Object.freeze({
-    x: 24,
-    y: 24,
-  }),
-  editable: true,
-  allowedOps: Object.freeze(["move", "hide", "show"]),
-  lockedOps: Object.freeze(["delete", "executeTargetAction", "modifyDomainData"]),
-});
+(function registerUiEditorLauncherButton(root, factory) {
+  const artifact = factory();
+  if (typeof module === "object" && module && typeof module.exports === "object") {
+    module.exports = artifact;
+  }
+  if (root && typeof root === "object") {
+    root.uiEditorLauncherButtonArtifact = artifact;
+  }
+})(typeof globalThis === "object" ? globalThis : undefined, function createUiEditorLauncherButtonArtifact() {
+  const uiEditorLauncherButton = Object.freeze({
+    id: "uiEditor.launcherButton",
+    type: "button",
+    role: "editor-launcher",
+    area: "overlay",
+    position: Object.freeze({
+      x: 24,
+      y: 24,
+    }),
+    editable: true,
+    allowedOps: Object.freeze(["move", "hide", "show"]),
+    lockedOps: Object.freeze(["delete", "executeTargetAction", "modifyDomainData"]),
+  });
 
-module.exports = {
-  uiEditorLauncherButton,
-};
+  return {
+    uiEditorLauncherButton,
+  };
+});


### PR DESCRIPTION
### Motivation
- Make the installed UI-Editor launcher visible in the DEV header at runtime while keeping it neutral and free of editor/domain logic. 
- Replace the old EditorLab/Scanstatus header button with the installed runtime launcher to avoid duplicate/legacy UI entry points. 
- Keep all editor functionality explicitly inactive: no panel, no hover/selection mode, no persistence, no DOM scanning and no automatic UI-detection. 

### Description
- Add a runtime launcher module `src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js` that mounts a neutral `UI-Editor` button from the installed artifact and toggles only a neutral launcher state. 
- Make the installed artifact measurable by exporting the artifact into the environment via `uiEditor/uiEditorLauncherButton.js` so the runtime loader can detect it. 
- Mount the runtime launcher from `CoreShell` by calling `installBbmUiEditorRuntimeLauncher` and gate visibility on a DEV flag, with `activeUiScope` prepared as `null`. 
- Remove the legacy UI-Editor / EditorLab header buttons and scan/status logic from `src/renderer/ui/MainHeader.js`, disabling the old scan path and related inspector runtime usage. 
- Add tests and test-harness wiring: register the new `scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs` in `scripts/test.cjs` and adjust `editorLabV2Access.test.cjs` and `projektverwaltungModule.test.cjs` to reflect the removed header buttons. 
- Update docs and status notes in `docs/UI_INSPEKTOR_AUFGABENHEFT.md` and `STATUS.md` to describe K19.14 and K19.14a changes and next steps. 

### Testing
- Ran the new launcher unit tests via `node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`, which validated artifact paths, CSS injection, mount behavior and neutral toggle handling and completed green. 
- Updated tests `node scripts/tests/editorLabV2Access.test.cjs` and `node scripts/tests/projektverwaltungModule.test.cjs` were exercised to assert that the old header buttons/scan are not rendered and those checks passed in the targeted environment. 
- Full `npm test` / entire test-suite execution could not be completed in this environment due to a missing Electron system dependency (`libatk-1.0.so.0`), as noted in `STATUS.md`, so only targeted launcher/module tests were run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a202154e77083229369d5e663365fb7)