### PR TITLE
K19.14-clean: UI-Editor-Launcher sauber anbinden

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2396,3 +2396,23 @@ Wichtig:
 - Risiken/Hinweise:
   - Die produktive Scope-Auswertung, Editor-Panel, Hover-/Auswahlmodus und Speicherung bleiben ausdruecklich nicht umgesetzt.
   - `npm test` ist in dieser Umgebung durch fehlendes Electron-Systempaket `libatk-1.0.so.0` blockiert; gezielte Launcher-/Artefaktpruefungen liefen gruen.
+
+### K19.14-clean – UI-Editor-Launcher sauber einbauen
+- Status: erledigt
+- Beschreibung:
+  - Installierter UI-Editor-Launcher sichtbar, alte Header-DEV-Buttons entfernt.
+  - Kein Panel, kein Scan, keine Speicherung, keine Fachlogik.
+  - EditorLab V2 und Restarbeiten V2 werden nicht mehr als globale Headerbuttons gerendert.
+- Betroffene Dateien:
+  - `src/renderer/ui/MainHeader.js`
+  - `src/renderer/app/CoreShell.js`
+  - `src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js`
+  - `scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`
+  - `scripts/tests/projektverwaltungModule.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - wird mit diesem Paket-Commit erstellt
+- Naechster offener Schritt:
+  - fachliche App-Sichtpruefung: UI-Editor sichtbar, EditorLab V2/Restarbeiten V2 nicht sichtbar, kein weisser Bildschirm.
+- Risiken/Hinweise:
+  - Es wurde kein spezieller Guardrail-Test zu `docs/UI_EDITOR_VERTRAG.md` gefunden; die Absicherung erfolgt ueber die gezielten Runtime-/Header-Tests.

--- a/STATUS.md
+++ b/STATUS.md
@@ -2416,3 +2416,23 @@ Wichtig:
   - fachliche App-Sichtpruefung: UI-Editor sichtbar, EditorLab V2/Restarbeiten V2 nicht sichtbar, kein weisser Bildschirm.
 - Risiken/Hinweise:
   - Es wurde kein spezieller Guardrail-Test zu `docs/UI_EDITOR_VERTRAG.md` gefunden; die Absicherung erfolgt ueber die gezielten Runtime-/Header-Tests.
+
+### K19.14-clean-Fix – UI-Editor-Launcher sichtbar machen
+- Status: erledigt
+- Beschreibung:
+  - Ursache behoben: Der Launcher wird jetzt direkt ueber das installierte Launcher-Artefakt importiert und muss nicht mehr auf einen spaeten Script-Tag-Load warten.
+  - Das installierte CSS positioniert den neutralen UI-Editor-Launcher oben rechts mit einer Z-Ebene oberhalb des Headers.
+  - `uiEditor/**/*` ist im Paket-Artefaktbestand enthalten, damit die installierten Launcher-Dateien auch ausserhalb des reinen Quellbaums verfuegbar bleiben.
+  - Kein Panel, kein Scan, keine Speicherung, keine Fachlogik; EditorLab V2 und Restarbeiten V2 bleiben aus dem Header entfernt.
+- Betroffene Dateien:
+  - `src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js`
+  - `uiEditor/uiEditorLauncherButton.css`
+  - `package.json`
+  - `scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - wird mit diesem Fix-Commit erstellt
+- Naechster offener Schritt:
+  - fachliche App-Sichtpruefung in einer Electron-Umgebung mit Systembibliotheken: UI-Editor sichtbar, EditorLab V2/Restarbeiten V2 nicht sichtbar, kein weisser Bildschirm.
+- Risiken/Hinweise:
+  - In dieser Umgebung bleibt `npm start`/`npm test` ueber Electron durch fehlendes `libatk-1.0.so.0` blockiert.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     },
     "files": [
       "src/**/*",
+      "uiEditor/**/*",
       "package.json",
       "build/bbm-icon.ico",
       "!src/main/db/app.db",

--- a/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+++ b/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
@@ -4,6 +4,8 @@ const path = require("node:path");
 const { importEsmFromFile } = require("./_esmLoader.cjs");
 
 const RUNTIME_PATH = path.join(__dirname, "../../src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js");
+const CSS_PATH = path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.css");
+const PACKAGE_PATH = path.join(__dirname, "../../package.json");
 
 function createFakeDocument() {
   const createNode = (tag, doc) => {
@@ -119,6 +121,24 @@ function findNode(node, predicate) {
   return found;
 }
 
+function getCssNumber(source, property) {
+  const match = String(source || "").match(new RegExp(`${property}\\s*:\\s*(\\d+)`));
+  return match ? Number(match[1]) : null;
+}
+
+function isMountedVisibleButton(doc, button) {
+  return Boolean(
+    button &&
+      button.tagName === "BUTTON" &&
+      button.parentElement === doc.body &&
+      button.textContent === "UI-Editor" &&
+      button.id === "uiEditor.launcherButton" &&
+      button.disabled !== true &&
+      button.getAttribute("data-ui-editor-installed-artifact") === "uiEditor/uiEditorLauncherButton.js" &&
+      button.getAttribute("aria-hidden") !== "true"
+  );
+}
+
 function matchesSelector(node, selector) {
   const raw = String(selector || "");
   if (raw === "button") return node.tagName === "BUTTON";
@@ -147,14 +167,21 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(mod.INSTALLED_LAUNCHER_CSS_PATH, "../../uiEditor/uiEditorLauncherButton.css");
 
     const source = fs.readFileSync(RUNTIME_PATH, "utf8");
+    const cssSource = fs.readFileSync(CSS_PATH, "utf8");
+    const packageJson = JSON.parse(fs.readFileSync(PACKAGE_PATH, "utf8"));
     assert.equal(source.includes("uiEditor/uiEditorLauncherButton.js"), true);
     assert.equal(source.includes("uiEditor/uiEditorLauncherButton.css"), true);
+    assert.equal(source.includes("../../../uiEditor/uiEditorLauncherButton.js"), true);
+    assert.equal(packageJson.build.files.includes("uiEditor/**/*"), true);
     assert.equal(source.includes("scanUiInspectorTargets"), false);
     assert.equal(source.includes("createUiInspectorPanel"), false);
     assert.equal(source.includes("localStorage"), false);
     assert.equal(source.includes("sessionStorage"), false);
     assert.equal(source.includes("MutationObserver"), false);
     assert.equal(source.includes("querySelectorAll"), false);
+    assert.equal(cssSource.includes("position: fixed"), true);
+    assert.equal(cssSource.includes("inset-inline-end: 24px"), true);
+    assert.equal(getCssNumber(cssSource, "z-index") > 12010, true);
   });
 
   await run("BBM UI-Editor-Runtime: Launcher ist nur im DEV-Kontext sichtbar", async () => {
@@ -170,12 +197,26 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
 
     const button = await mod.installBbmUiEditorRuntimeLauncher({ devEnabled: true, doc, win, activeUiScope: null });
     assert.equal(Boolean(button), true);
-    assert.equal(button.id, "uiEditor.launcherButton");
+    assert.equal(isMountedVisibleButton(doc, button), true);
     assert.equal(button.className, "ui-editor-launcher-button");
-    assert.equal(button.textContent, "UI-Editor");
-    assert.equal(button.getAttribute("data-ui-editor-installed-artifact"), "uiEditor/uiEditorLauncherButton.js");
     assert.equal(button.getAttribute("data-ui-editor-active-ui-scope"), "");
+    assert.equal(doc.querySelector('[data-ui-editor-launcher-host="true"]'), button);
     assert.equal(doc.querySelector('link[data-ui-editor-launcher-css="true"]').href, "../../uiEditor/uiEditorLauncherButton.css");
+  });
+
+  await run("BBM UI-Editor-Runtime: installierter Artifact-Import erzeugt sichtbaren Fake-DOM-Button", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const button = await mod.installBbmUiEditorRuntimeLauncher({
+      devEnabled: true,
+      doc,
+      win: globalThis,
+      activeUiScope: null,
+    });
+
+    assert.equal(isMountedVisibleButton(doc, button), true);
+    assert.equal(button.getAttribute("data-ui-editor-launcher-active"), "false");
+    assert.equal(Boolean(doc.querySelector('[data-ui-inspector-panel="true"]')), false);
   });
 
   await run("BBM UI-Editor-Runtime: Klick toggelt nur neutralen Launcher-State", async () => {

--- a/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+++ b/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
@@ -4,8 +4,6 @@ const path = require("node:path");
 const { importEsmFromFile } = require("./_esmLoader.cjs");
 
 const RUNTIME_PATH = path.join(__dirname, "../../src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js");
-const CORE_SHELL_PATH = path.join(__dirname, "../../src/renderer/app/CoreShell.js");
-const MAIN_HEADER_PATH = path.join(__dirname, "../../src/renderer/ui/MainHeader.js");
 
 function createFakeDocument() {
   const createNode = (tag, doc) => {
@@ -174,6 +172,7 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(Boolean(button), true);
     assert.equal(button.id, "uiEditor.launcherButton");
     assert.equal(button.className, "ui-editor-launcher-button");
+    assert.equal(button.textContent, "UI-Editor");
     assert.equal(button.getAttribute("data-ui-editor-installed-artifact"), "uiEditor/uiEditorLauncherButton.js");
     assert.equal(button.getAttribute("data-ui-editor-active-ui-scope"), "");
     assert.equal(doc.querySelector('link[data-ui-editor-launcher-css="true"]').href, "../../uiEditor/uiEditorLauncherButton.css");
@@ -205,14 +204,6 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(Boolean(doc.querySelector('[data-ui-inspector-panel="true"]')), false);
   });
 
-  await run("BBM UI-Editor-Runtime: CoreShell nutzt Runtime-Launcher statt alter Scanstatus-Grundlage", () => {
-    const coreShellSource = fs.readFileSync(CORE_SHELL_PATH, "utf8");
-    const mainHeaderSource = fs.readFileSync(MAIN_HEADER_PATH, "utf8");
-    assert.equal(coreShellSource.includes("installBbmUiEditorRuntimeLauncher"), true);
-    assert.equal(coreShellSource.includes("activeUiScope: null"), true);
-    assert.equal(mainHeaderSource.includes("_isUiEditorRuntimeLauncherEnabled"), true);
-    assert.equal(mainHeaderSource.includes("_isUiEditorEnabled() {\n    return false;\n  }"), true);
-  });
 }
 
 if (require.main === module) {

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -1058,7 +1058,18 @@ async function runProjektverwaltungModuleTests(run) {
     }
   });
 
-  await run("Projektverwaltung: alter UI-Editor-Scan bleibt im DEV-Header deaktiviert", async () => {
+  await run("Projektverwaltung: MainHeader/CoreShell ohne alte DEV-Buttons und ohne Scanstatus", async () => {
+    assert.equal(coreShellSource.includes("installBbmUiEditorRuntimeLauncher"), true);
+    assert.equal(coreShellSource.includes("activeUiScope: null"), true);
+    assert.equal(coreShellSource.includes("showEditorLabV2"), false);
+    assert.equal(coreShellSource.includes("showRestarbeitenV2Dev"), false);
+    assert.equal(coreShellSource.includes("scanUiInspectorTargets"), false);
+    assert.equal(mainHeaderSource.includes("scanUiInspectorTargets"), false);
+    assert.equal(mainHeaderSource.includes("createUiInspectorPanel"), false);
+    assert.equal(mainHeaderSource.includes("formatUiInspectorScanSummary"), false);
+    assert.equal(mainHeaderSource.includes("EditorLab V2"), false);
+    assert.equal(mainHeaderSource.includes("Restarbeiten V2"), false);
+
     const previousDocument = global.document;
     const previousWindow = global.window;
     const fakeDocument = createFakeDocumentWithBubbling();
@@ -1105,17 +1116,20 @@ async function runProjektverwaltungModuleTests(run) {
       };
 
       const header = new MainHeader({ router, version: "1.5.0" });
-      header.render();
-      header.refresh();
+      assert.doesNotThrow(() => header.render());
+      assert.doesNotThrow(() => header.refresh());
 
-      const editorButton = findNode(header.root, (node) => node?.tagName === "BUTTON" && node?.textContent === "Editor");
-      assert.ok(editorButton);
-      assert.equal(editorButton.dataset.uiEditorState, "off");
-      assert.equal(editorButton.disabled, true);
-      assert.equal(header.elUiEditorWrap.style.display, "none");
-      assert.equal(header.toggleUiEditorScan(), false);
+      const headerText = collectText(header.root);
+      assert.equal(headerText.includes("UI-Editor"), false);
+      assert.equal(headerText.includes("EditorLab V2"), false);
+      assert.equal(headerText.includes("Restarbeiten V2"), false);
+      assert.equal(headerText.includes("Scan"), false);
+      assert.equal(findNode(header.root, (node) => node?.tagName === "BUTTON" && node?.textContent === "Editor"), null);
+      assert.equal(header.elUiEditorWrap, null);
       assert.equal(header.elUiEditorPanel, null);
-      assert.equal(Boolean(findNode(fakeDocument.body, (node) => node?.attributes?.["data-ui-inspector-panel"] === "true")), false);
+      assert.equal(header.toggleUiEditorScan(), false);
+      assert.equal(header._isUiEditorRuntimeLauncherEnabled(), true);
+      assert.equal(Boolean(findNode(fakeDocument.body, (node) => node?.getAttribute?.("data-ui-inspector-panel") === "true")), false);
     } finally {
       global.document = previousDocument;
       global.window = previousWindow;

--- a/src/renderer/app/CoreShell.js
+++ b/src/renderer/app/CoreShell.js
@@ -103,7 +103,7 @@ export default class CoreShell {
     header.refresh();
     installBbmUiEditorRuntimeLauncher({
       header,
-      devEnabled: header._isUiEditorRuntimeLauncherEnabled?.() === true,
+      devEnabled: true,
       activeUiScope: null,
     });
     if (typeof updateContextButtons === "function") {

--- a/src/renderer/ui/MainHeader.js
+++ b/src/renderer/ui/MainHeader.js
@@ -10,8 +10,6 @@ import { resolveProtocolsDir } from "../utils/pdfProtocolsDir.js";
 import { PROTOKOLL_MODULE_ID } from "../app/modules/index.js";
 import { isModuleActive, refreshCachedActiveModuleAccess } from "../app/modules/moduleAccessState.js";
 import { getVisiblePrintDialogActions } from "../../shared/print/printModes.mjs";
-import { createUiInspectorPanel } from "../uiInspector/UiInspectorPanel.js";
-import { createUiInspectorRuntime, formatUiInspectorScanSummary, scanUiInspectorTargets } from "../uiInspector/UiInspectorRuntime.js";
 
 const PROTOCOL_DISABLED_MESSAGE = "Modul Protokoll ist fuer diese Lizenz nicht freigeschaltet.";
 
@@ -72,7 +70,7 @@ export default class MainHeader {
     this._uiEditorScanActive = false;
     this._uiEditorScanSummary = null;
     this._uiEditorSelectionMode = "frame";
-    this.uiInspectorRuntime = createUiInspectorRuntime({ initialSelectionMode: "frame" });
+    this.uiInspectorRuntime = null;
 
     this.elPrintBtn = null;
     this.elPrintWrap = null;
@@ -343,26 +341,6 @@ export default class MainHeader {
       };
     };
 
-    const applyUiEditorButtonStyle = (btn) => {
-      if (!btn) return;
-      btn.style.display = "inline-flex";
-      btn.style.alignItems = "center";
-      btn.style.justifyContent = "center";
-      btn.style.border = "1px solid #c8d0da";
-      btn.style.background = "#eef1f4";
-      btn.style.color = "#4b5563";
-      btn.style.borderRadius = "999px";
-      btn.style.fontSize = "11px";
-      btn.style.fontWeight = "800";
-      btn.style.lineHeight = "1";
-      btn.style.padding = "5px 10px";
-      btn.style.margin = "0";
-      btn.style.minHeight = "24px";
-      btn.style.cursor = "pointer";
-      btn.style.whiteSpace = "nowrap";
-      btn.style.boxShadow = "none";
-    };
-
     const runProjectAction = async (fn) => {
       const projectId = this.router?.currentProjectId || null;
       if (!projectId) return;
@@ -622,70 +600,9 @@ export default class MainHeader {
     printMenu.append(itemPreview, itemFirms, itemTodo, itemTopList, itemMeetingsClosed);
     printWrap.append(printBtn, printMenu);
 
-    const uiEditorWrap = document.createElement("div");
-    uiEditorWrap.style.display = "inline-flex";
-    uiEditorWrap.style.flexDirection = "column";
-    uiEditorWrap.style.alignItems = "flex-start";
-    uiEditorWrap.style.gap = "4px";
-
-    const uiEditorBtn = document.createElement("button");
-    uiEditorBtn.type = "button";
-    uiEditorBtn.textContent = "Editor";
-    applyUiEditorButtonStyle(uiEditorBtn);
-    uiEditorBtn.onclick = (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (uiEditorBtn.disabled) return;
-      this.toggleUiEditorScan();
-    };
-
-    const uiEditorStatus = document.createElement("div");
-    uiEditorStatus.style.display = "none";
-    uiEditorStatus.style.maxWidth = "320px";
-    uiEditorStatus.style.whiteSpace = "normal";
-    uiEditorStatus.style.boxSizing = "border-box";
-    uiEditorStatus.style.userSelect = "text";
-
-    uiEditorWrap.append(uiEditorBtn, uiEditorStatus);
-
-    const editorLabWrap = document.createElement("div");
-    editorLabWrap.style.display = "inline-flex";
-    editorLabWrap.style.flexDirection = "column";
-    editorLabWrap.style.alignItems = "flex-start";
-    editorLabWrap.style.gap = "4px";
-
-    const editorLabBtn = document.createElement("button");
-    editorLabBtn.type = "button";
-    editorLabBtn.textContent = "EditorLab V2";
-    applyUiEditorButtonStyle(editorLabBtn);
-    editorLabBtn.onclick = (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (editorLabBtn.disabled) return;
-      this.router?.showEditorLabV2?.();
-    };
-    editorLabBtn.title = "EditorLab V2 oeffnen";
-    editorLabWrap.append(editorLabBtn);
-
-    const restarbeitenV2Wrap = document.createElement("div");
-    restarbeitenV2Wrap.style.display = "inline-flex";
-    restarbeitenV2Wrap.style.flexDirection = "column";
-    restarbeitenV2Wrap.style.alignItems = "flex-start";
-    restarbeitenV2Wrap.style.gap = "4px";
-
-    const restarbeitenV2Btn = document.createElement("button");
-    restarbeitenV2Btn.type = "button";
-    restarbeitenV2Btn.textContent = "Restarbeiten V2";
-    applyUiEditorButtonStyle(restarbeitenV2Btn);
-    restarbeitenV2Btn.onclick = (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (restarbeitenV2Btn.disabled) return;
-      this.router?.showRestarbeitenV2Dev?.();
-    };
-    restarbeitenV2Btn.title = "Restarbeiten V2 oeffnen";
-    restarbeitenV2Wrap.append(restarbeitenV2Btn);
-
+    // K19.14-clean: Der sichtbare UI-Editor-Launcher wird in CoreShell
+    // aus dem installierten Artefaktbestand angebunden. MainHeader baut
+    // keine DEV-/Scan-/EditorLab-/Restarbeiten-V2-Headerbuttons mehr.
 
     const mailWrap = document.createElement("div");
     mailWrap.style.position = "relative";
@@ -846,13 +763,9 @@ export default class MainHeader {
     };
 
     // Ausgabe bleibt intern vorbereitet; direkte Header-Hauptaktionen laufen vorerst nur ueber die Quicklane.
-    if (this._isNewUi) {
-      actionWrap.append(uiEditorWrap);
-    } else {
-      actionWrap.append(setupWrap, uiEditorWrap);
+    if (!this._isNewUi) {
+      actionWrap.append(setupWrap);
     }
-    actionWrap.append(editorLabWrap);
-    actionWrap.append(restarbeitenV2Wrap);
 
     const stickyNotice = document.createElement("div");
     stickyNotice.style.gridColumn = "1 / span 3";
@@ -954,13 +867,13 @@ export default class MainHeader {
     this.elSetupWrap = setupWrap;
     this.elSetupBtn = setupBtn;
     this.elSetupMenu = setupMenu;
-    this.elUiEditorWrap = uiEditorWrap;
-    this.elUiEditorBtn = uiEditorBtn;
-    this.elUiEditorStatus = uiEditorStatus;
-    this.elEditorLabWrap = editorLabWrap;
-    this.elEditorLabBtn = editorLabBtn;
-    this.elRestarbeitenV2Wrap = restarbeitenV2Wrap;
-    this.elRestarbeitenV2Btn = restarbeitenV2Btn;
+    this.elUiEditorWrap = null;
+    this.elUiEditorBtn = null;
+    this.elUiEditorStatus = null;
+    this.elEditorLabWrap = null;
+    this.elEditorLabBtn = null;
+    this.elRestarbeitenV2Wrap = null;
+    this.elRestarbeitenV2Btn = null;
     this.elLogoGroup = logoGroup;
     this.elLogoWrap = logoWrap;
     this.elLogoImg = logoImg;
@@ -1709,179 +1622,67 @@ export default class MainHeader {
   }
 
   _isUiEditorRuntimeLauncherEnabled() {
-    return this._isNewUi;
+    return true;
   }
 
   _isEditorLabV2Enabled() {
-    return this._isNewUi;
+    return false;
   }
 
   _isRestarbeitenV2DevEnabled() {
-    return this._isNewUi;
+    return false;
   }
 
-  _setUiEditorStatusContent(summary = null) {
+  _setUiEditorStatusContent() {
     if (!this.elUiEditorStatus) return;
-
-    if (!summary) {
-      this.uiInspectorRuntime?.clearScanSummary?.();
-      this.elUiEditorStatus.replaceChildren();
-      this.elUiEditorStatus.style.display = "none";
-      if (typeof this.elUiEditorStatus.removeAttribute === "function") {
-        this.elUiEditorStatus.removeAttribute("data-ui-editor-status");
-      }
-      this.elUiEditorPanel?.unmount?.();
-      return;
-    }
-
-    const scan = formatUiInspectorScanSummary(summary);
-    this.uiInspectorRuntime?.setScanSummary?.(summary);
+    this.elUiEditorStatus.replaceChildren();
     this.elUiEditorStatus.style.display = "none";
-    this.elUiEditorStatus.dataset.uiEditorStatus = scan.status;
-    this.elUiEditorStatus.dataset.uiEditorState = scan.status;
-    this.elUiEditorStatus.dataset.uiEditorMode = this.uiInspectorRuntime?.getSelectionMode?.() || "frame";
-
-    if (!this.elUiEditorPanel) {
-      this.elUiEditorPanel = createUiInspectorPanel();
+    if (typeof this.elUiEditorStatus.removeAttribute === "function") {
+      this.elUiEditorStatus.removeAttribute("data-ui-editor-status");
     }
-    const panelHost = this.elUiEditorStatus.ownerDocument?.body || document.body || this.elUiEditorStatus;
-    this.elUiEditorPanel.mount(panelHost);
-
-    this.elUiEditorPanel.render({
-      scanSummary: summary,
-      selectionMode: this.uiInspectorRuntime?.getSelectionMode?.() || "frame",
-      selectionModeLabel: this.uiInspectorRuntime?.getSelectionModeLabel?.() || "Rahmen",
-      actions: {
-        setSelectionMode: (mode) => this.setUiEditorSelectionMode(mode),
-      },
-    });
   }
 
   _applyUiEditorButtonState() {
-    if (!this.elUiEditorBtn) return;
-
-    const enabled = this._isUiEditorEnabled();
-    const active = !!this._uiEditorScanActive;
-    const summary = this._uiEditorScanSummary || null;
-    const state = !enabled || !active ? "off" : summary?.status === "ok" ? "scan-ok" : "scan-warning";
-    const severity = !enabled || !active ? "off" : summary?.status === "ok" ? "ok" : "warning";
-
-    this.elUiEditorBtn.disabled = !enabled;
-    this.elUiEditorBtn.dataset.uiEditorState = state;
-    this.elUiEditorBtn.dataset.uiEditorSeverity = severity;
-    this.elUiEditorBtn.setAttribute("aria-pressed", active ? "true" : "false");
-
-    if (!enabled) {
-      this.elUiEditorBtn.style.background = "#ececec";
-      this.elUiEditorBtn.style.borderColor = "#b8b8b8";
-      this.elUiEditorBtn.style.color = "#575757";
-      this.elUiEditorBtn.style.boxShadow = "none";
-      this.elUiEditorBtn.title = "UI-Editor ist nur im DEV-Header verfuegbar.";
-      this._setUiEditorStatusContent(null);
-      if (this.elUiEditorWrap) this.elUiEditorWrap.style.display = "none";
-      return;
+    this._uiEditorScanActive = false;
+    this._uiEditorScanSummary = null;
+    this._setUiEditorStatusContent();
+    if (this.elUiEditorBtn) {
+      this.elUiEditorBtn.disabled = true;
+      this.elUiEditorBtn.dataset.uiEditorState = "off";
+      this.elUiEditorBtn.setAttribute("aria-pressed", "false");
     }
-
-    if (this.elUiEditorWrap) this.elUiEditorWrap.style.display = "inline-flex";
-
-    if (!active) {
-      this.elUiEditorBtn.style.background = "#eef1f4";
-      this.elUiEditorBtn.style.borderColor = "#c8d0da";
-      this.elUiEditorBtn.style.color = "#4b5563";
-      this.elUiEditorBtn.style.boxShadow = "none";
-      this.elUiEditorBtn.title = "UI-Editor Scan einschalten";
-      this._setUiEditorStatusContent(null);
-      return;
-    }
-
-    if (summary?.status === "ok") {
-      this.elUiEditorBtn.style.background = "#e8f7eb";
-      this.elUiEditorBtn.style.borderColor = "#16a34a";
-      this.elUiEditorBtn.style.color = "#166534";
-      this.elUiEditorBtn.style.boxShadow = "0 0 0 1px rgba(22,163,74,0.22) inset";
-      this.elUiEditorBtn.title = "UI-Editor Scan: vollständig";
-    } else {
-      this.elUiEditorBtn.style.background = "#fff5db";
-      this.elUiEditorBtn.style.borderColor = "#d97706";
-      this.elUiEditorBtn.style.color = "#92400e";
-      this.elUiEditorBtn.style.boxShadow = "0 0 0 1px rgba(217,119,6,0.22) inset";
-      this.elUiEditorBtn.title = "UI-Editor Scan: unvollständig";
-    }
-
-    this._setUiEditorStatusContent(summary);
+    if (this.elUiEditorWrap) this.elUiEditorWrap.style.display = "none";
   }
 
   _applyEditorLabButtonState() {
-    if (!this.elEditorLabWrap || !this.elEditorLabBtn) return;
-    const enabled = this._isEditorLabV2Enabled();
-    this.elEditorLabWrap.style.display = enabled ? "inline-flex" : "none";
-    this.elEditorLabBtn.disabled = !enabled;
-    this.elEditorLabBtn.setAttribute("aria-disabled", enabled ? "false" : "true");
-    this.elEditorLabBtn.title = enabled
-      ? "EditorLab V2 oeffnen"
-      : "EditorLab V2 ist nur im DEV-Testzugang verfuegbar.";
+    if (this.elEditorLabWrap) this.elEditorLabWrap.style.display = "none";
+    if (this.elEditorLabBtn) {
+      this.elEditorLabBtn.disabled = true;
+      this.elEditorLabBtn.setAttribute("aria-disabled", "true");
+    }
   }
 
   _applyRestarbeitenV2ButtonState() {
-    if (!this.elRestarbeitenV2Wrap || !this.elRestarbeitenV2Btn) return;
-    const enabled = this._isRestarbeitenV2DevEnabled();
-    this.elRestarbeitenV2Wrap.style.display = enabled ? "inline-flex" : "none";
-    this.elRestarbeitenV2Btn.disabled = !enabled;
-    this.elRestarbeitenV2Btn.setAttribute("aria-disabled", enabled ? "false" : "true");
-    this.elRestarbeitenV2Btn.title = enabled
-      ? "Restarbeiten V2 oeffnen"
-      : "Restarbeiten V2 ist nur im DEV-Testzugang verfuegbar.";
+    if (this.elRestarbeitenV2Wrap) this.elRestarbeitenV2Wrap.style.display = "none";
+    if (this.elRestarbeitenV2Btn) {
+      this.elRestarbeitenV2Btn.disabled = true;
+      this.elRestarbeitenV2Btn.setAttribute("aria-disabled", "true");
+    }
   }
 
-  setUiEditorSelectionMode(nextMode) {
-    const changed = this.uiInspectorRuntime?.setSelectionMode?.(nextMode) === true;
-    this._uiEditorSelectionMode = this.uiInspectorRuntime?.getSelectionMode?.() || "frame";
-    if (this._uiEditorScanActive && this._uiEditorScanSummary) {
-      this._setUiEditorStatusContent(this._uiEditorScanSummary);
-      this._applyUiEditorButtonState();
-    }
-    return changed;
+  setUiEditorSelectionMode() {
+    return false;
   }
 
   _scanUiEditorCurrentScreen() {
-    const root = this.router?.contentRoot || null;
-    if (!root) {
-      this._uiEditorScanSummary = {
-        schemaKey: "",
-        totalMarkers: 0,
-        frameCount: 0,
-        fieldCount: 0,
-        singleElementCount: 0,
-        unknownCount: 0,
-        missingImportantIds: [],
-        status: "warning",
-        statusLabel: "unvollständig",
-      };
-      this.uiInspectorRuntime?.setScanSummary?.(this._uiEditorScanSummary);
-      this._applyUiEditorButtonState();
-      return this._uiEditorScanSummary;
-    }
-
-    this._uiEditorScanSummary = scanUiInspectorTargets(root);
-    this.uiInspectorRuntime?.setScanSummary?.(this._uiEditorScanSummary);
-    this._applyUiEditorButtonState();
-    return this._uiEditorScanSummary;
+    return null;
   }
 
   toggleUiEditorScan() {
-    if (!this._isUiEditorEnabled()) return false;
-
-    this._uiEditorScanActive = !this._uiEditorScanActive;
-    if (this._uiEditorScanActive) {
-      this.uiInspectorRuntime?.setSelectionMode?.("frame");
-      this._uiEditorSelectionMode = this.uiInspectorRuntime?.getSelectionMode?.() || "frame";
-      this._scanUiEditorCurrentScreen();
-    } else {
-      this._uiEditorScanSummary = null;
-      this.uiInspectorRuntime?.clearScanSummary?.();
-      this._applyUiEditorButtonState();
-    }
-    return this._uiEditorScanActive;
+    this._uiEditorScanActive = false;
+    this._uiEditorScanSummary = null;
+    this._applyUiEditorButtonState();
+    return false;
   }
 
   _applyPrintButtonState() {

--- a/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
+++ b/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
@@ -1,3 +1,7 @@
+import * as installedLauncherButtonArtifactModule from "../../../uiEditor/uiEditorLauncherButton.js";
+
+void installedLauncherButtonArtifactModule;
+
 const INSTALLED_LAUNCHER_SCRIPT_PATH = "../../uiEditor/uiEditorLauncherButton.js";
 const INSTALLED_LAUNCHER_CSS_PATH = "../../uiEditor/uiEditorLauncherButton.css";
 const LAUNCHER_HOST_ATTRIBUTE = "data-ui-editor-launcher-host";

--- a/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
+++ b/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
@@ -85,14 +85,14 @@ function renderLauncherButton({ artifact, doc, host, state, onToggle = null }) {
   button.type = "button";
   button.id = artifact.id;
   button.className = "ui-editor-launcher-button";
-  button.textContent = "UI";
-  button.title = "UI-Editor Launcher";
+  button.textContent = "UI-Editor";
+  button.title = "UI-Editor";
   button.setAttribute(LAUNCHER_HOST_ATTRIBUTE, "true");
   button.setAttribute("data-ui-editor-installed-artifact", "uiEditor/uiEditorLauncherButton.js");
   button.setAttribute("data-ui-editor-launcher-id", artifact.id);
   button.setAttribute("data-ui-editor-launcher-role", artifact.role || "editor-launcher");
   button.setAttribute("data-ui-editor-active-ui-scope", state.activeUiScope == null ? "" : String(state.activeUiScope));
-  button.setAttribute("aria-label", "UI-Editor Launcher");
+  button.setAttribute("aria-label", "UI-Editor");
   syncLauncherButtonState(button, state);
 
   button.addEventListener("click", (event) => {

--- a/uiEditor/uiEditorLauncherButton.css
+++ b/uiEditor/uiEditorLauncherButton.css
@@ -1,8 +1,8 @@
 .ui-editor-launcher-button {
   position: fixed;
-  inset-inline-start: 24px;
+  inset-inline-end: 24px;
   inset-block-start: 24px;
-  z-index: 1000;
+  z-index: 13100;
   min-inline-size: 44px;
   min-block-size: 44px;
   border: 1px solid #516070;


### PR DESCRIPTION
### Motivation
- Sichtbar machen des installierten UI-Editor-Runtime-Launchers aus den gelieferten Artefakten und gleichzeitig alte, fehleranfällige DEV-Header-Buttons/Scanreste entfernen. 
- Sicherstellen, dass der Launcher nur einen neutralen Toggle-State bietet und keinerlei Panel-/Scan-/Speicher- oder Fachlogik startet. 

### Description
- `src/renderer/ui/MainHeader.js` bereinigt: entfernte `uiInspector`-Imports, entfernt Rendering der alten `Editor`/`EditorLab V2`/`Restarbeiten V2` Headerbuttons, `uiInspectorRuntime` auf `null` gesetzt und alle Scan-/Panel-Methoden neutralisiert. 
- `src/renderer/app/CoreShell.js` verdrahtet den Runtime-Launcher initial: `installBbmUiEditorRuntimeLauncher({ header, devEnabled: true, activeUiScope: null })` so dass der sichtbare Launcher aus dem installierten Artefaktbestand geladen wird. 
- `src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js` nutzt die installierten Artefaktpfade (`uiEditor/uiEditorLauncherButton.js` und `uiEditor/uiEditorLauncherButton.css`), rendert den Button mit ID `uiEditor.launcherButton`, Text `UI-Editor`, Attribut `data-ui-editor-installed-artifact=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2065d291ec83229b770046abe67bb5)