### PR TITLE
K19.16a: UI-Editor-Launcher zeigt registrierten Scope in Statusanzeige

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,11 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- K19.16a neutraler UI-Editor-Aktivmodus zeigt festen registrierten Scope:
+  - Der Statushinweis zeigt bei aktivem UI-Editor den registrierten Scope `protokoll.topsScreen` aus der BBM-Registry.
+  - Keine automatische Erkennung, kein Panel, kein Hover, keine Auswahl, keine Speicherung, kein DOM-Scan und keine Fachlogik.
+  - Naechster offener Schritt: fachliche Sichtpruefung per `npm start` auf dem Zielsystem.
+
 - K19.9a BBM-Testeinbindung nach Neuinstallation der UI-Editor-Artefakte sauber repariert:
   - Installierte Artefakt-Tests unter `uiEditor/tests/` bleiben generisch und werden nicht mehr direkt als BBM-Testmodul in `scripts/test.cjs` importiert.
   - BBM prueft installierte UI-Editor-Artefakte ueber den eigenen Test `scripts/tests/bbmUiEditorInstalledArtifacts.test.cjs`.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -1,7 +1,7 @@
 # UI-Inspektor Aufgabenheft
 
 ## Projektstatus
-Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.13a abgeschlossen (BBM-Test ist an aktuelle UI-Editor-Installer-Artefakte angepasst).
+Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.16a abgeschlossen (neutraler BBM-UI-Editor-Aktivmodus zeigt festen Registry-Scope).
 
 Aktueller Stand:
 - M1 bis M13.6a abgeschlossen.
@@ -9,6 +9,7 @@ Aktueller Stand:
 - K19.7 abgeschlossen: installierter Einstieg unter `uiEditor/` war mit dem offiziellen BBM-Registry-Einstieg verbunden, ohne produktive UI-Aenderung.
 - K19.9a abgeschlossen: `uiEditor/` enthaelt installierte UI-Editor-Artefakte; die echte BBM-Registry bleibt separat unter `src/renderer/uiEditor/bbmUiEditorRegistry.js`; `scripts/test.cjs` ist nicht direkt an installierte Artefakt-Testdateien gekoppelt.
 - K19.13a abgeschlossen: Der BBM-Artefakttest erkennt `uiEditor.global` robust ueber `id`, `uiScope`, `uiScopeId` oder den Registry-Schluessel und verlangt `uiEditor/targetAppRegistry.js` als installiertes Pflichtartefakt.
+- K19.16a abgeschlossen: Der neutrale UI-Editor-Aktivmodus zeigt den festen aktiven BBM-Registry-Scope `protokoll.topsScreen`; bei leerem Scope wird `nicht erkannt` angezeigt.
 
 ## Haken-System
 - `[x]` erledigt
@@ -46,6 +47,12 @@ Aktueller Stand:
 - [x] K19.7 Installierte UI-Editor-Grundstruktur mit echter BBM-Registry verbinden
 - [x] K19.9a BBM-Testeinbindung nach Neuinstallation der UI-Editor-Artefakte trennen
 - [x] K19.13a BBM-Test an aktuelle UI-Editor-Installer-Artefakte anpassen
+- [x] K19.16a UI-Editor zeigt festen registrierten Scope aus BBM-Registry
+
+## Statusupdate K19.16a
+- `CoreShell` uebergibt den festen aktiven Scope aus `src/renderer/uiEditor/bbmUiEditorRegistry.js` an den neutralen Runtime-Launcher.
+- Der aktive Statushinweis zeigt `UI-Editor aktiv` und `Scope: protokoll.topsScreen`; leere Scope-Werte fallen auf `Scope: nicht erkannt` zurueck.
+- Keine automatische Scope-Ermittlung, kein Router-Scan, kein DOM-Scan, kein Editor-Panel, kein Hover-Rahmen, keine Auswahl, keine Speicherung und keine Fachlogik.
 
 ## Statusupdate K19.13a
 - `scripts/tests/bbmUiEditorInstalledArtifacts.test.cjs` erkennt den globalen UI-Editor-Scope robust ueber `id`, `uiScope`, `uiScopeId` oder einen standardisierten Registry-Schluessel.

--- a/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+++ b/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
@@ -191,6 +191,7 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(cssSource.includes("position: fixed"), true);
     assert.equal(cssSource.includes("inset-inline-end: 24px"), true);
     assert.equal(cssSource.includes("ui-editor-launcher-status"), true);
+    assert.equal(cssSource.includes("white-space: pre-line"), true);
     assert.equal(cssSource.includes('[data-ui-editor-launcher-active="true"]'), true);
     assert.equal(getCssNumber(cssSource, "z-index") > 12010, true);
   });
@@ -258,7 +259,7 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(doc.body.getAttribute("data-ui-editor-active"), "true");
     const activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
     assert.equal(Boolean(activeStatus), true);
-    assert.equal(activeStatus.textContent, "UI-Editor aktiv");
+    assert.equal(activeStatus.textContent, "UI-Editor aktiv\nScope: nicht erkannt");
 
     button.click();
     assert.equal(button.dataset.uiEditorLauncherActive, "false");
@@ -274,6 +275,53 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(Boolean(doc.querySelector('[data-ui-editor-hover-frame="true"]')), false);
   });
 
+  await run("BBM UI-Editor-Runtime: aktiver Status zeigt uebergebenen bekannten Scope", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const win = {
+      uiEditorLauncherButtonArtifact: require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js")),
+    };
+    const toggles = [];
+    const button = await mod.installBbmUiEditorRuntimeLauncher({
+      devEnabled: true,
+      doc,
+      win,
+      activeUiScope: "protokoll.topsScreen",
+      onToggle: (event) => toggles.push(event),
+    });
+
+    assert.equal(button.getAttribute("data-ui-editor-active-ui-scope"), "protokoll.topsScreen");
+    button.click();
+
+    const activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
+    assert.equal(Boolean(activeStatus), true);
+    assert.equal(activeStatus.textContent, "UI-Editor aktiv\nScope: protokoll.topsScreen");
+    assert.deepEqual(toggles.map((event) => event.activeUiScope), ["protokoll.topsScreen"]);
+    assert.equal(Boolean(doc.querySelector('[data-ui-inspector-panel="true"]')), false);
+    assert.equal(Boolean(doc.querySelector('[data-ui-editor-panel="true"]')), false);
+    assert.equal(Boolean(doc.querySelector('[data-ui-editor-hover-frame="true"]')), false);
+  });
+
+  await run("BBM UI-Editor-Runtime: leerer Scope zeigt nicht erkannt", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const win = {
+      uiEditorLauncherButtonArtifact: require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js")),
+    };
+    const button = await mod.installBbmUiEditorRuntimeLauncher({
+      devEnabled: true,
+      doc,
+      win,
+      activeUiScope: "   ",
+    });
+
+    button.click();
+
+    const activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
+    assert.equal(Boolean(activeStatus), true);
+    assert.equal(activeStatus.textContent, "UI-Editor aktiv\nScope: nicht erkannt");
+  });
+
   await run("BBM UI-Editor-Runtime: bleibt ohne Scan, Speicherung und Ziel-App-Aktion", async () => {
     const source = fs.readFileSync(RUNTIME_PATH, "utf8");
     assert.equal(source.includes("scanUiInspectorTargets"), false);
@@ -285,6 +333,8 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(source.includes("writeFile"), false);
     assert.equal(source.includes("showEditorLabV2"), false);
     assert.equal(source.includes("showRestarbeitenV2"), false);
+    assert.equal(source.includes("getStatusScopeLabel"), true);
+    assert.equal(source.includes("activeUiScope"), true);
   });
 
 }

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -1060,7 +1060,9 @@ async function runProjektverwaltungModuleTests(run) {
 
   await run("Projektverwaltung: MainHeader/CoreShell ohne alte DEV-Buttons und ohne Scanstatus", async () => {
     assert.equal(coreShellSource.includes("installBbmUiEditorRuntimeLauncher"), true);
-    assert.equal(coreShellSource.includes("activeUiScope: null"), true);
+    assert.equal(coreShellSource.includes("getActiveUiScope"), true);
+    assert.equal(coreShellSource.includes("activeUiScope: getActiveUiScope()"), true);
+    assert.equal(coreShellSource.includes("activeUiScope: null"), false);
     assert.equal(coreShellSource.includes("showEditorLabV2"), false);
     assert.equal(coreShellSource.includes("showRestarbeitenV2Dev"), false);
     assert.equal(coreShellSource.includes("scanUiInspectorTargets"), false);

--- a/src/renderer/app/CoreShell.js
+++ b/src/renderer/app/CoreShell.js
@@ -21,6 +21,7 @@ import { registerCoreShellContextControls } from "./coreShellContextControls.js"
 import { registerCoreShellKeyboardHandling } from "./coreShellKeyboard.js";
 import { createCoreShellNavigationRuntime } from "./coreShellNavigationRuntime.js";
 import { installBbmUiEditorRuntimeLauncher } from "../uiEditor/BbmUiEditorRuntimeLauncher.js";
+import { getActiveUiScope } from "../uiEditor/bbmUiEditorRegistry.js";
 
 export default class CoreShell {
   constructor({ router, version } = {}) {
@@ -104,7 +105,7 @@ export default class CoreShell {
     installBbmUiEditorRuntimeLauncher({
       header,
       devEnabled: true,
-      activeUiScope: null,
+      activeUiScope: getActiveUiScope(),
     });
     if (typeof updateContextButtons === "function") {
       updateContextButtons();

--- a/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
+++ b/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
@@ -86,14 +86,19 @@ function removeExistingLauncher(doc = getDocument()) {
   doc?.body?.setAttribute?.(UI_EDITOR_ACTIVE_ATTRIBUTE, "false");
 }
 
-function ensureLauncherStatusHint(doc, host) {
+function getStatusScopeLabel(activeUiScope = null) {
+  const normalizedScope = String(activeUiScope == null ? "" : activeUiScope).trim();
+  return normalizedScope || "nicht erkannt";
+}
+
+function ensureLauncherStatusHint(doc, host, activeUiScope = null) {
   const existing = doc?.querySelector?.(`[${LAUNCHER_STATUS_ATTRIBUTE}="true"]`);
   if (existing) return existing;
   if (!doc?.createElement || !host?.appendChild) return null;
 
   const status = doc.createElement("div");
   status.className = "ui-editor-launcher-status";
-  status.textContent = "UI-Editor aktiv";
+  status.textContent = `UI-Editor aktiv\nScope: ${getStatusScopeLabel(activeUiScope)}`;
   status.setAttribute(LAUNCHER_STATUS_ATTRIBUTE, "true");
   status.setAttribute("role", "status");
   status.setAttribute("aria-live", "polite");
@@ -109,7 +114,7 @@ function syncLauncherButtonState(button, state, { doc = getDocument(), host = nu
   doc?.body?.setAttribute?.(UI_EDITOR_ACTIVE_ATTRIBUTE, active ? "true" : "false");
 
   if (active) {
-    ensureLauncherStatusHint(doc, host || button.parentElement);
+    ensureLauncherStatusHint(doc, host || button.parentElement, state?.activeUiScope);
   } else {
     removeExistingLauncherStatus(doc);
   }
@@ -187,6 +192,7 @@ export {
   getInstalledLauncherArtifact,
   isRuntimeLauncherDevEnabled,
   loadInstalledLauncherButton,
+  getStatusScopeLabel,
   ensureLauncherStatusHint,
   renderLauncherButton,
 };

--- a/uiEditor/uiEditorLauncherButton.css
+++ b/uiEditor/uiEditorLauncherButton.css
@@ -33,5 +33,6 @@
   font: inherit;
   font-size: 12px;
   line-height: 16px;
+  white-space: pre-line;
   pointer-events: none;
 }


### PR DESCRIPTION
### Motivation
- Der neutrale UI-Editor-Aktivmodus soll im aktiven Zustand einen bekannten, fest registrierten UI-Scope anzeigen und dabei keine automatische Erkennung, kein DOM-Scan und keine Editor-Funktionalität einführen.

### Description
- `CoreShell` übergibt den aktiven Registry-Scope an den Launcher, indem `getActiveUiScope()` aus `src/renderer/uiEditor/bbmUiEditorRegistry.js` an `installBbmUiEditorRuntimeLauncher` übergeben wird (`src/renderer/app/CoreShell.js`).
- `BbmUiEditorRuntimeLauncher` wurde erweitert: es gibt jetzt `getStatusScopeLabel()` und `ensureLauncherStatusHint(.., activeUiScope)` und die Statusanzeige zeigt im aktiven Zustand `UI-Editor aktiv` und in der nächsten Zeile `Scope: <wert>` oder `Scope: nicht erkannt` bei leerem/null-Wert (`src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js`).
- Das Status-CSS wurde angepasst, damit der Zeilenumbruch sichtbar ist (`white-space: pre-line` in `uiEditor/uiEditorLauncherButton.css`).
- Aufgabenheft und `STATUS.md` wurden um K19.16a ergänzt und die entsprechenden Tests aktualisiert (`scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`, `scripts/tests/projektverwaltungModule.test.cjs`).

### Testing
- Es wurden gezielt Unit/Runtime-Tests ausgeführt und bestanden: `node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs` (inkl. Fälle: bekannter Scope, leerer Scope, neutrales Toggle), `node scripts/tests/bbmUiEditorRegistry.test.cjs`, `node scripts/tests/editorLabV2Access.test.cjs` und `node scripts/tests/restarbeitenV2DevAccess.test.cjs` all passed.
- `git diff --check` ist sauber und es gibt keine whitespace-/diff-issues.
- `npm test` konnte in dieser Umgebung nicht vollständig grün laufen, weil das Electron-Binary wegen fehlender Systembibliothek `libatk-1.0.so.0` nicht startet; ein Versuch, die Systempakete nachzuinstallieren, scheiterte an Netzwerk/Proxy-Beschränkungen. Alltagsrelevante node-tests zur Änderung sind dennoch erfolgreich gelaufen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a208113f71c83229a575a2544920bec)