### PR TITLE
K19.17: Show read-only registered UI elements in neutral UI-Editor status

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,11 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- K19.17 neutraler UI-Editor-Aktivmodus zeigt registrierte UI-Elementliste rein lesend:
+  - Der Statushinweis zeigt bei aktivem UI-Editor den registrierten Scope `protokoll.topsScreen` und darunter die registrierten UI-Elemente aus der BBM-Registry.
+  - Keine Bearbeitung, keine Auswahl, keine Speicherung, kein DOM-Scan und keine Fachlogik.
+  - Naechster offener Schritt: fachliche Sichtpruefung per `npm start` auf dem Zielsystem.
+
 - K19.16a neutraler UI-Editor-Aktivmodus zeigt festen registrierten Scope:
   - Der Statushinweis zeigt bei aktivem UI-Editor den registrierten Scope `protokoll.topsScreen` aus der BBM-Registry.
   - Keine automatische Erkennung, kein Panel, kein Hover, keine Auswahl, keine Speicherung, kein DOM-Scan und keine Fachlogik.

--- a/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+++ b/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
@@ -192,6 +192,7 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(cssSource.includes("inset-inline-end: 24px"), true);
     assert.equal(cssSource.includes("ui-editor-launcher-status"), true);
     assert.equal(cssSource.includes("white-space: pre-line"), true);
+    assert.equal(cssSource.includes("max-inline-size: 360px"), true);
     assert.equal(cssSource.includes('[data-ui-editor-launcher-active="true"]'), true);
     assert.equal(getCssNumber(cssSource, "z-index") > 12010, true);
   });
@@ -259,7 +260,10 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(doc.body.getAttribute("data-ui-editor-active"), "true");
     const activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
     assert.equal(Boolean(activeStatus), true);
-    assert.equal(activeStatus.textContent, "UI-Editor aktiv\nScope: nicht erkannt");
+    assert.equal(
+      activeStatus.textContent,
+      "UI-Editor aktiv\nScope: nicht erkannt\n\nRegistrierte Elemente:\nnicht verfügbar"
+    );
 
     button.click();
     assert.equal(button.dataset.uiEditorLauncherActive, "false");
@@ -295,7 +299,10 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
 
     const activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
     assert.equal(Boolean(activeStatus), true);
-    assert.equal(activeStatus.textContent, "UI-Editor aktiv\nScope: protokoll.topsScreen");
+    assert.equal(
+      activeStatus.textContent,
+      "UI-Editor aktiv\nScope: protokoll.topsScreen\n\nRegistrierte Elemente:\nnicht verfügbar"
+    );
     assert.deepEqual(toggles.map((event) => event.activeUiScope), ["protokoll.topsScreen"]);
     assert.equal(Boolean(doc.querySelector('[data-ui-inspector-panel="true"]')), false);
     assert.equal(Boolean(doc.querySelector('[data-ui-editor-panel="true"]')), false);
@@ -319,8 +326,56 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
 
     const activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
     assert.equal(Boolean(activeStatus), true);
-    assert.equal(activeStatus.textContent, "UI-Editor aktiv\nScope: nicht erkannt");
+    assert.equal(
+      activeStatus.textContent,
+      "UI-Editor aktiv\nScope: nicht erkannt\n\nRegistrierte Elemente:\nnicht verfügbar"
+    );
   });
+
+  await run("BBM UI-Editor-Runtime: aktiver Status zeigt registrierte Elementliste rein lesend", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const win = {
+      uiEditorLauncherButtonArtifact: require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js")),
+    };
+    const button = await mod.installBbmUiEditorRuntimeLauncher({
+      devEnabled: true,
+      doc,
+      win,
+      activeUiScope: "protokoll.topsScreen",
+      registeredElements: [
+        { id: "protokoll.root", label: "Root", area: "Protokoll", projectId: "17", text: "Fachdaten" },
+        { id: "protokoll.header" },
+        { id: "  " },
+      ],
+    });
+
+    button.click();
+
+    const activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
+    assert.equal(Boolean(activeStatus), true);
+    assert.equal(activeStatus.textContent.includes("Registrierte Elemente:"), true);
+    assert.equal(activeStatus.textContent.includes("* protokoll.root (Root · Protokoll)"), true);
+    assert.equal(activeStatus.textContent.includes("* protokoll.header"), true);
+    assert.equal(activeStatus.textContent.includes("projectId"), false);
+    assert.equal(activeStatus.textContent.includes("Fachdaten"), false);
+    assert.equal(Boolean(doc.querySelector('[data-ui-editor-panel="true"]')), false);
+    assert.equal(Boolean(doc.querySelector('[data-ui-editor-hover-frame="true"]')), false);
+  });
+
+  await run("BBM UI-Editor-Runtime: Helper uebernimmt nur uebergebene Registry-Daten", async () => {
+    const mod = await loadRuntime();
+    assert.deepEqual(mod.normalizeReadonlyRegisteredElements(null), []);
+    assert.deepEqual(mod.normalizeReadonlyRegisteredElements([{ id: "x", value: "Fachdaten", label: "Name" }]), [
+      { id: "x", label: "Name", area: "" },
+    ]);
+    assert.equal(
+      mod.getReadonlyRegisteredElementsText([{ id: "x", name: "Element" }]),
+      "Registrierte Elemente:\n\n* x (Element)"
+    );
+    assert.equal(mod.getReadonlyRegisteredElementsText([]), "Registrierte Elemente:\nnicht verfügbar");
+  });
+
 
   await run("BBM UI-Editor-Runtime: bleibt ohne Scan, Speicherung und Ziel-App-Aktion", async () => {
     const source = fs.readFileSync(RUNTIME_PATH, "utf8");

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -1061,7 +1061,9 @@ async function runProjektverwaltungModuleTests(run) {
   await run("Projektverwaltung: MainHeader/CoreShell ohne alte DEV-Buttons und ohne Scanstatus", async () => {
     assert.equal(coreShellSource.includes("installBbmUiEditorRuntimeLauncher"), true);
     assert.equal(coreShellSource.includes("getActiveUiScope"), true);
-    assert.equal(coreShellSource.includes("activeUiScope: getActiveUiScope()"), true);
+    assert.equal(coreShellSource.includes("getBbmUiEditorRegistry"), true);
+    assert.equal(coreShellSource.includes("const activeUiScope = getActiveUiScope()"), true);
+    assert.equal(coreShellSource.includes("registeredElements: uiEditorRegistry?.elements"), true);
     assert.equal(coreShellSource.includes("activeUiScope: null"), false);
     assert.equal(coreShellSource.includes("showEditorLabV2"), false);
     assert.equal(coreShellSource.includes("showRestarbeitenV2Dev"), false);

--- a/src/renderer/app/CoreShell.js
+++ b/src/renderer/app/CoreShell.js
@@ -21,7 +21,7 @@ import { registerCoreShellContextControls } from "./coreShellContextControls.js"
 import { registerCoreShellKeyboardHandling } from "./coreShellKeyboard.js";
 import { createCoreShellNavigationRuntime } from "./coreShellNavigationRuntime.js";
 import { installBbmUiEditorRuntimeLauncher } from "../uiEditor/BbmUiEditorRuntimeLauncher.js";
-import { getActiveUiScope } from "../uiEditor/bbmUiEditorRegistry.js";
+import { getActiveUiScope, getBbmUiEditorRegistry } from "../uiEditor/bbmUiEditorRegistry.js";
 
 export default class CoreShell {
   constructor({ router, version } = {}) {
@@ -102,10 +102,13 @@ export default class CoreShell {
 
     router.showHome();
     header.refresh();
+    const activeUiScope = getActiveUiScope();
+    const uiEditorRegistry = getBbmUiEditorRegistry(activeUiScope);
     installBbmUiEditorRuntimeLauncher({
       header,
       devEnabled: true,
-      activeUiScope: getActiveUiScope(),
+      activeUiScope,
+      registeredElements: uiEditorRegistry?.elements,
     });
     if (typeof updateContextButtons === "function") {
       updateContextButtons();

--- a/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
+++ b/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
@@ -27,10 +27,26 @@ function getLauncherHost(doc, host = null) {
   return doc?.body || null;
 }
 
-function createLauncherState({ activeUiScope = null } = {}) {
+function normalizeReadonlyRegisteredElements(registeredElements = null) {
+  if (!Array.isArray(registeredElements)) return [];
+
+  return registeredElements
+    .map((element) => {
+      if (!element || typeof element !== "object") return null;
+      const id = String(element.id == null ? "" : element.id).trim();
+      if (!id) return null;
+      const label = String(element.label ?? element.name ?? "").trim();
+      const area = String(element.area ?? "").trim();
+      return { id, label, area };
+    })
+    .filter(Boolean);
+}
+
+function createLauncherState({ activeUiScope = null, registeredElements = null } = {}) {
   return {
     uiEditorLauncherActive: false,
     activeUiScope,
+    registeredElements: normalizeReadonlyRegisteredElements(registeredElements),
   };
 }
 
@@ -91,14 +107,34 @@ function getStatusScopeLabel(activeUiScope = null) {
   return normalizedScope || "nicht erkannt";
 }
 
-function ensureLauncherStatusHint(doc, host, activeUiScope = null) {
+function getReadonlyRegisteredElementsText(registeredElements = null) {
+  const elements = normalizeReadonlyRegisteredElements(registeredElements);
+  if (elements.length < 1) return "Registrierte Elemente:\nnicht verfügbar";
+
+  const lines = elements.map((element) => {
+    const details = [element.label, element.area].filter(Boolean).join(" · ");
+    return details ? `* ${element.id} (${details})` : `* ${element.id}`;
+  });
+  return ["Registrierte Elemente:", "", ...lines].join("\n");
+}
+
+function getLauncherStatusText({ activeUiScope = null, registeredElements = null } = {}) {
+  return [
+    "UI-Editor aktiv",
+    `Scope: ${getStatusScopeLabel(activeUiScope)}`,
+    "",
+    getReadonlyRegisteredElementsText(registeredElements),
+  ].join("\n");
+}
+
+function ensureLauncherStatusHint(doc, host, state = {}) {
   const existing = doc?.querySelector?.(`[${LAUNCHER_STATUS_ATTRIBUTE}="true"]`);
   if (existing) return existing;
   if (!doc?.createElement || !host?.appendChild) return null;
 
   const status = doc.createElement("div");
   status.className = "ui-editor-launcher-status";
-  status.textContent = `UI-Editor aktiv\nScope: ${getStatusScopeLabel(activeUiScope)}`;
+  status.textContent = getLauncherStatusText(state);
   status.setAttribute(LAUNCHER_STATUS_ATTRIBUTE, "true");
   status.setAttribute("role", "status");
   status.setAttribute("aria-live", "polite");
@@ -114,7 +150,7 @@ function syncLauncherButtonState(button, state, { doc = getDocument(), host = nu
   doc?.body?.setAttribute?.(UI_EDITOR_ACTIVE_ATTRIBUTE, active ? "true" : "false");
 
   if (active) {
-    ensureLauncherStatusHint(doc, host || button.parentElement, state?.activeUiScope);
+    ensureLauncherStatusHint(doc, host || button.parentElement, state);
   } else {
     removeExistingLauncherStatus(doc);
   }
@@ -167,6 +203,7 @@ export async function installBbmUiEditorRuntimeLauncher({
   header = null,
   devEnabled = null,
   activeUiScope = null,
+  registeredElements = null,
   doc = getDocument(),
   win = getWindow(),
   host = null,
@@ -180,7 +217,7 @@ export async function installBbmUiEditorRuntimeLauncher({
   ensureInstalledLauncherCss(doc);
   const artifact = await loadInstalledLauncherButton({ doc, win });
   const launcherHost = getLauncherHost(doc, host);
-  const state = createLauncherState({ activeUiScope });
+  const state = createLauncherState({ activeUiScope, registeredElements });
   return renderLauncherButton({ artifact, doc, host: launcherHost, state, onToggle });
 }
 
@@ -193,6 +230,9 @@ export {
   isRuntimeLauncherDevEnabled,
   loadInstalledLauncherButton,
   getStatusScopeLabel,
+  getReadonlyRegisteredElementsText,
+  getLauncherStatusText,
+  normalizeReadonlyRegisteredElements,
   ensureLauncherStatusHint,
   renderLauncherButton,
 };

--- a/uiEditor/uiEditorLauncherButton.css
+++ b/uiEditor/uiEditorLauncherButton.css
@@ -25,9 +25,12 @@
   inset-inline-end: 24px;
   inset-block-start: 76px;
   z-index: 13100;
-  padding: 6px 10px;
+  box-sizing: border-box;
+  min-inline-size: 220px;
+  max-inline-size: 360px;
+  padding: 8px 10px;
   border: 1px solid #bfdbfe;
-  border-radius: 999px;
+  border-radius: 12px;
   background: #eff6ff;
   color: #1e3a8a;
   font: inherit;


### PR DESCRIPTION
### Motivation
- Show a neutral, read-only listing of registered UI elements for the active registry scope `protokoll.topsScreen` when the UI-Editor is toggled on, without introducing any editing, selection, hover, persistence, DOM scanning or fachliche logic.
- Keep the existing neutral launcher behaviour and safety guarantees while surfacing registry metadata for visibility and QA.

### Description
- `CoreShell` now reads the active scope and registry and passes the registry elements into the runtime launcher via `getActiveUiScope()` and `getBbmUiEditorRegistry(...)` and the `registeredElements` parameter of `installBbmUiEditorRuntimeLauncher`. (`src/renderer/app/CoreShell.js`).
- `BbmUiEditorRuntimeLauncher` was extended with `normalizeReadonlyRegisteredElements`, `getReadonlyRegisteredElementsText` and `getLauncherStatusText` helpers and now stores a sanitized `registeredElements` list in the launcher state and renders the read-only list inside the existing status hint; the launcher remains neutral and does not enable any editor features. (`src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js`).
- Styling for the launcher status was adjusted so the multi-line, read-only list fits and remains neutral. (`uiEditor/uiEditorLauncherButton.css`).
- Tests updated/added to assert the new read-only list and helpers and to ensure no forbidden behavior was introduced (no DOM-scan, no storage, no editor panel, no hover frame); test files changed: `scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs` and `scripts/tests/projektverwaltungModule.test.cjs`.
- `STATUS.md` updated to record K19.17 milestone and non-editor guarantees. (`STATUS.md`).

### Testing
- Ran the runtime launcher unit tests with `node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs` and they passed (`ok`).
- Ran the full node test runner with `node scripts/test.cjs` and the suite passed (multiple OK results reported). 
- Verified `git diff --check` produced no issues. 
- `npm test` and `npm start` could not fully run in this container because Electron failed to start due to a missing system library (`libatk-1.0.so.0`), so interactive app smoke checks requiring Electron were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2085b0dcbc8322b27787551f775aa2)