### PR TITLE
M21: BBM als generische UI-Editor-Zielapp einordnen

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,6 +36,8 @@ Nicht jedes Modul ist ein auswählbares Projektmodul:
 - Auswählbare Projektmodule sind nur fachliche Arbeitsbereiche innerhalb eines Projekts.
 - Aktuell auswählbar ist `Protokoll`.
 - Spaeter moeglich ist `Restarbeiten`.
+- M21-Klarstellung: `Restarbeiten` ist in BBM bereits erreichbar, bleibt aber fachlich/funktional unfertig und ist fuer den UI-Editor nur Pilot-Scope.
+- M21-Klarstellung: `Protokoll` ist noch nicht fertig bereinigt und wird fuer UI-Editor-Themen defensiv/read-only eingeordnet.
 - `Ausgabe / Drucken / E-Mail` ist kein auswählbares Projektmodul, sondern ein Maschinenraum-Dienst.
 - `Audio / Diktat` ist kein auswählbares Projektmodul, sondern ein Maschinenraum-Dienst.
 - `Dictate` ist das Lizenz-/Produktfeature hinter dem sichtbaren Feature `audio`.
@@ -52,6 +54,7 @@ Nicht jedes Modul ist ein auswählbares Projektmodul:
 - Ein Projektklick startet nicht direkt `Protokoll`; er oeffnet den Projekt-Arbeitsbereich.
 - Der Projekt-Arbeitsbereich zeigt das aktive Projekt und bietet nur auswaehlbare Projektmodule an.
 - Aktuell ist `Protokoll` auswaehlbar; spaeter kann `Restarbeiten` hinzukommen.
+- Der UI-Editor-Status aendert diese Modulfreigabe nicht: `Restarbeiten` bleibt Pilot-Scope, `Protokoll` bleibt defensiv/read-only.
 - Maschinenraum-Dienste werden von Fachmodulen genutzt, aber nicht als gleichberechtigte Projektmodule angeboten.
 - Der Projekt-Arbeitsbereich ist technisch umgesetzt; der Projektklick fuehrt jetzt zuerst dort hin.
 
@@ -112,12 +115,30 @@ Dazu koennen insbesondere gehoeren:
 ### 3.3 Fachmodule
 Aktuell relevante Fachmodule:
 - `Protokoll`
+- `Restarbeiten` als erreichbarer, aber fachlich/funktional unfertiger Pilot-Scope fuer den UI-Editor
 
 Diese bleiben fachlich getrennt.
 
 `TopsScreen` ist **nicht** das Modul `Protokoll`, sondern nur der Arbeitsscreen fuer die Protokollerstellung innerhalb des Moduls `Protokoll`.
 
 Die heutige TOP-Workbench ist **nicht automatisch** der globale Standard fuer andere Module.
+
+### 3.4 UI-Editor-kit und Ziel-App-Prinzip
+
+BBM-Produktiv ist fuer das generische UI-Editor-kit nur Beispiel-/Pilot-Zielapp.
+
+Der UI-Editor bleibt generisch:
+- keine BBM-Fachlogik im Editor
+- keine Restarbeiten-Fachlogik im Editor
+- keine Protokoll-Fachlogik im Editor
+- keine Datenbank-, IPC- oder Speicherlogik als Editor-Fachlogik
+
+Das verbindliche Registry-Prinzip lautet:
+- Die Ziel-App liefert die ElementRegistry.
+- Der Editor liest ausschliesslich diese Registry.
+- Nicht registrierte Elemente existieren fuer den Editor nicht.
+- Der Editor darf die Ziel-App-Oberflaeche nicht selbst untersuchen.
+- Keine automatische UI-Erkennung, kein UI-Scanning, kein DOM-Scan und keine automatische Registry-Befuellung.
 
 ---
 
@@ -131,6 +152,7 @@ Bei allen Umbauten gelten dauerhaft diese Leitplanken:
 - kein abrupter Komplettumbau
 - keine aggressive Massenmigration
 - keine vorschnelle Generalisierung von Fachlogik
+- keine automatische UI-Erkennung, kein UI-Scanning und keine automatische Registry-Befuellung fuer den UI-Editor
 - bestehende Funktionalitaet bleibt erhalten
 - Uebergaenge duerfen voruebergehend bestehen, muessen aber bewusst und ehrlich benannt bleiben
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -27,6 +27,11 @@ Hinweis:
 - Audio / Diktat ist als Renderer-Modul begonnen; aktuell nur `TranscriptionService`, ohne Sidebar- oder Modulkatalog-Eintrag.
 - Lizenzverwaltung wird als naechster Admin-Meilenstein vorbereitet; Detailauftrag: [docs/modules/lizenzverwaltung.md](docs/modules/lizenzverwaltung.md).
 - Das Protokoll-Modul bleibt eingefroren.
+- M21: Das Protokoll-Modul ist noch nicht fertig bereinigt und fuer UI-Editor-Themen defensiv/read-only einzuordnen.
+- M21: `Restarbeiten` ist in BBM erreichbar, bleibt aber fachlich/funktional unfertig und ist der aktuelle Pilot-Scope fuer das generische UI-Editor-kit.
+- M21: BBM-Produktiv ist Beispiel-/Pilot-Zielapp; der UI-Editor bleibt generisch und enthaelt keine BBM-, Restarbeiten- oder Protokoll-Fachlogik.
+- M21: Die Ziel-App liefert die ElementRegistry; der Editor liest ausschliesslich diese Registry. Nicht registrierte Elemente existieren fuer den Editor nicht.
+- M21: Keine Selbstuntersuchung der Ziel-App-Oberflaeche, keine automatische UI-Erkennung, kein UI-Scanning, kein DOM-Scan und keine automatische Registry-Befuellung.
 - `npm test` war gruen.
 - Das Mutter-/Kind-Prinzip ist die verbindliche Leitlinie fuer alle weiteren Modularisierungsschritte.
 - Auswählbare Projektmodule und Maschinenraum-Bereiche sind architektonisch getrennt.

--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,16 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M21 BBM als Zielapp sauber vom generischen UI-Editor getrennt:
+  - BBM-Produktiv ist Beispiel-/Pilot-Zielapp fuer das generische UI-Editor-kit.
+  - Der UI-Editor bleibt generisch und enthaelt keine BBM-, Restarbeiten- oder Protokoll-Fachlogik.
+  - `Restarbeiten` ist in BBM erreichbar, bleibt aber fachlich/funktional unfertig und ist der aktuelle Pilot-Scope.
+  - `Protokoll` ist noch nicht fertig bereinigt und wird fuer UI-Editor-Themen defensiv/read-only behandelt.
+  - Registry-Prinzip festgeschrieben: Die Ziel-App liefert die ElementRegistry; der Editor liest ausschliesslich diese Registry; nicht registrierte Elemente existieren fuer den Editor nicht.
+  - Keine Selbstuntersuchung der Ziel-App-Oberflaeche, keine automatische UI-Erkennung, kein UI-Scanning, kein DOM-Scan und keine automatische Registry-Befuellung.
+  - Reines Doku-/Statuspaket; keine Code-, Fachlogik-, DB-, IPC-, UI-, Protokoll- oder Restarbeiten-Funktionsaenderung.
+  - Naechster offener Schritt: fachliche Sichtung der Doku-Klarstellung; weitere Umbauten nur mit gesondertem Auftrag.
+
 - M2.3 Restarbeiten Notizhistorie und Notiz-Popup umgesetzt:
   - Der Notiz-Button in der Restarbeiten-Editbox ist fuer gespeicherte Datensaetze aktiv und oeffnet ein einfaches Popup mit Historie, leerem Zustand, Eingabefeld, Hinzufuegen, Drucken und Schliessen.
   - Neue Notizen werden nur mit nicht leerem Text gespeichert; das Popup bleibt offen und aktualisiert die Historie.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -117,6 +117,10 @@ Der aktuell sinnvolle Hauptfokus liegt auf **Achse B und Achse C**, flankiert vo
 - `weitere Module` dosiert sichtbarer und tragfaehiger machen
 - kleine Nachweise und Konsolidierungen mitziehen, wo sie den Umbau direkt belegen
 - der erreichte Screen-Stand in `Protokoll` bleibt dabei sichtbar abgesichert
+- M21-Einordnung: `Restarbeiten` ist erreichbar, aber fachlich/funktional unfertig und fuer den UI-Editor nur Pilot-Scope.
+- M21-Einordnung: `Protokoll` ist noch nicht fertig bereinigt und wird fuer UI-Editor-Themen defensiv/read-only behandelt.
+- M21-Einordnung: BBM-Produktiv ist Beispiel-/Pilot-Zielapp fuer das generische UI-Editor-kit; die Ziel-App liefert die ElementRegistry, der Editor liest ausschliesslich diese Registry.
+- Keine Selbstuntersuchung der Ziel-App-Oberflaeche, keine automatische UI-Erkennung, kein UI-Scanning, kein DOM-Scan und keine automatische Registry-Befuellung.
 
 Der Kernrahmen bleibt weiter wichtig, aber die bereits erreichten kleinen Kernschritte sind fuer die naechsten Mini-Pakete nicht mehr der dominante erste Fokus.
 

--- a/docs/RESTARBEITEN_V2_KONZEPT.md
+++ b/docs/RESTARBEITEN_V2_KONZEPT.md
@@ -3,11 +3,14 @@
 ## 1. Grundsatz
 Restarbeiten V2 ist eine neue technische UI-Struktur fuer das erste echte Fachmodul auf der UI-V2-/Editor-V2-Basis.
 
+M21-Klarstellung: `Restarbeiten` ist in BBM erreichbar, bleibt aber fachlich/funktional unfertig und ist nur Pilot-Scope fuer das generische UI-Editor-kit. Der UI-Editor bleibt generisch; die Ziel-App liefert die ElementRegistry und der Editor liest ausschliesslich diese Registry.
+
 Regeln:
 - die alte Restarbeiten-UI dient hoechstens fachlich als Orientierung
 - der alte UI-Inspector-Pfad wird nicht repariert
 - die Protokoll-Editbox wird nicht umgebaut
 - Protokoll bleibt unberuehrt
+- keine automatische UI-Erkennung, kein UI-Scanning, kein DOM-Scan und keine automatische Registry-Befuellung
 
 Die neue Struktur wird bewusst sauber und getrennt aufgebaut.
 

--- a/docs/UI_EDITOR_GRUNDSATZ.md
+++ b/docs/UI_EDITOR_GRUNDSATZ.md
@@ -11,6 +11,15 @@ Die maßgebliche Architektur lautet:
 Der Editor liest bewusst registrierte UI- und PDF-Elemente.
 Die Ziel-App wird editorfaehig vorbereitet, bleibt dabei aber fachlich unabhaengig.
 
+M21-Klarstellung fuer BBM-Produktiv:
+- BBM-Produktiv ist Beispiel-/Pilot-Zielapp fuer das generische UI-Editor-kit.
+- `Restarbeiten` ist erreichbar, aber fachlich/funktional unfertig und nur Pilot-Scope.
+- `Protokoll` ist noch nicht fertig bereinigt und fuer UI-Editor-Themen defensiv/read-only einzuordnen.
+- Der UI-Editor bleibt generisch und enthaelt keine BBM-, Restarbeiten- oder Protokoll-Fachlogik.
+- Die Ziel-App liefert die ElementRegistry; der Editor liest ausschliesslich diese Registry.
+- Nicht registrierte Elemente existieren fuer den Editor nicht.
+- Keine Selbstuntersuchung der Ziel-App-Oberflaeche, keine automatische UI-Erkennung, kein UI-Scanning, kein DOM-Scan und keine automatische Registry-Befuellung.
+
 ## 2. Verbindliche Begriffe
 
 - Modul: fachlicher Bereich innerhalb der App

--- a/docs/UI_INSPEKTOR_ARBEITSVERTRAG.md
+++ b/docs/UI_INSPEKTOR_ARBEITSVERTRAG.md
@@ -36,6 +36,9 @@
 - kein BBM-Sonderding
 - Core des UI-Inspektors bleibt exportierbar und frei von BBM-Fachlogik
 - bestehende App-Bereiche werden nicht verändert, wenn der Auftrag nur Dokumentation betrifft
+- M21: Fuer neue Arbeiten gilt das generische UI-Editor-kit; BBM-Produktiv ist nur Beispiel-/Pilot-Zielapp.
+- M21: Die Ziel-App liefert die ElementRegistry; der Editor liest ausschliesslich diese Registry.
+- M21: Keine Selbstuntersuchung der Ziel-App-Oberflaeche, keine automatische UI-Erkennung, kein UI-Scanning, kein DOM-Scan und keine automatische Registry-Befuellung.
 
 ## 4. Definition of Done
 Ein UI-Inspektor-Auftrag ist nur fertig, wenn:
@@ -95,6 +98,7 @@ Ein UI-Inspektor-Auftrag ist nur fertig, wenn:
 - keine stillen Nebenänderungen
 - keine App-Fachlogik ändern
 - keine Vermischung von Profi-UI-Ausbildung und Inspektor-Entwicklung
+- keine automatische Element- oder Registry-Erzeugung aus der bestehenden UI
 
 ## 10. Ablauf je Auftrag
 

--- a/docs/UI_INSPEKTOR_ARCHITEKTUR.md
+++ b/docs/UI_INSPEKTOR_ARCHITEKTUR.md
@@ -3,6 +3,8 @@
 ## 1. Architekturziel
 Der UI-Inspektor wird als neues exportierbares Modul aufgebaut.
 
+M21-Klarstellung: Diese Datei enthaelt historischen UI-Inspektor-Kontext. Verbindliche Zielrichtung fuer neue Arbeiten ist das generische UI-Editor-kit. BBM-Produktiv ist nur Beispiel-/Pilot-Zielapp; der Editor bleibt frei von BBM-, Restarbeiten- und Protokoll-Fachlogik.
+
 Zielbild:
 - nicht BBM-spezifisch
 - kein Umbau des Tabellen-Kalibrators zur Hauptlösung
@@ -43,6 +45,13 @@ Wichtig:
 **Rolle im System:**
 - fachliche Erlaubnisliste, welche Stellschrauben pro Bereich sichtbar und änderbar sind
 - keine direkte Darstellung und keine Persistenzlogik
+
+**M21-Regel:**
+- Die Ziel-App liefert die ElementRegistry.
+- Der Editor liest ausschliesslich diese Registry.
+- Nicht registrierte Elemente existieren fuer den Editor nicht.
+- Der Editor darf die Ziel-App-Oberflaeche nicht selbst untersuchen.
+- Keine automatische UI-Erkennung, kein UI-Scanning, kein DOM-Scan und keine automatische Registry-Befuellung.
 
 ### 2.3 Overlay
 **Aufgaben:**
@@ -211,6 +220,8 @@ Typische Einstellungen:
 - Bereiche müssen nachträglich erkannt und markiert werden
 - Inspektor hilft beim Sichtbarmachen und kontrollierten Einstellen
 - Adapter und Landkarte dokumentieren nachträglich, was fachlich anfassbar ist
+
+M21-Status: Diese Bestandspassage ist historisch. "Erkannt" bedeutet keine automatische Bestandserkennung und keinen DOM-Scan. Bestehende bekannte Elemente duerfen nur bewusst, explizit und pruefbar in der ElementRegistry der Ziel-App beschrieben werden.
 
 ### Neue UI
 - bei UI-Neubau muss eine Bereichs-Landkarte mitgeliefert werden

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -10,6 +10,7 @@ Aktueller Stand:
 - K19.9a abgeschlossen: `uiEditor/` enthaelt installierte UI-Editor-Artefakte; die echte BBM-Registry bleibt separat unter `src/renderer/uiEditor/bbmUiEditorRegistry.js`; `scripts/test.cjs` ist nicht direkt an installierte Artefakt-Testdateien gekoppelt.
 - K19.13a abgeschlossen: Der BBM-Artefakttest erkennt `uiEditor.global` robust ueber `id`, `uiScope`, `uiScopeId` oder den Registry-Schluessel und verlangt `uiEditor/targetAppRegistry.js` als installiertes Pflichtartefakt.
 - K19.16a abgeschlossen: Der neutrale UI-Editor-Aktivmodus zeigt den festen aktiven BBM-Registry-Scope `protokoll.topsScreen`; bei leerem Scope wird `nicht erkannt` angezeigt.
+- M21 abgeschlossen: BBM-Produktiv ist als Beispiel-/Pilot-Zielapp vom generischen UI-Editor-kit getrennt dokumentiert; `Restarbeiten` ist erreichbarer unfertiger Pilot-Scope, `Protokoll` defensiv/read-only.
 
 ## Haken-System
 - `[x]` erledigt
@@ -48,6 +49,18 @@ Aktueller Stand:
 - [x] K19.9a BBM-Testeinbindung nach Neuinstallation der UI-Editor-Artefakte trennen
 - [x] K19.13a BBM-Test an aktuelle UI-Editor-Installer-Artefakte anpassen
 - [x] K19.16a UI-Editor zeigt festen registrierten Scope aus BBM-Registry
+- [x] M21 BBM-Zielapp sauber vom generischen UI-Editor-kit trennen
+
+## Statusupdate M21
+- BBM-Produktiv ist Beispiel-/Pilot-Zielapp fuer das generische UI-Editor-kit, nicht fachliche Grundlage des Editors.
+- Der UI-Editor bleibt generisch und enthaelt keine BBM-, Restarbeiten- oder Protokoll-Fachlogik.
+- `Restarbeiten` ist in BBM erreichbar, bleibt aber fachlich/funktional unfertig und ist nur Pilot-Scope.
+- `Protokoll` ist noch nicht fertig bereinigt und fuer UI-Editor-Themen defensiv/read-only einzuordnen.
+- Die Ziel-App liefert die ElementRegistry; der Editor liest ausschliesslich diese Registry.
+- Nicht registrierte Elemente existieren fuer den Editor nicht.
+- Keine Selbstuntersuchung der Ziel-App-Oberflaeche, keine automatische UI-Erkennung, kein UI-Scanning, kein DOM-Scan und keine automatische Registry-Befuellung.
+- Alte UI-Inspector-/Scan-Begriffe bleiben nur als historischer Kontext stehen und sind fuer neue Arbeiten keine Zielrichtung.
+- Reines Doku-/Statuspaket ohne Code-, Fachlogik-, DB-, IPC-, UI-, Protokoll- oder Restarbeiten-Funktionsaenderung.
 
 ## Statusupdate K19.16a
 - `CoreShell` uebergibt den festen aktiven Scope aus `src/renderer/uiEditor/bbmUiEditorRegistry.js` an den neutralen Runtime-Launcher.

--- a/docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md
+++ b/docs/UI_INSPEKTOR_ENTSCHEIDUNGEN.md
@@ -20,10 +20,14 @@
 
 **BegrÃ¼ndung:** So bleibt das Modul exportierbar, wÃ¤hrend App-Spezifika sauber ausgelagert werden.
 
+**M21-Klarstellung:** Fuer das generische UI-Editor-kit ist die von der Ziel-App gelieferte ElementRegistry verbindlich. Der Editor liest ausschliesslich diese Registry; nicht registrierte Elemente existieren fuer ihn nicht. BBM-Produktiv ist nur Beispiel-/Pilot-Zielapp.
+
 ## Entscheidung 005
 **Beschluss:** Bestehende UIs werden nachtrÃ¤glich erkannt/markiert; neue UIs werden kÃ¼nftig von Anfang an mit Bereichs-Landkarte gebaut.
 
 **BegrÃ¼ndung:** Das erlaubt BestandseinfÃ¼hrung und zukÃ¼nftige StabilitÃ¤t Ã¼ber einen gemeinsamen Arbeitsansatz.
+
+**M21-Status:** Historisch. Keine automatische UI-Erkennung, kein UI-Scanning, kein DOM-Scan und keine automatische Registry-Befuellung als Zielrichtung. Bestehende bekannte Elemente duerfen nur bewusst, explizit und pruefbar in der ElementRegistry der Ziel-App beschrieben werden.
 
 ## Entscheidung 006
 **Beschluss:** Der UI-Inspektor erhÃ¤lt einen verbindlichen Arbeitsvertrag.
@@ -81,10 +85,14 @@
 
 **BegrÃƒÂ¼ndung:** Der erste Schritt soll nur den aktuellen Screen scannen und den Zustand sichtbar machen, ohne Auswahl, Bearbeitung, Speicherung oder Overlay-Logik zu erweitern.
 
+**M21-Status:** Historisch. Scan-Begriffe beschreiben hier nur den alten Stand. Fuer neue Arbeiten gilt: keine Selbstuntersuchung der Ziel-App-Oberflaeche und keine automatische UI-Erkennung.
+
 ## Entscheidung 016
 **Beschluss:** Der UI-Editor-Scan bewertet nur Pflichtmarker als entscheidend, behandelt `restarbeiten.header` als optional und fasst Marker mit `::`-Suffixen als eine fachliche Basis-ID zusammen.
 
 **Begründung:** Damit der Status ehrlich bleibt, Mehrfachmarker nicht als fehlend zählen und ein nicht im Live-DOM verankerter Header nicht künstlich als Pflichtbedingung in den Scan eingeht.
+
+**M21-Status:** Historisch. Eine Registry darf nicht automatisch aus DOM-Markern befuellt werden; verbindlich ist nur die explizit gelieferte ElementRegistry der Ziel-App.
 ## Entscheidung 017
 **Beschluss:** M13.4b.1 verdrahtet im sichtbaren Scanpanel nur die Auswahlmodus-Schalter Rahmen/Feld/Einzelelement.
 

--- a/docs/UI_INSPEKTOR_PROJEKTAUFTRAG.md
+++ b/docs/UI_INSPEKTOR_PROJEKTAUFTRAG.md
@@ -3,6 +3,8 @@
 ## Was soll gebaut werden?
 Ein neues, exportierbares UI-Inspektor-Modul als eigenständiges Produktbaustein-System. Es soll in verschiedene Apps eingebaut werden können und unabhängig von BBM-Fachlogik funktionieren.
 
+M21-Klarstellung: Dieser Projektauftrag ist historischer UI-Inspektor-Kontext. Verbindliche Zielrichtung fuer neue Arbeiten ist das generische UI-Editor-kit. BBM-Produktiv ist nur Beispiel-/Pilot-Zielapp; der Editor liest ausschliesslich die von der Ziel-App gelieferte ElementRegistry und untersucht die Ziel-App-Oberflaeche nicht selbst.
+
 ## Für wen?
 Für fachliche Anwender ohne Programmierkenntnisse.
 
@@ -39,6 +41,7 @@ Der UI-Inspektor ist ausdrücklich **nicht**:
 Außerdem kein Ziel:
 - Änderungen an bestehender Fachlogik
 - Änderungen an Router, Datenbank, Print/PDF, Restarbeiten, Protokoll oder Projektverwaltung im Rahmen dieses Grundlagenpakets
+- automatische UI-Erkennung, UI-Scanning, DOM-Scan oder automatische Registry-Befuellung
 
 ## Unterschied Bestand / neue UI
 Bestand:

--- a/docs/UI_INSPEKTOR_START_HIER.md
+++ b/docs/UI_INSPEKTOR_START_HIER.md
@@ -22,6 +22,15 @@ Pflichtreihenfolge:
 - Zielgruppe: fachlicher Anwender ohne Programmierkenntnisse.
 - Bedienziel: echte UI-Bereiche sichtbar machen, anklicken, verständliche Stellschrauben anzeigen, später speichern/zurücksetzen.
 
+### M21-Klarstellung
+- Der Begriff UI-Inspector/UI-Inspektor beschreibt hier historischen Projektkontext; verbindliche Zielrichtung ist das generische UI-Editor-kit.
+- BBM-Produktiv ist nur Beispiel-/Pilot-Zielapp, nicht fachliche Grundlage des Editors.
+- `Restarbeiten` ist erreichbar, aber fachlich/funktional unfertig und nur Pilot-Scope.
+- `Protokoll` ist noch nicht fertig bereinigt und fuer UI-Editor-Themen defensiv/read-only einzuordnen.
+- Die Ziel-App liefert die ElementRegistry; der Editor liest ausschliesslich diese Registry.
+- Nicht registrierte Elemente existieren fuer den Editor nicht.
+- Historische Begriffe wie UI-Inspector, DOM-Scan, UI-Scanning, automatische Erkennung oder automatische Registry-Befuellung sind keine Zielrichtung und fuer neue Arbeiten verboten.
+
 ## 4. Aktueller Projektstand
 - M1.1 Projektfundament erledigt
 - M2 Arbeitsvertrag erledigt
@@ -75,6 +84,7 @@ Nicht fortführen:
 - Tabellen-Kalibrator als Bedienoberfläche des UI-Inspektors
 - direkte UI-Frickelei als Ersatz für den Inspektor
 - BBM-Fachlogik im Inspector-Core
+- DOM-Scan, UI-Scanning, automatische UI-Erkennung oder automatische Registry-Befuellung
 - vage Aufgaben wie „mach schöner“
 - Codearbeiten ohne Aufgabenheft-Update
 

--- a/docs/UI_INSPEKTOR_UMSETZUNGSPLAN.md
+++ b/docs/UI_INSPEKTOR_UMSETZUNGSPLAN.md
@@ -5,6 +5,8 @@
 - Er ist noch kein Code.
 - Er verhindert, dass der UI-Inspektor wieder als zu großes Paket begonnen wird.
 
+M21-Klarstellung: Dieser Plan ist historischer UI-Inspektor-Kontext. Neue Arbeiten folgen dem generischen UI-Editor-kit: Die Ziel-App liefert die ElementRegistry, der Editor liest ausschliesslich diese Registry, und es gibt keine automatische UI-Erkennung, kein UI-Scanning, keinen DOM-Scan und keine automatische Registry-Befuellung.
+
 ## 2. Grundregel der Umsetzung
 - Ein Meilenstein = ein klarer Zweck.
 - Ein Paket = ein Branch = ein Commit = ein PR/Merge.
@@ -13,6 +15,8 @@
 - Kein Tabellen-Kalibrator-Umbau.
 - Kein Restarbeiten-Umbau als Abkürzung.
 - Aufgabenheft wird nach jedem Paket aktualisiert.
+- `Restarbeiten` ist in BBM erreichbar, aber fachlich/funktional unfertig und nur Pilot-Scope.
+- `Protokoll` ist noch nicht fertig bereinigt und fuer UI-Editor-Themen defensiv/read-only.
 
 ## 3. Meilensteinplan ab M6
 

--- a/docs/ui-editor/EDITOR_BAUPLAN.md
+++ b/docs/ui-editor/EDITOR_BAUPLAN.md
@@ -14,17 +14,31 @@ Der Editor erfindet keine Elemente.
 Der Editor arbeitet nur mit der freigegebenen UI-Elementliste.
 Der Editor analysiert keine bestehende UI und migriert keine Legacy-UI automatisch.
 
+## M21-Kontext BBM-Produktiv
+
+BBM-Produktiv ist fuer dieses Kit Beispiel-/Pilot-Zielapp, nicht fachliche Grundlage des Editors.
+
+Der UI-Editor bleibt generisch und enthaelt keine BBM-, Restarbeiten- oder Protokoll-Fachlogik.
+
+Aktuelle BBM-Einordnung:
+- `Restarbeiten` ist erreichbar, aber fachlich/funktional unfertig und nur Pilot-Scope.
+- `Protokoll` ist noch nicht fertig bereinigt und fuer UI-Editor-Themen defensiv/read-only zu behandeln.
+
 ## 2. Grundprinzip
 
 Eine editorfaehige Anwendungs-App muss ihre UI beim Bau beschreiben.
 
 Diese Beschreibung besteht aus einer klassifizierten UI-Elementliste.
 
+Im M21-Sprachgebrauch ist diese Liste die von der Ziel-App gelieferte ElementRegistry.
+
 Diese Liste enthaelt alle Elemente, die der Editor sehen, pruefen oder veraendern darf.
 
 Nicht registrierte Elemente gelten fuer den Editor als nicht vorhanden.
 
 Bestehende UI wird nicht nachtraeglich per Bestandsanalyse, UI-Erkennung oder UI-Scan in eine automatische UI-Elementliste ueberfuehrt.
+
+Der Editor liest ausschliesslich die ElementRegistry der Ziel-App. Er untersucht die Ziel-App-Oberflaeche nicht selbst und befuellt keine Registry automatisch.
 
 ## 3. Eigenstaendige Editor-App
 

--- a/docs/ui-editor/ZIEL_APP_ANBINDUNG.md
+++ b/docs/ui-editor/ZIEL_APP_ANBINDUNG.md
@@ -8,6 +8,12 @@ Eine Ziel-App kann eine bestehende Anwendung oder eine neue Anwendung sein.
 
 Der UI-Editor bleibt eine eigenstaendige Editor-App. Er kann in die Ziel-App als Modul eingebunden werden, arbeitet aber nur ueber definierte Schnittstellen und Regeln.
 
+Aktuelle BBM-Einordnung nach M21:
+- BBM-Produktiv ist Beispiel-/Pilot-Zielapp fuer das generische UI-Editor-kit.
+- `Restarbeiten` ist in BBM erreichbar, aber fachlich/funktional unfertig und nur Pilot-Scope.
+- `Protokoll` ist noch nicht fertig bereinigt und fuer UI-Editor-Themen defensiv/read-only einzuordnen.
+- Der UI-Editor bleibt generisch und enthaelt keine BBM-, Restarbeiten- oder Protokoll-Fachlogik.
+
 ## 2. Grundsatz
 
 Die Ziel-App bleibt fachlich verantwortlich.
@@ -16,7 +22,15 @@ Der UI-Editor darf keine Fachlogik uebernehmen, keine Fachdaten veraendern und k
 
 Der UI-Editor arbeitet nur mit einer von der Ziel-App gelieferten, klassifizierten UI-Elementliste.
 
+Im M21-Sprachgebrauch ist diese Liste die ElementRegistry der Ziel-App.
+
+Die Ziel-App liefert die ElementRegistry.
+
+Der Editor liest ausschliesslich diese Registry.
+
 Nicht registrierte Elemente sind fuer den Editor nicht vorhanden.
+
+Der Editor darf die Ziel-App-Oberflaeche nicht selbst untersuchen.
 
 Die Regelpaket-Installation ist nur ein Ziel-App-Regelpaket-Bootstrap. Sie analysiert, scannt, erkennt, registriert oder migriert keine bestehende UI.
 
@@ -174,6 +188,7 @@ Die Ziel-App darf dem Editor nicht erlauben:
 - bestehende UI zu analysieren
 - bestehende UI zu scannen
 - eine automatische Bestandserkennung oder UI-Elementliste zu erzeugen
+- eine ElementRegistry automatisch zu befuellen
 - bestehende Legacy-UIs automatisch zu migrieren
 - nachtraegliche bewusste Registrierung als automatische Analyse, Scan, Erkennung oder Migration auszufuehren
 - Datenbankaktionen auszufuehren

--- a/docs/ui-landkarten/RESTARBEITEN.md
+++ b/docs/ui-landkarten/RESTARBEITEN.md
@@ -5,6 +5,8 @@
 - Sie ist fachliche Dokumentation und Vorbereitung.
 - Sie verändert die App nicht.
 
+M21-Klarstellung: Diese Datei ist historische Landkarten-Dokumentation. `Restarbeiten` ist in BBM erreichbar, bleibt aber fachlich/funktional unfertig und ist nur Pilot-Scope fuer das generische UI-Editor-kit. Neue Editor-Arbeiten laufen ueber die von der Ziel-App gelieferte ElementRegistry; keine automatische UI-Erkennung, kein UI-Scanning, kein DOM-Scan und keine automatische Registry-Befuellung.
+
 ## 2. Status
 - M9 DOM-Markierungen minimal eingeführt.
 - Marker-IDs sind technisch in der bestehenden Restarbeiten-UI verankert.
@@ -104,6 +106,8 @@ Hinweis:
 - M12.1 schärft die Landkarte als Voraussetzung für spätere Layoutänderungen nach: Gruppenmarker auf Container-Ebene, Feldmarker darunter.
 - `restarbeiten.header` ist aktuell kein Pflichtmarker im Live-DOM.
 - Wiederholte Marker mit `::1`, `::2` usw. zählen als eine fachliche Basis-ID und werden vom UI-Inspektor zusammengefasst.
+
+M21-Status: Diese Marker- und Inspector-Begriffe beschreiben Altstand/Historie. Sie sind keine Zielrichtung fuer neue Arbeiten und duerfen nicht als automatische Registry-Ableitung verstanden werden.
 
 ## 5. Einstell-Ebenen
 


### PR DESCRIPTION
M21 dokumentiert BBM-Produktiv als Beispiel-/Pilot-Zielapp für das generische UI-Editor-kit. Restarbeiten ist als erreichbares, aber unfertiges Pilot-Scope eingeordnet. Protokoll ist defensiv/read-only eingeordnet. Das Registry-Prinzip ist festgeschrieben: Zielapp liefert ElementRegistry, Editor liest nur diese Registry, keine automatische UI-Erkennung, kein UI-Scanning, keine automatische Registry-Befüllung. Keine Codeänderungen. Hinweis: npm test ist wegen eines bestehenden zeitabhängigen Restarbeiten-Tests rot und wird separat behandelt.