### PR TITLE
Test: Restarbeiten-Ampel-Datum stabilisieren

### DIFF
--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1257,7 +1257,13 @@ async function runRestarbeitenModuleTests(run) {
       );
 
       triggerValue(findByUiId(screen.root, "restarbeiten.editbox.meta.status"), "offen", "change");
-      triggerValue(findByUiId(screen.root, "restarbeiten.editbox.meta.dueDate"), "2026-06-20", "change");
+      const futureDueDate = new Date();
+      futureDueDate.setUTCDate(futureDueDate.getUTCDate() + 14);
+      triggerValue(
+        findByUiId(screen.root, "restarbeiten.editbox.meta.dueDate"),
+        futureDueDate.toISOString().slice(0, 10),
+        "change"
+      );
       assert.equal(screen.draft.ampelState, "gruen");
       assert.equal(findByUiId(screen.root, "restarbeiten.editbox.meta.ampel").children[0].dataset.state, "gruen");
     } finally {


### PR DESCRIPTION
Stabilisiert den zeitabhängigen Restarbeiten-Test. Statt eines festen Datums 2026-06-20 wird ein Datum 14 Tage in der Zukunft erzeugt. Keine Fachlogik, keine UI, keine DB/IPC-Wege und keine M21-Doku geändert. npm test ist grün.