### PR TITLE
M25: Restarbeiten Pflichtfelder Status und Ampel absichern

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,15 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M25 Restarbeiten Pflichtfelder, Status und Ampel technisch abgesichert:
+  - Pflichtfeldvollstaendigkeit wird in Liste und Editbox sichtbar als unvollstaendig markiert.
+  - Neue Restarbeiten koennen technisch nicht ohne Kurztext angelegt werden; fehlende weitere Pflichtfelder bleiben als Draft sichtbar unvollstaendig.
+  - Statuswerte sind fuer Restarbeiten auf `offen`, `in_arbeit` und `erledigt` begrenzt; unbekannte Werte werden nicht mehr still auf `offen` normalisiert.
+  - Die Ampel nutzt die M24-Regel: erledigt ist fristneutral, ohne Fertig-bis neutral, ueberfaellig rot, heute bis zehn Tage orange, ab elf Tagen gruen.
+  - UI-Editor-kit, Protokoll, PDF/Druck/Mail, Diktat/Audio, Fotoimport und Registry-Struktur blieben unveraendert.
+  - Neue UI-/PDF-Entwurfsentscheidung unter `docs/M25_UI_PDF_ENTWURFSENTSCHEIDUNG.md`.
+  - Naechster offener Schritt: M26 fachlich planen, insbesondere Verantwortlichen-/Ausgabe-/Abnahmegrenze ohne Editor-Fachlogik.
+
 - M24 Restarbeiten-Fachspezifikation finalisiert:
   - Neue Fachspezifikation unter `docs/M24_RESTARBEITEN_FACHSPEZIFIKATION.md`.
   - Ergebnis: Der erste Nutzstand ist als textbasierte, projektbezogene Restarbeitenliste mit Pflichtfeldern, Statusmodell, 10-Tage-Ampelregel, Auto-Save-Entscheidung, Soft-Delete und einfacher Ausgabe fachlich spezifiziert.

--- a/docs/M25_UI_PDF_ENTWURFSENTSCHEIDUNG.md
+++ b/docs/M25_UI_PDF_ENTWURFSENTSCHEIDUNG.md
@@ -1,0 +1,46 @@
+# M25 UI-/PDF-Entwurfsentscheidung: Restarbeiten Pflichtfelder, Status und Ampel
+
+## A. Art der Ausgabe
+
+- UI
+- Keine PDF-Aenderung
+
+## B. Editorfaehigkeit
+
+- editorfaehig: nein
+- Begruendung: M25 sichert fachliche Pflichtfeld-, Status- und Ampelregeln im BBM-Fachmodul Restarbeiten ab. Es entstehen keine neuen editorfaehigen Elemente und keine neue UI-Editor-Funktion.
+
+## C. Editorfaehige Elemente
+
+M25 legt keine neuen editorfaehigen Elemente an.
+
+Bestehende Restarbeiten-Elemente bleiben in ihrer bestehenden Registry-Struktur. Die sichtbare Pflichtfeldvollstaendigkeit nutzt vorhandene Restarbeiten-UI-Bereiche und fuehrt keine neue Editor-Operation ein.
+
+## D. Nicht editorfaehige Elemente / verbotene Editor-Ziele
+
+Nicht editorfaehig und nicht Ziel von M25 sind:
+
+- Fachaktionen
+- Speichern
+- Anlegen
+- Loeschen
+- Upload
+- Import
+- Autosave
+- fachliche IPC-/Datenaktionen
+- Datenbankaktionen
+- Statuswechsel als fachliche Aktion
+- Ampelberechnung
+- Pflichtfeldvalidierung
+
+## E. Parent-/Strukturregel
+
+M25 registriert keine neuen editorfaehigen Elemente. Es wird keine neue Parent-Struktur fuer den UI-Editor angelegt.
+
+Falls bestehende Restarbeiten-Elemente angezeigt werden, gelten weiterhin die vorhandenen Registry-Parents. Die sichtbare fachliche Validierung ist kein neues Editor-Ziel.
+
+## F. Pruef-/Testangabe
+
+- Fachliche M25-Regeln werden ueber Restarbeiten-Tests abgesichert.
+- Bestehende UI-Editor-Vertragstests bleiben unveraendert.
+- Es gibt fuer diese reine fachliche UI-Markierung keinen neuen separaten UI-Editor-Vertragscheck. Es wird keine neue Editor-Registry und kein neues editorfaehiges Element eingefuehrt.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -316,3 +316,11 @@ Dabei gilt:
 - Der Projektkachel-Start nutzt den bestehenden Projektmodulpfad `openProjectModule(projectId, "restarbeiten", { project })`.
 
 - Hotfix M13.2 nachgezogen: `Restarbeiten` ist fuer die Projektkachel nicht nur ueber Test-Stub sichtbar, sondern wird ueber die tatsaechliche Runtime-Projektmodulliste geliefert.
+
+### M25 Restarbeiten Pflichtfelder, Status und Ampel abgesichert (neu)
+- Restarbeiten nutzt eine fachmodulinterne Regelbasis fuer Pflichtfelder, Statuswerte und Ampel.
+- Pflichtfeldvollstaendigkeit wird sichtbar markiert, ohne neue UI-Editor-Funktion oder automatische UI-Erkennung einzufuehren.
+- Der erste technische Save/Create bleibt an einen vorhandenen Kurztext gebunden; weitere fehlende Pflichtfelder bleiben als unvollstaendiger Draft sichtbar.
+- Statuswerte sind auf `offen`, `in_arbeit` und `erledigt` begrenzt; unbekannte Status werden nicht still normalisiert.
+- Die Ampel folgt der M24-10-Tage-Regel und behandelt `erledigt` fristneutral.
+- Protokoll, UI-Editor-kit, PDF/Druck/Mail, Diktat/Audio, Fotoimport und Registry-Struktur bleiben ausserhalb dieses Pakets.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -25,6 +25,7 @@ const { runBbmUiEditorRuntimeLauncherTests } = require("./tests/bbmUiEditorRunti
 const { runProjektverwaltungModuleTests } = require("./tests/projektverwaltungModule.test.cjs");
 const { runRestarbeitenModuleTests } = require("./tests/restarbeitenModule.test.cjs");
 const { runRestarbeitenDataModelTests } = require("./tests/restarbeitenDataModel.test.cjs");
+const { runRestarbeitenRulesTests } = require("./tests/restarbeitenRules.test.cjs");
 const { runUiEditorContractTests } = require("./tests/uiEditorContract.test.cjs");
 const { runUiV2EditorV2RulesTests } = require("./tests/uiV2EditorV2Rules.test.cjs");
 const { runEditorLabV2Tests } = require("./tests/editorLabV2.test.cjs");
@@ -151,6 +152,7 @@ async function main() {
   await runProjektverwaltungModuleTests(run);
   await runRestarbeitenModuleTests(run);
   await runRestarbeitenDataModelTests(run);
+  await runRestarbeitenRulesTests(run);
   await runUiEditorContractTests(run);
   await runUiV2EditorV2RulesTests(run);
   await runEditorLabV2Tests(run);

--- a/scripts/tests/restarbeitenDataModel.test.cjs
+++ b/scripts/tests/restarbeitenDataModel.test.cjs
@@ -61,7 +61,7 @@ async function runRestarbeitenDataModelTests(run) {
     const conn = db.initDatabase();
     conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p1", "P1");
     conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p2", "P2");
-    const item = repo.createRestarbeitItem({ project_id: "p1", location_level_1: "Haus A", location_level_2: "EG", location_level_3: "WE 1", location_level_4: "Kueche", status: "unbekannt" });
+    const item = repo.createRestarbeitItem({ project_id: "p1", short_text: "Verortete Restarbeit", location_level_1: "Haus A", location_level_2: "EG", location_level_3: "WE 1", location_level_4: "Kueche" });
     assert.equal(item.location_level_1, "Haus A");
     assert.equal(item.location_level_4, "Kueche");
     assert.equal(item.status, "offen");
@@ -74,20 +74,33 @@ async function runRestarbeitenDataModelTests(run) {
     assert.notEqual(s1.project_id, s2.project_id);
   }));
 
-  await run("Statuswerte: verzug erlaubt, in_arbeit normalisiert und unbekannt faellt auf offen", async () => withTemp(({ db, repo }) => {
+  await run("Statuswerte: M25 erlaubt offen, in_arbeit und erledigt ohne stille Fallbacks", async () => withTemp(({ db, repo }) => {
     const conn = db.initDatabase();
     conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p1", "P1");
 
-    const overdue = repo.createRestarbeitItem({ project_id: "p1", short_text: "Verzug", status: "verzug" });
     const legacy = repo.createRestarbeitItem({ project_id: "p1", short_text: "Legacy", status: "in_arbeit" });
-    const invalid = repo.createRestarbeitItem({ project_id: "p1", short_text: "Invalid", status: "unbekannt" });
+    const legacySpace = repo.createRestarbeitItem({ project_id: "p1", short_text: "Legacy Space", status: "in arbeit" });
+    const done = repo.createRestarbeitItem({ project_id: "p1", short_text: "Done", status: "erledigt" });
+    const defaulted = repo.createRestarbeitItem({ project_id: "p1", short_text: "Default" });
 
-    assert.equal(overdue.status, "verzug");
-    assert.equal(legacy.status, "in arbeit");
-    assert.equal(invalid.status, "offen");
+    assert.equal(legacy.status, "in_arbeit");
+    assert.equal(legacySpace.status, "in_arbeit");
+    assert.equal(done.status, "erledigt");
+    assert.equal(defaulted.status, "offen");
 
-    const updated = repo.updateRestarbeitItem(invalid.id, { status: "verzug" });
-    assert.equal(updated.status, "verzug");
+    assert.throws(() => repo.createRestarbeitItem({ project_id: "p1", short_text: "Verzug", status: "verzug" }), /status invalid/);
+    assert.throws(() => repo.createRestarbeitItem({ project_id: "p1", short_text: "Invalid", status: "unbekannt" }), /status invalid/);
+    assert.throws(() => repo.updateRestarbeitItem(defaulted.id, { status: "verzug" }), /status invalid/);
+    assert.throws(() => repo.updateRestarbeitItem(defaulted.id, { status: "unbekannt" }), /status invalid/);
+  }));
+
+  await run("Restarbeit Create verlangt Kurztext", async () => withTemp(({ db, repo }) => {
+    const conn = db.initDatabase();
+    conn.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("p1", "P1");
+
+    assert.throws(() => repo.createRestarbeitItem({ project_id: "p1" }), /short_text required/);
+    assert.throws(() => repo.createRestarbeitItem({ project_id: "p1", short_text: "   " }), /short_text required/);
+    assert.throws(() => repo.createRestarbeitItem({ project_id: "p1", short_text: null }), /short_text required/);
   }));
 
   await run("item_class default, akzeptierte Werte und Normalisierung", async () => withTemp(({ db, repo }) => {
@@ -140,7 +153,7 @@ async function runRestarbeitenDataModelTests(run) {
       short_text: "Neu",
       long_text: "Lang neu",
       item_class: "MANGEL",
-      status: "unbekannt",
+      status: "in_arbeit",
       due_date: "2026-06-01",
       responsible_project_firm_id: "f2",
       responsible_label: "Firma B",
@@ -154,7 +167,7 @@ async function runRestarbeitenDataModelTests(run) {
     assert.equal(updated.short_text, "Neu");
     assert.equal(updated.long_text, "Lang neu");
     assert.equal(updated.item_class, "mangel");
-    assert.equal(updated.status, "offen");
+    assert.equal(updated.status, "in_arbeit");
     assert.equal(updated.due_date, "2026-06-01");
     assert.equal(updated.responsible_project_firm_id, "f2");
     assert.equal(updated.responsible_label, "Firma B");

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -462,7 +462,7 @@ async function runRestarbeitenModuleTests(run) {
     const listAmpel = findByUiId(rendered.root, "restarbeiten.record.ampel");
     assert.equal(Boolean(listAmpel), true);
     assert.equal(listAmpel.children.length, 0);
-    assert.equal(["rot", "gruen", "neutral"].includes(listAmpel.dataset.state), true);
+    assert.equal(["rot", "orange", "gruen", "neutral"].includes(listAmpel.dataset.state), true);
   });
 
   await run("Restarbeiten: Screen stellt Quicklane-Methoden und M1-Bereiche bereit", async () => {
@@ -885,7 +885,7 @@ async function runRestarbeitenModuleTests(run) {
     ]);
     assert.equal(rest.itemClassLabel, "Restarbeit");
     assert.equal(rest.locationLine, "EG \u00b7 Flur");
-    assert.equal(emptyLocation.locationLine, "\u2014");
+    assert.equal(emptyLocation.locationLine, "Ort/Bereich fehlt");
   });
 
   await run("Restarbeiten: Statusauswahlen enthalten die verbindlichen Werte", async () => {
@@ -900,13 +900,16 @@ async function runRestarbeitenModuleTests(run) {
       const editOptions = collectOptions(editbox.buildRestarbeitenEditbox());
       for (const expected of [
         { value: "offen", label: "Offen" },
-        { value: "in arbeit", label: "In Arbeit" },
+        { value: "in_arbeit", label: "In Arbeit" },
         { value: "erledigt", label: "Erledigt" },
-        { value: "verzug", label: "Verzug" },
       ]) {
         assert.equal(filterOptions.some((option) => option.value === expected.value && option.label === expected.label), true, `filter ${expected.value}`);
         assert.equal(editOptions.some((option) => option.value === expected.value && option.label === expected.label), true, `editbox ${expected.value}`);
       }
+      assert.equal(filterOptions.some((option) => option.value === "verzug"), false);
+      assert.equal(editOptions.some((option) => option.value === "verzug"), false);
+      assert.equal(filterOptions.some((option) => option.value === "in arbeit"), false);
+      assert.equal(editOptions.some((option) => option.value === "in arbeit"), false);
     } finally {
       globalThis.document = prevDocument;
     }
@@ -1188,7 +1191,7 @@ async function runRestarbeitenModuleTests(run) {
 
       triggerValue(findByUiId(root, "restarbeiten.editbox.text.short"), "Neue Restarbeit", "input");
       assert.equal(screen.draft.short_text, "Neue Restarbeit");
-      assert.equal(validation.textContent, "");
+      assert.equal(validation.textContent, "Unvollstaendig: Ort/Bereich, Verantwortlich, Fertig bis");
       assert.equal(renderCalls, 0);
 
       triggerValue(findByUiId(root, "restarbeiten.editbox.text.long"), "Lange Beschreibung", "input");
@@ -1199,8 +1202,8 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(screen.draft.location_level_1, "Haus A");
       assert.equal(renderCalls, 0);
 
-      triggerValue(findByUiId(root, "restarbeiten.editbox.meta.status"), "verzug", "change");
-      assert.equal(screen.draft.ampelState, "rot");
+      triggerValue(findByUiId(root, "restarbeiten.editbox.meta.status"), "in_arbeit", "change");
+      assert.equal(screen.draft.ampelState, "neutral");
       assert.equal(renderCalls, 1);
     } finally {
       globalThis.document = prevDocument;
@@ -1248,13 +1251,19 @@ async function runRestarbeitenModuleTests(run) {
     try {
       const screen = new mod.default({ projectId: "p-1", project: { id: "p-1" } });
       const root = screen.render();
-      triggerValue(findByUiId(root, "restarbeiten.editbox.meta.status"), "verzug", "change");
+      const yesterday = new Date();
+      yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+      triggerValue(findByUiId(root, "restarbeiten.editbox.meta.dueDate"), yesterday.toISOString().slice(0, 10), "change");
       assert.equal(screen.draft.ampelState, "rot");
       assert.equal(findByUiId(screen.root, "restarbeiten.editbox.meta.ampel").children[0].dataset.state, "rot");
       assert.equal(
         findByUiId(screen.root, "restarbeiten.editbox.meta.ampel").parentElement,
         findByUiId(screen.root, "restarbeiten.editbox.meta")
       );
+
+      triggerValue(findByUiId(screen.root, "restarbeiten.editbox.meta.status"), "erledigt", "change");
+      assert.equal(screen.draft.ampelState, "neutral");
+      assert.equal(findByUiId(screen.root, "restarbeiten.editbox.meta.ampel").children[0].dataset.state, "neutral");
 
       triggerValue(findByUiId(screen.root, "restarbeiten.editbox.meta.status"), "offen", "change");
       const futureDueDate = new Date();
@@ -1573,31 +1582,33 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(css.includes(".bbm-restarbeiten-note {\n  width: 24px;\n  height: 24px;\n  display: inline-flex;\n  align-items: center;\n  justify-content: center;\n  padding: 0;"), true);
   });
 
-  await run("Restarbeiten: Ampellogik nutzt keine Orange-Regel", async () => {
+  await run("Restarbeiten: Ampellogik nutzt 10-Tage-Warnfenster und erledigt ist neutral", async () => {
     const viewModel = await importEsmFromFile(
       path.join(__dirname, "../../src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js")
     );
-    const today = new Date(Date.UTC(2026, 5, 5));
+    const today = new Date(Date.UTC(2026, 5, 24));
     const cases = [
-      [{ status: "verzug" }, "rot"],
-      [{ status: "erledigt" }, "gruen"],
+      [{ status: "verzug" }, "neutral"],
+      [{ status: "erledigt" }, "neutral"],
+      [{ status: "erledigt", due_date: "2026-06-23" }, "neutral"],
       [{ status: "offen" }, "neutral"],
-      [{ status: "offen", due_date: "2026-06-05" }, "gruen"],
-      [{ status: "offen", due_date: "2026-06-20" }, "gruen"],
-      [{ status: "offen", due_date: "2026-06-04" }, "rot"],
+      [{ status: "offen", due_date: "2026-06-23" }, "rot"],
+      [{ status: "offen", due_date: "2026-06-24" }, "orange"],
+      [{ status: "offen", due_date: "2026-06-25" }, "orange"],
+      [{ status: "offen", due_date: "2026-07-04" }, "orange"],
+      [{ status: "offen", due_date: "2026-07-05" }, "gruen"],
       [{ status: "in arbeit" }, "neutral"],
-      [{ status: "in arbeit", due_date: "2026-06-20" }, "gruen"],
-      [{ status: "in arbeit", due_date: "2026-06-04" }, "rot"],
-      [{ status: "in_arbeit", due_date: "2026-06-20" }, "gruen"],
+      [{ status: "in arbeit", due_date: "2026-06-25" }, "orange"],
+      [{ status: "in_arbeit", due_date: "2026-07-05" }, "gruen"],
     ];
     const states = cases.map(([row, expected]) => {
       const actual = viewModel.getRestarbeitenAmpelState(row, today);
       assert.equal(actual, expected, JSON.stringify(row));
       return actual;
     });
-    assert.equal(states.includes("orange"), false);
-    assert.equal(viewModel.mapRestarbeitenStatusLabel("geprueft_erledigt"), "offen");
-    assert.equal(viewModel.mapRestarbeitenStatusLabel("zurueckgewiesen"), "offen");
+    assert.equal(states.includes("orange"), true);
+    assert.equal(viewModel.mapRestarbeitenStatusLabel("geprueft_erledigt"), "Status ungueltig");
+    assert.equal(viewModel.mapRestarbeitenStatusLabel("zurueckgewiesen"), "Status ungueltig");
     assert.equal(viewModel.getRestarbeitenAmpelState({ status: "geprueft_erledigt" }, today), "neutral");
     assert.equal(viewModel.getRestarbeitenAmpelState({ status: "zurueckgewiesen" }, today), "neutral");
   });

--- a/scripts/tests/restarbeitenRules.test.cjs
+++ b/scripts/tests/restarbeitenRules.test.cjs
@@ -1,0 +1,71 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+async function runRestarbeitenRulesTests(run) {
+  const rules = await importEsmFromFile(
+    path.join(__dirname, "../../src/renderer/modules/restarbeiten/domain/restarbeitenRules.js")
+  );
+  const today = new Date(Date.UTC(2026, 5, 24));
+
+  await run("Restarbeiten M25: Statuswerte sind auf offen, in_arbeit und erledigt begrenzt", () => {
+    assert.deepEqual(rules.RESTARBEITEN_STATUS_VALUES, ["offen", "in_arbeit", "erledigt"]);
+    assert.equal(rules.normalizeRestarbeitStatus("offen"), "offen");
+    assert.equal(rules.normalizeRestarbeitStatus("in_arbeit"), "in_arbeit");
+    assert.equal(rules.normalizeRestarbeitStatus("in arbeit"), "in_arbeit");
+    assert.equal(rules.normalizeRestarbeitStatus("erledigt"), "erledigt");
+    assert.equal(rules.normalizeRestarbeitStatus("verzug"), "");
+    assert.equal(rules.normalizeRestarbeitStatus("zurueckgestellt"), "");
+    assert.equal(rules.normalizeRestarbeitStatus("entfaellt"), "");
+    assert.equal(rules.normalizeRestarbeitStatus("problem"), "");
+    assert.equal(rules.normalizeRestarbeitStatus("abgenommen"), "");
+    assert.equal(rules.normalizeRestarbeitStatus("", { defaultForNew: true }), "offen");
+    assert.equal(rules.normalizeRestarbeitStatus("   "), "");
+    assert.equal(rules.getRestarbeitStatusLabel("unbekannt"), "Status ungueltig");
+  });
+
+  await run("Restarbeiten M25: Kurztext ist harte Erstellgrenze", () => {
+    assert.equal(rules.canCreateRestarbeitDraft({ short_text: "" }), false);
+    assert.equal(rules.canCreateRestarbeitDraft({ short_text: "   " }), false);
+    assert.equal(rules.canCreateRestarbeitDraft({ short_text: null }), false);
+    assert.equal(rules.canCreateRestarbeitDraft({ short_text: "Tuer einstellen" }), true);
+  });
+
+  await run("Restarbeiten M25: Pflichtfeldvollstaendigkeit erkennt fachliche Luecken", () => {
+    const complete = {
+      short_text: "Tuer einstellen",
+      location_level_1: "Haus A",
+      status: "offen",
+      responsible_label: "AB Bau",
+      due_date: "2026-07-10",
+    };
+    assert.equal(rules.isRestarbeitFachlichVollstaendig(complete), true);
+    assert.deepEqual(rules.getMissingRestarbeitRequiredFields(complete), []);
+
+    const missing = rules.getMissingRestarbeitRequiredFields({
+      short_text: "Tuer einstellen",
+      status: "unbekannt",
+    }).map((field) => field.label);
+    assert.deepEqual(missing, ["Ort/Bereich", "Status", "Verantwortlich", "Fertig bis"]);
+    assert.equal(
+      rules.getRestarbeitRequiredFieldSummary({ short_text: "Tuer einstellen", status: "unbekannt" }),
+      "Unvollstaendig: Ort/Bereich, Status, Verantwortlich, Fertig bis"
+    );
+  });
+
+  await run("Restarbeiten M25: Ampel ist friststabil mit 10-Tage-Warnfenster", () => {
+    assert.equal(rules.calculateRestarbeitAmpel({ status: "offen" }, today), "neutral");
+    assert.equal(rules.calculateRestarbeitAmpel({ status: "offen", due_date: "2026-06-23" }, today), "rot");
+    assert.equal(rules.calculateRestarbeitAmpel({ status: "offen", due_date: "2026-06-24" }, today), "orange");
+    assert.equal(rules.calculateRestarbeitAmpel({ status: "offen", due_date: "2026-06-25" }, today), "orange");
+    assert.equal(rules.calculateRestarbeitAmpel({ status: "offen", due_date: "2026-07-04" }, today), "orange");
+    assert.equal(rules.calculateRestarbeitAmpel({ status: "offen", due_date: "2026-07-05" }, today), "gruen");
+    assert.equal(rules.calculateRestarbeitAmpel({ status: "in_arbeit", due_date: "2026-06-23" }, today), "rot");
+    assert.equal(rules.calculateRestarbeitAmpel({ status: "in arbeit", due_date: "2026-06-25" }, today), "orange");
+    assert.equal(rules.calculateRestarbeitAmpel({ status: "erledigt", due_date: "2026-06-23" }, today), "neutral");
+    assert.equal(rules.calculateRestarbeitAmpel({ status: "erledigt", due_date: "2026-07-05" }, today), "neutral");
+    assert.equal(rules.calculateRestarbeitAmpel({ status: "unbekannt", due_date: "2026-06-23" }, today), "neutral");
+  });
+}
+
+module.exports = { runRestarbeitenRulesTests };

--- a/src/main/db/restarbeitenRepo.js
+++ b/src/main/db/restarbeitenRepo.js
@@ -3,9 +3,8 @@ const { initDatabase } = require("./database");
 
 const ALLOWED_STATUS = new Set([
   "offen",
-  "in arbeit",
+  "in_arbeit",
   "erledigt",
-  "verzug",
 ]);
 const ALLOWED_ITEM_CLASSES = new Set(["rest", "mangel"]);
 
@@ -21,13 +20,17 @@ function reqText(value, name) {
   return out;
 }
 
-function normalizeStatus(value) {
-  const clean = toText(value)?.toLowerCase();
-  if (!clean) return "offen";
+function normalizeStatus(value, { defaultForNew = false } = {}) {
+  const clean = toText(value)?.toLowerCase().replace(/\s+/g, "_");
+  if (!clean) return defaultForNew ? "offen" : null;
   if (ALLOWED_STATUS.has(clean)) return clean;
-  if (clean === "in_arbeit") return "in arbeit";
-  if (clean === "erledigt_gemeldet" || clean === "geprueft_erledigt") return "erledigt";
-  return "offen";
+  return null;
+}
+
+function reqStatus(value, options = {}) {
+  const normalized = normalizeStatus(value, options);
+  if (!normalized) throw new Error("status invalid");
+  return normalized;
 }
 
 function normalizeRestarbeitItemClass(value) {
@@ -47,7 +50,7 @@ function buildRestarbeitUpdatePatch(patch = {}) {
   if (patch.short_text !== undefined) out.short_text = toText(patch.short_text) || "";
   if (patch.long_text !== undefined) out.long_text = toText(patch.long_text) || "";
   if (patch.item_class !== undefined) out.item_class = normalizeRestarbeitItemClass(patch.item_class);
-  if (patch.status !== undefined) out.status = normalizeStatus(patch.status);
+  if (patch.status !== undefined) out.status = reqStatus(patch.status);
   if (patch.due_date !== undefined) out.due_date = toText(patch.due_date);
   if (patch.responsible_project_firm_id !== undefined) {
     out.responsible_project_firm_id = toText(patch.responsible_project_firm_id);
@@ -104,10 +107,10 @@ function createRestarbeitItem(projectIdOrPayload = {}, payload = {}) {
     location_level_2: toText(sourcePayload.location_level_2),
     location_level_3: toText(sourcePayload.location_level_3),
     location_level_4: toText(sourcePayload.location_level_4),
-    short_text: toText(sourcePayload.short_text) || "",
+    short_text: reqText(sourcePayload.short_text, "short_text"),
     long_text: toText(sourcePayload.long_text) || "",
     item_class: normalizeRestarbeitItemClass(sourcePayload.item_class),
-    status: normalizeStatus(sourcePayload.status),
+    status: reqStatus(sourcePayload.status, { defaultForNew: true }),
     due_date: toText(sourcePayload.due_date),
     responsible_project_firm_id: toText(sourcePayload.responsible_project_firm_id),
     responsible_label: toText(sourcePayload.responsible_label),

--- a/src/renderer/modules/restarbeiten/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenEditbox.js
@@ -1,4 +1,10 @@
 import { resolveLocationLabels } from "./RestarbeitenFilterbar.js";
+import {
+  RESTARBEITEN_STATUS_OPTIONS,
+  getMissingRestarbeitRequiredFields,
+  getRestarbeitRequiredFieldSummary,
+  normalizeRestarbeitStatus,
+} from "./domain/restarbeitenRules.js";
 
 function createEl(tag, { className = "", text = "", uiId = "" } = {}) {
   const el = document.createElement(tag);
@@ -209,12 +215,16 @@ export function buildRestarbeitenEditbox({
 } = {}) {
   const labels = resolveLocationLabels(settings);
   const canSave = Boolean(String(draft.short_text || "").trim());
+  const missingRequiredFields = getMissingRestarbeitRequiredFields(draft);
+  const validationText = canSave ? getRestarbeitRequiredFieldSummary(draft) : "Kurztext erforderlich";
+  const normalizedStatus = normalizeRestarbeitStatus(draft.status) || "";
   const currentRecordLabel = draft.id ? `Nr.: ${draft.running_number || "?"} in Bearbeitung` : "Nr.: neu in Bearbeitung";
   let validation = null;
   const root = createEl("section", {
     className: "bbm-restarbeiten-editbox",
     uiId: "restarbeiten.editbox",
   });
+  root.dataset.fachlichVollstaendig = String(missingRequiredFields.length === 0);
 
   const header = createEl("div", {
     className: "bbm-restarbeiten-editbox__header",
@@ -275,7 +285,11 @@ export function buildRestarbeitenEditbox({
       labelControls: [classToggle, actions],
       onInput: (short_text) => {
         const hasShortText = Boolean(String(short_text || "").trim());
-        if (validation) validation.textContent = hasShortText ? "" : "Kurztext erforderlich";
+        if (validation) {
+          validation.textContent = hasShortText
+            ? getRestarbeitRequiredFieldSummary({ ...draft, short_text })
+            : "Kurztext erforderlich";
+        }
         onDraftChange?.({ short_text }, { render: false });
       },
       onCommit: () => onAutoSave?.(),
@@ -340,14 +354,11 @@ export function buildRestarbeitenEditbox({
     createField({
       label: "Status",
       labelUiId: "restarbeiten.editbox.meta.status.label",
-      value: draft.status === "in_arbeit" ? "in arbeit" : draft.status || "offen",
+      value: normalizedStatus,
       type: "select",
-      options: [
-        { value: "offen", label: "Offen" },
-        { value: "in arbeit", label: "In Arbeit" },
-        { value: "erledigt", label: "Erledigt" },
-        { value: "verzug", label: "Verzug" },
-      ],
+      options: normalizedStatus
+        ? RESTARBEITEN_STATUS_OPTIONS
+        : [{ value: "", label: "Status ungueltig" }, ...RESTARBEITEN_STATUS_OPTIONS],
       uiId: "restarbeiten.editbox.meta.status",
       onInput: (status) => onDraftChange?.({ status }),
       onCommit: () => onAutoSave?.(),
@@ -373,7 +384,7 @@ export function buildRestarbeitenEditbox({
   );
   validation = createEl("span", {
     className: "bbm-restarbeiten-validation",
-    text: canSave ? "" : "Kurztext erforderlich",
+    text: validationText,
     uiId: "restarbeiten.editbox.validation.shortText",
   });
   meta.appendChild(validation);

--- a/src/renderer/modules/restarbeiten/RestarbeitenFilterbar.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenFilterbar.js
@@ -1,3 +1,5 @@
+import { RESTARBEITEN_STATUS_OPTIONS } from "./domain/restarbeitenRules.js";
+
 const DEFAULT_LOCATION_LABELS = ["Haus", "Geschoss", "Einheit", "Raum"];
 
 function createEl(tag, { className = "", text = "", uiId = "" } = {}) {
@@ -105,13 +107,7 @@ export function buildRestarbeitenFilterbar({
       label: "Status",
       labelUiId: "restarbeiten.filterbar.meta.status.label",
       value: filters.status || "",
-      options: [
-        { value: "", label: "Alle" },
-        { value: "offen", label: "Offen" },
-        { value: "in arbeit", label: "In Arbeit" },
-        { value: "erledigt", label: "Erledigt" },
-        { value: "verzug", label: "Verzug" },
-      ],
+      options: [{ value: "", label: "Alle" }, ...RESTARBEITEN_STATUS_OPTIONS],
       uiId: "restarbeiten.filterbar.meta.status",
       onChange: (status) => onFilterChange?.({ status }),
     }),

--- a/src/renderer/modules/restarbeiten/RestarbeitenList.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenList.js
@@ -63,6 +63,7 @@ export function buildRestarbeitenList({
     row.type = "button";
     row.setAttribute("data-ui-editor-template-id", "restarbeiten.record");
     row.setAttribute("data-bbm-restarbeiten-record-id", String(item.id ?? ""));
+    row.setAttribute("data-fachlich-vollstaendig", String(item.isFachlichVollstaendig !== false));
     row.setAttribute("aria-selected", String(item.id === selectedId));
     row.addEventListener("click", () => onSelect?.(item.id));
 
@@ -102,6 +103,9 @@ export function buildRestarbeitenList({
     }
     appendText(metaColumn, "", item.statusLabel, "restarbeiten.record.status");
     appendText(metaColumn, "", item.responsibleLabel, "restarbeiten.record.responsible");
+    if (item.requiredFieldSummary) {
+      appendText(metaColumn, "bbm-restarbeiten-record__required", item.requiredFieldSummary);
+    }
 
     row.append(numberColumn, contentColumn, metaColumn);
     records.appendChild(row);

--- a/src/renderer/modules/restarbeiten/domain/restarbeitenRules.js
+++ b/src/renderer/modules/restarbeiten/domain/restarbeitenRules.js
@@ -1,0 +1,115 @@
+export const RESTARBEITEN_STATUS_VALUES = Object.freeze(["offen", "in_arbeit", "erledigt"]);
+
+export const RESTARBEITEN_STATUS_OPTIONS = Object.freeze([
+  { value: "offen", label: "Offen" },
+  { value: "in_arbeit", label: "In Arbeit" },
+  { value: "erledigt", label: "Erledigt" },
+]);
+
+export const RESTARBEITEN_REQUIRED_FIELDS = Object.freeze([
+  { field: "short_text", label: "Kurztext" },
+  { field: "location", label: "Ort/Bereich" },
+  { field: "status", label: "Status" },
+  { field: "responsible", label: "Verantwortlich" },
+  { field: "due_date", label: "Fertig bis" },
+]);
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WARNING_DAYS = 10;
+
+export function toRestarbeitenText(value, fallback = "") {
+  const text = String(value ?? "").trim();
+  return text || fallback;
+}
+
+export function normalizeRestarbeitStatus(value, { defaultForNew = false } = {}) {
+  const raw = toRestarbeitenText(value).toLowerCase().replace(/\s+/g, "_");
+  if (!raw) return defaultForNew ? "offen" : "";
+  return RESTARBEITEN_STATUS_VALUES.includes(raw) ? raw : "";
+}
+
+export function isValidRestarbeitStatus(value) {
+  return Boolean(normalizeRestarbeitStatus(value));
+}
+
+export function getRestarbeitStatusLabel(value) {
+  const normalized = normalizeRestarbeitStatus(value);
+  if (normalized === "offen") return "offen";
+  if (normalized === "in_arbeit") return "in Arbeit";
+  if (normalized === "erledigt") return "erledigt";
+  return "Status ungueltig";
+}
+
+export function canCreateRestarbeitDraft(row = {}) {
+  return Boolean(toRestarbeitenText(row.short_text));
+}
+
+export function getMissingRestarbeitRequiredFields(row = {}) {
+  const missing = [];
+  if (!toRestarbeitenText(row.short_text)) missing.push(RESTARBEITEN_REQUIRED_FIELDS[0]);
+
+  const hasLocation = [1, 2, 3, 4].some((level) => toRestarbeitenText(row[`location_level_${level}`]));
+  if (!hasLocation) missing.push(RESTARBEITEN_REQUIRED_FIELDS[1]);
+
+  if (!isValidRestarbeitStatus(row.status)) missing.push(RESTARBEITEN_REQUIRED_FIELDS[2]);
+
+  if (!toRestarbeitenText(row.responsible_project_firm_id) && !toRestarbeitenText(row.responsible_label)) {
+    missing.push(RESTARBEITEN_REQUIRED_FIELDS[3]);
+  }
+
+  if (!toRestarbeitenText(row.due_date)) missing.push(RESTARBEITEN_REQUIRED_FIELDS[4]);
+  return missing;
+}
+
+export function isRestarbeitFachlichVollstaendig(row = {}) {
+  return getMissingRestarbeitRequiredFields(row).length === 0;
+}
+
+export function getRestarbeitRequiredFieldSummary(row = {}) {
+  const labels = getMissingRestarbeitRequiredFields(row).map((field) => field.label);
+  return labels.length ? `Unvollstaendig: ${labels.join(", ")}` : "";
+}
+
+function parseDateOnly(value) {
+  const text = toRestarbeitenText(value);
+  if (!text) return null;
+  const match = text.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (match) {
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    if (
+      parsed.getUTCFullYear() === year &&
+      parsed.getUTCMonth() === month - 1 &&
+      parsed.getUTCDate() === day
+    ) {
+      return parsed;
+    }
+    return null;
+  }
+  const parsed = new Date(text);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return new Date(Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate()));
+}
+
+function toDayStartUtc(dateLike = new Date()) {
+  const date = dateLike instanceof Date ? dateLike : new Date(dateLike);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+export function calculateRestarbeitAmpel(row = {}, today = new Date()) {
+  const status = normalizeRestarbeitStatus(row.status);
+  if (status === "erledigt") return "neutral";
+  if (!status) return "neutral";
+
+  const dueDate = parseDateOnly(row.due_date);
+  const todayStart = toDayStartUtc(today);
+  if (!dueDate || !todayStart) return "neutral";
+
+  const diffDays = Math.round((dueDate.getTime() - todayStart.getTime()) / DAY_MS);
+  if (diffDays < 0) return "rot";
+  if (diffDays <= WARNING_DAYS) return "orange";
+  return "gruen";
+}

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -15,6 +15,10 @@ import { buildRestarbeitenEditbox } from "../RestarbeitenEditbox.js";
 import { buildRestarbeitenQuicklane } from "../RestarbeitenQuicklane.js";
 import { ensureRestarbeitenStyles } from "../styles.js";
 import {
+  canCreateRestarbeitDraft,
+  normalizeRestarbeitStatus,
+} from "../domain/restarbeitenRules.js";
+import {
   cleanupPopupHandlers,
   createPopupOverlay,
   registerPopupCloseHandlers,
@@ -48,7 +52,7 @@ function emptyDraft() {
   return {
     id: "",
     item_class: "rest",
-    status: "offen",
+    status: normalizeRestarbeitStatus("", { defaultForNew: true }),
     short_text: "",
     long_text: "",
     due_date: "",
@@ -61,11 +65,9 @@ function emptyDraft() {
   };
 }
 
-function normalizeDraftStatus(value) {
-  const raw = normalizeText(value).toLowerCase();
-  if (raw === "in_arbeit") return "in arbeit";
-  if (["offen", "in arbeit", "erledigt", "verzug"].includes(raw)) return raw;
-  return "offen";
+function normalizeDraftStatus(value, { defaultForNew = false } = {}) {
+  const normalized = normalizeRestarbeitStatus(value, { defaultForNew });
+  return normalized || normalizeText(value).toLowerCase();
 }
 
 function prepareDraft(source = {}) {
@@ -73,9 +75,9 @@ function prepareDraft(source = {}) {
     ...emptyDraft(),
     ...source,
     item_class: normalizeText(source.item_class) === "mangel" ? "mangel" : "rest",
-    status: normalizeDraftStatus(source.status),
+    status: normalizeDraftStatus(source.status, { defaultForNew: !source.id }),
     responsible_project_firm_id: normalizeText(source.responsible_project_firm_id),
-    responsible_label: normalizeText(source.responsible_project_firm_id) ? normalizeText(source.responsible_label) : "",
+    responsible_label: normalizeText(source.responsible_label),
   };
   draft.ampelState = getRestarbeitenAmpelState(draft);
   return draft;
@@ -87,8 +89,12 @@ function buildSavePayload(draft = {}) {
   delete payload.created_at;
   delete payload.running_number;
   payload.item_class = normalizeText(payload.item_class) === "mangel" ? "mangel" : "rest";
-  payload.status = normalizeDraftStatus(payload.status);
-  if (!normalizeText(payload.responsible_project_firm_id)) payload.responsible_label = "";
+  const normalizedStatus = normalizeRestarbeitStatus(payload.status, { defaultForNew: !payload.id });
+  if (normalizedStatus) {
+    payload.status = normalizedStatus;
+  } else {
+    delete payload.status;
+  }
   return payload;
 }
 
@@ -248,7 +254,7 @@ export default class RestarbeitenScreen {
   _getFilteredItems() {
     return (this.items || []).filter((row) => {
       if (this.filters.itemClass !== "all" && normalizeText(row.item_class) !== this.filters.itemClass) return false;
-      if (this.filters.status && normalizeText(row.status) !== this.filters.status) return false;
+      if (this.filters.status && normalizeRestarbeitStatus(row.status) !== this.filters.status) return false;
       if (this.filters.dueDate && normalizeText(row.due_date).slice(0, 10) !== this.filters.dueDate) return false;
       if (this.filters.responsible && normalizeText(row.responsible_label) !== this.filters.responsible) return false;
       for (let i = 1; i <= 4; i += 1) {
@@ -281,7 +287,7 @@ export default class RestarbeitenScreen {
 
   async _saveDraft() {
     if (!this.projectId) return;
-    if (!normalizeText(this.draft.short_text)) return;
+    if (!canCreateRestarbeitDraft(this.draft)) return;
     const payload = buildSavePayload(this.draft);
     let createdId = "";
     if (payload.id) {
@@ -298,7 +304,7 @@ export default class RestarbeitenScreen {
   }
 
   async _autoSaveDraft() {
-    if (!normalizeText(this.draft.short_text)) return;
+    if (!canCreateRestarbeitDraft(this.draft)) return;
     await this._saveDraft();
   }
 

--- a/src/renderer/modules/restarbeiten/styles/restarbeiten.css
+++ b/src/renderer/modules/restarbeiten/styles/restarbeiten.css
@@ -386,6 +386,10 @@
   box-shadow: 0 0 0 2px rgba(135, 191, 255, 0.26);
 }
 
+.bbm-restarbeiten-record[data-fachlich-vollstaendig="false"] {
+  border-left: 3px solid var(--bbm-error);
+}
+
 .bbm-restarbeiten-record__number {
   font-size: 8.5pt;
   font-weight: 600;
@@ -467,6 +471,12 @@
   font-size: 8pt;
   font-weight: 400;
   line-height: 1.25;
+}
+
+.bbm-restarbeiten-record__required {
+  color: var(--bbm-error);
+  font-size: var(--bbm-rest-label-font-size);
+  font-weight: 700;
 }
 
 .bbm-restarbeiten-ampel {

--- a/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
+++ b/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
@@ -1,3 +1,11 @@
+import {
+  calculateRestarbeitAmpel,
+  getMissingRestarbeitRequiredFields,
+  getRestarbeitRequiredFieldSummary,
+  getRestarbeitStatusLabel,
+  isRestarbeitFachlichVollstaendig,
+} from "../domain/restarbeitenRules.js";
+
 function toText(value, fallback = "") {
   const text = String(value ?? "").trim();
   return text || fallback;
@@ -16,20 +24,12 @@ function mapItemClassLabel(value) {
 }
 
 export function mapRestarbeitenStatusLabel(value) {
-  const raw = toText(value).toLowerCase();
-  const map = {
-    offen: "offen",
-    "in arbeit": "in Arbeit",
-    in_arbeit: "in Arbeit",
-    erledigt: "erledigt",
-    verzug: "Verzug",
-  };
-  return map[raw] || "offen";
+  return getRestarbeitStatusLabel(value);
 }
 
 function joinLocation(parts = []) {
   const cleaned = parts.map((part) => toText(part)).filter(Boolean);
-  return cleaned.length ? cleaned.join(" \u00b7 ") : "\u2014";
+  return cleaned.length ? cleaned.join(" \u00b7 ") : "Ort/Bereich fehlt";
 }
 
 function formatDateDisplay(value, fallback = "\u2014") {
@@ -41,59 +41,16 @@ function formatDateDisplay(value, fallback = "\u2014") {
   return `${day}.${month}.${year.slice(-2)}`;
 }
 
-function parseDateOnly(value) {
-  const text = toText(value);
-  if (!text) return null;
-  const match = text.match(/^(\d{4})-(\d{2})-(\d{2})/);
-  if (match) {
-    const year = Number(match[1]);
-    const month = Number(match[2]);
-    const day = Number(match[3]);
-    const parsed = new Date(Date.UTC(year, month - 1, day));
-    if (
-      parsed.getUTCFullYear() === year &&
-      parsed.getUTCMonth() === month - 1 &&
-      parsed.getUTCDate() === day
-    ) {
-      return parsed;
-    }
-    return null;
-  }
-  const parsed = new Date(text);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return new Date(Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate()));
-}
-
-function toDayStartUtc(dateLike = new Date()) {
-  const date = dateLike instanceof Date ? dateLike : new Date(dateLike);
-  if (Number.isNaN(date.getTime())) return null;
-  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
-}
-
 export function getRestarbeitenAmpelState(row = {}, today = new Date()) {
-  const status = toText(row.status).toLowerCase();
-  if (status === "verzug") return "rot";
-  if (status === "erledigt") return "gruen";
-
-  const dueDate = parseDateOnly(row.due_date);
-  const todayStart = toDayStartUtc(today);
-  if (!todayStart) return "neutral";
-
-  if (dueDate && dueDate.getTime() < todayStart.getTime()) return "rot";
-
-  if (status === "offen" || status === "in arbeit" || status === "in_arbeit") {
-    return dueDate ? "gruen" : "neutral";
-  }
-
-  return "neutral";
+  return calculateRestarbeitAmpel(row, today);
 }
 
 export function toRestarbeitenListItem(row = {}, today = new Date()) {
   const itemClassToken = mapItemClassToken(row.item_class);
   const itemClassLabel = mapItemClassLabel(row.item_class);
   const statusLabel = mapRestarbeitenStatusLabel(row.status);
-  const dueDateLabel = formatDateDisplay(row.due_date, "\u2014");
-  const responsibleLabel = toText(row.responsible_label, "\u2014");
+  const dueDateLabel = formatDateDisplay(row.due_date, "Fertig bis fehlt");
+  const responsibleLabel = toText(row.responsible_label, "Verantwortlich fehlt");
   const ampelState = getRestarbeitenAmpelState(row, today);
   const locationLine = joinLocation([
     row.location_level_1,
@@ -103,6 +60,9 @@ export function toRestarbeitenListItem(row = {}, today = new Date()) {
   ]);
   const shortTextLine = toText(row.short_text, "\u2014");
   const longTextLine = toText(row.long_text, "\u2014");
+  const missingRequiredFields = getMissingRestarbeitRequiredFields(row);
+  const requiredFieldSummary = getRestarbeitRequiredFieldSummary(row);
+  const isFachlichVollstaendig = isRestarbeitFachlichVollstaendig(row);
 
   return {
     id: toText(row.id, ""),
@@ -123,6 +83,9 @@ export function toRestarbeitenListItem(row = {}, today = new Date()) {
     locationLevel4: toText(row.location_level_4, ""),
     shortTextLine,
     longTextLine,
+    missingRequiredFields,
+    requiredFieldSummary,
+    isFachlichVollstaendig,
     workLine1: shortTextLine,
     workLine2: longTextLine,
   };


### PR DESCRIPTION
M25 setzt die Restarbeiten-Regeln für Pflichtfelder, Statusmodell und Ampel um. Der UI-Editor bleibt generisch; Protokoll, PDF/Mail, Diktat/Audio und Fotoimport wurden nicht geändert. npm test ist grün. npm run test:node und npm run lint bleiben wegen bekannter Alt-/Umgebungsthemen außerhalb M25 rot.