### PR TITLE
M26: Restarbeiten Nachpflege und Bearbeitung absichern

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,14 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M26 Restarbeiten Nachpflege vorhandener Datensaetze abgesichert:
+  - Unvollstaendige Restarbeiten bleiben in der Liste als `Nachpflege erforderlich` sichtbar markiert.
+  - Die Editbox benennt bei vorhandenen Alt-Datensaetzen alle fehlenden Pflichtfelder, auch wenn der Kurztext leer ist.
+  - Vorhandene Datensaetze koennen feldweise nachgepflegt werden, ohne Platzhalter oder Fantasiewerte zu erzeugen.
+  - Neue Datensaetze bleiben weiter gegen Anlegen ohne Kurztext gesperrt.
+  - Statusmodell und M25-Ampellogik bleiben unveraendert.
+  - UI-Editor-kit, Protokoll, PDF/Druck/Mail, Diktat/Audio, Fotoimport und Lizenzierung blieben unveraendert.
+
 - M25 Restarbeiten Pflichtfelder, Status und Ampel technisch abgesichert:
   - Pflichtfeldvollstaendigkeit wird in Liste und Editbox sichtbar als unvollstaendig markiert.
   - Neue Restarbeiten koennen technisch nicht ohne Kurztext angelegt werden; fehlende weitere Pflichtfelder bleiben als Draft sichtbar unvollstaendig.

--- a/docs/M26_UI_PDF_ENTWURFSENTSCHEIDUNG.md
+++ b/docs/M26_UI_PDF_ENTWURFSENTSCHEIDUNG.md
@@ -1,0 +1,47 @@
+# M26 UI-/PDF-Entwurfsentscheidung: Restarbeiten Nachpflege
+
+## A. Art der Ausgabe
+
+- UI
+- Keine PDF-Aenderung
+
+## B. Editorfaehigkeit
+
+- editorfaehig: nein
+- Begruendung: M26 verbessert ausschliesslich die fachliche Sichtbarkeit unvollstaendiger Restarbeiten im BBM-Fachmodul. Es entstehen keine neuen editorfaehigen Elemente und keine neue UI-Editor-Funktion.
+
+## C. Editorfaehige Elemente
+
+M26 legt keine neuen editorfaehigen Elemente an.
+
+Bestehende Restarbeiten-Elemente und ihre Registry-Struktur bleiben unveraendert. Die Pflichtfeldhinweise sind fachliche Validierungs-/Nachpflegeanzeigen und keine Editor-Ziele.
+
+## D. Nicht editorfaehige Elemente / verbotene Editor-Ziele
+
+Nicht editorfaehig und nicht Ziel von M26 sind:
+
+- Fachaktionen
+- Speichern
+- Anlegen
+- Loeschen
+- Upload
+- Import
+- Autosave
+- fachliche IPC-/Datenaktionen
+- Datenbankaktionen
+- Statuswechsel als fachliche Aktion
+- Ampelberechnung
+- Pflichtfeldvalidierung
+- Nachpflegehinweise fuer vorhandene Datensaetze
+
+## E. Parent-/Strukturregel
+
+M26 registriert keine neuen editorfaehigen Elemente und legt keine neue Parent-Struktur fuer den UI-Editor an.
+
+Falls bestehende Restarbeiten-Elemente angezeigt werden, gelten weiterhin die vorhandenen Registry-Parents. Sichtbare Nachpflegehinweise sind kein neues Editor-Ziel.
+
+## F. Pruef-/Testangabe
+
+- Fachliche M26-Regeln werden ueber Restarbeiten-Tests abgesichert.
+- Bestehende UI-Editor-Vertragstests bleiben unveraendert.
+- Es gibt fuer diese fachliche UI-Markierung keinen neuen separaten UI-Editor-Vertragscheck, da keine neue Registry und kein neues editorfaehiges Element eingefuehrt wird.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -324,3 +324,10 @@ Dabei gilt:
 - Statuswerte sind auf `offen`, `in_arbeit` und `erledigt` begrenzt; unbekannte Status werden nicht still normalisiert.
 - Die Ampel folgt der M24-10-Tage-Regel und behandelt `erledigt` fristneutral.
 - Protokoll, UI-Editor-kit, PDF/Druck/Mail, Diktat/Audio, Fotoimport und Registry-Struktur bleiben ausserhalb dieses Pakets.
+
+### M26 Restarbeiten Nachpflege vorhandener Datensaetze abgesichert (neu)
+- Unvollstaendige Restarbeiten bleiben in Liste und Editbox klar als Nachpflegefaelle sichtbar.
+- Vorhandene Alt-Datensaetze koennen auch dann feldweise nachgepflegt werden, wenn der Kurztext noch fehlt.
+- Neue Datensaetze bleiben weiterhin gegen Anlegen ohne Kurztext gesperrt.
+- Es werden keine Platzhalter oder Fantasiewerte erzeugt; Statusmodell und M25-Ampellogik bleiben unveraendert.
+- Protokoll, UI-Editor-kit, PDF/Druck/Mail, Diktat/Audio, Fotoimport und Lizenzierung bleiben ausserhalb dieses Pakets.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -886,6 +886,11 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(rest.itemClassLabel, "Restarbeit");
     assert.equal(rest.locationLine, "EG \u00b7 Flur");
     assert.equal(emptyLocation.locationLine, "Ort/Bereich fehlt");
+    assert.equal(emptyLocation.nachpflegeLabel, "Nachpflege erforderlich");
+    assert.equal(
+      emptyLocation.requiredFieldSummary,
+      "Unvollstaendig: Kurztext, Ort/Bereich, Status, Verantwortlich, Fertig bis"
+    );
   });
 
   await run("Restarbeiten: Statusauswahlen enthalten die verbindlichen Werte", async () => {
@@ -1018,6 +1023,30 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(shortDictation.getAttribute("data-bbm-dictation-state"), "ready");
       assert.equal(findNodes(shortDictation, (node) => node.getAttribute?.("data-bbm-dictation-icon") === "ready").length, 1);
       assert.equal(findNodes(shortDictation, (node) => node.getAttribute?.("data-bbm-dictation-icon") === "recording").length, 1);
+    } finally {
+      globalThis.document = prevDocument;
+    }
+  });
+
+  await run("Restarbeiten: Editbox benennt fehlende Pflichtfelder bei bestehenden Alt-Datensaetzen", async () => {
+    const editbox = await importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/restarbeiten/RestarbeitenEditbox.js"));
+    const prevDocument = globalThis.document;
+    globalThis.document = createFakeDocument();
+    try {
+      const root = editbox.buildRestarbeitenEditbox({
+        draft: {
+          id: "ra-alt",
+          item_class: "rest",
+          status: "offen",
+          short_text: "",
+          location_level_1: "",
+          responsible_label: "",
+          due_date: "",
+        },
+      });
+      const validation = findByUiId(root, "restarbeiten.editbox.validation.shortText");
+      assert.equal(root.dataset.fachlichVollstaendig, "false");
+      assert.equal(validation.textContent, "Unvollstaendig: Kurztext, Ort/Bereich, Verantwortlich, Fertig bis");
     } finally {
       globalThis.document = prevDocument;
     }
@@ -1361,6 +1390,65 @@ async function runRestarbeitenModuleTests(run) {
       await flush();
       assert.equal(calls.length, 0);
       assert.equal(screen.draft.id, "");
+    } finally {
+      globalThis.document = prevDocument;
+      globalThis.window = prevWindow;
+    }
+  });
+
+  await run("Restarbeiten: Auto-Save pflegt bestehenden Alt-Datensatz ohne Kurztext nach", async () => {
+    const mod = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js")
+    );
+    const prevDocument = globalThis.document;
+    const prevWindow = globalThis.window;
+    const calls = [];
+    let rows = [{ id: "ra-alt", item_class: "rest", status: "offen", short_text: "", due_date: "" }];
+    globalThis.document = createFakeDocument();
+    globalThis.window = {
+      bbmDb: {
+        async restarbeitenListByProject() {
+          return { ok: true, items: rows };
+        },
+        async restarbeitenGetProjectSettings() {
+          return { ok: true, settings: {} };
+        },
+        async projectFirmsListByProject() {
+          return { ok: true, list: [] };
+        },
+        async restarbeitenUpdateItem(payload) {
+          calls.push({ type: "update", payload });
+          rows = rows.map((row) => (row.id === payload.id ? { ...row, ...payload.patch } : row));
+          return { ok: true, item: rows.find((row) => row.id === payload.id) };
+        },
+        async restarbeitenCreateItem(payload) {
+          calls.push({ type: "create", payload });
+          return { ok: true, item: { id: "should-not-create" } };
+        },
+      },
+      dispatchEvent() {},
+    };
+    try {
+      const screen = new mod.default({ projectId: "p-1", project: { id: "p-1" } });
+      screen.render();
+      await screen.load();
+      assert.equal(screen.draft.id, "ra-alt");
+      assert.equal(screen.draft.short_text, "");
+      assert.equal(screen.viewItems[0].nachpflegeLabel, "Nachpflege erforderlich");
+
+      const dueControl = triggerValue(findByUiId(screen.root, "restarbeiten.editbox.meta.dueDate"), "2026-07-15", "change");
+      triggerEvent(dueControl, "blur");
+      await flush();
+      await flush();
+      await flush();
+
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].type, "update");
+      assert.equal(calls[0].payload.id, "ra-alt");
+      assert.equal(calls[0].payload.patch.due_date, "2026-07-15");
+      assert.equal(calls[0].payload.patch.short_text, "");
+      assert.equal(calls[0].payload.patch.status, "offen");
+      assert.equal(calls[0].payload.patch.responsible_label, "");
     } finally {
       globalThis.document = prevDocument;
       globalThis.window = prevWindow;

--- a/scripts/tests/restarbeitenRules.test.cjs
+++ b/scripts/tests/restarbeitenRules.test.cjs
@@ -29,6 +29,9 @@ async function runRestarbeitenRulesTests(run) {
     assert.equal(rules.canCreateRestarbeitDraft({ short_text: "   " }), false);
     assert.equal(rules.canCreateRestarbeitDraft({ short_text: null }), false);
     assert.equal(rules.canCreateRestarbeitDraft({ short_text: "Tuer einstellen" }), true);
+    assert.equal(rules.canPersistRestarbeitDraft({ id: "", short_text: "" }), false);
+    assert.equal(rules.canPersistRestarbeitDraft({ id: "ra-alt", short_text: "" }), true);
+    assert.equal(rules.canPersistRestarbeitDraft({ id: "", short_text: "Tuer einstellen" }), true);
   });
 
   await run("Restarbeiten M25: Pflichtfeldvollstaendigkeit erkennt fachliche Luecken", () => {
@@ -51,6 +54,8 @@ async function runRestarbeitenRulesTests(run) {
       rules.getRestarbeitRequiredFieldSummary({ short_text: "Tuer einstellen", status: "unbekannt" }),
       "Unvollstaendig: Ort/Bereich, Status, Verantwortlich, Fertig bis"
     );
+    assert.equal(rules.getRestarbeitNachpflegeLabel({ short_text: "Tuer einstellen", status: "unbekannt" }), "Nachpflege erforderlich");
+    assert.equal(rules.getRestarbeitNachpflegeLabel(complete), "");
   });
 
   await run("Restarbeiten M25: Ampel ist friststabil mit 10-Tage-Warnfenster", () => {

--- a/src/renderer/modules/restarbeiten/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenEditbox.js
@@ -202,6 +202,12 @@ function createClassToggle({ value = "rest", uiId, labelUiId, onChange, onCommit
   return wrap;
 }
 
+function getValidationText(draft = {}) {
+  const hasShortText = Boolean(String(draft.short_text || "").trim());
+  if (hasShortText || draft.id) return getRestarbeitRequiredFieldSummary(draft);
+  return "Kurztext erforderlich";
+}
+
 export function buildRestarbeitenEditbox({
   settings = {},
   draft = {},
@@ -214,9 +220,8 @@ export function buildRestarbeitenEditbox({
   onAutoSave,
 } = {}) {
   const labels = resolveLocationLabels(settings);
-  const canSave = Boolean(String(draft.short_text || "").trim());
   const missingRequiredFields = getMissingRestarbeitRequiredFields(draft);
-  const validationText = canSave ? getRestarbeitRequiredFieldSummary(draft) : "Kurztext erforderlich";
+  const validationText = getValidationText(draft);
   const normalizedStatus = normalizeRestarbeitStatus(draft.status) || "";
   const currentRecordLabel = draft.id ? `Nr.: ${draft.running_number || "?"} in Bearbeitung` : "Nr.: neu in Bearbeitung";
   let validation = null;
@@ -284,11 +289,8 @@ export function buildRestarbeitenEditbox({
       maxLength: 87,
       labelControls: [classToggle, actions],
       onInput: (short_text) => {
-        const hasShortText = Boolean(String(short_text || "").trim());
         if (validation) {
-          validation.textContent = hasShortText
-            ? getRestarbeitRequiredFieldSummary({ ...draft, short_text })
-            : "Kurztext erforderlich";
+          validation.textContent = getValidationText({ ...draft, short_text });
         }
         onDraftChange?.({ short_text }, { render: false });
       },

--- a/src/renderer/modules/restarbeiten/RestarbeitenList.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenList.js
@@ -76,6 +76,9 @@ export function buildRestarbeitenList({
     );
     appendText(numberColumn, "bbm-restarbeiten-record__date", item.dateLine, "restarbeiten.record.createdAt");
     appendText(numberColumn, "bbm-restarbeiten-record__class", item.itemClassLabel, "restarbeiten.record.itemClass");
+    if (item.nachpflegeLabel) {
+      appendText(numberColumn, "bbm-restarbeiten-record__nachpflege", item.nachpflegeLabel);
+    }
     const photos = appendText(numberColumn, "bbm-restarbeiten-record__photos", "Fotos", "restarbeiten.record.photos");
     photos.setAttribute("role", "button");
     photos.setAttribute("tabindex", "0");

--- a/src/renderer/modules/restarbeiten/domain/restarbeitenRules.js
+++ b/src/renderer/modules/restarbeiten/domain/restarbeitenRules.js
@@ -44,6 +44,10 @@ export function canCreateRestarbeitDraft(row = {}) {
   return Boolean(toRestarbeitenText(row.short_text));
 }
 
+export function canPersistRestarbeitDraft(row = {}) {
+  return Boolean(toRestarbeitenText(row.id)) || canCreateRestarbeitDraft(row);
+}
+
 export function getMissingRestarbeitRequiredFields(row = {}) {
   const missing = [];
   if (!toRestarbeitenText(row.short_text)) missing.push(RESTARBEITEN_REQUIRED_FIELDS[0]);
@@ -68,6 +72,10 @@ export function isRestarbeitFachlichVollstaendig(row = {}) {
 export function getRestarbeitRequiredFieldSummary(row = {}) {
   const labels = getMissingRestarbeitRequiredFields(row).map((field) => field.label);
   return labels.length ? `Unvollstaendig: ${labels.join(", ")}` : "";
+}
+
+export function getRestarbeitNachpflegeLabel(row = {}) {
+  return getMissingRestarbeitRequiredFields(row).length ? "Nachpflege erforderlich" : "";
 }
 
 function parseDateOnly(value) {

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -15,7 +15,7 @@ import { buildRestarbeitenEditbox } from "../RestarbeitenEditbox.js";
 import { buildRestarbeitenQuicklane } from "../RestarbeitenQuicklane.js";
 import { ensureRestarbeitenStyles } from "../styles.js";
 import {
-  canCreateRestarbeitDraft,
+  canPersistRestarbeitDraft,
   normalizeRestarbeitStatus,
 } from "../domain/restarbeitenRules.js";
 import {
@@ -287,7 +287,7 @@ export default class RestarbeitenScreen {
 
   async _saveDraft() {
     if (!this.projectId) return;
-    if (!canCreateRestarbeitDraft(this.draft)) return;
+    if (!canPersistRestarbeitDraft(this.draft)) return;
     const payload = buildSavePayload(this.draft);
     let createdId = "";
     if (payload.id) {
@@ -304,7 +304,7 @@ export default class RestarbeitenScreen {
   }
 
   async _autoSaveDraft() {
-    if (!canCreateRestarbeitDraft(this.draft)) return;
+    if (!canPersistRestarbeitDraft(this.draft)) return;
     await this._saveDraft();
   }
 

--- a/src/renderer/modules/restarbeiten/styles/restarbeiten.css
+++ b/src/renderer/modules/restarbeiten/styles/restarbeiten.css
@@ -413,6 +413,15 @@
   line-height: 1.15;
 }
 
+.bbm-restarbeiten-record__nachpflege {
+  display: inline-block;
+  margin-top: 4px;
+  color: var(--bbm-error);
+  font-size: var(--bbm-rest-label-font-size);
+  font-weight: 700;
+  line-height: 1.15;
+}
+
 .bbm-restarbeiten-record__location,
 .bbm-restarbeiten-record__meta {
   color: var(--bbm-muted);

--- a/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
+++ b/src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js
@@ -1,6 +1,7 @@
 import {
   calculateRestarbeitAmpel,
   getMissingRestarbeitRequiredFields,
+  getRestarbeitNachpflegeLabel,
   getRestarbeitRequiredFieldSummary,
   getRestarbeitStatusLabel,
   isRestarbeitFachlichVollstaendig,
@@ -62,6 +63,7 @@ export function toRestarbeitenListItem(row = {}, today = new Date()) {
   const longTextLine = toText(row.long_text, "\u2014");
   const missingRequiredFields = getMissingRestarbeitRequiredFields(row);
   const requiredFieldSummary = getRestarbeitRequiredFieldSummary(row);
+  const nachpflegeLabel = getRestarbeitNachpflegeLabel(row);
   const isFachlichVollstaendig = isRestarbeitFachlichVollstaendig(row);
 
   return {
@@ -85,6 +87,7 @@ export function toRestarbeitenListItem(row = {}, today = new Date()) {
     longTextLine,
     missingRequiredFields,
     requiredFieldSummary,
+    nachpflegeLabel,
     isFachlichVollstaendig,
     workLine1: shortTextLine,
     workLine2: longTextLine,


### PR DESCRIPTION
M26 sichert die Nachpflege und Bearbeitung unvollstaendiger Restarbeiten ab.

Pruefung:
- npm test gruen
- git diff --check gruen
- fachliche Sichtpruefung in der App erfolgt