### PR TITLE
M27a: UI PDF Grundlagenpfade bereinigen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,13 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M27a UI-/PDF-Grundlagenpfade bereinigt:
+  - Die von `AGENTS.md` erwarteten Root-Pfade fuer UI-/PDF-Grundlagen sind als kurze Bruecken angelegt.
+  - Fuehrende Inhalte bleiben unter `docs/ui-editor/`; es wurde keine doppelte Fachlogik aufgebaut.
+  - `docs/UI_EDITOR_VERTRAG.md` verweist jetzt ebenfalls auf die fuehrende Fassung unter `docs/ui-editor/`.
+  - `docs/UI_PDF_ENTWURFSENTSCHEIDUNG.md` ist nur eine allgemeine Bruecke/Vorlage, keine M28-Entscheidung.
+  - Keine Restarbeiten-UI, keine Ausgabeansicht, keine PDF-/Druck-/Mail-Funktion, kein UI-Editor-kit-Code, kein Protokoll und keine Datenbank wurden geaendert.
+
 - M27 Restarbeiten Ausgabe- und Abnahmegrenze fachlich festgelegt:
   - Neue Doku unter `docs/M27_RESTARBEITEN_AUSGABE_ABNAHMEGRENZE.md`.
   - Die erste einfache Ausgabe ist fachlich als projektbezogene Restarbeitenliste abgegrenzt.

--- a/docs/EDITOR_BAUPLAN.md
+++ b/docs/EDITOR_BAUPLAN.md
@@ -1,0 +1,13 @@
+# Editor-Bauplan
+
+Diese Datei ist eine Bruecke fuer den in `AGENTS.md` erwarteten Pflichtpfad.
+
+Die fuehrende Fassung liegt hier:
+
+- [docs/ui-editor/EDITOR_BAUPLAN.md](ui-editor/EDITOR_BAUPLAN.md)
+
+## Regel
+
+Keine doppelte Fachlogik an diesem Pfad pflegen.
+
+Bei UI-/PDF-Aufgaben ist die verlinkte fuehrende Fassung zu lesen und anzuwenden. Bei Widerspruch gelten direkte Nutzeranweisung, `AGENTS.md`, aufgabenspezifische Plandateien und danach die fuehrende UI-Editor-Dokumentation.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -339,3 +339,10 @@ Dabei gilt:
 - Erledigte Restarbeiten duerfen enthalten sein, muessen aber klar erkennbar erledigt und fristneutral behandelt sein.
 - Sortierung und Filterung sind nur fachlich beschrieben; PDF, Druck, Mail, Fotos und Detailanhaenge bleiben spaetere Pakete.
 - Protokoll, UI-Editor-kit, Datenbank, Diktat/Audio und technische Ausgabewege bleiben ausserhalb dieses Pakets.
+
+### M27a UI-/PDF-Grundlagenpfade bereinigt (neu)
+- Die in `AGENTS.md` erwarteten UI-/PDF-Grundlagenpfade unter `docs/` sind als kurze Bruecken vorhanden.
+- Fuehrende Inhalte bleiben unter `docs/ui-editor/`; es wurde keine doppelte Fachlogik aufgebaut.
+- `docs/UI_EDITOR_VERTRAG.md` ist ebenfalls auf die fuehrende Vertragsfassung unter `docs/ui-editor/` ausgerichtet.
+- `docs/UI_PDF_ENTWURFSENTSCHEIDUNG.md` ist eine allgemeine Bruecke/Vorlage und keine M28-Entscheidung.
+- Restarbeiten-UI, Ausgabeansicht, PDF, Druck, Mail, UI-Editor-kit-Code, Protokoll und Datenbank bleiben unveraendert.

--- a/docs/UI_BAU_UND_PRUEFREGELN.md
+++ b/docs/UI_BAU_UND_PRUEFREGELN.md
@@ -1,0 +1,13 @@
+# UI-Bau- und Pruefregeln
+
+Diese Datei ist eine Bruecke fuer den in `AGENTS.md` erwarteten Pflichtpfad.
+
+Die fuehrende Fassung liegt hier:
+
+- [docs/ui-editor/UI_BAU_UND_PRUEFREGELN.md](ui-editor/UI_BAU_UND_PRUEFREGELN.md)
+
+## Regel
+
+Keine doppelte Fachlogik an diesem Pfad pflegen.
+
+Vor editorrelevantem UI-/PDF-Bau muss eine vollstaendige UI-/PDF-Entwurfsentscheidung vorliegen. Fachlogik, Fachdaten, Datenbankaktionen, fachliche IPC-Wege und automatische DOM-/UI-Erkennung bleiben ausgeschlossen.

--- a/docs/UI_EDITOR_VERTRAG.md
+++ b/docs/UI_EDITOR_VERTRAG.md
@@ -1,59 +1,13 @@
 # UI-Editor Vertrag
 
-## Zweck
-- Dieser Vertrag legt verbindlich fest, wie neue oder neu strukturierte UIs editorfaehig aufgebaut werden.
-- Der Editor soll nicht raten, sondern klare Metadaten direkt aus der UI erhalten.
+Diese Datei ist eine Bruecke fuer den in `AGENTS.md` erwarteten Pflichtpfad.
 
-## Geltung
-- Jede neue UI muss editorfaehig geplant werden.
-- Kein neues UI-Modul ohne Editor-Struktur.
-- Protokoll-UI bleibt unberuehrt; Startbereich fuer den Vertrag ist Restarbeiten.
+Die fuehrende Fassung liegt hier:
 
-## Pflichtattribute pro editierbarem Element
-Jedes editorrelevante Element braucht:
-- `data-ui-inspector-id`
-- `data-ui-editor-kind`
-- `data-ui-editor-label`
-- `data-ui-editor-parent`
-- `data-ui-editor-editable`
-- optional: `data-ui-editor-ops`
+- [docs/ui-editor/UI_EDITOR_VERTRAG.md](ui-editor/UI_EDITOR_VERTRAG.md)
 
-## Erlaubte kind-Werte
-- `frame`
-- `field`
-- `single`
+## Regel
 
-Bedeutung:
-- `frame` = Rahmen/Gruppe/Container
-- `field` = Eingabe-/Text-/Listenfeld
-- `single` = Button, Label, Restzeichen, kleine Anzeige
+Keine doppelte Fachlogik an diesem Pfad pflegen.
 
-## Parent-Regel
-- Jedes Element ausser Root braucht einen Parent.
-- Der Parent muss als Editor-Ziel existieren.
-
-## Editor-Regeln
-- Eine Auswahl = genau ein Ziel.
-- Eine Aenderung = nur dieses Ziel.
-- Keine automatische Aenderung von Parent, Child oder Geschwistern.
-
-## Trefferregel
-- `elementFromPoint` + `closest("[data-ui-inspector-id]")`.
-- Typ/Kind entscheidet, ob ein Ziel im aktuellen Modus erlaubt ist.
-- Wenn `closest` nicht direkt aufloesbar ist, darf ein Ziel gewinnen, wenn dessen Element den Top-Treffer enthaelt.
-
-## Speichern
-- Solange nur Vorschau-/Editor-Entwicklung laeuft: keine Speicherung.
-
-## Beispiel-DOM
-```html
-<div
-  data-ui-inspector-id="restarbeiten.editbox.kurztext"
-  data-ui-editor-kind="frame"
-  data-ui-editor-label="Kurztext"
-  data-ui-editor-parent="restarbeiten.editbox"
-  data-ui-editor-editable="true"
-  data-ui-editor-ops="move,resize"
->
-</div>
-```
+Der UI-Editor bleibt fachneutral. Er darf keine Fachlogik ausfuehren, keine Fachdaten aendern, keine bestehende UI automatisch analysieren oder scannen und keine Registry automatisch befuellen.

--- a/docs/UI_ELEMENT_KATALOG.md
+++ b/docs/UI_ELEMENT_KATALOG.md
@@ -1,0 +1,13 @@
+# UI-Elementkatalog
+
+Diese Datei ist eine Bruecke fuer den in `AGENTS.md` erwarteten Pflichtpfad.
+
+Die fuehrende Fassung liegt hier:
+
+- [docs/ui-editor/UI_ELEMENT_KATALOG.md](ui-editor/UI_ELEMENT_KATALOG.md)
+
+## Regel
+
+Keine doppelte Fachlogik an diesem Pfad pflegen.
+
+Der UI-Editor darf keine Elemente erraten, keine bestehende UI scannen und keine automatische Elementliste erzeugen. Massgeblich ist die verlinkte fuehrende Fassung.

--- a/docs/UI_PDF_ENTWURFSENTSCHEIDUNG.md
+++ b/docs/UI_PDF_ENTWURFSENTSCHEIDUNG.md
@@ -1,0 +1,13 @@
+# UI-/PDF-Entwurfsentscheidung
+
+Diese Datei ist eine Bruecke fuer den in `AGENTS.md` erwarteten Pflichtpfad.
+
+Die fuehrende allgemeine Vorlage und Vertragsfassung liegt hier:
+
+- [docs/ui-editor/UI_PDF_ENTWURFSENTSCHEIDUNG.md](ui-editor/UI_PDF_ENTWURFSENTSCHEIDUNG.md)
+
+## Regel
+
+Keine doppelte Fachlogik an diesem Pfad pflegen.
+
+Vor jeder UI- oder PDF-Umsetzung muss eine aufgabenspezifische Entwurfsentscheidung vorliegen. Diese Bruecke ist keine Entscheidung fuer M28 oder ein anderes Umsetzungspaket.

--- a/docs/ZIEL_APP_ANBINDUNG.md
+++ b/docs/ZIEL_APP_ANBINDUNG.md
@@ -1,0 +1,13 @@
+# Ziel-App-Anbindung
+
+Diese Datei ist eine Bruecke fuer den in `AGENTS.md` erwarteten Pflichtpfad.
+
+Die fuehrende Fassung liegt hier:
+
+- [docs/ui-editor/ZIEL_APP_ANBINDUNG.md](ui-editor/ZIEL_APP_ANBINDUNG.md)
+
+## Regel
+
+Keine doppelte Fachlogik an diesem Pfad pflegen.
+
+Die Ziel-App liefert die klassifizierte ElementRegistry. Der UI-Editor bleibt generisch, liest ausschliesslich diese Registry und enthaelt keine BBM-, Restarbeiten- oder Protokoll-Fachlogik.


### PR DESCRIPTION
Markdown-Doku. Pflichtpfade fuer UI/PDF-Grundlagen bereinigt.