### PR TITLE
M28: Restarbeiten einfache Ausgabeansicht vorbereiten

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,14 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M28 Restarbeiten einfache Ausgabeansicht technisch vorbereitet:
+  - Eine rein app-interne, lesende Ausgabevorschau ist im Restarbeiten-Modul vorhanden.
+  - Die Vorschau zeigt Nr., Kurztext, Ort/Bereich, Verantwortlich, Fertig bis, Status, Ampel/Fristbewertung und Hinweise auf unvollstaendige Pflichtfelder.
+  - Unvollstaendige Datensaetze bleiben sichtbar und werden als unvollstaendig gekennzeichnet; fehlende Fachwerte bleiben leer.
+  - Erledigte Datensaetze bleiben sichtbar und werden als erledigt/fristneutral behandelt.
+  - Die Vorschau speichert nicht, erzeugt keine Fantasiewerte und nutzt keine neuen IPC-, Datenbank-, PDF-, Druck- oder Mailwege.
+  - UI-Editor-kit, generische Editorlogik, Protokoll, Fotoausgabe, Diktat/Audio, Datenbank und Lizenzierung blieben unveraendert.
+
 - M27a UI-/PDF-Grundlagenpfade bereinigt:
   - Die von `AGENTS.md` erwarteten Root-Pfade fuer UI-/PDF-Grundlagen sind als kurze Bruecken angelegt.
   - Fuehrende Inhalte bleiben unter `docs/ui-editor/`; es wurde keine doppelte Fachlogik aufgebaut.

--- a/docs/M28_RESTARBEITEN_EINFACHE_AUSGABEANSICHT.md
+++ b/docs/M28_RESTARBEITEN_EINFACHE_AUSGABEANSICHT.md
@@ -1,0 +1,72 @@
+# M28 Restarbeiten einfache Ausgabeansicht
+
+## Kurzfazit
+
+M28 bereitet eine einfache, rein app-interne Ausgabevorschau fuer `Restarbeiten` vor.
+
+Die Vorschau ist kein PDF, kein Druckweg und keine Mail-Anbindung. Sie zeigt eine lesende projektbezogene Restarbeitenliste und aendert keine Daten.
+
+## UI-/PDF-Entwurfsentscheidung
+
+- Art der Ausgabe: UI.
+- PDF: nein.
+- Druck-/PDF-Struktur: nein.
+- Editorfaehig: nein.
+- Begruendung: Die Ausgabevorschau ist eine fachliche, lesende App-Ansicht. Es werden keine neuen editorfaehigen Elemente, keine neue UI-Editor-Registry und keine Tabellenlayout-Editor-Freigabe angelegt.
+- Pruefung: Restarbeiten-ViewModel-/DOM-Tests und `npm test`. Ein UI-Editor-Vertragscheck ist fuer M28 nicht einschlaegig, weil keine neuen Editor-Ziele entstehen.
+
+## Umfang
+
+Die Ausgabevorschau zeigt je Restarbeit:
+
+- Nr.
+- Kurztext
+- Ort/Bereich
+- Verantwortlich
+- Fertig bis
+- Status
+- Ampel / Fristbewertung
+- Hinweis auf unvollstaendige Pflichtfelder
+
+Unvollstaendige Datensaetze bleiben sichtbar und werden mit einem Unvollstaendig-Hinweis gekennzeichnet.
+
+Erledigte Datensaetze bleiben sichtbar und sind als `erledigt` sowie fristneutral erkennbar.
+
+## Datenregeln
+
+- Keine Fantasiewerte erzeugen.
+- Keine Platzhalter als Fachwerte ausgeben.
+- Fehlende Felder bleiben leer und werden ueber den Hinweis auf unvollstaendige Pflichtfelder kenntlich.
+- Die Ausgabevorschau speichert nicht.
+- Die Ausgabevorschau legt nichts an.
+- Die Ausgabevorschau loescht nichts.
+- Die Ausgabevorschau nutzt keine neuen IPC-, Datenbank-, PDF-, Druck- oder Mailwege.
+
+## Sortierung
+
+Die Ausgabevorschau nutzt eine einfache nachvollziehbare Sortierung:
+
+1. nicht erledigte Restarbeiten vor erledigten Restarbeiten
+2. kritische Fristen vor unkritischen Fristen
+3. danach Fertig-bis-Datum
+4. danach laufende Nummer
+
+Es wurde keine grosse neue Filterlogik gebaut. Die vorhandenen Restarbeiten-Filter bleiben die Quelle fuer die angezeigten Zeilen.
+
+## Bewusst nicht Teil von M28
+
+- echte PDF-Erzeugung
+- Druckfunktion
+- Mail-Anbindung
+- Fotoausgabe
+- Diktat-/Audioaenderung
+- UI-Editor-kit-Aenderung
+- generische Editorlogik
+- Protokoll-Aenderung
+- Datenbankmigration
+- Lizenzierung
+- Tabellenlayout-Editor-Aufnahme
+
+## Naechster sinnvoller Schritt
+
+Ein spaeteres Paket kann entscheiden, ob aus dieser internen Vorschau ein echter PDF-, Druck- oder Mailweg entsteht. Dafuer ist dann eine neue UI-/PDF-Entwurfsentscheidung noetig.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -346,3 +346,11 @@ Dabei gilt:
 - `docs/UI_EDITOR_VERTRAG.md` ist ebenfalls auf die fuehrende Vertragsfassung unter `docs/ui-editor/` ausgerichtet.
 - `docs/UI_PDF_ENTWURFSENTSCHEIDUNG.md` ist eine allgemeine Bruecke/Vorlage und keine M28-Entscheidung.
 - Restarbeiten-UI, Ausgabeansicht, PDF, Druck, Mail, UI-Editor-kit-Code, Protokoll und Datenbank bleiben unveraendert.
+
+### M28 Restarbeiten einfache Ausgabeansicht technisch vorbereitet (neu)
+- Eine rein app-interne Ausgabevorschau zeigt die M27-Felder als lesende projektbezogene Restarbeitenliste.
+- Unvollstaendige Datensaetze bleiben sichtbar und werden ohne Fantasiewerte oder Platzhalter als unvollstaendig gekennzeichnet.
+- Erledigte Datensaetze bleiben sichtbar und werden erledigt/fristneutral behandelt.
+- Die Ausgabevorschau nutzt eine einfache Sortierung; grosse neue Filterlogik wurde nicht gebaut.
+- Es wurden keine neuen IPC-, Datenbank-, PDF-, Druck-, Mail-, Foto-, Diktat-/Audio- oder Lizenzierungswege angelegt.
+- UI-Editor-kit, generische Editorlogik, Protokoll und Tabellenlayout-Editor blieben ausserhalb dieses Pakets.

--- a/docs/UI_EDITOR_VERTRAG.md
+++ b/docs/UI_EDITOR_VERTRAG.md
@@ -11,3 +11,14 @@ Die fuehrende Fassung liegt hier:
 Keine doppelte Fachlogik an diesem Pfad pflegen.
 
 Der UI-Editor bleibt fachneutral. Er darf keine Fachlogik ausfuehren, keine Fachdaten aendern, keine bestehende UI automatisch analysieren oder scannen und keine Registry automatisch befuellen.
+
+## Pruefanker
+
+Diese Bruecke nennt die Pflichtbegriffe fuer bestehende Vertragspruefungen. Die fachliche Auslegung bleibt in der fuehrenden Fassung.
+
+- Startbereich fuer den Vertrag ist Restarbeiten.
+- Protokoll-UI bleibt unberuehrt.
+- Eine Auswahl = genau ein Ziel.
+- Eine Aenderung = nur dieses Ziel.
+- Pflichtattribute: `data-ui-inspector-id`, `data-ui-editor-kind`, `data-ui-editor-label`, `data-ui-editor-parent`, `data-ui-editor-editable`, `data-ui-editor-ops`.
+- Erlaubte Grundarten: `frame`, `field`, `single`.

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -798,8 +798,8 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(projectAction.getAttribute("aria-label"), "Projekt");
     assert.equal(firmsAction.title, "Firmen");
     assert.equal(firmsAction.getAttribute("aria-label"), "Firmen");
-    assert.equal(previewAction.title, "PDF-Vorschau");
-    assert.equal(previewAction.getAttribute("aria-label"), "PDF-Vorschau");
+    assert.equal(previewAction.title, "Ausgabevorschau");
+    assert.equal(previewAction.getAttribute("aria-label"), "Ausgabevorschau");
     assert.equal(printAction.title, "Drucken noch nicht verfügbar");
     assert.equal(printAction.getAttribute("aria-label"), "Drucken");
     assert.equal(mailAction.title, "E-Mail noch nicht verfügbar");
@@ -871,6 +871,9 @@ async function runRestarbeitenModuleTests(run) {
     const viewModel = await importEsmFromFile(
       path.join(__dirname, "../../src/renderer/modules/restarbeiten/viewModel/restarbeitenListItems.js")
     );
+    const outputViewModel = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/viewModel/restarbeitenOutputViewModel.js")
+    );
     assert.equal(typeof dataSource.listRestarbeitenByProject, "function");
     assert.equal(typeof dataSource.getRestarbeitenProjectSettings, "function");
     assert.equal(typeof dataSource.listRestarbeitAttachments, "function");
@@ -879,6 +882,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(typeof dataSource.listResponsibleProjectFirms, "function");
     assert.equal(typeof dataSource.softDeleteRestarbeitItem, "function");
     assert.equal(typeof viewModel.toRestarbeitenListItems, "function");
+    assert.equal(typeof outputViewModel.toRestarbeitenOutputRows, "function");
     const [rest, emptyLocation] = viewModel.toRestarbeitenListItems([
       { id: "r", item_class: "rest", running_number: 1, location_level_1: "EG", location_level_2: "Flur" },
       { id: "e", item_class: "mangel", running_number: 2 },
@@ -891,6 +895,101 @@ async function runRestarbeitenModuleTests(run) {
       emptyLocation.requiredFieldSummary,
       "Unvollstaendig: Kurztext, Ort/Bereich, Status, Verantwortlich, Fertig bis"
     );
+  });
+
+  await run("Restarbeiten M28: Ausgabe-ViewModel bleibt lesend, vollstaendig und ohne Platzhalter", async () => {
+    const outputViewModel = await importEsmFromFile(
+      path.join(__dirname, "../../src/renderer/modules/restarbeiten/viewModel/restarbeitenOutputViewModel.js")
+    );
+    const today = new Date(Date.UTC(2026, 5, 24));
+    const rows = outputViewModel.toRestarbeitenOutputRows(
+      [
+        {
+          id: "done",
+          running_number: 3,
+          short_text: "Abnahme erfolgt",
+          location_level_1: "Haus B",
+          responsible_label: "Elektro GmbH",
+          due_date: "2026-06-01",
+          status: "erledigt",
+        },
+        {
+          id: "incomplete",
+          running_number: 2,
+          status: "offen",
+        },
+        {
+          id: "late",
+          running_number: 1,
+          short_text: "Tuer einstellen",
+          location_level_1: "Haus A",
+          location_level_2: "EG",
+          responsible_label: "Schreinerei",
+          due_date: "2026-06-23",
+          status: "offen",
+        },
+      ],
+      today
+    );
+
+    assert.deepEqual(rows.map((row) => row.id), ["late", "incomplete", "done"]);
+    assert.equal(rows[0].number, "1");
+    assert.equal(rows[0].shortText, "Tuer einstellen");
+    assert.equal(rows[0].location, "Haus A \u00b7 EG");
+    assert.equal(rows[0].responsible, "Schreinerei");
+    assert.equal(rows[0].dueDateLabel, "23.06.26");
+    assert.equal(rows[0].statusLabel, "offen");
+    assert.equal(rows[0].ampelLabel, "rot");
+    assert.equal(rows[0].incompleteHint, "");
+
+    assert.equal(rows[1].shortText, "");
+    assert.equal(rows[1].location, "");
+    assert.equal(rows[1].responsible, "");
+    assert.equal(rows[1].dueDateLabel, "");
+    assert.equal(rows[1].incompleteHint, "Unvollstaendig: Kurztext, Ort/Bereich, Verantwortlich, Fertig bis");
+    assert.equal(rows[1].isComplete, false);
+
+    assert.equal(rows[2].isDone, true);
+    assert.equal(rows[2].statusLabel, "erledigt");
+    assert.equal(rows[2].ampelLabel, "neutral");
+  });
+
+  await run("Restarbeiten M28: Ausgabevorschau zeigt nur lesende Liste und keine Editbox", async () => {
+    const rendered = await renderRouteScreen({ keepGlobals: true });
+    try {
+      const previewAction = findByUiId(rendered.root, "restarbeiten.quicklane.action.pdfPreview");
+      previewAction.dispatchEvent({ type: "click", preventDefault() {} });
+
+      const preview = findByData(rendered.root, "data-bbm-restarbeiten-output-preview", "true");
+      const screenRoot = findByUiId(rendered.root, "restarbeiten.root");
+      assert.equal(Boolean(preview), true, "output preview");
+      assert.equal(screenRoot.getAttribute("data-output-preview"), "true");
+      assert.equal(findByUiId(rendered.root, "restarbeiten.editbox"), null);
+
+      const text = collectText(preview);
+      for (const expected of [
+        "Nr.",
+        "Kurztext",
+        "Ort/Bereich",
+        "Verantwortlich",
+        "Fertig bis",
+        "Status",
+        "Ampel",
+        "Hinweis",
+        "Abdichtung im Bad fehlt",
+        "Mueller Trockenbau",
+        "offen",
+      ]) {
+        assert.equal(text.includes(expected), true, expected);
+      }
+
+      const rows = findNodes(preview, (entry) => entry.getAttribute?.("data-bbm-restarbeiten-output-row") === "true");
+      assert.equal(rows.length >= 1, true);
+      assert.equal(rows.every((row) => row.getAttribute("data-bbm-restarbeiten-output-complete") === "true"), true);
+      assert.equal(typeof rendered.root.querySelector("[data-bbm-restarbeiten-output-preview=\"true\"]"), "object");
+    } finally {
+      rendered.restoreGlobals();
+    }
   });
 
   await run("Restarbeiten: Statusauswahlen enthalten die verbindlichen Werte", async () => {

--- a/src/renderer/modules/restarbeiten/RestarbeitenOutputPreview.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenOutputPreview.js
@@ -1,0 +1,74 @@
+function createEl(tag, { className = "", text = "" } = {}) {
+  const el = document.createElement(tag);
+  if (className) el.className = className;
+  if (text) el.textContent = text;
+  return el;
+}
+
+function appendCell(row, className, text) {
+  const cell = createEl("div", { className, text });
+  row.appendChild(cell);
+  return cell;
+}
+
+function buildHeader() {
+  const header = createEl("div", { className: "bbm-restarbeiten-output__row bbm-restarbeiten-output__row--header" });
+  for (const label of ["Nr.", "Kurztext", "Ort/Bereich", "Verantwortlich", "Fertig bis", "Status", "Ampel", "Hinweis"]) {
+    appendCell(header, "bbm-restarbeiten-output__cell", label);
+  }
+  return header;
+}
+
+function buildRow(item) {
+  const row = createEl("article", { className: "bbm-restarbeiten-output__row" });
+  row.setAttribute("data-bbm-restarbeiten-output-row", "true");
+  row.setAttribute("data-bbm-restarbeiten-output-complete", item.isComplete ? "true" : "false");
+  row.setAttribute("data-bbm-restarbeiten-output-done", item.isDone ? "true" : "false");
+  row.setAttribute("data-bbm-restarbeiten-output-ampel", item.ampelState || "neutral");
+
+  appendCell(row, "bbm-restarbeiten-output__cell", item.number);
+  appendCell(row, "bbm-restarbeiten-output__cell", item.shortText);
+  appendCell(row, "bbm-restarbeiten-output__cell", item.location);
+  appendCell(row, "bbm-restarbeiten-output__cell", item.responsible);
+  appendCell(row, "bbm-restarbeiten-output__cell", item.dueDateLabel);
+  appendCell(row, "bbm-restarbeiten-output__cell", item.statusLabel);
+  appendCell(row, "bbm-restarbeiten-output__cell", item.ampelLabel);
+  appendCell(row, "bbm-restarbeiten-output__cell bbm-restarbeiten-output__hint", item.incompleteHint);
+  return row;
+}
+
+export function buildRestarbeitenOutputPreview({
+  items = [],
+  projectName = "",
+  onClose = null,
+} = {}) {
+  const main = createEl("main", { className: "bbm-restarbeiten-main bbm-restarbeiten-output" });
+  main.setAttribute("data-bbm-restarbeiten-output-preview", "true");
+
+  const paper = createEl("section", { className: "bbm-restarbeiten-paper bbm-restarbeiten-output__paper" });
+  const header = createEl("header", { className: "bbm-restarbeiten-output__header" });
+  const title = createEl("h2", { text: "Restarbeiten Ausgabevorschau" });
+  const meta = createEl("div", {
+    className: "bbm-restarbeiten-output__meta",
+    text: projectName ? `Projekt: ${projectName}` : "",
+  });
+  const close = createEl("button", { className: "bbm-restarbeiten-button", text: "Zur Bearbeitung" });
+  close.type = "button";
+  close.addEventListener("click", () => onClose?.());
+  header.append(title, meta, close);
+
+  const table = createEl("section", { className: "bbm-restarbeiten-output__table" });
+  table.appendChild(buildHeader());
+  if (!items.length) {
+    table.appendChild(createEl("div", {
+      className: "bbm-restarbeiten-empty",
+      text: "Keine Restarbeiten vorhanden.",
+    }));
+  } else {
+    for (const item of items) table.appendChild(buildRow(item));
+  }
+
+  paper.append(header, table);
+  main.appendChild(paper);
+  return main;
+}

--- a/src/renderer/modules/restarbeiten/RestarbeitenQuicklane.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenQuicklane.js
@@ -211,7 +211,8 @@ export function buildRestarbeitenQuicklane({
     createButton({
       id: "restarbeiten.quicklane.action.pdfPreview",
       icon: "📄",
-      title: "PDF-Vorschau",
+      title: "Ausgabevorschau",
+      ariaLabel: "Ausgabevorschau",
       onClick: onPreview,
     }),
     createButton({

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -12,8 +12,10 @@ import { toRestarbeitenListItems, getRestarbeitenAmpelState } from "../viewModel
 import { buildRestarbeitenFilterbar } from "../RestarbeitenFilterbar.js";
 import { buildRestarbeitenMainBody } from "../RestarbeitenMainBody.js";
 import { buildRestarbeitenEditbox } from "../RestarbeitenEditbox.js";
+import { buildRestarbeitenOutputPreview } from "../RestarbeitenOutputPreview.js";
 import { buildRestarbeitenQuicklane } from "../RestarbeitenQuicklane.js";
 import { ensureRestarbeitenStyles } from "../styles.js";
+import { toRestarbeitenOutputRows } from "../viewModel/restarbeitenOutputViewModel.js";
 import {
   canPersistRestarbeitDraft,
   normalizeRestarbeitStatus,
@@ -157,6 +159,7 @@ export default class RestarbeitenScreen {
     };
     this._lastRestarbeitNotePrint = null;
     this.quicklanePinned = false;
+    this.outputPreviewOpen = false;
   }
 
   render() {
@@ -213,11 +216,18 @@ export default class RestarbeitenScreen {
   }
 
   openRestarbeitenPreview() {
-    this._setStubMessage("PDF Voransicht folgt in M2.");
+    this.outputPreviewOpen = true;
+    this.error = null;
+    this._renderShell();
   }
 
   openRestarbeitenOutput() {
-    this._setStubMessage("Ausgabe, Druck und E-Mail folgen in M2.");
+    this.openRestarbeitenPreview();
+  }
+
+  closeRestarbeitenPreview() {
+    this.outputPreviewOpen = false;
+    this._renderShell();
   }
 
   openRestarbeitPhotos(restarbeitId = this.selectedId) {
@@ -506,6 +516,7 @@ export default class RestarbeitenScreen {
     this.root.replaceChildren();
     const filteredRows = this._getFilteredItems();
     this.viewItems = toRestarbeitenListItems(filteredRows);
+    this.root.setAttribute("data-output-preview", this.outputPreviewOpen ? "true" : "false");
     const responsibleOptions = this.responsibleFirms
       .map((firm) => ({
         value: normalizeText(firm.id),
@@ -542,26 +553,37 @@ export default class RestarbeitenScreen {
         },
         onClose: () => this.router?.showProjectWorkspace?.(this.projectId, { project: this.project }),
       }),
-      buildRestarbeitenMainBody({
-        items: this.viewItems,
-        selectedId: this.selectedId,
-        showAmpel: this.showAmpelInList,
-        showLongtext: this.showLongtextInList,
-        onSelect: (id) => this._selectItem(id),
-        onPhotos: (id) => this.openRestarbeitPhotos(id),
-      }),
-      buildRestarbeitenEditbox({
-        settings: this.settings,
-        draft: this.draft,
-        showAmpel: this.showAmpelInList,
-        responsibleOptions,
-        onNew: () => this._newDraft(),
-        onDraftChange: (patch, options) => this._updateDraft(patch, options),
-        onDelete: () => this._deleteDraft().catch((err) => this._setStubMessage(err?.message || String(err))),
-        onNote: () => this._openNotesPopup().catch((err) => this._setStubMessage(err?.message || String(err))),
-        onAutoSave: () => this._autoSaveDraft().catch((err) => this._setStubMessage(err?.message || String(err))),
-      })
+      this.outputPreviewOpen
+        ? buildRestarbeitenOutputPreview({
+            items: toRestarbeitenOutputRows(filteredRows),
+            projectName: normalizeText(this.project?.name || this.project?.project_name || this.project?.title),
+            onClose: () => this.closeRestarbeitenPreview(),
+          })
+        : buildRestarbeitenMainBody({
+            items: this.viewItems,
+            selectedId: this.selectedId,
+            showAmpel: this.showAmpelInList,
+            showLongtext: this.showLongtextInList,
+            onSelect: (id) => this._selectItem(id),
+            onPhotos: (id) => this.openRestarbeitPhotos(id),
+          })
     );
+
+    if (!this.outputPreviewOpen) {
+      this.root.appendChild(
+        buildRestarbeitenEditbox({
+          settings: this.settings,
+          draft: this.draft,
+          showAmpel: this.showAmpelInList,
+          responsibleOptions,
+          onNew: () => this._newDraft(),
+          onDraftChange: (patch, options) => this._updateDraft(patch, options),
+          onDelete: () => this._deleteDraft().catch((err) => this._setStubMessage(err?.message || String(err))),
+          onNote: () => this._openNotesPopup().catch((err) => this._setStubMessage(err?.message || String(err))),
+          onAutoSave: () => this._autoSaveDraft().catch((err) => this._setStubMessage(err?.message || String(err))),
+        })
+      );
+    }
 
     if (this.isLoading || this.error) {
       const status = document.createElement("div");

--- a/src/renderer/modules/restarbeiten/styles/restarbeiten.css
+++ b/src/renderer/modules/restarbeiten/styles/restarbeiten.css
@@ -39,6 +39,10 @@
   overflow: hidden;
 }
 
+.bbm-restarbeiten-screen[data-output-preview="true"] {
+  grid-template-rows: 96px minmax(0, 1fr);
+}
+
 .bbm-restarbeiten-screen,
 .bbm-restarbeiten-screen * {
   box-sizing: border-box;
@@ -485,6 +489,95 @@
 .bbm-restarbeiten-record__required {
   color: var(--bbm-error);
   font-size: var(--bbm-rest-label-font-size);
+  font-weight: 700;
+}
+
+.bbm-restarbeiten-output {
+  display: grid;
+  justify-content: center;
+}
+
+.bbm-restarbeiten-output__paper {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 14px;
+  overflow: auto;
+}
+
+.bbm-restarbeiten-output__header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 4px 12px;
+  align-items: center;
+  border-bottom: 1px solid var(--bbm-line);
+  padding-bottom: 10px;
+}
+
+.bbm-restarbeiten-output__header h2 {
+  margin: 0;
+  color: var(--bbm-text);
+  font-size: 13pt;
+  line-height: 1.2;
+}
+
+.bbm-restarbeiten-output__meta {
+  grid-column: 1;
+  color: var(--bbm-muted);
+  font-size: var(--bbm-rest-meta-font-size);
+}
+
+.bbm-restarbeiten-output__header .bbm-restarbeiten-button {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+}
+
+.bbm-restarbeiten-output__table {
+  display: grid;
+  align-content: start;
+  gap: 4px;
+  min-width: 0;
+}
+
+.bbm-restarbeiten-output__row {
+  display: grid;
+  grid-template-columns: 42px minmax(120px, 1.4fr) minmax(110px, 1fr) minmax(90px, 0.8fr) 68px 66px 54px minmax(120px, 1fr);
+  gap: 6px;
+  align-items: start;
+  padding: 7px 6px;
+  border: 1px solid var(--bbm-line);
+  border-radius: 6px;
+  background: var(--bbm-surface-soft);
+  color: var(--bbm-text);
+  font-size: 7.8pt;
+  line-height: 1.25;
+}
+
+.bbm-restarbeiten-output__row--header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--bbm-panel);
+  color: var(--bbm-muted);
+  font-size: var(--bbm-rest-table-head-font-size);
+  font-weight: 700;
+}
+
+.bbm-restarbeiten-output__row[data-bbm-restarbeiten-output-complete="false"] {
+  border-left: 3px solid var(--bbm-error);
+}
+
+.bbm-restarbeiten-output__row[data-bbm-restarbeiten-output-done="true"] {
+  color: var(--bbm-muted);
+  background: #f5f7fb;
+}
+
+.bbm-restarbeiten-output__cell {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.bbm-restarbeiten-output__hint {
+  color: var(--bbm-error);
   font-weight: 700;
 }
 

--- a/src/renderer/modules/restarbeiten/viewModel/restarbeitenOutputViewModel.js
+++ b/src/renderer/modules/restarbeiten/viewModel/restarbeitenOutputViewModel.js
@@ -1,0 +1,91 @@
+import {
+  normalizeRestarbeitStatus,
+  toRestarbeitenText,
+} from "../domain/restarbeitenRules.js";
+import {
+  getRestarbeitenAmpelState,
+  mapRestarbeitenStatusLabel,
+  toRestarbeitenListItem,
+} from "./restarbeitenListItems.js";
+
+const AMPEL_LABELS = Object.freeze({
+  rot: "rot",
+  orange: "orange",
+  gruen: "gruen",
+  neutral: "neutral",
+});
+
+const AMPEL_SORT = Object.freeze({
+  rot: 0,
+  orange: 1,
+  gruen: 2,
+  neutral: 3,
+});
+
+function toDateSortValue(value) {
+  const text = toRestarbeitenText(value);
+  if (!text) return Number.MAX_SAFE_INTEGER;
+  const match = text.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return Number.MAX_SAFE_INTEGER - 1;
+  return Number(`${match[1]}${match[2]}${match[3]}`);
+}
+
+function toNumberSortValue(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : Number.MAX_SAFE_INTEGER;
+}
+
+function compareOutputRows(a, b) {
+  const aDone = a.statusKey === "erledigt" ? 1 : 0;
+  const bDone = b.statusKey === "erledigt" ? 1 : 0;
+  if (aDone !== bDone) return aDone - bDone;
+
+  const aAmpel = AMPEL_SORT[a.ampelState] ?? AMPEL_SORT.neutral;
+  const bAmpel = AMPEL_SORT[b.ampelState] ?? AMPEL_SORT.neutral;
+  if (aAmpel !== bAmpel) return aAmpel - bAmpel;
+
+  const aDate = toDateSortValue(a.rawDueDate);
+  const bDate = toDateSortValue(b.rawDueDate);
+  if (aDate !== bDate) return aDate - bDate;
+
+  return toNumberSortValue(a.rawNumber) - toNumberSortValue(b.rawNumber);
+}
+
+export function toRestarbeitenOutputRow(row = {}, today = new Date()) {
+  const listItem = toRestarbeitenListItem(row, today);
+  const statusKey = normalizeRestarbeitStatus(row.status);
+  const ampelState = getRestarbeitenAmpelState(row, today);
+  const missingLabels = listItem.missingRequiredFields.map((field) => field.label);
+
+  return {
+    id: listItem.id,
+    number: toRestarbeitenText(row.running_number),
+    shortText: toRestarbeitenText(row.short_text),
+    location: [
+      row.location_level_1,
+      row.location_level_2,
+      row.location_level_3,
+      row.location_level_4,
+    ].map((part) => toRestarbeitenText(part)).filter(Boolean).join(" · "),
+    responsible: toRestarbeitenText(row.responsible_label),
+    dueDate: toRestarbeitenText(row.due_date),
+    dueDateLabel: toRestarbeitenText(row.due_date) ? listItem.dueDateLabel : "",
+    statusKey,
+    statusLabel: mapRestarbeitenStatusLabel(row.status),
+    ampelState,
+    ampelLabel: AMPEL_LABELS[ampelState] || AMPEL_LABELS.neutral,
+    isComplete: listItem.isFachlichVollstaendig,
+    incompleteHint: missingLabels.length ? `Unvollstaendig: ${missingLabels.join(", ")}` : "",
+    missingRequiredFields: missingLabels,
+    isDone: statusKey === "erledigt",
+    rawDueDate: row.due_date,
+    rawNumber: row.running_number,
+  };
+}
+
+export function toRestarbeitenOutputRows(rows = [], today = new Date()) {
+  if (!Array.isArray(rows)) return [];
+  return rows
+    .map((row) => toRestarbeitenOutputRow(row, today))
+    .sort(compareOutputRows);
+}


### PR DESCRIPTION
M28 bereitet eine einfache app-interne Ausgabevorschau fuer Restarbeiten vor.

Umfang:
- lesendes Ausgabe-ViewModel fuer Restarbeiten
- einfache Vorschaukomponente ohne Editbox und ohne Speichern
- Kennzeichnung unvollstaendiger und erledigter Datensaetze
- Doku- und Statusaktualisierung

Pruefung:
- git diff --check ohne Fehler, nur CRLF/LF-Hinweis
- npm test bestanden