### PR TITLE
M30: UI Editor Bedienung fuer Layoutspeicher absichern

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,14 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M30 Globale UI-Editor-Bedienoberflaeche fuer Speichern, Laden und Reset abgesichert:
+  - Der bestehende EditorScopeInspector stellt fuer registrierte UI-Elemente neutrale Layout-Controls bereit: Aenderung anwenden/speichern, gespeicherten Zustand laden/anwenden und auf Standard zuruecksetzen.
+  - Die Bedienlogik nutzt ausschliesslich den vorhandenen EditorRuntime-/HostAdapter-/LayoutPersistence-Pfad aus M29 und gibt sichtbare Erfolgs- oder Blockade-Statusmeldungen zurueck.
+  - Unbekannte Elemente, nicht layoutneutrale Operationen sowie Fach-, DOM- und Datenbankpayloads werden sichtbar blockiert und nicht gespeichert.
+  - Es wurde keine Ziel-App-UI gescannt, keine automatische Registry-Befuellung eingefuehrt, keine Fachdaten gespeichert und keine Datenbank-/IPC-Fachlogik geaendert.
+  - Keine PDF-, Druck-, Mail-, Diktat-/Audio-, Protokoll- oder Restarbeiten-Fachlogik wurde geaendert.
+  - Neue Doku: `docs/M30_UI_EDITOR_BEDIENOBERFLAECHE_SPEICHERN_LADEN_RESET.md`.
+
 - M29 Globaler UI-Editor fuer Speichern, Laden und Reset abgesichert:
   - Der vorhandene EditorRuntime-/HostAdapter-Pfad fuer `restarbeiten.ui.main` kann erlaubte neutrale Layoutaenderungen speichern, ueber `getCurrentLayoutState()` laden und ueber `resetLayoutState()` zuruecksetzen.
   - Gespeichert werden nur neutrale Layoutwerte zu bewusst registrierten Elementen; unbekannte Element-IDs, gesperrte Operationen und Fach-/DOM-/Datenbank-/IPC-/Datensatz-Payloads werden blockiert.

--- a/docs/M30_UI_EDITOR_BEDIENOBERFLAECHE_SPEICHERN_LADEN_RESET.md
+++ b/docs/M30_UI_EDITOR_BEDIENOBERFLAECHE_SPEICHERN_LADEN_RESET.md
@@ -1,0 +1,62 @@
+# M30 UI-Editor Bedienoberflaeche Speichern/Laden/Reset
+
+## Ergebnis
+
+M30 sichert die Bedienlogik fuer den globalen UI-Editor im bestehenden EditorRuntime-Kontext ab.
+
+Der EditorScopeInspector kann fuer bewusst registrierte UI-Elemente jetzt ein neutrales Layout-Control-Modell liefern:
+
+- Aenderung anwenden/speichern
+- gespeicherten Zustand laden/anwenden
+- auf Standard zuruecksetzen
+
+Jede Bedienaktion liefert eine sichtbare Statusrueckmeldung mit `success` oder `blocked`.
+
+## Technischer Rahmen
+
+Die Umsetzung verwendet ausschliesslich die vorhandene Struktur:
+
+- EditorRuntime
+- ElementRegistry
+- HostAdapter
+- LayoutPersistence aus M29
+
+Der Inspector haelt pro Scope denselben HostAdapter im aktuellen Editor-Kontext, damit Speichern, Laden und Reset denselben Layoutzustand bedienen.
+
+## Grenzen
+
+Die Bedienung arbeitet nur mit neutralen Layoutwerten und registrierten Elementen.
+
+Blockiert werden:
+
+- unbekannte Element-IDs
+- nicht layoutneutrale Operationen
+- gesperrte oder nicht erlaubte Operationen
+- Fachpayloads
+- DOM-/CSS-Payloads
+- Datenbank-, IPC- oder Datensatzpayloads
+
+Der Editor scannt keine bestehende UI, erzeugt keine automatische Registry und nutzt keine DOM-Erkennung als Speichergrundlage.
+
+## Nicht geaendert
+
+- keine PDF-Bearbeitung
+- keine PDF-Ausgabe
+- kein Druck
+- keine Mail
+- kein Diktat/Audio
+- keine Protokoll-Fachlogik
+- keine Restarbeiten-Fachlogik
+- keine Datenbankmigration
+- keine fachlichen IPC-Wege
+- keine neue Editor-Grundsatzentscheidung
+
+## Pruefung
+
+Die Absicherung liegt in:
+
+- `scripts/tests/editorScopeInspector.test.cjs`
+- `scripts/tests/restarbeitenEditorHostAdapter.test.cjs`
+- `scripts/tests/editorBoundary.safety.test.cjs`
+- `scripts/tests/editorAltVersucheBoundary.test.cjs`
+- Gesamtlauf ueber `npm test`

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -362,3 +362,13 @@ Dabei gilt:
 - Es wurde keine automatische DOM-Erkennung, keine automatische Registry-Befuellung und kein Fachspeicher eingefuehrt.
 - PDF, Druck, Mail, Diktat/Audio, Protokoll-Fachlogik, Restarbeiten-Fachlogik, Datenbankmigration und neue fachliche IPC-Wege bleiben ausserhalb dieses Pakets.
 - Neue Doku: `docs/M29_UI_EDITOR_GLOBAL_SPEICHERN_LADEN.md`.
+
+### M30 Globale UI-Editor-Bedienoberflaeche Speichern/Laden/Reset abgesichert (neu)
+- Der bestehende EditorScopeInspector stellt ein neutrales Layout-Control-Modell fuer registrierte UI-Elemente bereit.
+- Bedienaktionen sind: Aenderung anwenden/speichern, gespeicherten Zustand laden/anwenden und auf Standard zuruecksetzen.
+- Erfolg und Fehler werden als Statusmeldungen zurueckgegeben; ungueltige Aktionen werden sichtbar blockiert.
+- Die Bedienlogik nutzt nur den vorhandenen HostAdapter- und LayoutPersistence-Pfad aus M29.
+- Unbekannte Elemente, nicht layoutneutrale Operationen sowie Fach-, DOM- und Datenbankpayloads werden nicht gespeichert.
+- Es wurde keine Ziel-App-UI gescannt, keine automatische Registry-Befuellung eingefuehrt und keine Fachlogik oder Datenbankmigration geaendert.
+- PDF, Druck, Mail, Diktat/Audio, Protokoll-Fachlogik und Restarbeiten-Fachlogik bleiben ausserhalb dieses Pakets.
+- Neue Doku: `docs/M30_UI_EDITOR_BEDIENOBERFLAECHE_SPEICHERN_LADEN_RESET.md`.

--- a/scripts/tests/editorAltVersucheBoundary.test.cjs
+++ b/scripts/tests/editorAltVersucheBoundary.test.cjs
@@ -11,6 +11,8 @@ const CURRENT_EDITOR_FILES = [
   path.join(REPO_ROOT, "src/renderer/editorRuntime/changeRequests/editorChangeRequestValidator.js"),
   path.join(REPO_ROOT, "src/renderer/editorRuntime/host/bbmEditorHostAdapterContract.js"),
   path.join(REPO_ROOT, "src/renderer/editorRuntime/host/bbmEditorHostAdapterFactory.js"),
+  path.join(REPO_ROOT, "src/renderer/editorRuntime/inspector/editorLayoutControls.js"),
+  path.join(REPO_ROOT, "src/renderer/editorRuntime/inspector/editorScopeInspector.js"),
   path.join(REPO_ROOT, "src/renderer/editorRuntime/layout/editorLayoutPersistence.js"),
   path.join(REPO_ROOT, "src/renderer/editorRuntime/layout/editorLayoutStateModel.js"),
   path.join(REPO_ROOT, "src/renderer/editorRuntime/registry/editorRegistryModel.js"),

--- a/scripts/tests/editorBoundary.safety.test.cjs
+++ b/scripts/tests/editorBoundary.safety.test.cjs
@@ -11,6 +11,8 @@ const FILES_TO_CHECK = [
   path.join(REPO_ROOT, "src/renderer/editorRuntime/changeRequests/editorChangeRequestValidator.js"),
   path.join(REPO_ROOT, "src/renderer/editorRuntime/host/bbmEditorHostAdapterContract.js"),
   path.join(REPO_ROOT, "src/renderer/editorRuntime/host/bbmEditorHostAdapterFactory.js"),
+  path.join(REPO_ROOT, "src/renderer/editorRuntime/inspector/editorLayoutControls.js"),
+  path.join(REPO_ROOT, "src/renderer/editorRuntime/inspector/editorScopeInspector.js"),
   path.join(REPO_ROOT, "src/renderer/editorRuntime/layout/editorLayoutPersistence.js"),
   path.join(REPO_ROOT, "src/renderer/editorRuntime/layout/editorLayoutStateModel.js"),
   path.join(REPO_ROOT, "src/renderer/editorRuntime/registry/editorRegistryModel.js"),

--- a/scripts/tests/editorScopeInspector.test.cjs
+++ b/scripts/tests/editorScopeInspector.test.cjs
@@ -83,6 +83,102 @@ async function runEditorScopeInspectorTests(run) {
     assert.deepEqual(operationsResult.operations.effectiveOps, detailsResult.details.effectiveOps);
   });
 
+  await run("EditorScopeInspector: Layout-Control-Panel bietet Save/Load/Reset fuer registriertes Element", () => {
+    const panel = inspector.getLayoutControlPanel("restarbeiten.ui.main", "restarbeiten.editbox.text.short");
+    assert.equal(panel.ok, true);
+    assert.equal(panel.status.kind, "ready");
+    assert.equal(panel.selectedElement.id, "restarbeiten.editbox.text.short");
+    assert.ok(panel.controls.some((control) => control.id === "editor.layout.applySave" && control.enabled));
+    assert.ok(panel.controls.some((control) => control.id === "editor.layout.loadSaved" && control.enabled));
+    assert.ok(panel.controls.some((control) => control.id === "editor.layout.resetDefault" && control.enabled));
+    const saveControl = panel.controls.find((control) => control.id === "editor.layout.applySave");
+    assert.ok(saveControl.allowedOps.includes("move"));
+    assert.equal(saveControl.allowedOps.includes("label"), false);
+  });
+
+  await run("EditorScopeInspector: Layout-Aenderung wird angewendet und sichtbar bestaetigt", () => {
+    const applyResult = inspector.applyLayoutChange("restarbeiten.ui.main", {
+      elementId: "restarbeiten.editbox.text.short",
+      operation: "move",
+      payload: { x: 14, y: 28 },
+    });
+    assert.equal(applyResult.ok, true);
+    assert.equal(applyResult.blocked, false);
+    assert.equal(applyResult.status.kind, "success");
+    assert.equal(applyResult.status.message.includes("angewendet"), true);
+    assert.deepEqual(applyResult.layoutEntry.layoutValue, { x: 14, y: 28 });
+  });
+
+  await run("EditorScopeInspector: gespeicherter Layoutzustand wird geladen und gemeldet", () => {
+    const loadResult = inspector.loadLayoutState("restarbeiten.ui.main", {
+      elementId: "restarbeiten.editbox.text.short",
+    });
+    assert.equal(loadResult.ok, true);
+    assert.equal(loadResult.status.kind, "success");
+    assert.equal(loadResult.currentLayoutEntry.elementId, "restarbeiten.editbox.text.short");
+    assert.deepEqual(loadResult.currentLayoutEntry.layoutValue, { x: 14, y: 28 });
+  });
+
+  await run("EditorScopeInspector: Reset stellt den Standardzustand nachvollziehbar wieder her", () => {
+    const resetResult = inspector.resetLayoutState("restarbeiten.ui.main", {
+      elementId: "restarbeiten.editbox.text.short",
+    });
+    assert.equal(resetResult.ok, true);
+    assert.equal(resetResult.status.kind, "success");
+    assert.deepEqual(resetResult.layoutState, []);
+
+    const loadResult = inspector.loadLayoutState("restarbeiten.ui.main", {
+      elementId: "restarbeiten.editbox.text.short",
+    });
+    assert.equal(loadResult.ok, true);
+    assert.equal(loadResult.currentLayoutEntry, null);
+    assert.equal(loadResult.status.message.includes("Standardzustand"), true);
+  });
+
+  await run("EditorScopeInspector: unbekanntes Element blockiert sichtbare Bedienaktionen", () => {
+    const panel = inspector.getLayoutControlPanel("restarbeiten.ui.main", "restarbeiten.editbox.unknown");
+    assert.equal(panel.ok, false);
+    assert.equal(panel.status.kind, "blocked");
+    assert.equal(panel.status.reason, "ELEMENT_UNKNOWN");
+    assert.equal(panel.controls.every((control) => control.enabled === false), true);
+  });
+
+  await run("EditorScopeInspector: nicht layoutneutrale Operation wird sichtbar blockiert", () => {
+    const result = inspector.applyLayoutChange("restarbeiten.ui.main", {
+      elementId: "restarbeiten.editbox.text.short.label",
+      operation: "label",
+      payload: { label: "Kurztext" },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.blocked, true);
+    assert.equal(result.reason, "OPERATION_NOT_LAYOUT_CONTROL_SAFE");
+    assert.equal(result.status.kind, "blocked");
+  });
+
+  await run("EditorScopeInspector: Fach-, DOM- und Datenbankpayloads werden nicht gespeichert", () => {
+    const forbiddenPayloads = [
+      { projectId: "p-1" },
+      { domNode: { id: "x" } },
+      { database: "app.db" },
+    ];
+
+    for (const payload of forbiddenPayloads) {
+      const result = inspector.applyLayoutChange("restarbeiten.ui.main", {
+        elementId: "restarbeiten.editbox.text.short",
+        operation: "move",
+        payload,
+      });
+      assert.equal(result.ok, false);
+      assert.equal(result.blocked, true);
+      assert.equal(result.status.kind, "blocked");
+    }
+
+    const loadResult = inspector.loadLayoutState("restarbeiten.ui.main", {
+      elementId: "restarbeiten.editbox.text.short",
+    });
+    assert.equal(loadResult.currentLayoutEntry, null);
+  });
+
   await run("EditorScopeInspector: unbekannter Scope wird sauber behandelt", () => {
     const unknown = inspector.inspectScope("does.not.exist");
     assert.equal(unknown.ok, false);

--- a/src/renderer/editorRuntime/inspector/editorLayoutControls.js
+++ b/src/renderer/editorRuntime/inspector/editorLayoutControls.js
@@ -1,0 +1,319 @@
+import { SAFE_LAYOUT_OPERATIONS } from "../layout/editorLayoutPersistence.js";
+import { getEditorElementDetails } from "./editorElementDetails.js";
+
+const CONTROL_IDS = Object.freeze({
+  applySave: "editor.layout.applySave",
+  loadSaved: "editor.layout.loadSaved",
+  resetDefault: "editor.layout.resetDefault",
+});
+
+function normalizeString(value) {
+  return String(value ?? "").trim();
+}
+
+function clonePlain(value) {
+  if (value === null || value === undefined) return value;
+  return structuredClone(value);
+}
+
+function findLayoutEntry(layoutState, elementId) {
+  const needle = normalizeString(elementId);
+  if (!Array.isArray(layoutState) || !needle) return null;
+  return layoutState.find((entry) => normalizeString(entry?.elementId) === needle) || null;
+}
+
+function toSafeLayoutOps(details) {
+  const effectiveOps = Array.isArray(details?.effectiveOps) ? details.effectiveOps : [];
+  return effectiveOps.filter((operation) => SAFE_LAYOUT_OPERATIONS.includes(operation));
+}
+
+function createControl({ id, label, enabled, reason = null, allowedOps = [] }) {
+  return {
+    id,
+    label,
+    kind: "button",
+    enabled: Boolean(enabled),
+    reason,
+    allowedOps: [...allowedOps],
+  };
+}
+
+function createBlockedPanel({ scope, elementId, detailsResult, layoutState }) {
+  const reason = detailsResult.errors?.[0]?.code || "ELEMENT_UNAVAILABLE";
+  return {
+    ok: false,
+    scope,
+    elementId: normalizeString(elementId),
+    selectedElement: null,
+    currentLayoutEntry: null,
+    controls: [
+      createControl({
+        id: CONTROL_IDS.applySave,
+        label: "Aenderung anwenden/speichern",
+        enabled: false,
+        reason,
+      }),
+      createControl({
+        id: CONTROL_IDS.loadSaved,
+        label: "Gespeicherten Zustand laden/anwenden",
+        enabled: false,
+        reason,
+      }),
+      createControl({
+        id: CONTROL_IDS.resetDefault,
+        label: "Auf Standard zuruecksetzen",
+        enabled: false,
+        reason,
+      }),
+    ],
+    status: {
+      kind: "blocked",
+      message: "Aktion blockiert: Element ist nicht registriert.",
+      reason,
+    },
+    layoutState,
+    errors: detailsResult.errors || [],
+    warnings: detailsResult.warnings || [],
+  };
+}
+
+export function createEditorLayoutControlPanel({ scope, registry, hostAdapter, elementId } = {}) {
+  const layoutState = typeof hostAdapter?.getCurrentLayoutState === "function"
+    ? hostAdapter.getCurrentLayoutState()
+    : [];
+  const detailsResult = getEditorElementDetails(registry, elementId);
+
+  if (!detailsResult.ok) {
+    return createBlockedPanel({ scope, elementId, detailsResult, layoutState });
+  }
+
+  const safeLayoutOps = toSafeLayoutOps(detailsResult.details);
+  const currentLayoutEntry = findLayoutEntry(layoutState, elementId);
+
+  return {
+    ok: true,
+    scope,
+    elementId: normalizeString(elementId),
+    selectedElement: detailsResult.details,
+    currentLayoutEntry: clonePlain(currentLayoutEntry),
+    controls: [
+      createControl({
+        id: CONTROL_IDS.applySave,
+        label: "Aenderung anwenden/speichern",
+        enabled: safeLayoutOps.length > 0,
+        reason: safeLayoutOps.length > 0 ? null : "NO_SAFE_LAYOUT_OPERATION",
+        allowedOps: safeLayoutOps,
+      }),
+      createControl({
+        id: CONTROL_IDS.loadSaved,
+        label: "Gespeicherten Zustand laden/anwenden",
+        enabled: true,
+        allowedOps: [],
+      }),
+      createControl({
+        id: CONTROL_IDS.resetDefault,
+        label: "Auf Standard zuruecksetzen",
+        enabled: true,
+        allowedOps: [],
+      }),
+    ],
+    status: {
+      kind: "ready",
+      message: currentLayoutEntry
+        ? "Gespeicherter Layoutzustand ist verfuegbar."
+        : "Standardzustand ist aktiv.",
+      reason: null,
+    },
+    layoutState,
+    errors: [],
+    warnings: [],
+  };
+}
+
+function buildChangeRequest({ scope, elementId, operation, payload }) {
+  const timestamp = new Date().toISOString();
+  return {
+    changeId: `editor-layout-${timestamp}`,
+    targetAppId: normalizeString(scope?.targetAppId) || "bbm",
+    moduleId: normalizeString(scope?.moduleId),
+    scopeId: normalizeString(scope?.scopeId),
+    elementId: normalizeString(elementId),
+    operation: normalizeString(operation),
+    payload: payload && typeof payload === "object" && !Array.isArray(payload) ? payload : {},
+    createdAt: timestamp,
+    source: "editor-runtime",
+  };
+}
+
+export function applyEditorLayoutChange({ scope, registry, hostAdapter, elementId, operation, payload } = {}) {
+  const panel = createEditorLayoutControlPanel({ scope, registry, hostAdapter, elementId });
+  if (!panel.ok) {
+    return {
+      ok: false,
+      blocked: true,
+      reason: panel.status.reason,
+      status: panel.status,
+      panel,
+      errors: panel.errors,
+      warnings: panel.warnings,
+    };
+  }
+
+  const normalizedOperation = normalizeString(operation);
+  const applyControl = panel.controls.find((control) => control.id === CONTROL_IDS.applySave);
+  if (!applyControl?.allowedOps.includes(normalizedOperation)) {
+    return {
+      ok: false,
+      blocked: true,
+      reason: "OPERATION_NOT_LAYOUT_CONTROL_SAFE",
+      status: {
+        kind: "blocked",
+        message: "Aenderung wurde blockiert: Operation ist fuer dieses Element nicht als neutrale Layoutaenderung freigegeben.",
+        reason: "OPERATION_NOT_LAYOUT_CONTROL_SAFE",
+      },
+      panel,
+      errors: [],
+      warnings: [],
+    };
+  }
+
+  const result = hostAdapter.submitChangeRequest(
+    buildChangeRequest({ scope, elementId, operation: normalizedOperation, payload })
+  );
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      blocked: true,
+      reason: result.reason || "CHANGE_REQUEST_BLOCKED",
+      status: {
+        kind: "blocked",
+        message: "Aenderung wurde blockiert.",
+        reason: result.reason || "CHANGE_REQUEST_BLOCKED",
+      },
+      result,
+      panel,
+      errors: result.validation?.errors || [],
+      warnings: result.validation?.warnings || [],
+    };
+  }
+
+  return {
+    ok: true,
+    blocked: false,
+    reason: null,
+    status: {
+      kind: "success",
+      message: "Aenderung wurde angewendet und gespeichert.",
+      reason: null,
+    },
+    layoutEntry: result.layoutEntry,
+    layoutState: hostAdapter.getCurrentLayoutState(),
+    result,
+    panel,
+    errors: [],
+    warnings: [],
+  };
+}
+
+export function loadEditorLayoutState({ registry, hostAdapter, elementId = null } = {}) {
+  const layoutState = typeof hostAdapter?.getCurrentLayoutState === "function"
+    ? hostAdapter.getCurrentLayoutState()
+    : [];
+  const normalizedElementId = normalizeString(elementId);
+
+  if (normalizedElementId) {
+    const detailsResult = getEditorElementDetails(registry, normalizedElementId);
+    if (!detailsResult.ok) {
+      return {
+        ok: false,
+        blocked: true,
+        reason: detailsResult.errors?.[0]?.code || "ELEMENT_UNAVAILABLE",
+        status: {
+          kind: "blocked",
+          message: "Gespeicherter Zustand wurde nicht geladen: Element ist nicht registriert.",
+          reason: detailsResult.errors?.[0]?.code || "ELEMENT_UNAVAILABLE",
+        },
+        layoutState,
+        currentLayoutEntry: null,
+        errors: detailsResult.errors || [],
+        warnings: detailsResult.warnings || [],
+      };
+    }
+  }
+
+  const currentLayoutEntry = normalizedElementId ? findLayoutEntry(layoutState, normalizedElementId) : null;
+  return {
+    ok: true,
+    blocked: false,
+    reason: null,
+    status: {
+      kind: "success",
+      message: currentLayoutEntry || !normalizedElementId
+        ? "Gespeicherter Layoutzustand wurde geladen."
+        : "Kein gespeicherter Layoutzustand vorhanden; Standardzustand bleibt aktiv.",
+      reason: null,
+    },
+    layoutState,
+    currentLayoutEntry: clonePlain(currentLayoutEntry),
+    errors: [],
+    warnings: [],
+  };
+}
+
+export function resetEditorLayoutState({ registry, hostAdapter, elementId = null } = {}) {
+  const normalizedElementId = normalizeString(elementId);
+  if (normalizedElementId) {
+    const detailsResult = getEditorElementDetails(registry, normalizedElementId);
+    if (!detailsResult.ok) {
+      return {
+        ok: false,
+        blocked: true,
+        reason: detailsResult.errors?.[0]?.code || "ELEMENT_UNAVAILABLE",
+        status: {
+          kind: "blocked",
+          message: "Reset wurde blockiert: Element ist nicht registriert.",
+          reason: detailsResult.errors?.[0]?.code || "ELEMENT_UNAVAILABLE",
+        },
+        layoutState: typeof hostAdapter?.getCurrentLayoutState === "function" ? hostAdapter.getCurrentLayoutState() : [],
+        errors: detailsResult.errors || [],
+        warnings: detailsResult.warnings || [],
+      };
+    }
+  }
+
+  const result = hostAdapter.resetLayoutState({ elementId: normalizedElementId || null });
+  if (!result.ok) {
+    return {
+      ok: false,
+      blocked: true,
+      reason: result.reason || "RESET_BLOCKED",
+      status: {
+        kind: "blocked",
+        message: "Reset wurde blockiert.",
+        reason: result.reason || "RESET_BLOCKED",
+      },
+      layoutState: result.layoutState || [],
+      result,
+      errors: [],
+      warnings: [],
+    };
+  }
+
+  return {
+    ok: true,
+    blocked: false,
+    reason: null,
+    status: {
+      kind: "success",
+      message: "Standardzustand wurde wiederhergestellt.",
+      reason: null,
+    },
+    layoutState: result.layoutState,
+    result,
+    errors: [],
+    warnings: [],
+  };
+}
+
+export { CONTROL_IDS as EDITOR_LAYOUT_CONTROL_IDS };

--- a/src/renderer/editorRuntime/inspector/editorScopeInspector.js
+++ b/src/renderer/editorRuntime/inspector/editorScopeInspector.js
@@ -1,6 +1,12 @@
 import { BBM_EDITOR_CATALOG, findEditorScope, listEditorModules, listEditorScopes } from "../catalog/bbmEditorCatalog.js";
 import { createBbmEditorHostAdapter } from "../host/bbmEditorHostAdapterFactory.js";
 import { validateEditorRegistry } from "../registry/editorRegistryValidator.js";
+import {
+  applyEditorLayoutChange,
+  createEditorLayoutControlPanel,
+  loadEditorLayoutState,
+  resetEditorLayoutState,
+} from "./editorLayoutControls.js";
 import { buildEditorRegistryTree } from "./editorRegistryTree.js";
 
 function normalizeId(value) {
@@ -15,6 +21,7 @@ function findCatalogScope(catalog, scopeId) {
       if (normalizeId(scope.scopeId) === needle) {
         return {
           ...scope,
+          targetAppId: catalog.targetAppId || "bbm",
           moduleId: module.moduleId,
           moduleLabel: module.moduleLabel,
         };
@@ -28,6 +35,16 @@ export function createEditorScopeInspector({
   catalog = BBM_EDITOR_CATALOG,
   hostAdapterFactory = createBbmEditorHostAdapter,
 } = {}) {
+  const hostAdapters = new Map();
+
+  function getHostAdapter(scopeId) {
+    const normalizedScopeId = normalizeId(scopeId);
+    if (!hostAdapters.has(normalizedScopeId)) {
+      hostAdapters.set(normalizedScopeId, hostAdapterFactory(normalizedScopeId));
+    }
+    return hostAdapters.get(normalizedScopeId);
+  }
+
   function getAvailableModules() {
     return Array.isArray(catalog?.modules)
       ? catalog.modules.map((module) => ({
@@ -70,7 +87,7 @@ export function createEditorScopeInspector({
 
     let hostAdapter;
     try {
-      hostAdapter = hostAdapterFactory(scope.scopeId);
+      hostAdapter = getHostAdapter(scope.scopeId);
     } catch (error) {
       const errorEntry = {
         code: error?.code || "HOST_ADAPTER_ERROR",
@@ -108,10 +125,138 @@ export function createEditorScopeInspector({
     };
   }
 
+  function prepareScopeContext(scopeId) {
+    const inspection = inspectScope(scopeId);
+    if (!inspection.ok) {
+      return {
+        ok: false,
+        inspection,
+        scope: inspection.scope,
+        registry: inspection.registry,
+        hostAdapter: null,
+      };
+    }
+
+    return {
+      ok: true,
+      inspection,
+      scope: inspection.scope,
+      registry: inspection.registry,
+      hostAdapter: getHostAdapter(inspection.scope.scopeId),
+    };
+  }
+
+  function getLayoutControlPanel(scopeId, elementId) {
+    const context = prepareScopeContext(scopeId);
+    if (!context.ok) {
+      return {
+        ok: false,
+        scope: context.scope,
+        elementId: normalizeId(elementId),
+        selectedElement: null,
+        currentLayoutEntry: null,
+        controls: [],
+        status: {
+          kind: "blocked",
+          message: "Scope kann nicht bedient werden.",
+          reason: context.inspection.errors?.[0]?.code || "SCOPE_UNAVAILABLE",
+        },
+        errors: context.inspection.errors || [],
+        warnings: context.inspection.warnings || [],
+      };
+    }
+
+    return createEditorLayoutControlPanel({
+      scope: context.scope,
+      registry: context.registry,
+      hostAdapter: context.hostAdapter,
+      elementId,
+    });
+  }
+
+  function applyLayoutChange(scopeId, { elementId, operation, payload } = {}) {
+    const context = prepareScopeContext(scopeId);
+    if (!context.ok) {
+      return {
+        ok: false,
+        blocked: true,
+        reason: context.inspection.errors?.[0]?.code || "SCOPE_UNAVAILABLE",
+        status: {
+          kind: "blocked",
+          message: "Aenderung wurde blockiert: Scope ist nicht verfuegbar.",
+        },
+        errors: context.inspection.errors || [],
+        warnings: context.inspection.warnings || [],
+      };
+    }
+
+    return applyEditorLayoutChange({
+      scope: context.scope,
+      registry: context.registry,
+      hostAdapter: context.hostAdapter,
+      elementId,
+      operation,
+      payload,
+    });
+  }
+
+  function loadLayoutState(scopeId, { elementId = null } = {}) {
+    const context = prepareScopeContext(scopeId);
+    if (!context.ok) {
+      return {
+        ok: false,
+        blocked: true,
+        reason: context.inspection.errors?.[0]?.code || "SCOPE_UNAVAILABLE",
+        status: {
+          kind: "blocked",
+          message: "Gespeicherter Zustand wurde nicht geladen: Scope ist nicht verfuegbar.",
+        },
+        layoutState: [],
+        currentLayoutEntry: null,
+        errors: context.inspection.errors || [],
+        warnings: context.inspection.warnings || [],
+      };
+    }
+
+    return loadEditorLayoutState({
+      registry: context.registry,
+      hostAdapter: context.hostAdapter,
+      elementId,
+    });
+  }
+
+  function resetLayoutState(scopeId, { elementId = null } = {}) {
+    const context = prepareScopeContext(scopeId);
+    if (!context.ok) {
+      return {
+        ok: false,
+        blocked: true,
+        reason: context.inspection.errors?.[0]?.code || "SCOPE_UNAVAILABLE",
+        status: {
+          kind: "blocked",
+          message: "Reset wurde blockiert: Scope ist nicht verfuegbar.",
+        },
+        layoutState: [],
+        errors: context.inspection.errors || [],
+        warnings: context.inspection.warnings || [],
+      };
+    }
+
+    return resetEditorLayoutState({
+      registry: context.registry,
+      hostAdapter: context.hostAdapter,
+      elementId,
+    });
+  }
+
   return {
     getAvailableModules,
     getAvailableScopes,
     inspectScope,
+    getLayoutControlPanel,
+    applyLayoutChange,
+    loadLayoutState,
+    resetLayoutState,
   };
 }
 


### PR DESCRIPTION
M30 sichert neutrale Bediencontrols im bestehenden EditorRuntime-Kontext ab.

Umfang:
- Layout-Control-Modell fuer Anwenden/Speichern, Laden/Anwenden und Reset
- sichtbare success/blocked-Statusmeldungen
- Blockade unbekannter Elemente, nicht neutraler Operationen und Fach-/DOM-/DB-Payloads
- Tests und Doku aktualisiert

Pruefung:
- git diff --check bestanden
- node scripts/ui-editor-contract-check.cjs --self-test bestanden
- npm test bestanden