### PR TITLE
M31: UI Editor sichtbar in der App anbinden

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,15 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M31 Globale UI-Editor-Bedienung sichtbar in der App angebunden:
+  - Die bestehende UI-Editor-Launcher-/Statusoberflaeche zeigt fuer registrierte Auswahlziele eine sichtbare neutrale Layoutbedienung.
+  - Fuer den vorhandenen Restarbeiten-Pilot wird der sichtbare Scope `restarbeiten.screen` auf den bestehenden Layout-/HostAdapter-Scope `restarbeiten.ui.main` abgebildet.
+  - Sichtbar sind ausgewaehltes registriertes Element, Layout-Scope, neutrale Operation, Anwenden/Speichern, Laden und Reset sowie Erfolg-/Blockiert-Meldungen.
+  - Die Bedienung nutzt die M30-Inspector-Controls und den M29-HostAdapter-/LayoutPersistence-Pfad; nicht registrierte Layoutziele bleiben blockiert.
+  - Es wurde keine automatische DOM-Erkennung, keine automatische Registry-Befuellung, keine Fachwertbearbeitung und keine Datenbankmigration eingefuehrt.
+  - Keine PDF-, Druck-, Mail-, Diktat-/Audio-, Protokoll- oder Restarbeiten-Fachlogik wurde geaendert.
+  - Neue Doku: `docs/M31_UI_EDITOR_SICHTBARE_BEDIENUNG_IN_APP.md`.
+
 - M30 Globale UI-Editor-Bedienoberflaeche fuer Speichern, Laden und Reset abgesichert:
   - Der bestehende EditorScopeInspector stellt fuer registrierte UI-Elemente neutrale Layout-Controls bereit: Aenderung anwenden/speichern, gespeicherten Zustand laden/anwenden und auf Standard zuruecksetzen.
   - Die Bedienlogik nutzt ausschliesslich den vorhandenen EditorRuntime-/HostAdapter-/LayoutPersistence-Pfad aus M29 und gibt sichtbare Erfolgs- oder Blockade-Statusmeldungen zurueck.

--- a/docs/M31_UI_EDITOR_SICHTBARE_BEDIENUNG_IN_APP.md
+++ b/docs/M31_UI_EDITOR_SICHTBARE_BEDIENUNG_IN_APP.md
@@ -1,0 +1,71 @@
+# M31 UI-Editor sichtbare Bedienung in der App
+
+## Ergebnis
+
+M31 bindet die in M30 abgesicherte neutrale Layoutbedienung sichtbar an die bestehende UI-Editor-Launcher-/Statusoberflaeche an.
+
+Im aktiven UI-Editor-Modus zeigt die App fuer eine registrierte Auswahl:
+
+- ausgewaehltes registriertes Element,
+- zugeordneten Layout-Scope,
+- neutrale Layoutoperation,
+- Anwenden/Speichern,
+- Laden,
+- Reset,
+- sichtbare Erfolg- oder Blockiert-Meldung.
+
+## Scope-Anbindung
+
+Die sichtbare App-Auswahl bleibt registrybasiert.
+
+Fuer den vorhandenen Restarbeiten-Pilot gilt:
+
+- sichtbarer UI-Scope: `restarbeiten.screen`
+- Layout-/HostAdapter-Scope: `restarbeiten.ui.main`
+
+Diese Zuordnung ist fest und bewusst. Es wird kein Scope aus DOM, CSS, Texten oder Reihenfolgen abgeleitet.
+
+## Technischer Rahmen
+
+Die sichtbare Bedienung nutzt:
+
+- die bestehende UI-Editor-Launcher-Oberflaeche,
+- die registrierte Zielauswahl,
+- den M30-EditorScopeInspector,
+- den M29-HostAdapter-/LayoutPersistence-Pfad.
+
+Gespeichert werden nur neutrale Layoutwerte. Laden und Reset laufen ueber dieselben bestehenden Inspector-/HostAdapter-Methoden.
+
+## Blockaden
+
+Sichtbar blockiert werden:
+
+- keine registrierte Auswahl,
+- kein zugeordneter Layout-Scope,
+- Element nicht im Layoutscope registriert,
+- nicht layoutneutrale Operationen,
+- ungueltige HostAdapter-Rueckmeldungen.
+
+Fachwerte, DOM-/CSS-Werte, Datenbank-, IPC- oder Datensatzpayloads werden nicht als Layoutgrundlage verwendet.
+
+## Nicht geaendert
+
+- keine PDF-Bearbeitung
+- keine PDF-Ausgabe
+- kein Druck
+- keine Mail
+- kein Diktat/Audio
+- keine Protokoll-Fachlogik
+- keine Restarbeiten-Fachlogik
+- keine Datenbankmigration
+- keine fachlichen IPC-Wege
+- keine neue Editor-Grundsatzentscheidung
+
+## Pruefung
+
+Die sichtbare Anbindung ist abgesichert durch:
+
+- `scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`
+- `scripts/tests/editorScopeInspector.test.cjs`
+- `scripts/tests/restarbeitenEditorHostAdapter.test.cjs`
+- Gesamtlauf ueber `npm test`

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -372,3 +372,13 @@ Dabei gilt:
 - Es wurde keine Ziel-App-UI gescannt, keine automatische Registry-Befuellung eingefuehrt und keine Fachlogik oder Datenbankmigration geaendert.
 - PDF, Druck, Mail, Diktat/Audio, Protokoll-Fachlogik und Restarbeiten-Fachlogik bleiben ausserhalb dieses Pakets.
 - Neue Doku: `docs/M30_UI_EDITOR_BEDIENOBERFLAECHE_SPEICHERN_LADEN_RESET.md`.
+
+### M31 Globale UI-Editor-Bedienung sichtbar in der App angebunden (neu)
+- Die bestehende UI-Editor-Launcher-/Statusoberflaeche zeigt fuer registrierte Auswahlziele eine sichtbare neutrale Layoutbedienung.
+- Fuer den vorhandenen Restarbeiten-Pilot wird der sichtbare Scope `restarbeiten.screen` auf den bestehenden Layout-/HostAdapter-Scope `restarbeiten.ui.main` abgebildet.
+- Sichtbar sind ausgewaehltes Element, Layout-Scope, neutrale Operation, Anwenden/Speichern, Laden, Reset und Erfolg-/Blockiert-Meldungen.
+- Die Bedienung nutzt die vorhandenen M30-Inspector-Controls und den M29-HostAdapter-/LayoutPersistence-Pfad.
+- Nicht registrierte Layoutziele und ungueltige Aktionen bleiben sichtbar blockiert.
+- Es wurde keine automatische DOM-Erkennung, keine automatische Registry-Befuellung, keine Fachwertbearbeitung und keine Datenbankmigration eingefuehrt.
+- PDF, Druck, Mail, Diktat/Audio, Protokoll-Fachlogik und Restarbeiten-Fachlogik bleiben ausserhalb dieses Pakets.
+- Neue Doku: `docs/M31_UI_EDITOR_SICHTBARE_BEDIENUNG_IN_APP.md`.

--- a/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+++ b/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
@@ -230,8 +230,27 @@ function matchesSelector(node, selector) {
   if (raw === "[data-ui-editor-scope-list=\"true\"]") {
     return node.getAttribute("data-ui-editor-scope-list") === "true";
   }
+  if (raw === "[data-ui-editor-layout-controls=\"true\"]") {
+    return node.getAttribute("data-ui-editor-layout-controls") === "true";
+  }
+  if (raw === "[data-ui-editor-layout-selected=\"true\"]") {
+    return node.getAttribute("data-ui-editor-layout-selected") === "true";
+  }
+  if (raw === "[data-ui-editor-layout-message=\"true\"]") {
+    return node.getAttribute("data-ui-editor-layout-message") === "true";
+  }
+  if (raw === "[data-ui-editor-layout-operation=\"true\"]") {
+    return node.getAttribute("data-ui-editor-layout-operation") === "true";
+  }
+  if (raw === "[data-ui-editor-layout-state=\"true\"]") {
+    return node.getAttribute("data-ui-editor-layout-state") === "true";
+  }
   if (raw === "[data-ui-editor-id]") {
     return Boolean(node.getAttribute("data-ui-editor-id"));
+  }
+  const layoutActionMatch = raw.match(/^\[data-ui-editor-layout-action="([^"]+)"\]$/);
+  if (layoutActionMatch) {
+    return node.getAttribute("data-ui-editor-layout-action") === layoutActionMatch[1];
   }
   const uiEditorIdMatch = raw.match(/^\[data-ui-editor-id="([^"]+)"\]$/);
   if (uiEditorIdMatch) {
@@ -277,6 +296,7 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(cssSource.includes("ui-editor-launcher-status"), true);
     assert.equal(cssSource.includes("ui-editor-launcher-status__header"), true);
     assert.equal(cssSource.includes("ui-editor-launcher-status-reopen"), true);
+    assert.equal(cssSource.includes("ui-editor-layout-control"), true);
     assert.equal(cssSource.includes('data-ui-editor-panel-collapsed="true"'), true);
     assert.equal(cssSource.includes('data-ui-editor-panel-hidden="true"'), true);
     assert.equal(cssSource.includes("white-space: pre-line"), true);
@@ -365,6 +385,159 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(Boolean(doc.querySelector('[data-ui-inspector-panel="true"]')), false);
     assert.equal(Boolean(doc.querySelector('[data-ui-editor-panel="true"]')), false);
     assert.equal(Boolean(doc.querySelector('[data-ui-editor-hover-frame="true"]')), false);
+  });
+
+  await run("BBM UI-Editor-Runtime: sichtbare Layoutbedienung zeigt Auswahl und Save/Load/Reset", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const win = {
+      uiEditorLauncherButtonArtifact: require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js")),
+    };
+    const calls = [];
+    const layoutInspector = {
+      getLayoutControlPanel(scopeId, elementId) {
+        calls.push(["panel", scopeId, elementId]);
+        return {
+          ok: true,
+          elementId,
+          selectedElement: { id: elementId, name: "Kurztext" },
+          currentLayoutEntry: null,
+          controls: [
+            {
+              id: "editor.layout.applySave",
+              enabled: true,
+              allowedOps: ["move", "resize"],
+            },
+            { id: "editor.layout.loadSaved", enabled: true, allowedOps: [] },
+            { id: "editor.layout.resetDefault", enabled: true, allowedOps: [] },
+          ],
+          status: { kind: "ready", message: "Standardzustand ist aktiv.", reason: null },
+        };
+      },
+      applyLayoutChange(scopeId, request) {
+        calls.push(["apply", scopeId, request]);
+        return {
+          ok: true,
+          status: { kind: "success", message: "Aenderung wurde angewendet und gespeichert.", reason: null },
+          layoutEntry: { elementId: request.elementId, operation: request.operation, layoutValue: request.payload },
+        };
+      },
+      loadLayoutState(scopeId, request) {
+        calls.push(["load", scopeId, request]);
+        return {
+          ok: true,
+          status: { kind: "success", message: "Gespeicherter Layoutzustand wurde geladen.", reason: null },
+          currentLayoutEntry: { elementId: request.elementId, operation: "move", layoutValue: { x: 0, y: 0 } },
+        };
+      },
+      resetLayoutState(scopeId, request) {
+        calls.push(["reset", scopeId, request]);
+        return {
+          ok: true,
+          status: { kind: "success", message: "Standardzustand wurde wiederhergestellt.", reason: null },
+          layoutState: [],
+        };
+      },
+    };
+    const registry = {
+      uiScope: "restarbeiten.screen",
+      moduleId: "restarbeiten",
+      elements: [
+        { id: "restarbeiten.editbox.text.short", name: "Kurztext", type: "field", role: "content", parentId: "restarbeiten.editbox", allowedOps: ["inspect", "move"], lockedOps: [] },
+      ],
+    };
+    const button = await mod.installBbmUiEditorRuntimeLauncher({
+      devEnabled: true,
+      doc,
+      win,
+      activeUiScope: "restarbeiten.screen",
+      registryResolver: () => registry,
+      layoutInspector,
+      layoutScopeResolver: (uiScope) => uiScope === "restarbeiten.screen" ? "restarbeiten.ui.main" : null,
+    });
+    const target = doc.createElement("input");
+    target.setAttribute("data-ui-editor-id", "restarbeiten.editbox.text.short");
+    doc.body.appendChild(target);
+
+    button.click();
+    doc.dispatchEvent({ type: "click", target });
+
+    let panel = doc.querySelector('[data-ui-editor-layout-controls="true"]');
+    assert.equal(Boolean(panel), true);
+    assert.equal(doc.querySelector('[data-ui-editor-layout-selected="true"]').textContent.includes("restarbeiten.editbox.text.short"), true);
+    assert.equal(Boolean(doc.querySelector('[data-ui-editor-layout-action="applySave"]')), true);
+    assert.equal(Boolean(doc.querySelector('[data-ui-editor-layout-action="loadSaved"]')), true);
+    assert.equal(Boolean(doc.querySelector('[data-ui-editor-layout-action="resetDefault"]')), true);
+
+    doc.querySelector('[data-ui-editor-layout-action="applySave"]').click();
+    assert.deepEqual(calls.find((call) => call[0] === "apply"), [
+      "apply",
+      "restarbeiten.ui.main",
+      {
+        elementId: "restarbeiten.editbox.text.short",
+        operation: "move",
+        payload: { x: 0, y: 0 },
+      },
+    ]);
+    assert.equal(getStatusText(doc.querySelector('[data-ui-editor-launcher-status="true"]')).includes("Layout: Aenderung wurde angewendet"), true);
+
+    doc.querySelector('[data-ui-editor-layout-action="loadSaved"]').click();
+    assert.ok(calls.some((call) => call[0] === "load" && call[1] === "restarbeiten.ui.main"));
+    assert.equal(getStatusText(doc.querySelector('[data-ui-editor-launcher-status="true"]')).includes("Layout: Gespeicherter Layoutzustand wurde geladen."), true);
+
+    doc.querySelector('[data-ui-editor-layout-action="resetDefault"]').click();
+    assert.ok(calls.some((call) => call[0] === "reset" && call[1] === "restarbeiten.ui.main"));
+    assert.equal(getStatusText(doc.querySelector('[data-ui-editor-launcher-status="true"]')).includes("Layout: Standardzustand wurde wiederhergestellt."), true);
+    panel = doc.querySelector('[data-ui-editor-layout-controls="true"]');
+    assert.equal(Boolean(panel), true);
+  });
+
+  await run("BBM UI-Editor-Runtime: Layoutbedienung blockiert nicht registrierte Layoutziele sichtbar", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const win = {
+      uiEditorLauncherButtonArtifact: require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js")),
+    };
+    const layoutInspector = {
+      getLayoutControlPanel(_scopeId, elementId) {
+        return {
+          ok: false,
+          elementId,
+          selectedElement: null,
+          currentLayoutEntry: null,
+          controls: [],
+          status: {
+            kind: "blocked",
+            message: "Aktion blockiert: Element ist nicht registriert.",
+            reason: "ELEMENT_UNKNOWN",
+          },
+        };
+      },
+    };
+    const button = await mod.installBbmUiEditorRuntimeLauncher({
+      devEnabled: true,
+      doc,
+      win,
+      activeUiScope: "restarbeiten.screen",
+      registryResolver: () => ({
+        uiScope: "restarbeiten.screen",
+        moduleId: "restarbeiten",
+        elements: [
+          { id: "restarbeiten.only.visible", name: "Nur sichtbar", type: "field", role: "content", parentId: "restarbeiten.root", allowedOps: ["inspect"], lockedOps: [] },
+        ],
+      }),
+      layoutInspector,
+      layoutScopeResolver: () => "restarbeiten.ui.main",
+    });
+    const target = doc.createElement("div");
+    target.setAttribute("data-ui-editor-id", "restarbeiten.only.visible");
+    doc.body.appendChild(target);
+
+    button.click();
+    doc.dispatchEvent({ type: "click", target });
+
+    assert.equal(doc.querySelector('[data-ui-editor-layout-message="true"]').textContent.includes("blockiert"), true);
+    assert.equal(Boolean(doc.querySelector('[data-ui-editor-layout-action="applySave"]')), false);
   });
 
   await run("BBM UI-Editor-Runtime: aktiver Status zeigt uebergebenen bekannten Scope", async () => {
@@ -999,6 +1172,10 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(coreShellSource.includes("activeScopeId: activeUiScope"), true);
     assert.equal(source.includes("getStatusScopeLabel"), true);
     assert.equal(source.includes("activeUiScope"), true);
+    assert.equal(source.includes("layoutInspector"), true);
+    assert.equal(source.includes("layoutScopeResolver"), true);
+    assert.equal(coreShellSource.includes("createEditorScopeInspector"), true);
+    assert.equal(coreShellSource.includes('"restarbeiten.screen": "restarbeiten.ui.main"'), true);
   });
 
 }

--- a/src/renderer/app/CoreShell.js
+++ b/src/renderer/app/CoreShell.js
@@ -22,9 +22,14 @@ import { registerCoreShellKeyboardHandling } from "./coreShellKeyboard.js";
 import { createCoreShellNavigationRuntime } from "./coreShellNavigationRuntime.js";
 import { installBbmUiEditorRuntimeLauncher } from "../uiEditor/BbmUiEditorRuntimeLauncher.js";
 import { getActiveUiScope, getAvailableUiScopes, getBbmUiEditorRegistry } from "../uiEditor/bbmUiEditorRegistry.js";
+import { createEditorScopeInspector } from "../editorRuntime/inspector/editorScopeInspector.js";
 
 const HOST_UI_SCOPE_BY_SECTION = Object.freeze({
   restarbeiten: "restarbeiten.screen",
+});
+
+const LAYOUT_SCOPE_BY_UI_SCOPE = Object.freeze({
+  "restarbeiten.screen": "restarbeiten.ui.main",
 });
 
 function resolveActiveHostUiScope(router) {
@@ -36,6 +41,10 @@ function resolveActiveHostUiScope(router) {
   }
 
   return getActiveUiScope();
+}
+
+function resolveLayoutScopeForUiScope(uiScope) {
+  return LAYOUT_SCOPE_BY_UI_SCOPE[String(uiScope || "").trim()] || null;
 }
 
 export default class CoreShell {
@@ -95,6 +104,7 @@ export default class CoreShell {
     });
 
     let uiEditorRuntimeRefreshToken = 0;
+    const uiEditorLayoutInspector = createEditorScopeInspector();
     const refreshUiEditorRuntimeLauncher = () => {
       const activeUiScope = resolveActiveHostUiScope(router);
       const uiEditorRegistry = getBbmUiEditorRegistry(activeUiScope);
@@ -108,6 +118,8 @@ export default class CoreShell {
           registeredElements: uiEditorRegistry?.elements,
           availableUiScopes: getAvailableUiScopes(),
           registryResolver: getBbmUiEditorRegistry,
+          layoutInspector: uiEditorLayoutInspector,
+          layoutScopeResolver: resolveLayoutScopeForUiScope,
         })
       ).catch((error) => {
         if (refreshToken === uiEditorRuntimeRefreshToken) {

--- a/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
+++ b/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
@@ -109,7 +109,14 @@ function normalizeReadonlyRegistry(registry = null) {
   };
 }
 
-function createLauncherState({ activeUiScope = null, registeredElements = null, availableUiScopes = null, registryResolver = null } = {}) {
+function createLauncherState({
+  activeUiScope = null,
+  registeredElements = null,
+  availableUiScopes = null,
+  registryResolver = null,
+  layoutInspector = null,
+  layoutScopeResolver = null,
+} = {}) {
   const normalizedScope = String(activeUiScope == null ? "" : activeUiScope).trim();
   const resolver = typeof registryResolver === "function" ? registryResolver : null;
   const selectedRegistry = resolver && normalizedScope
@@ -132,6 +139,15 @@ function createLauncherState({ activeUiScope = null, registeredElements = null, 
     win: null,
     availableUiScopes: normalizeAvailableUiScopes(availableUiScopes),
     registryResolver: resolver,
+    layoutInspector: layoutInspector && typeof layoutInspector === "object" ? layoutInspector : null,
+    layoutScopeResolver: typeof layoutScopeResolver === "function" ? layoutScopeResolver : null,
+    layoutOperation: "move",
+    layoutX: 0,
+    layoutY: 0,
+    layoutWidth: 320,
+    layoutHeight: 80,
+    layoutGap: 8,
+    layoutStatus: null,
   };
 }
 
@@ -325,6 +341,8 @@ function getReadonlyLauncherStatusText(state = {}) {
     selectedElement ? `Auswahl: ${selectedElement.id}` : "Auswahl: keine",
     state.selectionMessage ? `Auswahl-Hinweis: ${state.selectionMessage}` : "",
     selectedElement ? `Name: ${selectedElement.name || selectedElement.label || ""}` : "",
+    state.layoutStatus?.message ? `Layout: ${state.layoutStatus.message}` : "",
+    state.layoutStatus?.reason ? `Layout-Grund: ${state.layoutStatus.reason}` : "",
     "",
     getReadonlyRegistryElementsText(registry.elements),
   ].filter((line) => line !== "").join("\n");
@@ -411,8 +429,277 @@ function ensureLauncherStatusHint(doc, host, state = {}) {
 function updateLauncherStatusHint(doc, host, state = {}) {
   const status = ensureLauncherStatusHint(doc, host, state);
   const content = getLauncherStatusContentNode(status);
-  if (content) content.textContent = getReadonlyLauncherStatusText(state);
+  if (content) {
+    while (content.firstChild && typeof content.removeChild === "function") {
+      content.removeChild(content.firstChild);
+    }
+    if (Array.isArray(content.children)) content.children = [];
+    content.textContent = getReadonlyLauncherStatusText(state);
+  }
   return status;
+}
+
+function getLayoutScopeForState(state = {}) {
+  if (typeof state.layoutScopeResolver !== "function") return null;
+  const registry = getSelectedRegistryFromState(state);
+  const scope = state.layoutScopeResolver(registry.uiScope || state.activeUiScope);
+  const normalizedScope = String(scope == null ? "" : scope).trim();
+  return normalizedScope || null;
+}
+
+function getLayoutPanelForState(state = {}) {
+  const layoutScope = getLayoutScopeForState(state);
+  const elementId = String(state.selectedElement?.id || "").trim();
+  if (!state.layoutInspector || !layoutScope || !elementId) return null;
+  if (typeof state.layoutInspector.getLayoutControlPanel !== "function") return null;
+  return state.layoutInspector.getLayoutControlPanel(layoutScope, elementId);
+}
+
+function getSafeLayoutOperations(panel = null) {
+  const applyControl = Array.isArray(panel?.controls)
+    ? panel.controls.find((control) => control.id === "editor.layout.applySave")
+    : null;
+  return Array.isArray(applyControl?.allowedOps) ? applyControl.allowedOps : [];
+}
+
+function ensureLayoutOperation(state = {}, operations = []) {
+  if (operations.includes(state.layoutOperation)) return state.layoutOperation;
+  state.layoutOperation = operations[0] || "move";
+  return state.layoutOperation;
+}
+
+function createNeutralLayoutPayload(state = {}) {
+  const operation = String(state.layoutOperation || "").trim();
+  if (operation === "move") {
+    return {
+      x: Number(state.layoutX) || 0,
+      y: Number(state.layoutY) || 0,
+    };
+  }
+  if (operation === "resize") {
+    return {
+      width: Number(state.layoutWidth) || 320,
+      height: Number(state.layoutHeight) || 80,
+    };
+  }
+  if (operation === "width") return { width: Number(state.layoutWidth) || 320 };
+  if (operation === "height") return { height: Number(state.layoutHeight) || 80 };
+  if (operation === "spacing") return { gap: Number(state.layoutGap) || 8 };
+  return {};
+}
+
+function appendLayoutNumberInput(doc, container, { label, value, onInput }) {
+  const wrapper = doc.createElement("label");
+  wrapper.className = "ui-editor-layout-control__field";
+  const labelNode = doc.createElement("span");
+  labelNode.textContent = label;
+  const input = doc.createElement("input");
+  input.type = "number";
+  input.value = String(value);
+  input.setAttribute("data-ui-editor-layout-input", label);
+  input.addEventListener("input", () => onInput(input.value));
+  wrapper.append(labelNode, input);
+  container.appendChild(wrapper);
+  return input;
+}
+
+function renderLayoutPayloadInputs(doc, container, state = {}) {
+  const operation = String(state.layoutOperation || "").trim();
+  if (operation === "move") {
+    appendLayoutNumberInput(doc, container, {
+      label: "x",
+      value: state.layoutX,
+      onInput: (nextValue) => {
+        state.layoutX = nextValue;
+      },
+    });
+    appendLayoutNumberInput(doc, container, {
+      label: "y",
+      value: state.layoutY,
+      onInput: (nextValue) => {
+        state.layoutY = nextValue;
+      },
+    });
+  } else if (operation === "resize") {
+    appendLayoutNumberInput(doc, container, {
+      label: "width",
+      value: state.layoutWidth,
+      onInput: (nextValue) => {
+        state.layoutWidth = nextValue;
+      },
+    });
+    appendLayoutNumberInput(doc, container, {
+      label: "height",
+      value: state.layoutHeight,
+      onInput: (nextValue) => {
+        state.layoutHeight = nextValue;
+      },
+    });
+  } else if (operation === "width") {
+    appendLayoutNumberInput(doc, container, {
+      label: "width",
+      value: state.layoutWidth,
+      onInput: (nextValue) => {
+        state.layoutWidth = nextValue;
+      },
+    });
+  } else if (operation === "height") {
+    appendLayoutNumberInput(doc, container, {
+      label: "height",
+      value: state.layoutHeight,
+      onInput: (nextValue) => {
+        state.layoutHeight = nextValue;
+      },
+    });
+  } else if (operation === "spacing") {
+    appendLayoutNumberInput(doc, container, {
+      label: "gap",
+      value: state.layoutGap,
+      onInput: (nextValue) => {
+        state.layoutGap = nextValue;
+      },
+    });
+  }
+}
+
+function refreshLauncherPanel(doc, host, state = {}) {
+  const status = updateLauncherStatusHint(doc, host, state);
+  renderReadonlyScopeButtons(doc, status, state);
+  renderLayoutControls(doc, status, state);
+  return status;
+}
+
+function renderLayoutControls(doc, status, state = {}) {
+  const content = getLauncherStatusContentNode(status);
+  if (!doc?.createElement || !content) return null;
+
+  const layoutScope = getLayoutScopeForState(state);
+  const panel = getLayoutPanelForState(state);
+  const selectedElement = state.selectedElement || null;
+  const section = doc.createElement("div");
+  section.className = "ui-editor-layout-control";
+  section.setAttribute("data-ui-editor-layout-controls", "true");
+
+  const title = doc.createElement("strong");
+  title.textContent = "Layout";
+  section.appendChild(title);
+
+  const selected = doc.createElement("div");
+  selected.setAttribute("data-ui-editor-layout-selected", "true");
+  selected.textContent = selectedElement
+    ? `Ausgewaehltes Element: ${selectedElement.id}`
+    : "Ausgewaehltes Element: keine registrierte Auswahl";
+  section.appendChild(selected);
+
+  const scopeLine = doc.createElement("div");
+  scopeLine.textContent = layoutScope ? `Layout-Scope: ${layoutScope}` : "Layout-Scope: nicht verfuegbar";
+  section.appendChild(scopeLine);
+
+  if (!selectedElement || !layoutScope || !state.layoutInspector) {
+    const empty = doc.createElement("div");
+    empty.setAttribute("data-ui-editor-layout-message", "true");
+    empty.textContent = "Layoutbedienung wartet auf eine registrierte Auswahl.";
+    section.appendChild(empty);
+    content.appendChild(section);
+    return section;
+  }
+
+  if (!panel?.ok) {
+    const blocked = doc.createElement("div");
+    blocked.setAttribute("data-ui-editor-layout-message", "true");
+    blocked.textContent = panel?.status?.message || "Layoutbedienung blockiert.";
+    section.appendChild(blocked);
+    content.appendChild(section);
+    return section;
+  }
+
+  const operations = getSafeLayoutOperations(panel);
+  const operation = ensureLayoutOperation(state, operations);
+  const controlsRow = doc.createElement("div");
+  controlsRow.className = "ui-editor-layout-control__row";
+
+  const operationLabel = doc.createElement("label");
+  operationLabel.className = "ui-editor-layout-control__field";
+  const operationLabelText = doc.createElement("span");
+  operationLabelText.textContent = "Operation";
+  const operationSelect = doc.createElement("select");
+  operationSelect.setAttribute("data-ui-editor-layout-operation", "true");
+  for (const safeOperation of operations) {
+    const option = doc.createElement("option");
+    option.value = safeOperation;
+    option.textContent = safeOperation;
+    if (safeOperation === operation) option.selected = true;
+    operationSelect.appendChild(option);
+  }
+  operationSelect.addEventListener("change", () => {
+    state.layoutOperation = operationSelect.value;
+    refreshLauncherPanel(doc, status.parentElement, state);
+  });
+  operationLabel.append(operationLabelText, operationSelect);
+  controlsRow.appendChild(operationLabel);
+  renderLayoutPayloadInputs(doc, controlsRow, state);
+  section.appendChild(controlsRow);
+
+  const buttonRow = doc.createElement("div");
+  buttonRow.className = "ui-editor-layout-control__buttons";
+
+  const saveButton = doc.createElement("button");
+  saveButton.type = "button";
+  saveButton.textContent = "Anwenden/Speichern";
+  saveButton.setAttribute("data-ui-editor-layout-action", "applySave");
+  saveButton.disabled = operations.length < 1;
+  saveButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const result = state.layoutInspector.applyLayoutChange(layoutScope, {
+      elementId: selectedElement.id,
+      operation: state.layoutOperation,
+      payload: createNeutralLayoutPayload(state),
+    });
+    state.layoutStatus = result.status || null;
+    refreshLauncherPanel(doc, status.parentElement, state);
+  });
+
+  const loadButton = doc.createElement("button");
+  loadButton.type = "button";
+  loadButton.textContent = "Laden";
+  loadButton.setAttribute("data-ui-editor-layout-action", "loadSaved");
+  loadButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const result = state.layoutInspector.loadLayoutState(layoutScope, {
+      elementId: selectedElement.id,
+    });
+    state.layoutStatus = result.status || null;
+    refreshLauncherPanel(doc, status.parentElement, state);
+  });
+
+  const resetButton = doc.createElement("button");
+  resetButton.type = "button";
+  resetButton.textContent = "Reset";
+  resetButton.setAttribute("data-ui-editor-layout-action", "resetDefault");
+  resetButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const result = state.layoutInspector.resetLayoutState(layoutScope, {
+      elementId: selectedElement.id,
+    });
+    state.layoutStatus = result.status || null;
+    refreshLauncherPanel(doc, status.parentElement, state);
+  });
+
+  buttonRow.append(saveButton, loadButton, resetButton);
+  section.appendChild(buttonRow);
+
+  const stateLine = doc.createElement("div");
+  stateLine.setAttribute("data-ui-editor-layout-state", "true");
+  stateLine.textContent = panel.currentLayoutEntry
+    ? `Gespeichert: ${panel.currentLayoutEntry.operation}`
+    : panel.status.message;
+  section.appendChild(stateLine);
+
+  content.appendChild(section);
+  return section;
 }
 
 function setActiveScopeInState(state, nextScope) {
@@ -422,6 +709,7 @@ function setActiveScopeInState(state, nextScope) {
   state.selectedRegistry = state.registryResolver
     ? normalizeReadonlyRegistry(state.registryResolver(normalizedScope))
     : normalizeReadonlyRegistry({ uiScope: normalizedScope, elements: [] });
+  state.layoutStatus = null;
 }
 
 function installLauncherTargetSelectionController(doc, host, state) {
@@ -438,15 +726,14 @@ function installLauncherTargetSelectionController(doc, host, state) {
       state.hoverElement = selection.element;
       state.hoverTargetNode = selection.targetElement;
       state.hoverMessage = selection.message || "";
-      const status = updateLauncherStatusHint(doc, host, state);
-      renderReadonlyScopeButtons(doc, status, state);
+      refreshLauncherPanel(doc, host, state);
     },
     onSelectionChange(selection) {
       state.selectedElement = selection.element;
       state.selectedTargetNode = selection.targetElement;
       state.selectionMessage = selection.message || "";
-      const status = updateLauncherStatusHint(doc, host, state);
-      renderReadonlyScopeButtons(doc, status, state);
+      state.layoutStatus = null;
+      refreshLauncherPanel(doc, host, state);
     },
   });
   controller?.install?.();
@@ -472,8 +759,7 @@ function renderReadonlyScopeButtons(doc, status, state) {
       event.preventDefault();
       event.stopPropagation();
       setActiveScopeInState(state, scope.uiScope);
-      const updatedStatus = updateLauncherStatusHint(doc, status.parentElement, state);
-      renderReadonlyScopeButtons(doc, updatedStatus, state);
+      const updatedStatus = refreshLauncherPanel(doc, status.parentElement, state);
       installLauncherTargetSelectionController(doc, status.parentElement, state);
     });
     scopeList.appendChild(button);
@@ -490,8 +776,7 @@ function syncLauncherButtonState(button, state, { doc = getDocument(), host = nu
   doc?.body?.setAttribute?.(UI_EDITOR_ACTIVE_ATTRIBUTE, active ? "true" : "false");
 
   if (active) {
-    const status = updateLauncherStatusHint(doc, host || button.parentElement, state);
-    renderReadonlyScopeButtons(doc, status, state);
+    const status = refreshLauncherPanel(doc, host || button.parentElement, state);
     installLauncherTargetSelectionController(doc, host || button.parentElement, state);
   } else {
     removeLauncherTargetSelectionController(state);
@@ -534,8 +819,8 @@ function handleUiEditorDocumentClick(event, { state, doc, host }) {
   event?.preventDefault?.();
   event?.stopPropagation?.();
   markUiEditorTargetSelection(state, targetNode, registryElement);
-  const status = updateLauncherStatusHint(doc, host, state);
-  renderReadonlyScopeButtons(doc, status, state);
+  state.layoutStatus = null;
+  refreshLauncherPanel(doc, host, state);
 }
 
 function installLauncherDocumentClickHandler(doc, host, state) {
@@ -598,6 +883,8 @@ export async function installBbmUiEditorRuntimeLauncher({
   registeredElements = null,
   availableUiScopes = null,
   registryResolver = null,
+  layoutInspector = null,
+  layoutScopeResolver = null,
   doc = getDocument(),
   win = getWindow(),
   host = null,
@@ -611,7 +898,14 @@ export async function installBbmUiEditorRuntimeLauncher({
   ensureInstalledLauncherCss(doc);
   const artifact = await loadInstalledLauncherButton({ doc, win });
   const launcherHost = getLauncherHost(doc, host);
-  const state = createLauncherState({ activeUiScope, registeredElements, availableUiScopes, registryResolver });
+  const state = createLauncherState({
+    activeUiScope,
+    registeredElements,
+    availableUiScopes,
+    registryResolver,
+    layoutInspector,
+    layoutScopeResolver,
+  });
   state.win = win || null;
   return renderLauncherButton({ artifact, doc, host: launcherHost, state, onToggle });
 }

--- a/uiEditor/uiEditorLauncherButton.css
+++ b/uiEditor/uiEditorLauncherButton.css
@@ -97,3 +97,48 @@
   color: #0f172a;
   cursor: pointer;
 }
+
+.ui-editor-layout-control {
+  margin-block-start: 12px;
+  padding-block-start: 10px;
+  border-block-start: 1px solid #cbd5e1;
+  white-space: normal;
+}
+
+.ui-editor-layout-control__row,
+.ui-editor-layout-control__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-block-start: 8px;
+}
+
+.ui-editor-layout-control__field {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.ui-editor-layout-control input,
+.ui-editor-layout-control select {
+  max-inline-size: 96px;
+  min-block-size: 28px;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  padding: 3px 6px;
+  font: inherit;
+}
+
+.ui-editor-layout-control button {
+  min-block-size: 30px;
+  border: 1px solid #94a3b8;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #0f172a;
+  cursor: pointer;
+}
+
+.ui-editor-layout-control button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
M31 bindet die sichtbare UI-Editor-Layoutbedienung im bestehenden App-/Editor-Kontext an.

Umfang:
- sichtbare Layoutbedienung im UI-Editor-Launcher/Statusbereich
- Auswahl, Layout-Scope, neutrale Operationen, Anwenden/Speichern, Laden und Reset
- Erfolg- und Blockiert-Meldungen
- Tests und Doku aktualisiert

Pruefung:
- node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs bestanden
- editorScopeInspector-Direktlauf bestanden
- restarbeitenEditorHostAdapter-Direktlauf bestanden
- git diff --check bestanden
- node scripts/ui-editor-contract-check.cjs --self-test bestanden
- npm test bestanden