### PR TITLE
M32: UI Editor App-Smoke-Test dokumentieren

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,15 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M32 Globalen UI-Editor im App-Kontext per Smoke-Test und Abnahmeprotokoll geprueft:
+  - Neue Abnahmedoku: `docs/M32_UI_EDITOR_APP_SMOKE_TEST.md`.
+  - `npm start` startete die App sichtbar; das Fenster `BBM` war vorhanden und antwortend.
+  - Der UI-Editor-Launcher war im DEV-Kontext oben rechts sichtbar.
+  - Die weitere Bedienfolge fuer registrierte Auswahl, Layout-Scope, Anwenden/Speichern, Laden, Reset und sichtbare Blockaden ist technisch durch `npm test` abgedeckt.
+  - `git diff --check` und `npm test` liefen gruen; `npm test` endete mit `Alle Tests bestanden.`
+  - Es war keine Codekorrektur noetig.
+  - Keine PDF-, Druck-, Mail-, Diktat-/Audio-, Protokoll- oder Restarbeiten-Fachlogik wurde geaendert.
+
 - M31 Globale UI-Editor-Bedienung sichtbar in der App angebunden:
   - Die bestehende UI-Editor-Launcher-/Statusoberflaeche zeigt fuer registrierte Auswahlziele eine sichtbare neutrale Layoutbedienung.
   - Fuer den vorhandenen Restarbeiten-Pilot wird der sichtbare Scope `restarbeiten.screen` auf den bestehenden Layout-/HostAdapter-Scope `restarbeiten.ui.main` abgebildet.

--- a/docs/M32_UI_EDITOR_APP_SMOKE_TEST.md
+++ b/docs/M32_UI_EDITOR_APP_SMOKE_TEST.md
@@ -1,0 +1,79 @@
+# M32 UI-Editor App-Smoke-Test
+
+## Zweck
+
+M32 prueft den globalen UI-Editor im App-Kontext nach M29, M30 und M31.
+
+Es wurde keine neue Funktion gebaut und keine neue Architekturentscheidung getroffen.
+
+## Grundlage
+
+- M29: neutrale Layoutaenderungen koennen gespeichert, geladen und zurueckgesetzt werden.
+- M30: neutrale Controls fuer Anwenden/Speichern, Laden und Reset sind im EditorRuntime-Kontext abgesichert.
+- M31: sichtbare UI-Editor-Bedienung ist in der App angebunden.
+
+## Pruefumfang
+
+| Punkt | Ergebnis | Nachweis |
+| --- | --- | --- |
+| App startet mit `npm start` | bestanden | Electron startete, IPCs wurden registriert, DB wurde geoeffnet, Fenster `BBM` war sichtbar und antwortend |
+| UI-Editor-Launcher sichtbar im DEV-Kontext | bestanden | Sichtpruefung im laufenden BBM-Fenster: Button `UI-Editor` oben rechts sichtbar |
+| Registriertes Element kann ausgewaehlt werden | technisch bestanden | `npm test`, besonders `bbmUiEditorRuntimeLauncher.test.cjs`: Klick auf registrierte Restarbeiten-/Protokoll-IDs waehlt und markiert Ziele |
+| Layout-Scope wird angezeigt | technisch bestanden | `npm test`: sichtbare Layoutbedienung zeigt Auswahl und Scope-Mapping `restarbeiten.screen` -> `restarbeiten.ui.main` |
+| Neutrale Layoutaenderung kann angewendet/gespeichert werden | technisch bestanden | `npm test`: `EditorScopeInspector` und Runtime-Launcher bestaetigen Apply/Save |
+| Gespeicherter Zustand kann geladen/angewendet werden | technisch bestanden | `npm test`: `loadLayoutState()` liefert gespeicherten Layoutzustand |
+| Reset setzt auf Standard zurueck | technisch bestanden | `npm test`: `resetLayoutState()` entfernt gespeicherten Elementzustand |
+| Blockierte Aktionen zeigen sichtbare Meldung | technisch bestanden | `npm test`: unbekannte Elemente und nicht layoutneutrale Operationen werden sichtbar blockiert |
+| Keine Fachwerte werden veraendert | bestanden | Tests blockieren Fach-, DOM-, Datenbank- und IPC-Payloads; keine Codeaenderung in Fachlogik |
+| Keine PDF-/Druck-/Mail-/Audio-Pfade werden beruehrt | bestanden | Keine Codeaenderung; Doku-/Statuspaket bleibt ausserhalb dieser Pfade |
+
+## Lokale App-Sichtung
+
+`npm start` wurde ausgefuehrt.
+
+Beobachtung:
+- `electron-builder install-app-deps` lief durch.
+- `electron .` startete.
+- Main-Prozess registrierte die erwarteten IPCs.
+- Datenbank unter `C:\Users\Steffen\AppData\Roaming\baubesprechungs-manager\app.db` wurde geoeffnet.
+- Ein sichtbares, antwortendes Fenster mit Titel `BBM` war vorhanden.
+- Im Fenster war der `UI-Editor`-Launcher oben rechts sichtbar.
+
+Grenze der lokalen Sichtung:
+- Die weitere Bedienfolge wurde in dieser Sitzung nicht als vollstaendige manuelle Klick-Abnahme im echten App-Fenster bestaetigt.
+- Die Bedienfolge ist technisch ueber `npm test` abgedeckt.
+
+## Pruefungen
+
+```powershell
+git diff --check
+npm test
+npm start
+```
+
+Ergebnis:
+- `git diff --check`: bestanden
+- `npm test`: bestanden, Ausgabe endete mit `Alle Tests bestanden.`
+- `npm start`: App startete sichtbar; Session wurde anschliessend per `Ctrl+C` beendet.
+
+## Nicht geaendert
+
+- Keine PDF-Bearbeitung
+- Keine PDF-Ausgabe
+- Kein Druck
+- Keine Mail
+- Keine Diktat-/Audioaenderung
+- Keine Restarbeiten-Fachlogik
+- Keine Protokoll-Fachlogik
+- Keine Datenbankmigration
+- Keine neue Editor-Grundsatzentscheidung
+- Keine UI-Umbauaktion
+
+## Ergebnis
+
+M32 ist als Smoke-Test- und Abnahmedokumentation abgeschlossen.
+
+Es war keine Codekorrektur noetig.
+
+Offener Punkt:
+- Eine zusaetzliche fachliche Klick-Abnahme im echten App-Fenster kann durch den Nutzer erfolgen, wenn die sichtbare Bedienung final fachlich bestaetigt werden soll.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -382,3 +382,13 @@ Dabei gilt:
 - Es wurde keine automatische DOM-Erkennung, keine automatische Registry-Befuellung, keine Fachwertbearbeitung und keine Datenbankmigration eingefuehrt.
 - PDF, Druck, Mail, Diktat/Audio, Protokoll-Fachlogik und Restarbeiten-Fachlogik bleiben ausserhalb dieses Pakets.
 - Neue Doku: `docs/M31_UI_EDITOR_SICHTBARE_BEDIENUNG_IN_APP.md`.
+
+### M32 Globaler UI-Editor App-Smoke-Test und Abnahmeprotokoll (neu)
+- Der globale UI-Editor wurde als reines Pruef- und Dokumentationspaket im App-Kontext abgenommen.
+- `npm start` startete die App sichtbar; das Fenster `BBM` war vorhanden und antwortend.
+- Der UI-Editor-Launcher war im DEV-Kontext sichtbar.
+- Die Bedienfolge fuer registrierte Auswahl, Layout-Scope, Anwenden/Speichern, Laden, Reset und sichtbare Blockaden ist technisch durch `npm test` abgedeckt.
+- `git diff --check` und `npm test` liefen gruen.
+- Es wurde keine Codekorrektur vorgenommen.
+- PDF, Druck, Mail, Diktat/Audio, Protokoll-Fachlogik, Restarbeiten-Fachlogik, Datenbankmigration und neue Editor-Grundsatzentscheidungen blieben ausserhalb dieses Pakets.
+- Neue Doku: `docs/M32_UI_EDITOR_APP_SMOKE_TEST.md`.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -3,6 +3,8 @@
 ## Projektstatus
 Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.16a abgeschlossen (neutraler BBM-UI-Editor-Aktivmodus zeigt festen Registry-Scope).
 
+Statusupdate: M32 abgeschlossen (globaler UI-Editor im App-Kontext per Smoke-Test und Abnahmeprotokoll geprueft).
+
 Aktueller Stand:
 - M1 bis M13.6a abgeschlossen.
 - K19.0 abgeschlossen: erste explizite UI-Elementliste fuer das Protokoll-Modul, ohne Editor-Integration und ohne produktive UI-Aenderung.
@@ -11,6 +13,7 @@ Aktueller Stand:
 - K19.13a abgeschlossen: Der BBM-Artefakttest erkennt `uiEditor.global` robust ueber `id`, `uiScope`, `uiScopeId` oder den Registry-Schluessel und verlangt `uiEditor/targetAppRegistry.js` als installiertes Pflichtartefakt.
 - K19.16a abgeschlossen: Der neutrale UI-Editor-Aktivmodus zeigt den festen aktiven BBM-Registry-Scope `protokoll.topsScreen`; bei leerem Scope wird `nicht erkannt` angezeigt.
 - M21 abgeschlossen: BBM-Produktiv ist als Beispiel-/Pilot-Zielapp vom generischen UI-Editor-kit getrennt dokumentiert; `Restarbeiten` ist erreichbarer unfertiger Pilot-Scope, `Protokoll` defensiv/read-only.
+- M32 abgeschlossen: App-Start und sichtbarer Launcher wurden lokal geprueft; die Save/Load/Reset-Bedienfolge und Blockaden sind durch `npm test` abgedeckt.
 
 ## Haken-System
 - `[x]` erledigt
@@ -50,6 +53,17 @@ Aktueller Stand:
 - [x] K19.13a BBM-Test an aktuelle UI-Editor-Installer-Artefakte anpassen
 - [x] K19.16a UI-Editor zeigt festen registrierten Scope aus BBM-Registry
 - [x] M21 BBM-Zielapp sauber vom generischen UI-Editor-kit trennen
+- [x] M32 Globalen UI-Editor im App-Kontext per Smoke-Test und Abnahmeprotokoll pruefen
+
+## Statusupdate M32
+- Der globale UI-Editor wurde nach M29/M30/M31 als reines Smoke-Test- und Abnahmepaket geprueft.
+- Neue Abnahmedoku: `docs/M32_UI_EDITOR_APP_SMOKE_TEST.md`.
+- `npm start` startete die App sichtbar; das Fenster `BBM` war vorhanden und antwortend.
+- Der UI-Editor-Launcher war im DEV-Kontext sichtbar.
+- Registrierte Auswahl, Layout-Scope, Anwenden/Speichern, Laden, Reset und sichtbare Blockaden sind technisch durch `npm test` abgedeckt.
+- Es wurde keine Codekorrektur vorgenommen.
+- Keine PDF-/Druck-/Mail-/Audio-, Protokoll- oder Restarbeiten-Fachlogik wurde geaendert.
+- Naechster Schritt: fachliche Klick-Abnahme durch den Nutzer, falls die sichtbare Bedienfolge im echten App-Fenster zusaetzlich bestaetigt werden soll.
 
 ## Statusupdate M21
 - BBM-Produktiv ist Beispiel-/Pilot-Zielapp fuer das generische UI-Editor-kit, nicht fachliche Grundlage des Editors.


### PR DESCRIPTION
M32 dokumentiert den App-Smoke-Test und die Abnahme des globalen UI-Editors.

Umfang:
- neue Abnahmedoku docs/M32_UI_EDITOR_APP_SMOKE_TEST.md
- STATUS.md aktualisiert
- docs/MODULARISIERUNGSPLAN.md aktualisiert
- docs/UI_INSPEKTOR_AUFGABENHEFT.md aktualisiert
- keine Codeaenderung

Pruefung:
- git diff --check bestanden
- npm test bestanden, endet mit Alle Tests bestanden
- npm start: App startete sichtbar, Fenster BBM vorhanden und antwortend, UI-Editor-Launcher oben rechts sichtbar