### PR TITLE
M33: UI Editor Protokoll-Scope anbinden

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,16 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M33 Globalen UI-Editor fuer den Protokoll-/TOPS-Scope sichtbar angebunden:
+  - Neue Doku: `docs/M33_UI_EDITOR_PROTOKOLL_SCOPE_ANBINDUNG.md`.
+  - Der sichtbare App-Scope `protokoll.topsScreen` ist nun auch als neutraler EditorRuntime-/Layout-Scope angebunden.
+  - Registrierte TOPS-Quicklane-Elemente koennen im sichtbaren globalen UI-Editor ausgewaehlt werden; Layout-Scope, Anwenden/Speichern, Laden und Reset sind verfuegbar.
+  - Blockierte Aktionen fuer unbekannte Elemente und Fach-/DOM-/Datenbankpayloads werden weiter sichtbar bzw. technisch blockiert.
+  - `restarbeiten.screen` bleibt unveraendert auf `restarbeiten.ui.main` abgebildet und bedienbar.
+  - Es wurde keine automatische DOM-Erkennung, keine automatische Registry-Befuellung und keine Fachwertbearbeitung eingefuehrt.
+  - Keine PDF-, Druck-, Mail-, Diktat-/Audio-, Protokoll- oder Restarbeiten-Fachlogik wurde geaendert.
+  - `git diff --check`, `node scripts/ui-editor-contract-check.cjs --self-test`, `npm test` und `npm start` liefen gruen.
+
 - M32 Globalen UI-Editor im App-Kontext per Smoke-Test und Abnahmeprotokoll geprueft:
   - Neue Abnahmedoku: `docs/M32_UI_EDITOR_APP_SMOKE_TEST.md`.
   - `npm start` startete die App sichtbar; das Fenster `BBM` war vorhanden und antwortend.

--- a/docs/M33_UI_EDITOR_PROTOKOLL_SCOPE_ANBINDUNG.md
+++ b/docs/M33_UI_EDITOR_PROTOKOLL_SCOPE_ANBINDUNG.md
@@ -1,0 +1,85 @@
+# M33 UI-Editor Protokoll-/TOPS-Scope-Anbindung
+
+## Zweck
+
+M33 bindet den globalen UI-Editor zusaetzlich fuer den vorhandenen Protokoll-/TOPS-Scope sichtbar an.
+
+Es wurde keine neue Editor-Grundsatzentscheidung getroffen. Der Editor bleibt global, fachneutral und arbeitet nur mit registrierten UI-Editor-Elementen.
+
+## Grundlage
+
+- M29: neutrale Layoutaenderungen koennen gespeichert, geladen und zurueckgesetzt werden.
+- M30: neutrale Controls fuer Anwenden/Speichern, Laden und Reset sind im EditorRuntime-Kontext abgesichert.
+- M31: sichtbare UI-Editor-Bedienung ist in der App angebunden.
+- M32: App-Smoke-Test wurde dokumentiert und bestanden.
+
+## Umsetzung
+
+- Der sichtbare App-Scope `protokoll.topsScreen` wird im globalen UI-Editor weiterhin ueber die vorhandene BBM-UI-Editor-Registry bereitgestellt.
+- Der Layout-Scope fuer `protokoll.topsScreen` ist nun ebenfalls `protokoll.topsScreen`.
+- Fuer den neutralen EditorRuntime-Pfad wurde eine Protokoll/TOPS-Registry mit den bereits vorhandenen Quicklane-IDs angelegt.
+- Der HostAdapter fuer `protokoll.topsScreen` speichert, laedt und resetet ausschliesslich neutrale Layoutwerte.
+- `restarbeiten.screen` bleibt unveraendert auf `restarbeiten.ui.main` abgebildet.
+
+## Bedienbarer Scope
+
+| Bereich | Ergebnis |
+| --- | --- |
+| Sichtbarer UI-Scope | `protokoll.topsScreen` |
+| Layout-Scope | `protokoll.topsScreen` |
+| Modul | `protokoll` |
+| Bedienbare registrierte Elemente | TOPS-Quicklane, Gruppen und Quicklane-Buttons |
+| Speicherart | neutraler EditorRuntime-Layoutspeicher |
+
+## Abnahmeumfang
+
+| Punkt | Ergebnis | Nachweis |
+| --- | --- | --- |
+| Vorhandenen Protokoll-/TOPS-Scope in Registry verwenden | bestanden | `bbmUiEditorRegistry.js` bleibt Quelle fuer sichtbare Auswahl; `CoreShell` nutzt `protokoll.topsScreen` fuer TOPS |
+| Sichtbare Auswahl registrierter TOPS-/Protokoll-Elemente ermoeglichen | bestanden | Runtime-Test waehlt `protokoll.topsScreen.quicklane` und zeigt die Auswahl |
+| Layout-Scope korrekt anzeigen | bestanden | Runtime-Test prueft `Layout-Scope: protokoll.topsScreen` |
+| Anwenden/Speichern, Laden und Reset ermoeglichen | bestanden | HostAdapter- und Inspector-Tests pruefen Apply/Load/Reset fuer `protokoll.topsScreen.quicklane` |
+| Blockierte Aktionen sichtbar melden | bestanden | Inspector- und HostAdapter-Tests blockieren unbekannte Elemente und Fachpayloads |
+| Restarbeiten-Pilot nicht beschaedigen | bestanden | bestehendes Mapping `restarbeiten.screen` -> `restarbeiten.ui.main` bleibt erhalten; bestehende Tests laufen weiter |
+| Keine Fachwerte veraendern | bestanden | Fach-, DOM-, Datenbank- und Textpayloads werden abgelehnt |
+| Keine automatische DOM-Erkennung einfuehren | bestanden | Runtime-Tests sichern weiter gegen Scan-/Auto-Registry-Begriffe ab |
+| Nur registrierte UI-Editor-Elemente verwenden | bestanden | Protokoll/TOPS-HostAdapter akzeptiert nur IDs aus der Runtime-Registry |
+
+## Nicht geaendert
+
+- Keine PDF-Bearbeitung
+- Keine PDF-Ausgabe
+- Kein Druck
+- Keine Mail
+- Keine Diktat-/Audioaenderung
+- Keine Protokoll-Fachlogik
+- Keine Restarbeiten-Fachlogik
+- Keine Datenbankmigration
+- Keine neue Editor-Grundsatzentscheidung
+- Keine grosse UI-Umbauaktion
+
+## Pruefungen
+
+```powershell
+git diff --check
+node scripts/ui-editor-contract-check.cjs --self-test
+npm test
+npm start
+```
+
+Ergebnis:
+- `git diff --check`: bestanden
+- `node scripts/ui-editor-contract-check.cjs --self-test`: bestanden
+- `npm test`: bestanden, Ausgabe endete mit `Alle Tests bestanden.`
+- `npm start`: App startete sichtbar; das Fenster `BBM` war vorhanden und antwortend.
+
+## Grenze der Sichtung
+
+Die technische Bedienfolge fuer Protokoll/TOPS ist durch Tests abgesichert. Eine zusaetzliche fachliche Klick-Abnahme im echten App-Fenster kann durch den Nutzer erfolgen, wenn die sichtbare Bedienung final fachlich bestaetigt werden soll.
+
+## Ergebnis
+
+M33 ist abgeschlossen:
+- Protokoll-/TOPS-Scope ist im sichtbaren globalen UI-Editor bedienbar.
+- Restarbeiten-Scope bleibt bedienbar.
+- Der Editor bleibt fachneutral und nutzt nur registrierte Elemente.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -392,3 +392,13 @@ Dabei gilt:
 - Es wurde keine Codekorrektur vorgenommen.
 - PDF, Druck, Mail, Diktat/Audio, Protokoll-Fachlogik, Restarbeiten-Fachlogik, Datenbankmigration und neue Editor-Grundsatzentscheidungen blieben ausserhalb dieses Pakets.
 - Neue Doku: `docs/M32_UI_EDITOR_APP_SMOKE_TEST.md`.
+
+### M33 Globaler UI-Editor Protokoll-/TOPS-Scope-Anbindung (neu)
+- Der globale UI-Editor ist zusaetzlich fuer den vorhandenen Scope `protokoll.topsScreen` bedienbar.
+- Die sichtbare Auswahl nutzt weiterhin nur registrierte TOPS-/Protokoll-Elemente; es wurde keine DOM-Erkennung und keine automatische Registry-Befuellung eingefuehrt.
+- Der neutrale EditorRuntime-/Layout-Scope fuer TOPS ist `protokoll.topsScreen`.
+- Registrierte TOPS-Quicklane-Elemente koennen neutral angewendet/gespeichert, geladen und zurueckgesetzt werden.
+- Unbekannte Elemente sowie Fach-, DOM- und Datenbankpayloads werden blockiert.
+- Der Restarbeiten-Pilot bleibt ueber `restarbeiten.screen` -> `restarbeiten.ui.main` unveraendert bedienbar.
+- PDF, Druck, Mail, Diktat/Audio, Protokoll-Fachlogik, Restarbeiten-Fachlogik, Datenbankmigration und neue Editor-Grundsatzentscheidungen blieben ausserhalb dieses Pakets.
+- Neue Doku: `docs/M33_UI_EDITOR_PROTOKOLL_SCOPE_ANBINDUNG.md`.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -3,7 +3,7 @@
 ## Projektstatus
 Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.16a abgeschlossen (neutraler BBM-UI-Editor-Aktivmodus zeigt festen Registry-Scope).
 
-Statusupdate: M32 abgeschlossen (globaler UI-Editor im App-Kontext per Smoke-Test und Abnahmeprotokoll geprueft).
+Statusupdate: M33 abgeschlossen (globaler UI-Editor fuer den Protokoll-/TOPS-Scope sichtbar angebunden).
 
 Aktueller Stand:
 - M1 bis M13.6a abgeschlossen.
@@ -14,6 +14,7 @@ Aktueller Stand:
 - K19.16a abgeschlossen: Der neutrale UI-Editor-Aktivmodus zeigt den festen aktiven BBM-Registry-Scope `protokoll.topsScreen`; bei leerem Scope wird `nicht erkannt` angezeigt.
 - M21 abgeschlossen: BBM-Produktiv ist als Beispiel-/Pilot-Zielapp vom generischen UI-Editor-kit getrennt dokumentiert; `Restarbeiten` ist erreichbarer unfertiger Pilot-Scope, `Protokoll` defensiv/read-only.
 - M32 abgeschlossen: App-Start und sichtbarer Launcher wurden lokal geprueft; die Save/Load/Reset-Bedienfolge und Blockaden sind durch `npm test` abgedeckt.
+- M33 abgeschlossen: Der globale UI-Editor ist zusaetzlich fuer registrierte TOPS-Quicklane-Elemente im Scope `protokoll.topsScreen` bedienbar; Restarbeiten bleibt bedienbar.
 
 ## Haken-System
 - `[x]` erledigt
@@ -54,6 +55,16 @@ Aktueller Stand:
 - [x] K19.16a UI-Editor zeigt festen registrierten Scope aus BBM-Registry
 - [x] M21 BBM-Zielapp sauber vom generischen UI-Editor-kit trennen
 - [x] M32 Globalen UI-Editor im App-Kontext per Smoke-Test und Abnahmeprotokoll pruefen
+- [x] M33 Globalen UI-Editor fuer den Protokoll-/TOPS-Scope sichtbar anbinden
+
+## Statusupdate M33
+- Der globale UI-Editor nutzt fuer `protokoll.topsScreen` nun einen neutralen EditorRuntime-/Layout-Scope.
+- Registrierte TOPS-Quicklane-Elemente koennen sichtbar ausgewaehlt werden; Layout-Scope, Anwenden/Speichern, Laden und Reset sind verfuegbar.
+- Neue Doku: `docs/M33_UI_EDITOR_PROTOKOLL_SCOPE_ANBINDUNG.md`.
+- Der Restarbeiten-Pilot bleibt ueber `restarbeiten.screen` -> `restarbeiten.ui.main` unveraendert bedienbar.
+- Unbekannte Elemente und Fach-/DOM-/Datenbankpayloads werden blockiert.
+- Keine PDF-/Druck-/Mail-/Audio-, Protokoll- oder Restarbeiten-Fachlogik wurde geaendert.
+- Naechster Schritt: fachliche Klick-Abnahme durch den Nutzer, falls die sichtbare TOPS-Bedienfolge im echten App-Fenster zusaetzlich bestaetigt werden soll.
 
 ## Statusupdate M32
 - Der globale UI-Editor wurde nach M29/M30/M31 als reines Smoke-Test- und Abnahmepaket geprueft.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -30,6 +30,7 @@ const { runUiEditorContractTests } = require("./tests/uiEditorContract.test.cjs"
 const { runUiV2EditorV2RulesTests } = require("./tests/uiV2EditorV2Rules.test.cjs");
 const { runEditorLabV2Tests } = require("./tests/editorLabV2.test.cjs");
 const { runEditorRuntimeCatalogTests } = require("./tests/editorRuntime.catalog.test.cjs");
+const { runProtokollEditorHostAdapterTests } = require("./tests/protokollEditorHostAdapter.test.cjs");
 const { runRestarbeitenEditorHostAdapterTests } = require("./tests/restarbeitenEditorHostAdapter.test.cjs");
 const { runRestarbeitenEditorRegistryDomAnchorsTests } = require("./tests/restarbeitenEditorRegistry.domAnchors.test.cjs");
 const { runEditorScopeInspectorTests } = require("./tests/editorScopeInspector.test.cjs");
@@ -157,6 +158,7 @@ async function main() {
   await runUiV2EditorV2RulesTests(run);
   await runEditorLabV2Tests(run);
   await runEditorRuntimeCatalogTests(run);
+  await runProtokollEditorHostAdapterTests(run);
   await runRestarbeitenEditorHostAdapterTests(run);
   await runRestarbeitenEditorRegistryDomAnchorsTests(run);
   await runEditorScopeInspectorTests(run);

--- a/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+++ b/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
@@ -1137,6 +1137,94 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(getStatusText(activeStatus).includes("Name: Protokoll"), true);
   });
 
+  await run("BBM UI-Editor-Runtime: TOPS-Scope zeigt Layout-Scope und neutrale Controls", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const win = {
+      uiEditorLauncherButtonArtifact: require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js")),
+    };
+    const calls = [];
+    const layoutInspector = {
+      getLayoutControlPanel(scopeId, elementId) {
+        calls.push(["panel", scopeId, elementId]);
+        return {
+          ok: true,
+          elementId,
+          selectedElement: { id: elementId, name: "TOPS Quicklane" },
+          currentLayoutEntry: null,
+          controls: [
+            { id: "editor.layout.applySave", enabled: true, allowedOps: ["move", "hide", "show"] },
+            { id: "editor.layout.loadSaved", enabled: true, allowedOps: [] },
+            { id: "editor.layout.resetDefault", enabled: true, allowedOps: [] },
+          ],
+          status: { kind: "ready", message: "Standardzustand ist aktiv.", reason: null },
+        };
+      },
+      applyLayoutChange(scopeId, request) {
+        calls.push(["apply", scopeId, request]);
+        return {
+          ok: true,
+          status: { kind: "success", message: "Aenderung wurde angewendet und gespeichert.", reason: null },
+          layoutEntry: { elementId: request.elementId, operation: request.operation, layoutValue: request.payload },
+        };
+      },
+      loadLayoutState(scopeId, request) {
+        calls.push(["load", scopeId, request]);
+        return {
+          ok: true,
+          status: { kind: "success", message: "Gespeicherter Layoutzustand wurde geladen.", reason: null },
+          currentLayoutEntry: { elementId: request.elementId, operation: "move", layoutValue: { x: 0, y: 0 } },
+        };
+      },
+      resetLayoutState(scopeId, request) {
+        calls.push(["reset", scopeId, request]);
+        return {
+          ok: true,
+          status: { kind: "success", message: "Standardzustand wurde wiederhergestellt.", reason: null },
+          layoutState: [],
+        };
+      },
+    };
+    const registry = {
+      uiScope: "protokoll.topsScreen",
+      moduleId: "protokoll",
+      elements: [
+        { id: "protokoll.topsScreen.quicklane", name: "TOPS Quicklane", type: "toolbar", role: "layout", parentId: "protokoll.root", allowedOps: ["inspect", "move"], lockedOps: [] },
+      ],
+    };
+    const button = await mod.installBbmUiEditorRuntimeLauncher({
+      devEnabled: true,
+      doc,
+      win,
+      activeUiScope: "protokoll.topsScreen",
+      registryResolver: () => registry,
+      layoutInspector,
+      layoutScopeResolver: (uiScope) => uiScope === "protokoll.topsScreen" ? "protokoll.topsScreen" : null,
+    });
+    const target = doc.createElement("aside");
+    target.setAttribute("data-ui-editor-id", "protokoll.topsScreen.quicklane");
+    doc.body.appendChild(target);
+
+    button.click();
+    doc.dispatchEvent({ type: "click", target });
+
+    const activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
+    assert.equal(getStatusText(activeStatus).includes("Scope: protokoll.topsScreen"), true);
+    const layoutPanel = doc.querySelector('[data-ui-editor-layout-controls="true"]');
+    assert.equal(layoutPanel.children.some((child) => child.textContent === "Layout-Scope: protokoll.topsScreen"), true);
+    assert.equal(doc.querySelector('[data-ui-editor-layout-selected="true"]').textContent.includes("protokoll.topsScreen.quicklane"), true);
+    assert.ok(calls.some((call) => call[0] === "panel" && call[1] === "protokoll.topsScreen"));
+
+    doc.querySelector('[data-ui-editor-layout-action="applySave"]').click();
+    assert.ok(calls.some((call) => call[0] === "apply" && call[1] === "protokoll.topsScreen"));
+
+    doc.querySelector('[data-ui-editor-layout-action="loadSaved"]').click();
+    assert.ok(calls.some((call) => call[0] === "load" && call[1] === "protokoll.topsScreen"));
+
+    doc.querySelector('[data-ui-editor-layout-action="resetDefault"]').click();
+    assert.ok(calls.some((call) => call[0] === "reset" && call[1] === "protokoll.topsScreen"));
+  });
+
   await run("BBM UI-Editor-Runtime: bleibt ohne Scan, Speicherung und Ziel-App-Aktion", async () => {
     const source = fs.readFileSync(RUNTIME_PATH, "utf8");
     const coreShellSource = fs.readFileSync(CORE_SHELL_PATH, "utf8");
@@ -1175,6 +1263,7 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(source.includes("layoutInspector"), true);
     assert.equal(source.includes("layoutScopeResolver"), true);
     assert.equal(coreShellSource.includes("createEditorScopeInspector"), true);
+    assert.equal(coreShellSource.includes('"protokoll.topsScreen": "protokoll.topsScreen"'), true);
     assert.equal(coreShellSource.includes('"restarbeiten.screen": "restarbeiten.ui.main"'), true);
   });
 

--- a/scripts/tests/editorRuntime.catalog.test.cjs
+++ b/scripts/tests/editorRuntime.catalog.test.cjs
@@ -3,6 +3,10 @@ const path = require("node:path");
 const { importEsmFromFile } = require("./_esmLoader.cjs");
 
 const CATALOG_PATH = path.join(__dirname, "../../src/renderer/editorRuntime/catalog/bbmEditorCatalog.js");
+const PROTOKOLL_SCOPE_PATH = path.join(
+  __dirname,
+  "../../src/renderer/modules/protokoll/editor/protokollEditorScopes.js"
+);
 const RESTARBEITEN_SCOPE_PATH = path.join(
   __dirname,
   "../../src/renderer/modules/restarbeiten/editor/restarbeitenEditorScopes.js"
@@ -19,9 +23,18 @@ const HOST_CONTRACT_PATH = path.join(
 );
 
 async function runEditorRuntimeCatalogTests(run) {
-  const [{ BBM_EDITOR_CATALOG, listEditorModules, findEditorScope }, scopeModule, scopeTypes, registryModel, validator, hostContract] =
+  const [
+    { BBM_EDITOR_CATALOG, listEditorModules, findEditorScope },
+    protokollScopeModule,
+    restarbeitenScopeModule,
+    scopeTypes,
+    registryModel,
+    validator,
+    hostContract,
+  ] =
     await Promise.all([
       importEsmFromFile(CATALOG_PATH),
+      importEsmFromFile(PROTOKOLL_SCOPE_PATH),
       importEsmFromFile(RESTARBEITEN_SCOPE_PATH),
       importEsmFromFile(SCOPE_TYPES_PATH),
       importEsmFromFile(REGISTRY_MODEL_PATH),
@@ -41,6 +54,33 @@ async function runEditorRuntimeCatalogTests(run) {
     assert.equal(restarbeiten.moduleLabel, "Restarbeiten");
   });
 
+  await run("EditorRuntime: Modul protokoll existiert", () => {
+    const modules = listEditorModules();
+    const protokoll = modules.find((module) => module.moduleId === "protokoll");
+    assert.ok(protokoll);
+    assert.equal(protokoll.moduleLabel, "Protokoll");
+  });
+
+  await run("EditorRuntime: Scope protokoll.topsScreen existiert", () => {
+    const scope = findEditorScope("protokoll.topsScreen");
+    assert.ok(scope);
+    assert.equal(scope.scopeId, "protokoll.topsScreen");
+    assert.equal(scope.kind, "ui");
+    assert.equal(scope.status, "ready");
+    assert.equal(Array.isArray(scope.registry), true);
+    assert.ok(scope.registry.length > 0);
+  });
+
+  await run("EditorRuntime: Protokoll-Scope-Helfer liefert den Ready-Scope", () => {
+    const scopes = protokollScopeModule.getProtokollEditorScopes();
+    const scope = scopes.find((entry) => entry.scopeId === protokollScopeModule.PROTOKOLL_TOPS_UI_SCOPE_ID);
+    assert.ok(scope);
+    assert.equal(scope.status, "ready");
+    assert.equal(scope.moduleId, "protokoll");
+    assert.equal(Array.isArray(scope.registry), true);
+    assert.ok(scope.registry.some((entry) => entry.id === "protokoll.topsScreen.quicklane"));
+  });
+
   await run("EditorRuntime: Scope restarbeiten.ui.main existiert", () => {
     const scope = findEditorScope("restarbeiten.ui.main");
     assert.ok(scope);
@@ -52,8 +92,8 @@ async function runEditorRuntimeCatalogTests(run) {
   });
 
   await run("EditorRuntime: Restarbeiten-Scope-Helfer liefert den Ready-Scope", () => {
-    const scopes = scopeModule.getRestarbeitenEditorScopes();
-    const scope = scopes.find((entry) => entry.scopeId === scopeModule.RESTARBEITEN_MAIN_UI_SCOPE_ID);
+    const scopes = restarbeitenScopeModule.getRestarbeitenEditorScopes();
+    const scope = scopes.find((entry) => entry.scopeId === restarbeitenScopeModule.RESTARBEITEN_MAIN_UI_SCOPE_ID);
     assert.ok(scope);
     assert.equal(scope.status, "ready");
     assert.equal(scope.moduleId, "restarbeiten");

--- a/scripts/tests/editorScopeInspector.test.cjs
+++ b/scripts/tests/editorScopeInspector.test.cjs
@@ -34,12 +34,23 @@ async function runEditorScopeInspectorTests(run) {
     assert.ok(modules.some((module) => module.moduleId === "restarbeiten"));
   });
 
+  await run("EditorScopeInspector: listet Modul protokoll", () => {
+    const modules = inspector.getAvailableModules();
+    assert.ok(modules.some((module) => module.moduleId === "protokoll"));
+  });
+
   await run("EditorScopeInspector: listet Scope restarbeiten.ui.main", () => {
     const scopes = inspector.getAvailableScopes();
     assert.ok(scopes.some((scope) => scope.scopeId === "restarbeiten.ui.main"));
   });
 
+  await run("EditorScopeInspector: listet Scope protokoll.topsScreen", () => {
+    const scopes = inspector.getAvailableScopes();
+    assert.ok(scopes.some((scope) => scope.scopeId === "protokoll.topsScreen"));
+  });
+
   const result = inspector.inspectScope("restarbeiten.ui.main");
+  const protokollResult = inspector.inspectScope("protokoll.topsScreen");
 
   await run("EditorScopeInspector: inspectScope ist ok", () => {
     assert.equal(result.ok, true);
@@ -55,6 +66,15 @@ async function runEditorScopeInspectorTests(run) {
   await run("EditorScopeInspector: Registry-Validation ist ok", () => {
     assert.equal(result.registryValidation.ok, true);
     assert.deepEqual(result.registryValidation.errors, []);
+  });
+
+  await run("EditorScopeInspector: Protokoll/TOPS-Scope ist valide", () => {
+    assert.equal(protokollResult.ok, true);
+    assert.equal(protokollResult.scope.scopeId, "protokoll.topsScreen");
+    assert.equal(protokollResult.registryValidation.ok, true);
+    assert.deepEqual(protokollResult.registryValidation.errors, []);
+    assert.equal(protokollResult.treeResult.tree.id, "protokoll.root");
+    assert.ok(protokollResult.registry.some((entry) => entry.id === "protokoll.topsScreen.quicklane"));
   });
 
   await run("EditorScopeInspector: Baum hat root restarbeiten.root", () => {
@@ -88,6 +108,19 @@ async function runEditorScopeInspectorTests(run) {
     assert.equal(panel.ok, true);
     assert.equal(panel.status.kind, "ready");
     assert.equal(panel.selectedElement.id, "restarbeiten.editbox.text.short");
+    assert.ok(panel.controls.some((control) => control.id === "editor.layout.applySave" && control.enabled));
+    assert.ok(panel.controls.some((control) => control.id === "editor.layout.loadSaved" && control.enabled));
+    assert.ok(panel.controls.some((control) => control.id === "editor.layout.resetDefault" && control.enabled));
+    const saveControl = panel.controls.find((control) => control.id === "editor.layout.applySave");
+    assert.ok(saveControl.allowedOps.includes("move"));
+    assert.equal(saveControl.allowedOps.includes("label"), false);
+  });
+
+  await run("EditorScopeInspector: Protokoll/TOPS bietet Save/Load/Reset fuer registriertes Element", () => {
+    const panel = inspector.getLayoutControlPanel("protokoll.topsScreen", "protokoll.topsScreen.quicklane");
+    assert.equal(panel.ok, true);
+    assert.equal(panel.status.kind, "ready");
+    assert.equal(panel.selectedElement.id, "protokoll.topsScreen.quicklane");
     assert.ok(panel.controls.some((control) => control.id === "editor.layout.applySave" && control.enabled));
     assert.ok(panel.controls.some((control) => control.id === "editor.layout.loadSaved" && control.enabled));
     assert.ok(panel.controls.some((control) => control.id === "editor.layout.resetDefault" && control.enabled));
@@ -135,6 +168,31 @@ async function runEditorScopeInspectorTests(run) {
     assert.equal(loadResult.status.message.includes("Standardzustand"), true);
   });
 
+  await run("EditorScopeInspector: Protokoll/TOPS Layoutzustand wird angewendet, geladen und resetet", () => {
+    const applyResult = inspector.applyLayoutChange("protokoll.topsScreen", {
+      elementId: "protokoll.topsScreen.quicklane",
+      operation: "move",
+      payload: { x: 6, y: 12 },
+    });
+    assert.equal(applyResult.ok, true);
+    assert.equal(applyResult.blocked, false);
+    assert.equal(applyResult.status.kind, "success");
+    assert.deepEqual(applyResult.layoutEntry.layoutValue, { x: 6, y: 12 });
+
+    const loadResult = inspector.loadLayoutState("protokoll.topsScreen", {
+      elementId: "protokoll.topsScreen.quicklane",
+    });
+    assert.equal(loadResult.ok, true);
+    assert.equal(loadResult.currentLayoutEntry.elementId, "protokoll.topsScreen.quicklane");
+    assert.deepEqual(loadResult.currentLayoutEntry.layoutValue, { x: 6, y: 12 });
+
+    const resetResult = inspector.resetLayoutState("protokoll.topsScreen", {
+      elementId: "protokoll.topsScreen.quicklane",
+    });
+    assert.equal(resetResult.ok, true);
+    assert.deepEqual(resetResult.layoutState, []);
+  });
+
   await run("EditorScopeInspector: unbekanntes Element blockiert sichtbare Bedienaktionen", () => {
     const panel = inspector.getLayoutControlPanel("restarbeiten.ui.main", "restarbeiten.editbox.unknown");
     assert.equal(panel.ok, false);
@@ -177,6 +235,21 @@ async function runEditorScopeInspectorTests(run) {
       elementId: "restarbeiten.editbox.text.short",
     });
     assert.equal(loadResult.currentLayoutEntry, null);
+  });
+
+  await run("EditorScopeInspector: Protokoll/TOPS blockiert Restarbeiten-ID und Fachpayload sichtbar", () => {
+    const wrongElement = inspector.getLayoutControlPanel("protokoll.topsScreen", "restarbeiten.quicklane");
+    assert.equal(wrongElement.ok, false);
+    assert.equal(wrongElement.status.kind, "blocked");
+
+    const forbiddenPayload = inspector.applyLayoutChange("protokoll.topsScreen", {
+      elementId: "protokoll.topsScreen.quicklane",
+      operation: "move",
+      payload: { topId: "top-1" },
+    });
+    assert.equal(forbiddenPayload.ok, false);
+    assert.equal(forbiddenPayload.blocked, true);
+    assert.equal(forbiddenPayload.status.kind, "blocked");
   });
 
   await run("EditorScopeInspector: unbekannter Scope wird sauber behandelt", () => {

--- a/scripts/tests/protokollEditorHostAdapter.test.cjs
+++ b/scripts/tests/protokollEditorHostAdapter.test.cjs
@@ -1,0 +1,158 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const HOST_FACTORY_PATH = path.join(
+  __dirname,
+  "../../src/renderer/editorRuntime/host/bbmEditorHostAdapterFactory.js"
+);
+const HOST_CONTRACT_PATH = path.join(
+  __dirname,
+  "../../src/renderer/editorRuntime/host/bbmEditorHostAdapterContract.js"
+);
+const LAYOUT_PERSISTENCE_PATH = path.join(
+  __dirname,
+  "../../src/renderer/editorRuntime/layout/editorLayoutPersistence.js"
+);
+const REGISTRY_PATH = path.join(
+  __dirname,
+  "../../src/renderer/modules/protokoll/editor/registries/protokollTopsUiRegistry.js"
+);
+
+async function runProtokollEditorHostAdapterTests(run) {
+  const [{ createBbmEditorHostAdapter }, { validateHostAdapterShape }, layoutPersistence, registryModule] = await Promise.all([
+    importEsmFromFile(HOST_FACTORY_PATH),
+    importEsmFromFile(HOST_CONTRACT_PATH),
+    importEsmFromFile(LAYOUT_PERSISTENCE_PATH),
+    importEsmFromFile(REGISTRY_PATH),
+  ]);
+
+  const registry = registryModule.getProtokollTopsUiRegistry();
+  const validChangeRequest = {
+    changeId: "chg-protokoll-1",
+    targetAppId: "bbm",
+    moduleId: "protokoll",
+    scopeId: "protokoll.topsScreen",
+    elementId: "protokoll.topsScreen.quicklane",
+    operation: "move",
+    payload: {
+      x: 12,
+      y: 24,
+    },
+    createdAt: "2026-07-08T10:00:00.000Z",
+    source: "ui",
+  };
+
+  await run("Protokoll HostAdapter: Factory liefert Adapter fuer den TOPS-Scope", () => {
+    const adapter = createBbmEditorHostAdapter("protokoll.topsScreen");
+    assert.ok(adapter);
+    assert.equal(typeof adapter.getRegistry, "function");
+    assert.equal(typeof adapter.getCurrentLayoutState, "function");
+    assert.equal(typeof adapter.submitChangeRequest, "function");
+    assert.equal(typeof adapter.resetLayoutState, "function");
+  });
+
+  const layoutStorage = layoutPersistence.createEditorLayoutMemoryStorage();
+  const adapter = createBbmEditorHostAdapter("protokoll.topsScreen", { layoutStorage });
+
+  await run("Protokoll HostAdapter: Shape ist valide", () => {
+    const shape = validateHostAdapterShape(adapter);
+    assert.equal(shape.ok, true);
+    assert.deepEqual(shape.errors, []);
+  });
+
+  await run("Protokoll HostAdapter: Registry enthaelt registrierte TOPS-Quicklane-Elemente", () => {
+    const adapterRegistry = adapter.getRegistry();
+    const ids = new Set(adapterRegistry.map((entry) => entry.id));
+    assert.equal(Array.isArray(adapterRegistry), true);
+    assert.ok(adapterRegistry.length > 0);
+    assert.equal(adapterRegistry[0].id, registry[0].id);
+    assert.equal(ids.has("protokoll.topsScreen.quicklane"), true);
+    assert.equal(ids.has("protokoll.topsScreen.quicklane.group.output"), true);
+    assert.equal(ids.has("protokoll.topsScreen.quicklane.action.print"), true);
+  });
+
+  await run("Protokoll HostAdapter: gueltiger Change Request speichert neutralen Layoutwert", () => {
+    const result = adapter.submitChangeRequest(validChangeRequest);
+    assert.equal(result.ok, true);
+    assert.equal(result.blocked, false);
+    assert.equal(result.reason, null);
+    assert.equal(result.validation.ok, true);
+    assert.deepEqual(result.layoutEntry.layoutValue, { x: 12, y: 24 });
+    assert.equal(result.layoutEntry.moduleId, "protokoll");
+    assert.equal(result.layoutEntry.scopeId, "protokoll.topsScreen");
+  });
+
+  await run("Protokoll HostAdapter: gespeicherter Layoutwert wird geladen und resetbar", () => {
+    const state = adapter.getCurrentLayoutState();
+    assert.equal(state.length, 1);
+    assert.equal(state[0].elementId, "protokoll.topsScreen.quicklane");
+    assert.deepEqual(state[0].layoutValue, { x: 12, y: 24 });
+
+    const resetResult = adapter.resetLayoutState({ elementId: "protokoll.topsScreen.quicklane" });
+    assert.equal(resetResult.ok, true);
+    assert.deepEqual(resetResult.layoutState, []);
+    assert.deepEqual(adapter.getCurrentLayoutState(), []);
+  });
+
+  await run("Protokoll HostAdapter: Restarbeiten-ID wird im Protokoll-Scope blockiert", () => {
+    const result = adapter.submitChangeRequest({
+      ...validChangeRequest,
+      elementId: "restarbeiten.quicklane",
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.blocked, true);
+    assert.equal(result.reason, "INVALID_CHANGE_REQUEST");
+    assert.ok(result.validation.errors.some((error) => error.code === "ELEMENT_ID_UNKNOWN"));
+  });
+
+  await run("Protokoll HostAdapter: Fach-, DOM- und Datenbankwerte werden nicht gespeichert", () => {
+    const forbiddenPayloads = [
+      { topId: "top-1" },
+      { projectId: "p-1" },
+      { domNode: { id: "x" } },
+      { database: "app.db" },
+      { text: "Fachdaten" },
+    ];
+
+    for (const payload of forbiddenPayloads) {
+      const result = adapter.submitChangeRequest({
+        ...validChangeRequest,
+        payload,
+      });
+      assert.equal(result.ok, false);
+      assert.equal(result.blocked, true);
+      assert.equal(result.reason, "INVALID_CHANGE_REQUEST");
+    }
+
+    assert.deepEqual(adapter.getCurrentLayoutState(), []);
+  });
+
+  await run("Protokoll HostAdapter: nicht erlaubte und verbotene Aktionen werden blockiert", () => {
+    const labelResult = adapter.submitChangeRequest({
+      ...validChangeRequest,
+      operation: "label",
+      payload: { label: "TOPS" },
+    });
+    assert.equal(labelResult.reason, "INVALID_CHANGE_REQUEST");
+    assert.ok(labelResult.validation.errors.some((error) => error.code === "OPERATION_NOT_ALLOWED"));
+
+    const deleteResult = adapter.submitChangeRequest({
+      ...validChangeRequest,
+      operation: "delete",
+    });
+    assert.equal(deleteResult.reason, "INVALID_CHANGE_REQUEST");
+    assert.ok(deleteResult.validation.errors.some((error) => error.code === "FORBIDDEN_OPERATION"));
+  });
+
+  await run("Protokoll HostAdapter: Reset unbekannter elementId wird blockiert", () => {
+    const result = adapter.resetLayoutState({ elementId: "protokoll.topsScreen.unknown" });
+    assert.equal(result.ok, false);
+    assert.equal(result.blocked, true);
+    assert.equal(result.reason, "ELEMENT_ID_UNKNOWN");
+  });
+
+  if (!process.exitCode) console.log("protokollEditorHostAdapter.test.cjs passed");
+}
+
+module.exports = { runProtokollEditorHostAdapterTests };

--- a/scripts/tests/restarbeitenEditorRegistry.domAnchors.test.cjs
+++ b/scripts/tests/restarbeitenEditorRegistry.domAnchors.test.cjs
@@ -88,7 +88,9 @@ async function runRestarbeitenEditorRegistryDomAnchorsTests(run) {
   });
 
   await run("Restarbeiten EditorRegistry: Catalog verwendet den Ready-Scope", () => {
-    const scope = BBM_EDITOR_CATALOG.modules[0].scopes[0];
+    const restarbeitenModule = BBM_EDITOR_CATALOG.modules.find((entry) => entry.moduleId === "restarbeiten");
+    const scope = restarbeitenModule?.scopes?.find((entry) => entry.scopeId === scopeModule.RESTARBEITEN_MAIN_UI_SCOPE_ID);
+    assert.ok(scope);
     assert.equal(scope.scopeId, scopeModule.RESTARBEITEN_MAIN_UI_SCOPE_ID);
     assert.equal(scope.status, "ready");
     assert.equal(scope.registry.length > 0, true);

--- a/src/renderer/app/CoreShell.js
+++ b/src/renderer/app/CoreShell.js
@@ -29,6 +29,7 @@ const HOST_UI_SCOPE_BY_SECTION = Object.freeze({
 });
 
 const LAYOUT_SCOPE_BY_UI_SCOPE = Object.freeze({
+  "protokoll.topsScreen": "protokoll.topsScreen",
   "restarbeiten.screen": "restarbeiten.ui.main",
 });
 

--- a/src/renderer/editorRuntime/catalog/bbmEditorCatalog.js
+++ b/src/renderer/editorRuntime/catalog/bbmEditorCatalog.js
@@ -1,9 +1,23 @@
 import { EDITOR_SCOPE_KINDS, isEditorScopeKind } from "../scopes/editorScopeTypes.js";
+import { getProtokollTopsUiRegistry, PROTOKOLL_TOPS_UI_SCOPE_ID } from "../../modules/protokoll/editor/protokollEditorScopes.js";
 import { getRestarbeitenMainUiRegistry, RESTARBEITEN_MAIN_UI_SCOPE_ID } from "../../modules/restarbeiten/editor/restarbeitenEditorScopes.js";
 
 export const BBM_EDITOR_CATALOG = Object.freeze({
   targetAppId: "bbm",
   modules: Object.freeze([
+    Object.freeze({
+      moduleId: "protokoll",
+      moduleLabel: "Protokoll",
+      scopes: Object.freeze([
+        Object.freeze({
+          scopeId: PROTOKOLL_TOPS_UI_SCOPE_ID,
+          scopeLabel: "Protokoll TOPS",
+          kind: "ui",
+          registry: getProtokollTopsUiRegistry(),
+          status: "ready",
+        }),
+      ]),
+    }),
     Object.freeze({
       moduleId: "restarbeiten",
       moduleLabel: "Restarbeiten",

--- a/src/renderer/editorRuntime/host/bbmEditorHostAdapterFactory.js
+++ b/src/renderer/editorRuntime/host/bbmEditorHostAdapterFactory.js
@@ -1,7 +1,12 @@
+import { createProtokollTopsUiHostAdapter } from "../../modules/protokoll/editor/protokollTopsUiHostAdapter.js";
 import { createRestarbeitenMainUiHostAdapter } from "../../modules/restarbeiten/editor/restarbeitenMainUiHostAdapter.js";
 
 export function createBbmEditorHostAdapter(scopeId, options = {}) {
   const normalizedScopeId = String(scopeId || "").trim();
+  if (normalizedScopeId === "protokoll.topsScreen") {
+    return createProtokollTopsUiHostAdapter(options);
+  }
+
   if (normalizedScopeId === "restarbeiten.ui.main") {
     return createRestarbeitenMainUiHostAdapter(options);
   }

--- a/src/renderer/modules/protokoll/editor/protokollEditorScopes.js
+++ b/src/renderer/modules/protokoll/editor/protokollEditorScopes.js
@@ -1,0 +1,18 @@
+import { getProtokollTopsUiRegistry } from "./registries/protokollTopsUiRegistry.js";
+
+export const PROTOKOLL_TOPS_UI_SCOPE_ID = "protokoll.topsScreen";
+
+export function getProtokollEditorScopes() {
+  return [
+    {
+      moduleId: "protokoll",
+      scopeId: PROTOKOLL_TOPS_UI_SCOPE_ID,
+      scopeLabel: "Protokoll TOPS",
+      kind: "ui",
+      status: "ready",
+      registry: getProtokollTopsUiRegistry(),
+    },
+  ];
+}
+
+export { getProtokollTopsUiRegistry };

--- a/src/renderer/modules/protokoll/editor/protokollTopsUiHostAdapter.js
+++ b/src/renderer/modules/protokoll/editor/protokollTopsUiHostAdapter.js
@@ -1,0 +1,103 @@
+import { getProtokollTopsUiRegistry, PROTOKOLL_TOPS_UI_SCOPE_ID } from "./protokollEditorScopes.js";
+import { validateEditorChangeRequest } from "../../../editorRuntime/changeRequests/editorChangeRequestValidator.js";
+import { validateHostAdapterShape } from "../../../editorRuntime/host/bbmEditorHostAdapterContract.js";
+import {
+  createEditorLayoutMemoryStorage,
+  createEditorLayoutStore,
+  normalizeEditorLayoutValue,
+} from "../../../editorRuntime/layout/editorLayoutPersistence.js";
+
+const SCOPE = Object.freeze({
+  targetAppId: "bbm",
+  moduleId: "protokoll",
+  scopeId: PROTOKOLL_TOPS_UI_SCOPE_ID,
+});
+
+function cloneRegistry(registry) {
+  return registry.map((entry) => ({
+    ...entry,
+    allowedOps: [...entry.allowedOps],
+    lockedOps: [...entry.lockedOps],
+  }));
+}
+
+export function createProtokollTopsUiHostAdapter({ layoutStorage = createEditorLayoutMemoryStorage() } = {}) {
+  const registry = getProtokollTopsUiRegistry();
+  const layoutStore = createEditorLayoutStore({
+    scope: SCOPE,
+    storage: layoutStorage,
+  });
+
+  const adapter = {
+    getRegistry() {
+      return cloneRegistry(registry);
+    },
+
+    getCurrentLayoutState() {
+      return layoutStore.list();
+    },
+
+    submitChangeRequest(changeRequest) {
+      const validation = validateEditorChangeRequest(changeRequest, {
+        scope: SCOPE,
+        registry,
+      });
+
+      if (!validation.ok) {
+        return {
+          ok: false,
+          blocked: true,
+          reason: "INVALID_CHANGE_REQUEST",
+          validation,
+        };
+      }
+
+      const layoutValueResult = normalizeEditorLayoutValue(changeRequest.operation, changeRequest.payload);
+      if (!layoutValueResult.ok) {
+        return {
+          ok: false,
+          blocked: true,
+          reason: layoutValueResult.reason,
+          validation,
+        };
+      }
+
+      const layoutEntry = layoutStore.save(changeRequest, layoutValueResult.layoutValue);
+      return {
+        ok: true,
+        blocked: false,
+        reason: null,
+        validation,
+        layoutEntry,
+      };
+    },
+
+    resetLayoutState({ elementId = null } = {}) {
+      const normalizedElementId = String(elementId || "").trim();
+      if (normalizedElementId && !registry.some((entry) => entry.id === normalizedElementId)) {
+        return {
+          ok: false,
+          blocked: true,
+          reason: "ELEMENT_ID_UNKNOWN",
+          layoutState: layoutStore.list(),
+        };
+      }
+
+      return {
+        ok: true,
+        blocked: false,
+        reason: null,
+        layoutState: layoutStore.reset(normalizedElementId || null),
+      };
+    },
+  };
+
+  const shape = validateHostAdapterShape(adapter);
+  if (!shape.ok) {
+    const error = new Error("Protokoll TOPS HostAdapter contract validation failed");
+    error.details = shape.errors;
+    throw error;
+  }
+
+  return adapter;
+}

--- a/src/renderer/modules/protokoll/editor/registries/protokollTopsUiRegistry.js
+++ b/src/renderer/modules/protokoll/editor/registries/protokollTopsUiRegistry.js
@@ -1,0 +1,176 @@
+const ROOT_OPS = Object.freeze(["move", "resize", "hide", "show", "spacing", "width", "height"]);
+const TOOLBAR_OPS = Object.freeze(["move", "resize", "hide", "show", "spacing", "width", "height"]);
+const GROUP_OPS = Object.freeze(["move", "resize", "hide", "show", "spacing"]);
+const BUTTON_OPS = Object.freeze(["hide", "show"]);
+
+function createRegistryEntry({ id, name, type, role, parentId, order, allowedOps, lockedOps = [] }) {
+  const safeAllowedOps = [...allowedOps];
+  const safeLockedOps = [...lockedOps];
+  return Object.freeze({
+    id,
+    name,
+    type,
+    role,
+    parentId,
+    order,
+    visible: true,
+    editable: safeAllowedOps.length > 0,
+    allowedOps: safeAllowedOps,
+    lockedOps: safeLockedOps,
+  });
+}
+
+const PROTOKOLL_TOPS_UI_REGISTRY = Object.freeze([
+  createRegistryEntry({
+    id: "protokoll.root",
+    name: "Protokoll",
+    type: "root",
+    role: "system",
+    parentId: null,
+    order: 1,
+    allowedOps: ROOT_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane",
+    name: "TOPS Quicklane",
+    type: "toolbar",
+    role: "layout",
+    parentId: "protokoll.root",
+    order: 10,
+    allowedOps: TOOLBAR_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.group.navigation",
+    name: "Quicklane Navigation",
+    type: "group",
+    role: "navigation",
+    parentId: "protokoll.topsScreen.quicklane",
+    order: 10,
+    allowedOps: GROUP_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.pin",
+    name: "Fixieren",
+    type: "button",
+    role: "navigation",
+    parentId: "protokoll.topsScreen.quicklane.group.navigation",
+    order: 10,
+    allowedOps: BUTTON_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.action.project",
+    name: "Projekt",
+    type: "button",
+    role: "navigation",
+    parentId: "protokoll.topsScreen.quicklane.group.navigation",
+    order: 20,
+    allowedOps: BUTTON_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.action.firms",
+    name: "Firmen",
+    type: "button",
+    role: "navigation",
+    parentId: "protokoll.topsScreen.quicklane.group.navigation",
+    order: 30,
+    allowedOps: BUTTON_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.action.participants",
+    name: "Anwesende",
+    type: "button",
+    role: "navigation",
+    parentId: "protokoll.topsScreen.quicklane.group.navigation",
+    order: 40,
+    allowedOps: BUTTON_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.group.visibility",
+    name: "Quicklane Anzeige",
+    type: "group",
+    role: "visibility",
+    parentId: "protokoll.topsScreen.quicklane",
+    order: 20,
+    allowedOps: GROUP_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.action.ampel",
+    name: "Ampel",
+    type: "button",
+    role: "visibility",
+    parentId: "protokoll.topsScreen.quicklane.group.visibility",
+    order: 10,
+    allowedOps: BUTTON_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.action.longtext",
+    name: "Langtext",
+    type: "button",
+    role: "visibility",
+    parentId: "protokoll.topsScreen.quicklane.group.visibility",
+    order: 20,
+    allowedOps: BUTTON_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.group.filter",
+    name: "Quicklane Filter",
+    type: "group",
+    role: "visibility",
+    parentId: "protokoll.topsScreen.quicklane",
+    order: 30,
+    allowedOps: GROUP_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.action.topFilter",
+    name: "TOP-Filter",
+    type: "button",
+    role: "visibility",
+    parentId: "protokoll.topsScreen.quicklane.group.filter",
+    order: 10,
+    allowedOps: BUTTON_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.group.output",
+    name: "Quicklane Ausgabe",
+    type: "group",
+    role: "action",
+    parentId: "protokoll.topsScreen.quicklane",
+    order: 40,
+    allowedOps: GROUP_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.action.preview",
+    name: "PDF Voransicht",
+    type: "button",
+    role: "action",
+    parentId: "protokoll.topsScreen.quicklane.group.output",
+    order: 10,
+    allowedOps: BUTTON_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.action.print",
+    name: "Drucken",
+    type: "button",
+    role: "action",
+    parentId: "protokoll.topsScreen.quicklane.group.output",
+    order: 20,
+    allowedOps: BUTTON_OPS,
+  }),
+  createRegistryEntry({
+    id: "protokoll.topsScreen.quicklane.action.mail",
+    name: "E-Mail",
+    type: "button",
+    role: "action",
+    parentId: "protokoll.topsScreen.quicklane.group.output",
+    order: 30,
+    allowedOps: BUTTON_OPS,
+  }),
+]);
+
+export function getProtokollTopsUiRegistry() {
+  return PROTOKOLL_TOPS_UI_REGISTRY.map((entry) => ({
+    ...entry,
+    allowedOps: [...entry.allowedOps],
+    lockedOps: [...entry.lockedOps],
+  }));
+}


### PR DESCRIPTION
M33 bindet den Protokoll-/TOPS-Scope zusätzlich als neutralen EditorRuntime-/Layout-Scope im globalen UI-Editor an.

Umfang:
- protokoll.topsScreen als EditorRuntime-/Layout-Scope angebunden
- registrierte TOPS-Quicklane-Elemente auswählbar
- Layout-Scope, Anwenden/Speichern, Laden und Reset bedienbar
- Restarbeiten-Pilot bleibt über restarbeiten.screen -> restarbeiten.ui.main bedienbar
- Tests und Doku aktualisiert

Prüfung:
- git diff --check bestanden
- node scripts/ui-editor-contract-check.cjs --self-test bestanden
- npm test bestanden, endet mit Alle Tests bestanden
- npm start: App startete, Fenster BBM sichtbar und responding

Keine PDF-/Druck-/Mail-/Audio-, Protokoll- oder Restarbeiten-Fachlogik geändert.