### PR TITLE
M34: UI Editor Scope-Wechsel absichern

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,16 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M34 UI-Editor Scope-Wechsel und Bedienfuehrung abgesichert:
+  - Neue Doku: `docs/M34_UI_EDITOR_SCOPE_WECHSEL_BEDIENFUEHRUNG.md`.
+  - Die Statusanzeige nennt den aktiven UI-Scope jetzt eindeutig als `Aktiver UI-Scope`.
+  - Beim Wechsel zwischen `protokoll.topsScreen` und `restarbeiten.screen` wird eine alte Auswahl sauber geloescht; falsche Scope-/Element-Kombinationen wirken nicht weiter.
+  - Speichern/Laden/Reset bleiben an den aktuell aufgeloesten Layout-Scope gebunden, also `protokoll.topsScreen` bzw. `restarbeiten.ui.main`.
+  - Unbekannte Scopes zeigen eine sichtbare blockierte Layoutmeldung mit Grund.
+  - Es wurde keine automatische DOM-Erkennung, keine neue Registry-Befuellung und keine Fachwertbearbeitung eingefuehrt.
+  - Keine PDF-, Druck-, Mail-, Diktat-/Audio-, Protokoll- oder Restarbeiten-Fachlogik wurde geaendert.
+  - `git diff --check`, `node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`, `node scripts/ui-editor-contract-check.cjs --self-test`, `npm test` und `npm start` liefen gruen.
+
 - M33 Globalen UI-Editor fuer den Protokoll-/TOPS-Scope sichtbar angebunden:
   - Neue Doku: `docs/M33_UI_EDITOR_PROTOKOLL_SCOPE_ANBINDUNG.md`.
   - Der sichtbare App-Scope `protokoll.topsScreen` ist nun auch als neutraler EditorRuntime-/Layout-Scope angebunden.

--- a/docs/M34_UI_EDITOR_SCOPE_WECHSEL_BEDIENFUEHRUNG.md
+++ b/docs/M34_UI_EDITOR_SCOPE_WECHSEL_BEDIENFUEHRUNG.md
@@ -1,0 +1,90 @@
+# M34 UI-Editor Scope-Wechsel und Bedienfuehrung
+
+## Zweck
+
+M34 stabilisiert die Bedienfuehrung des globalen UI-Editors, sobald mehr als ein echter Scope sichtbar bedienbar ist.
+
+Es wurde keine neue Editor-Grundsatzentscheidung getroffen. Der Editor bleibt global, fachneutral und arbeitet nur mit registrierten UI-Editor-Elementen.
+
+## Grundlage
+
+- M29: neutrale Layoutaenderungen koennen gespeichert, geladen und zurueckgesetzt werden.
+- M30: neutrale Controls fuer Anwenden/Speichern, Laden und Reset sind abgesichert.
+- M31: sichtbare Bedienung ist in der App angebunden.
+- M32: App-Smoke-Test ist dokumentiert.
+- M33: Restarbeiten- und Protokoll-/TOPS-Scope sind angebunden.
+
+## Umsetzung
+
+- Die Statusanzeige nennt den aktiven UI-Scope explizit als `Aktiver UI-Scope`.
+- Beim Scope-Wechsel wird die bisherige Zielauswahl samt Markierung geloescht.
+- Das Launcher-Attribut `data-ui-editor-active-ui-scope` wird beim Scope-Wechsel aktualisiert.
+- Die Layoutbedienung prueft vor neutralen Layoutaktionen, ob die Auswahl zur aktuell aktiven Registry gehoert.
+- Unbekannte oder nicht verfuegbare Scopes zeigen eine sichtbare blockierte Layoutmeldung mit Grund.
+- Speichern/Laden/Reset bleiben an den aktuell aufgeloesten Layout-Scope gebunden.
+
+## Scope-Verhalten
+
+| UI-Scope | Layout-Scope | Ergebnis |
+| --- | --- | --- |
+| `restarbeiten.screen` | `restarbeiten.ui.main` | bleibt bedienbar |
+| `protokoll.topsScreen` | `protokoll.topsScreen` | bleibt bedienbar |
+| unbekannter Scope | nicht verfuegbar | Layoutbedienung wird sichtbar blockiert |
+
+## Abnahmeumfang
+
+| Punkt | Ergebnis | Nachweis |
+| --- | --- | --- |
+| Aktiven Scope sichtbar anzeigen | bestanden | Runtime-Status zeigt `Aktiver UI-Scope: ...` |
+| Alte Auswahl beim Scope-Wechsel verhindern | bestanden | Runtime-Test wechselt von TOPS nach Restarbeiten und erwartet `Auswahl: keine` |
+| Auswahlzustand passt zum aktuellen Scope | bestanden | Klick auf altes TOPS-Ziel bleibt im Restarbeiten-Scope wirkungslos |
+| Speichern/Laden/Reset wirken auf aktuellen Layout-Scope | bestanden | Runtime-Test prueft Apply/Load/Reset fuer `restarbeiten.ui.main` nach Scope-Wechsel |
+| Blockierte Aktionen sind verstaendlich | bestanden | unbekannter Scope zeigt `Layoutbedienung blockiert: ...` |
+| Unbekannte Scopes sauber behandeln | bestanden | Runtime-Test blockiert `unknown.scope` ohne LayoutInspector-Aufruf |
+| Restarbeiten bleibt bedienbar | bestanden | bestehende Restarbeiten-Tests und M34-Wechseltest laufen gruen |
+| Protokoll/TOPS bleibt bedienbar | bestanden | bestehende TOPS-Scope-Tests laufen gruen |
+| Keine automatische DOM-Erkennung | bestanden | bestehende Runtime-Guardrails bleiben gruen |
+| Keine Fachwerte veraendern | bestanden | keine Fach-, DB-, IPC- oder Datensatzpfade geaendert |
+
+## Nicht geaendert
+
+- Keine PDF-Bearbeitung
+- Keine PDF-Ausgabe
+- Kein Druck
+- Keine Mail
+- Keine Diktat-/Audioaenderung
+- Keine Protokoll-Fachlogik
+- Keine Restarbeiten-Fachlogik
+- Keine Datenbankmigration
+- Keine automatische DOM-Erkennung
+- Keine neue Editor-Architekturentscheidung
+- Keine grosse UI-Umbauaktion
+
+## Pruefungen
+
+```powershell
+node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+git diff --check
+node scripts/ui-editor-contract-check.cjs --self-test
+npm test
+npm start
+```
+
+Ergebnis:
+- `node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`: bestanden
+- `node scripts/ui-editor-contract-check.cjs --self-test`: bestanden
+- `npm test`: bestanden, Ausgabe endete mit `Alle Tests bestanden.`
+- `npm start`: App startete sichtbar; ein Fenster `BBM` war vorhanden und antwortend.
+- `git diff --check`: bestanden
+
+## Grenze der Sichtung
+
+Die technische Scope-Wechsel-Bedienung ist durch Tests abgesichert. Eine zusaetzliche fachliche Klick-Abnahme im echten App-Fenster kann durch den Nutzer erfolgen, wenn die sichtbare Bedienfolge final bestaetigt werden soll.
+
+## Ergebnis
+
+M34 ist abgeschlossen:
+- Scope-Wechsel zwischen Restarbeiten und Protokoll/TOPS ist robust.
+- Der aktive Scope ist sichtbar und eindeutig.
+- Falsche Scope-/Element-Kombinationen werden blockiert oder gar nicht erst ausgewaehlt.
+- Restarbeiten und Protokoll/TOPS bleiben bedienbar.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -402,3 +402,12 @@ Dabei gilt:
 - Der Restarbeiten-Pilot bleibt ueber `restarbeiten.screen` -> `restarbeiten.ui.main` unveraendert bedienbar.
 - PDF, Druck, Mail, Diktat/Audio, Protokoll-Fachlogik, Restarbeiten-Fachlogik, Datenbankmigration und neue Editor-Grundsatzentscheidungen blieben ausserhalb dieses Pakets.
 - Neue Doku: `docs/M33_UI_EDITOR_PROTOKOLL_SCOPE_ANBINDUNG.md`.
+
+### M34 UI-Editor Scope-Wechsel und Bedienfuehrung abgesichert (neu)
+- Die sichtbare Bedienung nennt den aktiven UI-Scope eindeutig als `Aktiver UI-Scope`.
+- Beim Wechsel zwischen `protokoll.topsScreen` und `restarbeiten.screen` wird die bisherige Auswahl geloescht und kann nicht im falschen Scope weiterwirken.
+- Speichern/Laden/Reset nutzen weiterhin den aktuell sichtbaren/aktiven Layout-Scope: `protokoll.topsScreen` bzw. `restarbeiten.ui.main`.
+- Unbekannte oder nicht verfuegbare Scopes werden sichtbar blockiert und erhalten keine Layoutaktion.
+- Bestehende Restarbeiten- und Protokoll/TOPS-Scope-Tests bleiben gruen; neue Runtime-Tests sichern den Scope-Wechsel ab.
+- PDF, Druck, Mail, Diktat/Audio, Protokoll-Fachlogik, Restarbeiten-Fachlogik, Datenbankmigration, automatische DOM-Erkennung und neue Editor-Grundsatzentscheidungen blieben ausserhalb dieses Pakets.
+- Neue Doku: `docs/M34_UI_EDITOR_SCOPE_WECHSEL_BEDIENFUEHRUNG.md`.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -3,7 +3,7 @@
 ## Projektstatus
 Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.16a abgeschlossen (neutraler BBM-UI-Editor-Aktivmodus zeigt festen Registry-Scope).
 
-Statusupdate: M33 abgeschlossen (globaler UI-Editor fuer den Protokoll-/TOPS-Scope sichtbar angebunden).
+Statusupdate: M34 abgeschlossen (UI-Editor Scope-Wechsel und Bedienfuehrung abgesichert).
 
 Aktueller Stand:
 - M1 bis M13.6a abgeschlossen.
@@ -15,6 +15,7 @@ Aktueller Stand:
 - M21 abgeschlossen: BBM-Produktiv ist als Beispiel-/Pilot-Zielapp vom generischen UI-Editor-kit getrennt dokumentiert; `Restarbeiten` ist erreichbarer unfertiger Pilot-Scope, `Protokoll` defensiv/read-only.
 - M32 abgeschlossen: App-Start und sichtbarer Launcher wurden lokal geprueft; die Save/Load/Reset-Bedienfolge und Blockaden sind durch `npm test` abgedeckt.
 - M33 abgeschlossen: Der globale UI-Editor ist zusaetzlich fuer registrierte TOPS-Quicklane-Elemente im Scope `protokoll.topsScreen` bedienbar; Restarbeiten bleibt bedienbar.
+- M34 abgeschlossen: Aktiver UI-Scope, Auswahl und Layout-Scope sind beim Wechsel zwischen Restarbeiten und Protokoll/TOPS eindeutig; alte Auswahlen werden geloescht und unbekannte Scopes sichtbar blockiert.
 
 ## Haken-System
 - `[x]` erledigt
@@ -56,6 +57,16 @@ Aktueller Stand:
 - [x] M21 BBM-Zielapp sauber vom generischen UI-Editor-kit trennen
 - [x] M32 Globalen UI-Editor im App-Kontext per Smoke-Test und Abnahmeprotokoll pruefen
 - [x] M33 Globalen UI-Editor fuer den Protokoll-/TOPS-Scope sichtbar anbinden
+- [x] M34 UI-Editor Scope-Wechsel und Bedienfuehrung absichern
+
+## Statusupdate M34
+- Der globale UI-Editor zeigt den aktiven UI-Scope eindeutig als `Aktiver UI-Scope`.
+- Ein Wechsel zwischen `protokoll.topsScreen` und `restarbeiten.screen` loescht die bisherige Auswahl und verhindert, dass alte Ziele im falschen Scope weiterwirken.
+- Layoutaktionen bleiben an den aktuell aufgeloesten Layout-Scope gebunden: `protokoll.topsScreen` oder `restarbeiten.ui.main`.
+- Unbekannte Scopes zeigen eine sichtbare blockierte Layoutmeldung.
+- Neue Doku: `docs/M34_UI_EDITOR_SCOPE_WECHSEL_BEDIENFUEHRUNG.md`.
+- Keine PDF-/Druck-/Mail-/Audio-, Protokoll- oder Restarbeiten-Fachlogik wurde geaendert.
+- Naechster Schritt: fachliche Klick-Abnahme durch den Nutzer, falls die sichtbare Scope-Wechsel-Bedienfolge im echten App-Fenster zusaetzlich bestaetigt werden soll.
 
 ## Statusupdate M33
 - Der globale UI-Editor nutzt fuer `protokoll.topsScreen` nun einen neutralen EditorRuntime-/Layout-Scope.

--- a/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+++ b/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
@@ -694,6 +694,167 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(Boolean(doc.querySelector('[data-ui-editor-hover-frame="true"]')), false);
   });
 
+  await run("BBM UI-Editor-Runtime: Scope-Wechsel setzt Auswahl zurueck und Layoutaktionen nutzen aktuellen Scope", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const win = {
+      uiEditorLauncherButtonArtifact: require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js")),
+    };
+    const calls = [];
+    const layoutInspector = {
+      getLayoutControlPanel(scopeId, elementId) {
+        calls.push(["panel", scopeId, elementId]);
+        return {
+          ok: true,
+          elementId,
+          selectedElement: { id: elementId, name: elementId },
+          currentLayoutEntry: null,
+          controls: [
+            { id: "editor.layout.applySave", enabled: true, allowedOps: ["move"] },
+            { id: "editor.layout.loadSaved", enabled: true, allowedOps: [] },
+            { id: "editor.layout.resetDefault", enabled: true, allowedOps: [] },
+          ],
+          status: { kind: "ready", message: "Standardzustand ist aktiv.", reason: null },
+        };
+      },
+      applyLayoutChange(scopeId, request) {
+        calls.push(["apply", scopeId, request]);
+        return {
+          ok: true,
+          status: { kind: "success", message: "Aenderung wurde angewendet und gespeichert.", reason: null },
+          layoutEntry: { elementId: request.elementId, operation: request.operation, layoutValue: request.payload },
+        };
+      },
+      loadLayoutState(scopeId, request) {
+        calls.push(["load", scopeId, request]);
+        return {
+          ok: true,
+          status: { kind: "success", message: "Gespeicherter Layoutzustand wurde geladen.", reason: null },
+          currentLayoutEntry: { elementId: request.elementId, operation: "move", layoutValue: { x: 0, y: 0 } },
+        };
+      },
+      resetLayoutState(scopeId, request) {
+        calls.push(["reset", scopeId, request]);
+        return {
+          ok: true,
+          status: { kind: "success", message: "Standardzustand wurde wiederhergestellt.", reason: null },
+          layoutState: [],
+        };
+      },
+    };
+    const registries = {
+      "protokoll.topsScreen": {
+        uiScope: "protokoll.topsScreen",
+        moduleId: "protokoll",
+        elements: [
+          { id: "protokoll.topsScreen.quicklane", name: "TOPS Quicklane", type: "toolbar", role: "layout", parentId: "protokoll.root", allowedOps: ["inspect", "move"], lockedOps: [] },
+        ],
+      },
+      "restarbeiten.screen": {
+        uiScope: "restarbeiten.screen",
+        moduleId: "restarbeiten",
+        elements: [
+          { id: "restarbeiten.editbox.text.short", name: "Kurztext", type: "field", role: "content", parentId: "restarbeiten.editbox", allowedOps: ["inspect", "move"], lockedOps: [] },
+        ],
+      },
+    };
+    const button = await mod.installBbmUiEditorRuntimeLauncher({
+      devEnabled: true,
+      doc,
+      win,
+      activeUiScope: "protokoll.topsScreen",
+      availableUiScopes: [
+        { uiScope: "protokoll.topsScreen", moduleId: "protokoll", status: "available" },
+        { uiScope: "restarbeiten.screen", moduleId: "restarbeiten", status: "available" },
+      ],
+      registryResolver: (scopeId) => registries[scopeId] || { ok: false, uiScope: scopeId, elements: [], reason: "unknown" },
+      layoutInspector,
+      layoutScopeResolver: (uiScope) => uiScope === "restarbeiten.screen" ? "restarbeiten.ui.main" : uiScope,
+    });
+    const protokollTarget = doc.createElement("aside");
+    protokollTarget.setAttribute("data-ui-editor-id", "protokoll.topsScreen.quicklane");
+    const restarbeitenTarget = doc.createElement("input");
+    restarbeitenTarget.setAttribute("data-ui-editor-id", "restarbeiten.editbox.text.short");
+    doc.body.append(protokollTarget, restarbeitenTarget);
+
+    button.click();
+    doc.dispatchEvent({ type: "click", target: protokollTarget });
+    let activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
+    assert.equal(getStatusText(activeStatus).includes("Aktiver UI-Scope: protokoll.topsScreen"), true);
+    assert.equal(getStatusText(activeStatus).includes("Auswahl: protokoll.topsScreen.quicklane"), true);
+    assert.equal(protokollTarget.getAttribute("data-ui-editor-selected"), "true");
+
+    doc.querySelector('[data-ui-editor-scope-option="restarbeiten.screen"]').click();
+    activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
+    assert.equal(button.getAttribute("data-ui-editor-active-ui-scope"), "restarbeiten.screen");
+    assert.equal(protokollTarget.getAttribute("data-ui-editor-selected"), "false");
+    assert.equal(getStatusText(activeStatus).includes("Aktiver UI-Scope: restarbeiten.screen"), true);
+    assert.equal(getStatusText(activeStatus).includes("Auswahl: keine"), true);
+    assert.equal(doc.querySelector('[data-ui-editor-layout-selected="true"]').textContent, "Ausgewaehltes Element: keine registrierte Auswahl");
+    assert.equal(Boolean(doc.querySelector('[data-ui-editor-layout-action="applySave"]')), false);
+
+    doc.dispatchEvent({ type: "click", target: protokollTarget });
+    activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
+    assert.equal(getStatusText(activeStatus).includes("Auswahl: keine"), true);
+    assert.notEqual(protokollTarget.getAttribute("data-ui-editor-selected"), "true");
+
+    doc.dispatchEvent({ type: "click", target: restarbeitenTarget });
+    activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
+    assert.equal(getStatusText(activeStatus).includes("Auswahl: restarbeiten.editbox.text.short"), true);
+    assert.equal(restarbeitenTarget.getAttribute("data-ui-editor-selected"), "true");
+    assert.equal(doc.querySelector('[data-ui-editor-layout-selected="true"]').textContent.includes("restarbeiten.editbox.text.short"), true);
+    assert.equal(doc.querySelector('[data-ui-editor-layout-controls="true"]').children.some((child) => child.textContent === "Layout-Scope: restarbeiten.ui.main"), true);
+
+    doc.querySelector('[data-ui-editor-layout-action="applySave"]').click();
+    doc.querySelector('[data-ui-editor-layout-action="loadSaved"]').click();
+    doc.querySelector('[data-ui-editor-layout-action="resetDefault"]').click();
+    assert.ok(calls.some((call) => call[0] === "apply" && call[1] === "restarbeiten.ui.main" && call[2].elementId === "restarbeiten.editbox.text.short"));
+    assert.ok(calls.some((call) => call[0] === "load" && call[1] === "restarbeiten.ui.main" && call[2].elementId === "restarbeiten.editbox.text.short"));
+    assert.ok(calls.some((call) => call[0] === "reset" && call[1] === "restarbeiten.ui.main" && call[2].elementId === "restarbeiten.editbox.text.short"));
+  });
+
+  await run("BBM UI-Editor-Runtime: unbekannter Scope blockiert Layoutbedienung verstaendlich", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const win = {
+      uiEditorLauncherButtonArtifact: require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js")),
+    };
+    const button = await mod.installBbmUiEditorRuntimeLauncher({
+      devEnabled: true,
+      doc,
+      win,
+      activeUiScope: "protokoll.topsScreen",
+      availableUiScopes: [
+        { uiScope: "protokoll.topsScreen", moduleId: "protokoll", status: "available" },
+        { uiScope: "unknown.scope", moduleId: "unknown", status: "blocked" },
+      ],
+      registryResolver: (scopeId) => scopeId === "protokoll.topsScreen"
+        ? {
+            uiScope: "protokoll.topsScreen",
+            moduleId: "protokoll",
+            elements: [{ id: "protokoll.root", name: "Protokoll", type: "root", role: "layout", parentId: null, allowedOps: ["inspect"], lockedOps: [] }],
+          }
+        : { ok: false, uiScope: scopeId, elements: [], reason: `Unknown UI scope: ${scopeId}` },
+      layoutInspector: {
+        getLayoutControlPanel() {
+          throw new Error("unknown scope must not request layout controls");
+        },
+      },
+      layoutScopeResolver: (uiScope) => uiScope === "protokoll.topsScreen" ? uiScope : null,
+    });
+
+    button.click();
+    doc.querySelector('[data-ui-editor-scope-option="unknown.scope"]').click();
+
+    const activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
+    const layoutMessage = doc.querySelector('[data-ui-editor-layout-message="true"]');
+    assert.equal(button.getAttribute("data-ui-editor-active-ui-scope"), "unknown.scope");
+    assert.equal(getStatusText(activeStatus).includes("Aktiver UI-Scope: unknown.scope"), true);
+    assert.equal(getStatusText(activeStatus).includes("Hinweis: Unknown UI scope: unknown.scope"), true);
+    assert.equal(layoutMessage.textContent, "Layoutbedienung blockiert: Unknown UI scope: unknown.scope");
+    assert.equal(Boolean(doc.querySelector('[data-ui-editor-layout-action="applySave"]')), false);
+  });
+
   await run("BBM UI-Editor-Runtime: Klick auf registrierte Restarbeiten-ID waehlt und markiert Ziel", async () => {
     const mod = await loadRuntime();
     const doc = createFakeDocument();

--- a/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
+++ b/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
@@ -332,6 +332,7 @@ function getReadonlyLauncherStatusText(state = {}) {
     "UI-Editor aktiv",
     getAvailableUiScopesText(scopes),
     "",
+    `Aktiver UI-Scope: ${getStatusScopeLabel(registry.uiScope || state.activeUiScope)}`,
     `Scope: ${getStatusScopeLabel(registry.uiScope || state.activeUiScope)}`,
     `Modul: ${registry.moduleId || "nicht verfuegbar"}`,
     `Elemente: ${registry.elements.length}`,
@@ -455,6 +456,13 @@ function getLayoutPanelForState(state = {}) {
   return state.layoutInspector.getLayoutControlPanel(layoutScope, elementId);
 }
 
+function isSelectedElementInActiveRegistry(state = {}) {
+  const elementId = String(state.selectedElement?.id || "").trim();
+  if (!elementId) return true;
+  const registry = getSelectedRegistryFromState(state);
+  return registry.elements.some((element) => element.id === elementId);
+}
+
 function getSafeLayoutOperations(panel = null) {
   const applyControl = Array.isArray(panel?.controls)
     ? panel.controls.find((control) => control.id === "editor.layout.applySave")
@@ -576,6 +584,7 @@ function renderLayoutControls(doc, status, state = {}) {
   const layoutScope = getLayoutScopeForState(state);
   const panel = getLayoutPanelForState(state);
   const selectedElement = state.selectedElement || null;
+  const registry = getSelectedRegistryFromState(state);
   const section = doc.createElement("div");
   section.className = "ui-editor-layout-control";
   section.setAttribute("data-ui-editor-layout-controls", "true");
@@ -594,6 +603,26 @@ function renderLayoutControls(doc, status, state = {}) {
   const scopeLine = doc.createElement("div");
   scopeLine.textContent = layoutScope ? `Layout-Scope: ${layoutScope}` : "Layout-Scope: nicht verfuegbar";
   section.appendChild(scopeLine);
+
+  if (registry.ok === false) {
+    const blocked = doc.createElement("div");
+    blocked.setAttribute("data-ui-editor-layout-message", "true");
+    blocked.textContent = registry.reason
+      ? `Layoutbedienung blockiert: ${registry.reason}`
+      : "Layoutbedienung blockiert: Scope ist nicht verfuegbar.";
+    section.appendChild(blocked);
+    content.appendChild(section);
+    return section;
+  }
+
+  if (selectedElement && !isSelectedElementInActiveRegistry(state)) {
+    const blocked = doc.createElement("div");
+    blocked.setAttribute("data-ui-editor-layout-message", "true");
+    blocked.textContent = "Layoutbedienung blockiert: Auswahl gehoert nicht zum aktiven Scope.";
+    section.appendChild(blocked);
+    content.appendChild(section);
+    return section;
+  }
 
   if (!selectedElement || !layoutScope || !state.layoutInspector) {
     const empty = doc.createElement("div");
@@ -706,6 +735,7 @@ function setActiveScopeInState(state, nextScope) {
   const normalizedScope = String(nextScope == null ? "" : nextScope).trim();
   removeLauncherTargetSelectionController(state);
   state.activeUiScope = normalizedScope;
+  launcherHostNode?.setAttribute?.("data-ui-editor-active-ui-scope", normalizedScope);
   state.selectedRegistry = state.registryResolver
     ? normalizeReadonlyRegistry(state.registryResolver(normalizedScope))
     : normalizeReadonlyRegistry({ uiScope: normalizedScope, elements: [] });


### PR DESCRIPTION
M34 stabilisiert Scope-Wechsel, Statusanzeige und Bedienführung im globalen UI-Editor.

Umfang:
- aktiver UI-Scope wird eindeutig angezeigt
- Scope-Wechsel loescht alte Auswahl
- falsche Scope-/Element-Kombinationen werden blockiert
- Layoutaktionen bleiben auf den aktuell aktiven Layout-Scope begrenzt
- Tests und Doku aktualisiert

Pruefung:
- node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs bestanden
- git diff --check bestanden
- node scripts/ui-editor-contract-check.cjs --self-test bestanden
- npm test bestanden, endet mit Alle Tests bestanden
- npm start: App startete, Fenster BBM sichtbar und responding

Keine PDF-/Druck-/Mail-/Audio-, Protokoll-/Restarbeiten-Fachlogik oder DB-Migration angefasst.