### PR TITLE
M35: UI Editor Bedienhinweise und Abnahmegrenzen klaeren

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,16 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M35 UI-Editor Bedienhinweise und Abnahmegrenzen festgezogen:
+  - Neue Doku: `docs/M35_UI_EDITOR_BEDIENHINWEISE_ABNAHMEGRENZEN.md`.
+  - Die sichtbare UI-Editor-Bedienung nennt die Bediengrenze: nur neutrale Layoutaenderungen, keine Fachwerte.
+  - PDF, Druck, Mail, Audio und DB-Fachlogik werden sichtbar als nicht Teil dieses Editors benannt.
+  - Das Layoutpanel zeigt ausgewaehltes Element, Layout-Scope, erlaubte neutrale Layoutoperationen und Block-/Statusmeldungen.
+  - Kein ausgewaehltes Element und unbekannte Elemente im aktiven Scope erzeugen sichtbare Blockmeldungen.
+  - Restarbeiten- und Protokoll/TOPS-Bedienung bleiben auf den bestehenden Scopes.
+  - Es wurde keine automatische DOM-Erkennung, keine weitere Modul-Anbindung und keine Fachlogik eingefuehrt.
+  - `git diff --check`, `node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`, `node uiEditor/tests/uiEditorInstallation.test.cjs`, `node scripts/ui-editor-contract-check.cjs --self-test`, `npm test` und `npm start` liefen gruen.
+
 - M34 UI-Editor Scope-Wechsel und Bedienfuehrung abgesichert:
   - Neue Doku: `docs/M34_UI_EDITOR_SCOPE_WECHSEL_BEDIENFUEHRUNG.md`.
   - Die Statusanzeige nennt den aktiven UI-Scope jetzt eindeutig als `Aktiver UI-Scope`.

--- a/docs/M35_UI_EDITOR_BEDIENHINWEISE_ABNAHMEGRENZEN.md
+++ b/docs/M35_UI_EDITOR_BEDIENHINWEISE_ABNAHMEGRENZEN.md
@@ -1,0 +1,103 @@
+# M35 UI-Editor Bedienhinweise und Abnahmegrenzen
+
+## Zweck
+
+M35 macht die sichtbare Bedienfuehrung und die Abnahmegrenzen des globalen UI-Editors klarer.
+
+Es wurde keine neue Editor-Architektur eingefuehrt, kein weiterer Fachscope angebunden und keine Fachlogik geaendert.
+
+## Grundlage
+
+- M29: Layoutaenderungen koennen gespeichert, geladen und zurueckgesetzt werden.
+- M30: neutrale Bediencontrols sind abgesichert.
+- M31: sichtbare Bedienung ist in der App angebunden.
+- M32: App-Smoke-Test ist dokumentiert.
+- M33: Restarbeiten- und Protokoll-/TOPS-Scope sind angebunden.
+- M34: Scope-Wechsel und falsche Scope-/Element-Kombinationen sind abgesichert.
+
+## Umsetzung
+
+- Die Statusanzeige nennt weiterhin den aktiven UI-Scope und ergaenzt die sichtbare Bediengrenze:
+  - nur neutrale Layoutaenderungen
+  - keine Fachwerte
+  - PDF, Druck, Mail, Audio und DB-Fachlogik sind nicht Teil dieses Editors
+- Das Layoutpanel zeigt:
+  - ausgewaehltes Element
+  - Layout-Scope
+  - erlaubte neutrale Layoutoperationen
+  - aktuellen Speicher-/Lade-/Reset-Status
+  - blockierende Gruende
+- Wenn kein registriertes Element ausgewaehlt ist, wird die Layoutbedienung sichtbar blockiert.
+- Markierte, aber im aktiven Scope nicht registrierte Elemente erzeugen eine sichtbare Blockmeldung.
+- Falscher Scope, unbekannter Scope, unbekanntes Element und nicht erlaubte Layoutoperationen bleiben sichtbar blockiert.
+
+## Abnahmegrenzen
+
+| Bereich | Ergebnis |
+| --- | --- |
+| Fachwerte | werden nicht bearbeitet |
+| PDF | nicht Teil dieses Editors |
+| Druck | nicht Teil dieses Editors |
+| Mail | nicht Teil dieses Editors |
+| Audio/Diktat | nicht Teil dieses Editors |
+| Datenbank-Fachlogik | nicht Teil dieses Editors |
+| Automatische DOM-Erkennung | nicht eingefuehrt |
+| Weitere Modul-Anbindung | nicht eingefuehrt |
+
+## Abnahmeumfang
+
+| Punkt | Ergebnis | Nachweis |
+| --- | --- | --- |
+| Aktiver Scope sichtbar | bestanden | Runtime-Status zeigt `Aktiver UI-Scope` |
+| Ausgewaehltes Element sichtbar | bestanden | Layoutpanel zeigt `Ausgewaehltes Element` |
+| Erlaubte neutrale Operationen sichtbar | bestanden | Layoutpanel zeigt `Erlaubte neutrale Layoutoperationen` |
+| Speicher-/Lade-/Reset-Status sichtbar | bestanden | Runtime-Status und Layoutpanel zeigen Layoutstatus |
+| Kein Element ausgewaehlt | bestanden | sichtbare Blockmeldung `Kein registriertes Element ausgewaehlt` |
+| Falscher/unbekannter Scope | bestanden | unbekannte Scopes blockieren sichtbar |
+| Unbekanntes Element | bestanden | Auswahl-Hinweis und Layoutblockade im aktiven Scope |
+| Nicht erlaubte Operation | bestanden | bestehende Inspector-Tests blockieren nicht freigegebene Operationen |
+| Keine layoutneutrale Aenderung | bestanden | bestehende Inspector-Tests blockieren Fach-/DOM-/DB-Payloads |
+| Restarbeiten bleibt bedienbar | bestanden | bestehende Runtime- und HostAdapter-Tests bleiben gruen |
+| Protokoll/TOPS bleibt bedienbar | bestanden | bestehende Runtime- und HostAdapter-Tests bleiben gruen |
+
+## Nicht geaendert
+
+- Keine PDF-Bearbeitung
+- Keine PDF-Ausgabe
+- Kein Druck
+- Keine Mail
+- Keine Diktat-/Audioaenderung
+- Keine Protokoll-Fachlogik
+- Keine Restarbeiten-Fachlogik
+- Keine Datenbankmigration
+- Keine neue Editor-Architekturentscheidung
+- Keine weitere Modul-Anbindung
+- Keine grosse UI-Umbauaktion
+
+## Pruefungen
+
+```powershell
+node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+git diff --check
+node scripts/ui-editor-contract-check.cjs --self-test
+npm test
+npm start
+```
+
+Ergebnis:
+- `node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`: bestanden
+- `git diff --check`: bestanden
+- `node scripts/ui-editor-contract-check.cjs --self-test`: bestanden
+- `npm test`: bestanden, Ausgabe endete mit `Alle Tests bestanden.`
+- `npm start`: App startete sichtbar; ein Fenster `BBM` war vorhanden und antwortend.
+
+## Grenze der Sichtung
+
+Die technische Bedienfuehrung und die Blockademeldungen sind durch Tests abgesichert. Eine zusaetzliche fachliche Klick-Abnahme im echten App-Fenster bleibt Aufgabe der fachlichen Abnahme.
+
+## Ergebnis
+
+M35 ist abgeschlossen:
+- UI-Editor-Bedienung ist fuer Nutzer verstaendlicher.
+- Blockademeldungen sind klarer.
+- Abnahmegrenzen sind sichtbar dokumentiert.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -411,3 +411,12 @@ Dabei gilt:
 - Bestehende Restarbeiten- und Protokoll/TOPS-Scope-Tests bleiben gruen; neue Runtime-Tests sichern den Scope-Wechsel ab.
 - PDF, Druck, Mail, Diktat/Audio, Protokoll-Fachlogik, Restarbeiten-Fachlogik, Datenbankmigration, automatische DOM-Erkennung und neue Editor-Grundsatzentscheidungen blieben ausserhalb dieses Pakets.
 - Neue Doku: `docs/M34_UI_EDITOR_SCOPE_WECHSEL_BEDIENFUEHRUNG.md`.
+
+### M35 UI-Editor Bedienhinweise und Abnahmegrenzen festgezogen (neu)
+- Die globale UI-Editor-Bedienung zeigt klarer, dass nur neutrale Layoutaenderungen bearbeitet werden und keine Fachwerte.
+- PDF, Druck, Mail, Audio und DB-Fachlogik werden sichtbar als nicht Teil dieses Editors benannt.
+- Das Layoutpanel zeigt aktiven Layout-Scope, ausgewaehltes Element, erlaubte neutrale Layoutoperationen und aktuelle Block-/Statusmeldungen.
+- Kein ausgewaehltes Element, unbekannte Elemente, falscher Scope und unbekannter Scope werden sichtbar blockiert.
+- Restarbeiten- und Protokoll/TOPS-Bedienung bleiben auf den bestehenden Scopes; keine weitere Modul-Anbindung wurde eingefuehrt.
+- PDF, Druck, Mail, Diktat/Audio, Protokoll-Fachlogik, Restarbeiten-Fachlogik, Datenbankmigration, automatische DOM-Erkennung und neue Editor-Architekturentscheidungen blieben ausserhalb dieses Pakets.
+- Neue Doku: `docs/M35_UI_EDITOR_BEDIENHINWEISE_ABNAHMEGRENZEN.md`.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -3,7 +3,7 @@
 ## Projektstatus
 Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.16a abgeschlossen (neutraler BBM-UI-Editor-Aktivmodus zeigt festen Registry-Scope).
 
-Statusupdate: M34 abgeschlossen (UI-Editor Scope-Wechsel und Bedienfuehrung abgesichert).
+Statusupdate: M35 abgeschlossen (UI-Editor Bedienhinweise und Abnahmegrenzen festgezogen).
 
 Aktueller Stand:
 - M1 bis M13.6a abgeschlossen.
@@ -16,6 +16,7 @@ Aktueller Stand:
 - M32 abgeschlossen: App-Start und sichtbarer Launcher wurden lokal geprueft; die Save/Load/Reset-Bedienfolge und Blockaden sind durch `npm test` abgedeckt.
 - M33 abgeschlossen: Der globale UI-Editor ist zusaetzlich fuer registrierte TOPS-Quicklane-Elemente im Scope `protokoll.topsScreen` bedienbar; Restarbeiten bleibt bedienbar.
 - M34 abgeschlossen: Aktiver UI-Scope, Auswahl und Layout-Scope sind beim Wechsel zwischen Restarbeiten und Protokoll/TOPS eindeutig; alte Auswahlen werden geloescht und unbekannte Scopes sichtbar blockiert.
+- M35 abgeschlossen: Bedienhinweise und Abnahmegrenzen sind sichtbar festgezogen; der Editor bleibt fachneutral und bearbeitet keine Fachwerte.
 
 ## Haken-System
 - `[x]` erledigt
@@ -58,6 +59,16 @@ Aktueller Stand:
 - [x] M32 Globalen UI-Editor im App-Kontext per Smoke-Test und Abnahmeprotokoll pruefen
 - [x] M33 Globalen UI-Editor fuer den Protokoll-/TOPS-Scope sichtbar anbinden
 - [x] M34 UI-Editor Scope-Wechsel und Bedienfuehrung absichern
+- [x] M35 UI-Editor Bedienhinweise und Abnahmegrenzen festziehen
+
+## Statusupdate M35
+- Die sichtbare UI-Editor-Bedienung ergaenzt klare Bediengrenzen: nur neutrale Layoutaenderungen, keine Fachwerte.
+- PDF, Druck, Mail, Audio und DB-Fachlogik werden sichtbar als nicht Teil dieses Editors benannt.
+- Das Layoutpanel zeigt ausgewaehltes Element, Layout-Scope, erlaubte neutrale Layoutoperationen und Block-/Statusmeldungen.
+- Kein ausgewaehltes Element und unbekannte Elemente im aktiven Scope werden sichtbar blockiert.
+- Neue Doku: `docs/M35_UI_EDITOR_BEDIENHINWEISE_ABNAHMEGRENZEN.md`.
+- Keine PDF-/Druck-/Mail-/Audio-, Protokoll- oder Restarbeiten-Fachlogik wurde geaendert.
+- `git diff --check`, Runtime-Test, Installations-/Neutralitaetstest, Vertrags-Selftest, `npm test` und `npm start` liefen gruen.
 
 ## Statusupdate M34
 - Der globale UI-Editor zeigt den aktiven UI-Scope eindeutig als `Aktiver UI-Scope`.

--- a/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+++ b/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
@@ -239,6 +239,12 @@ function matchesSelector(node, selector) {
   if (raw === "[data-ui-editor-layout-message=\"true\"]") {
     return node.getAttribute("data-ui-editor-layout-message") === "true";
   }
+  if (raw === "[data-ui-editor-layout-boundary=\"true\"]") {
+    return node.getAttribute("data-ui-editor-layout-boundary") === "true";
+  }
+  if (raw === "[data-ui-editor-layout-ops=\"true\"]") {
+    return node.getAttribute("data-ui-editor-layout-ops") === "true";
+  }
   if (raw === "[data-ui-editor-layout-operation=\"true\"]") {
     return node.getAttribute("data-ui-editor-layout-operation") === "true";
   }
@@ -465,6 +471,9 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     let panel = doc.querySelector('[data-ui-editor-layout-controls="true"]');
     assert.equal(Boolean(panel), true);
     assert.equal(doc.querySelector('[data-ui-editor-layout-selected="true"]').textContent.includes("restarbeiten.editbox.text.short"), true);
+    assert.equal(doc.querySelector('[data-ui-editor-layout-boundary="true"]').textContent.includes("keine Fachwerte"), true);
+    assert.equal(doc.querySelector('[data-ui-editor-layout-boundary="true"]').textContent.includes("PDF-, Druck-, Mail-, Audio- oder DB-Fachlogik"), true);
+    assert.equal(doc.querySelector('[data-ui-editor-layout-ops="true"]').textContent, "Erlaubte neutrale Layoutoperationen: move, resize");
     assert.equal(Boolean(doc.querySelector('[data-ui-editor-layout-action="applySave"]')), true);
     assert.equal(Boolean(doc.querySelector('[data-ui-editor-layout-action="loadSaved"]')), true);
     assert.equal(Boolean(doc.querySelector('[data-ui-editor-layout-action="resetDefault"]')), true);
@@ -490,6 +499,45 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(getStatusText(doc.querySelector('[data-ui-editor-launcher-status="true"]')).includes("Layout: Standardzustand wurde wiederhergestellt."), true);
     panel = doc.querySelector('[data-ui-editor-layout-controls="true"]');
     assert.equal(Boolean(panel), true);
+  });
+
+  await run("BBM UI-Editor-Runtime: Bedienhinweise zeigen Grenzen und keine-Auswahl-Blockade", async () => {
+    const mod = await loadRuntime();
+    const doc = createFakeDocument();
+    const win = {
+      uiEditorLauncherButtonArtifact: require(path.join(__dirname, "../../uiEditor/uiEditorLauncherButton.js")),
+    };
+    const button = await mod.installBbmUiEditorRuntimeLauncher({
+      devEnabled: true,
+      doc,
+      win,
+      activeUiScope: "restarbeiten.screen",
+      availableUiScopes: [{ uiScope: "restarbeiten.screen", moduleId: "restarbeiten", status: "available" }],
+      registryResolver: () => ({
+        uiScope: "restarbeiten.screen",
+        moduleId: "restarbeiten",
+        elements: [
+          { id: "restarbeiten.editbox.text.short", name: "Kurztext", type: "field", role: "content", parentId: "restarbeiten.editbox", allowedOps: ["inspect", "move"], lockedOps: [] },
+        ],
+      }),
+      layoutInspector: {
+        getLayoutControlPanel() {
+          throw new Error("layout controls must wait for a registered selection");
+        },
+      },
+      layoutScopeResolver: () => "restarbeiten.ui.main",
+    });
+
+    button.click();
+
+    const activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
+    assert.equal(getStatusText(activeStatus).includes("Aktiver UI-Scope: restarbeiten.screen"), true);
+    assert.equal(getStatusText(activeStatus).includes("Bediengrenze: Nur neutrale Layoutaenderungen; keine Fachwerte."), true);
+    assert.equal(getStatusText(activeStatus).includes("Nicht Teil dieses Editors: PDF, Druck, Mail, Audio und DB-Fachlogik."), true);
+    assert.equal(doc.querySelector('[data-ui-editor-layout-selected="true"]').textContent, "Ausgewaehltes Element: keine registrierte Auswahl");
+    assert.equal(doc.querySelector('[data-ui-editor-layout-ops="true"]').textContent, "Erlaubte neutrale Layoutoperationen: keine, bis ein registriertes Element ausgewaehlt ist.");
+    assert.equal(doc.querySelector('[data-ui-editor-layout-message="true"]').textContent, "Layoutbedienung blockiert: Kein registriertes Element ausgewaehlt.");
+    assert.equal(Boolean(doc.querySelector('[data-ui-editor-layout-action="applySave"]')), false);
   });
 
   await run("BBM UI-Editor-Runtime: Layoutbedienung blockiert nicht registrierte Layoutziele sichtbar", async () => {
@@ -536,6 +584,7 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     button.click();
     doc.dispatchEvent({ type: "click", target });
 
+    assert.equal(doc.querySelector('[data-ui-editor-layout-boundary="true"]').textContent.includes("keine Fachwerte"), true);
     assert.equal(doc.querySelector('[data-ui-editor-layout-message="true"]').textContent.includes("blockiert"), true);
     assert.equal(Boolean(doc.querySelector('[data-ui-editor-layout-action="applySave"]')), false);
   });
@@ -852,6 +901,7 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(getStatusText(activeStatus).includes("Aktiver UI-Scope: unknown.scope"), true);
     assert.equal(getStatusText(activeStatus).includes("Hinweis: Unknown UI scope: unknown.scope"), true);
     assert.equal(layoutMessage.textContent, "Layoutbedienung blockiert: Unknown UI scope: unknown.scope");
+    assert.equal(doc.querySelector('[data-ui-editor-layout-boundary="true"]').textContent.includes("DB-Fachlogik"), true);
     assert.equal(Boolean(doc.querySelector('[data-ui-editor-layout-action="applySave"]')), false);
   });
 
@@ -1261,6 +1311,8 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(withoutId.getAttribute("data-ui-editor-selected"), null);
     const activeStatus = doc.querySelector('[data-ui-editor-launcher-status="true"]');
     assert.equal(getStatusText(activeStatus).includes("Auswahl: keine"), true);
+    assert.equal(getStatusText(activeStatus).includes("Auswahl-Hinweis: Element ist im aktiven Scope nicht registriert."), true);
+    assert.equal(getStatusText(activeStatus).includes("Layout: Layoutbedienung blockiert: Unbekanntes Element im aktiven Scope."), true);
     assert.equal(getStatusText(activeStatus).includes("restarbeiten.unknown"), false);
   });
 

--- a/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
+++ b/src/renderer/uiEditor/BbmUiEditorRuntimeLauncher.js
@@ -336,6 +336,8 @@ function getReadonlyLauncherStatusText(state = {}) {
     `Scope: ${getStatusScopeLabel(registry.uiScope || state.activeUiScope)}`,
     `Modul: ${registry.moduleId || "nicht verfuegbar"}`,
     `Elemente: ${registry.elements.length}`,
+    "Bediengrenze: Nur neutrale Layoutaenderungen; keine Fachwerte.",
+    "Nicht Teil dieses Editors: PDF, Druck, Mail, Audio und DB-Fachlogik.",
     registry.ok === false && registry.reason ? `Hinweis: ${registry.reason}` : "",
     hoverElement ? `Hover: ${hoverElement.id}` : "Hover: keine",
     state.hoverMessage ? `Hover-Hinweis: ${state.hoverMessage}` : "",
@@ -470,6 +472,20 @@ function getSafeLayoutOperations(panel = null) {
   return Array.isArray(applyControl?.allowedOps) ? applyControl.allowedOps : [];
 }
 
+function getLayoutOperationsHint(operations = [], selectedElement = null) {
+  if (operations.length > 0) return `Erlaubte neutrale Layoutoperationen: ${operations.join(", ")}`;
+  if (selectedElement) return "Erlaubte neutrale Layoutoperationen: keine fuer diese Auswahl freigegeben.";
+  return "Erlaubte neutrale Layoutoperationen: keine, bis ein registriertes Element ausgewaehlt ist.";
+}
+
+function appendLayoutMessage(doc, section, message) {
+  const node = doc.createElement("div");
+  node.setAttribute("data-ui-editor-layout-message", "true");
+  node.textContent = message;
+  section.appendChild(node);
+  return node;
+}
+
 function ensureLayoutOperation(state = {}, operations = []) {
   if (operations.includes(state.layoutOperation)) return state.layoutOperation;
   state.layoutOperation = operations[0] || "move";
@@ -582,7 +598,6 @@ function renderLayoutControls(doc, status, state = {}) {
   if (!doc?.createElement || !content) return null;
 
   const layoutScope = getLayoutScopeForState(state);
-  const panel = getLayoutPanelForState(state);
   const selectedElement = state.selectedElement || null;
   const registry = getSelectedRegistryFromState(state);
   const section = doc.createElement("div");
@@ -604,45 +619,61 @@ function renderLayoutControls(doc, status, state = {}) {
   scopeLine.textContent = layoutScope ? `Layout-Scope: ${layoutScope}` : "Layout-Scope: nicht verfuegbar";
   section.appendChild(scopeLine);
 
+  const boundaryLine = doc.createElement("div");
+  boundaryLine.setAttribute("data-ui-editor-layout-boundary", "true");
+  boundaryLine.textContent = "Grenze: Nur neutrale Layoutaenderungen; keine Fachwerte, PDF-, Druck-, Mail-, Audio- oder DB-Fachlogik.";
+  section.appendChild(boundaryLine);
+
   if (registry.ok === false) {
-    const blocked = doc.createElement("div");
-    blocked.setAttribute("data-ui-editor-layout-message", "true");
-    blocked.textContent = registry.reason
+    appendLayoutMessage(doc, section, registry.reason
       ? `Layoutbedienung blockiert: ${registry.reason}`
-      : "Layoutbedienung blockiert: Scope ist nicht verfuegbar.";
-    section.appendChild(blocked);
+      : "Layoutbedienung blockiert: Scope ist nicht verfuegbar.");
     content.appendChild(section);
     return section;
   }
 
   if (selectedElement && !isSelectedElementInActiveRegistry(state)) {
-    const blocked = doc.createElement("div");
-    blocked.setAttribute("data-ui-editor-layout-message", "true");
-    blocked.textContent = "Layoutbedienung blockiert: Auswahl gehoert nicht zum aktiven Scope.";
-    section.appendChild(blocked);
+    appendLayoutMessage(doc, section, "Layoutbedienung blockiert: Auswahl gehoert nicht zum aktiven Scope.");
     content.appendChild(section);
     return section;
   }
 
-  if (!selectedElement || !layoutScope || !state.layoutInspector) {
-    const empty = doc.createElement("div");
-    empty.setAttribute("data-ui-editor-layout-message", "true");
-    empty.textContent = "Layoutbedienung wartet auf eine registrierte Auswahl.";
-    section.appendChild(empty);
+  if (!selectedElement) {
+    const operationsLine = doc.createElement("div");
+    operationsLine.setAttribute("data-ui-editor-layout-ops", "true");
+    operationsLine.textContent = getLayoutOperationsHint([], null);
+    section.appendChild(operationsLine);
+    appendLayoutMessage(doc, section, "Layoutbedienung blockiert: Kein registriertes Element ausgewaehlt.");
     content.appendChild(section);
     return section;
   }
+
+  if (!layoutScope) {
+    appendLayoutMessage(doc, section, "Layoutbedienung blockiert: Kein Layout-Scope verfuegbar.");
+    content.appendChild(section);
+    return section;
+  }
+
+  if (!state.layoutInspector) {
+    appendLayoutMessage(doc, section, "Layoutbedienung blockiert: Layoutpruefung ist nicht verfuegbar.");
+    content.appendChild(section);
+    return section;
+  }
+
+  const panel = getLayoutPanelForState(state);
 
   if (!panel?.ok) {
-    const blocked = doc.createElement("div");
-    blocked.setAttribute("data-ui-editor-layout-message", "true");
-    blocked.textContent = panel?.status?.message || "Layoutbedienung blockiert.";
-    section.appendChild(blocked);
+    appendLayoutMessage(doc, section, panel?.status?.message || "Layoutbedienung blockiert.");
     content.appendChild(section);
     return section;
   }
 
   const operations = getSafeLayoutOperations(panel);
+  const operationsLine = doc.createElement("div");
+  operationsLine.setAttribute("data-ui-editor-layout-ops", "true");
+  operationsLine.textContent = getLayoutOperationsHint(operations, selectedElement);
+  section.appendChild(operationsLine);
+
   const operation = ensureLayoutOperation(state, operations);
   const controlsRow = doc.createElement("div");
   controlsRow.className = "ui-editor-layout-control__row";
@@ -762,7 +793,13 @@ function installLauncherTargetSelectionController(doc, host, state) {
       state.selectedElement = selection.element;
       state.selectedTargetNode = selection.targetElement;
       state.selectionMessage = selection.message || "";
-      state.layoutStatus = null;
+      state.layoutStatus = !selection.element && selection.message
+        ? {
+            kind: "blocked",
+            message: "Layoutbedienung blockiert: Unbekanntes Element im aktiven Scope.",
+            reason: "ELEMENT_UNKNOWN",
+          }
+        : null;
       refreshLauncherPanel(doc, host, state);
     },
   });
@@ -844,7 +881,21 @@ function handleUiEditorDocumentClick(event, { state, doc, host }) {
   const targetNode = findClickedUiEditorTarget(event);
   const uiEditorId = String(targetNode?.getAttribute?.("data-ui-editor-id") || "").trim();
   const registryElement = getRegisteredElementById(state, uiEditorId);
-  if (!targetNode || !registryElement) return;
+  if (!targetNode) return;
+
+  if (!registryElement) {
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    clearUiEditorTargetSelection(state);
+    state.selectionMessage = "Element ist im aktiven Scope nicht registriert.";
+    state.layoutStatus = {
+      kind: "blocked",
+      message: "Layoutbedienung blockiert: Unbekanntes Element im aktiven Scope.",
+      reason: "ELEMENT_UNKNOWN",
+    };
+    refreshLauncherPanel(doc, host, state);
+    return;
+  }
 
   event?.preventDefault?.();
   event?.stopPropagation?.();

--- a/uiEditor/targetSelection.js
+++ b/uiEditor/targetSelection.js
@@ -202,14 +202,14 @@ function applyHoverMarker(targetElement) {
   return previousStyle;
 }
 
-function cloneSelection(activeScopeId, registryElement, targetElement) {
+function cloneSelection(activeScopeId, registryElement, targetElement, message = "") {
   return {
     activeScopeId,
     elementId: registryElement?.id || null,
     element: registryElement ? { ...registryElement } : null,
     targetElement: targetElement || null,
     hasTargetElement: Boolean(targetElement),
-    message: registryElement && !targetElement ? "Registry-Gruppe gewaehlt, kein DOM-Wrapper gefunden." : "",
+    message: message || (registryElement && !targetElement ? "Registry-Gruppe gewaehlt, kein DOM-Wrapper gefunden." : ""),
   };
 }
 
@@ -292,6 +292,7 @@ function createTargetSelectionController(options = {}) {
   let selectedRegistryElement = null;
   let selectedElementId = null;
   let selectedPreviousStyle = null;
+  let selectedMessage = "";
   let hoveredTargetElement = null;
   let hoveredRegistryElement = null;
   let hoveredElementId = null;
@@ -299,7 +300,7 @@ function createTargetSelectionController(options = {}) {
   let installed = false;
 
   function getSelection() {
-    return cloneSelection(activeScopeId, selectedRegistryElement, selectedTargetElement);
+    return cloneSelection(activeScopeId, selectedRegistryElement, selectedTargetElement, selectedMessage);
   }
 
   function getHover() {
@@ -321,6 +322,7 @@ function createTargetSelectionController(options = {}) {
     selectedRegistryElement = null;
     selectedElementId = null;
     selectedPreviousStyle = null;
+    selectedMessage = "";
     if (typeof uiState?.clearSelection === "function") {
       uiState.clearSelection();
     }
@@ -375,6 +377,7 @@ function createTargetSelectionController(options = {}) {
     selectedTargetElement = targetElement;
     selectedRegistryElement = registryElement;
     selectedElementId = registryElement.id;
+    selectedMessage = "";
     selectedPreviousStyle = targetElement ? applyTargetMarker(targetElement) : null;
     notifySelectionChange();
     return true;
@@ -388,7 +391,19 @@ function createTargetSelectionController(options = {}) {
 
   function handleClick(event) {
     const resolvedTarget = resolveRegisteredTargetFromChain(event, registryIndex, targetAttributeName, root);
-    if (!resolvedTarget) return false;
+    if (!resolvedTarget) {
+      const targetElement = findClosestTargetElement(event, targetAttributeName);
+      if (!targetElement) return false;
+      clearHover({ notify: false });
+      clearSelection();
+      selectedMessage = "Element ist im aktiven Scope nicht registriert.";
+      notifySelectionChange();
+      if (!isEditableEventTarget(event)) {
+        event?.preventDefault?.();
+      }
+      event?.stopPropagation?.();
+      return false;
+    }
     const selected = selectResolvedTarget(resolvedTarget.targetElement, resolvedTarget.registryElement);
     if (selected) {
       if (!isEditableEventTarget(event)) {


### PR DESCRIPTION
M35 macht die Bedienführung und Abnahmegrenzen des globalen UI-Editors klarer.

Umfang:
- aktiver Scope, Auswahl, Layout-Scope und erlaubte neutrale Layoutoperationen klarer sichtbar
- verständlichere Status- und Blockmeldungen
- unbekannte markierte Elemente im aktiven Scope erzeugen sichtbare Blockmeldung
- Bediengrenzen sichtbar: keine Fachwerte, PDF, Druck, Mail, Audio oder DB-Fachlogik
- Tests und Doku aktualisiert

Prüfung:
- node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs bestanden
- node uiEditor/tests/uiEditorInstallation.test.cjs bestanden
- git diff --check bestanden
- node scripts/ui-editor-contract-check.cjs --self-test bestanden
- npm test bestanden, endet mit Alle Tests bestanden
- npm start: App startete, Fenster BBM sichtbar und responding

Keine Fachlogik, keine weitere Modul-Anbindung und keine automatische DOM-Erkennung geändert.