### PR TITLE
M36: UI Editor Fixstand und Abnahme dokumentieren

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -17,6 +17,15 @@ Sie ergÃ¤nzt:
 
 ## Aktueller Gesamtstand
 
+- M36 UI-Editor Fixstand nach M29 bis M35 dokumentiert:
+  - Neue Doku: `docs/M36_UI_EDITOR_FIXSTAND_ABNAHME.md`.
+  - Der Fixstand haelt fest, dass der globale UI-Editor neutrale Layoutaenderungen speichern, laden und resetten kann.
+  - Bedienbar sind die Scopes `restarbeiten.screen` -> `restarbeiten.ui.main` und `protokoll.topsScreen` -> `protokoll.topsScreen`.
+  - Scope-Wechsel, Blockademeldungen, Bedienhinweise und Abnahmegrenzen aus M34/M35 bleiben Stand der Abnahme.
+  - Ausdruecklich nicht Teil des Editors bleiben PDF, Druck, Mail, Audio/Diktat, Fachlogik, Datenbankmigration, automatische DOM-Erkennung und weitere Modul-Anbindung.
+  - M36 ist ein reines Doku-/Fixstandpaket ohne Code-, UI- oder Architekturaenderung.
+  - `git diff --check`, `node scripts/ui-editor-contract-check.cjs --self-test` und `npm test` liefen gruen.
+
 - M35 UI-Editor Bedienhinweise und Abnahmegrenzen festgezogen:
   - Neue Doku: `docs/M35_UI_EDITOR_BEDIENHINWEISE_ABNAHMEGRENZEN.md`.
   - Die sichtbare UI-Editor-Bedienung nennt die Bediengrenze: nur neutrale Layoutaenderungen, keine Fachwerte.

--- a/docs/M36_UI_EDITOR_FIXSTAND_ABNAHME.md
+++ b/docs/M36_UI_EDITOR_FIXSTAND_ABNAHME.md
@@ -1,0 +1,131 @@
+# M36 UI-Editor Fixstand und Abnahme
+
+## Zweck
+
+M36 dokumentiert den Fixstand des globalen UI-Editors nach M29 bis M35.
+
+Dieses Paket baut keine neue Funktion, trifft keine neue Architekturentscheidung und bindet keinen weiteren Scope an.
+
+## Fixstand
+
+Der globale UI-Editor kann aktuell:
+
+- neutrale Layoutaenderungen fuer registrierte Elemente anwenden und speichern
+- gespeicherte neutrale Layoutzustaende laden und anwenden
+- gespeicherte Layoutzustaende auf Standard zuruecksetzen
+- sichtbar in der App im DEV-Kontext bedient werden
+- registrierte Elemente im aktiven Scope auswaehlen
+- aktiven UI-Scope, Layout-Scope, ausgewaehltes Element und erlaubte neutrale Layoutoperationen anzeigen
+- Speicher-, Lade-, Reset- und Blockadestatus sichtbar melden
+- Scope-Wechsel zwischen den angebundenen Scopes sauber behandeln
+- falsche Scope-/Element-Kombinationen blockieren
+- Bediengrenzen sichtbar anzeigen
+
+## Angebundene Scopes
+
+| Sichtbarer UI-Scope | Layout-Scope | Stand |
+| --- | --- | --- |
+| `restarbeiten.screen` | `restarbeiten.ui.main` | bedienbar |
+| `protokoll.topsScreen` | `protokoll.topsScreen` | bedienbar |
+
+Der Editor arbeitet nur mit registrierten UI-Editor-Elementen aus der Ziel-App-Registry. Nicht registrierte Elemente gelten fuer den Editor als nicht vorhanden oder werden sichtbar blockiert.
+
+## Bediengrenzen
+
+Der UI-Editor bearbeitet ausschliesslich neutrale Layoutwerte.
+
+Zulaessig sind nur Operationen, die fuer das jeweilige registrierte Element freigegeben sind, zum Beispiel:
+
+- `move`
+- `resize`
+- `width`
+- `height`
+- `spacing`
+- weitere neutrale Operationen nur, wenn sie registriert und vom HostAdapter erlaubt sind
+
+Alle Aenderungen laufen ueber den bestehenden EditorRuntime-/Inspector-/HostAdapter-Pfad. Layoutdaten und Fachdaten bleiben getrennt.
+
+## Ausdruecklich nicht Teil des Editors
+
+- keine PDF-Bearbeitung
+- keine PDF-Ausgabe
+- kein Druck
+- keine Mail
+- keine Audio-/Diktataenderung
+- keine Protokoll-Fachlogik
+- keine Restarbeiten-Fachlogik
+- keine Datenbankmigration
+- keine fachlichen IPC-/Datenaktionen
+- keine Fachwerte
+- keine Fachbutton-Ausfuehrung
+- keine automatische DOM-Erkennung
+- keine automatische Registry-Befuellung
+- keine weitere Modul-Anbindung
+- keine neue Editor-Architektur
+
+## Abgesicherte Blockaden
+
+Der Fixstand blockiert sichtbar:
+
+- kein registriertes Element ausgewaehlt
+- unbekannter Scope
+- falscher Scope
+- unbekanntes Element im aktiven Scope
+- nicht erlaubte Operation
+- gesperrte Operation
+- nicht layoutneutrale Aenderung
+- Fach-, DOM-, Datenbank- oder Datensatzpayloads
+
+## Pruefanker
+
+Der Stand ist insbesondere abgesichert durch:
+
+- `scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs`
+- `scripts/tests/editorScopeInspector.test.cjs`
+- `scripts/tests/restarbeitenEditorHostAdapter.test.cjs`
+- `scripts/tests/protokollEditorHostAdapter.test.cjs`
+- `scripts/tests/bbmUiEditorRegistry.test.cjs`
+- `uiEditor/tests/uiEditorInstallation.test.cjs`
+- `scripts/ui-editor-contract-check.cjs --self-test`
+- `npm test`
+
+## Naechste Themen erst nach diesem Fixstand
+
+Erst nach diesem dokumentierten Fixstand duerfen separat geplant werden:
+
+- fachliche Klick-Abnahme im echten App-Fenster
+- weitere UI-Editor-Usability-Verbesserungen als eigenes Paket
+- weitere bewusst registrierte UI-Editor-Elemente
+- weitere Scopes oder Module, nur mit eigener Entwurfsentscheidung und eigenem Auftrag
+- erweiterte Layoutoperationen, nur wenn neutral, registriert und testgesichert
+- produktive Freigabe- oder Nutzerfuehrungsfragen
+
+Nicht als Folgepaket ohne neuen Auftrag erlaubt sind:
+
+- automatische DOM-Erkennung
+- automatische Bestandsmigration
+- PDF-/Druck-/Mail-/Audio-Anbindung
+- Fachlogik- oder Datenbankumbau
+- breite UI-Umbauten
+
+## Pruefungen fuer M36
+
+```powershell
+git diff --check
+node scripts/ui-editor-contract-check.cjs --self-test
+npm test
+```
+
+Ergebnis:
+- `git diff --check`: bestanden
+- `node scripts/ui-editor-contract-check.cjs --self-test`: bestanden
+- `npm test`: bestanden, Ausgabe endete mit `Alle Tests bestanden.`
+
+## Ergebnis
+
+M36 ist ein Dokumentations- und Abnahmepaket:
+
+- Der globale UI-Editor-Fixstand nach M29 bis M35 ist dokumentiert.
+- Die angebundenen Scopes sind benannt.
+- Bediengrenzen und Nicht-Ziele sind festgehalten.
+- Nachfolgethemen sind als spaetere, eigene Pakete abgegrenzt.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -420,3 +420,11 @@ Dabei gilt:
 - Restarbeiten- und Protokoll/TOPS-Bedienung bleiben auf den bestehenden Scopes; keine weitere Modul-Anbindung wurde eingefuehrt.
 - PDF, Druck, Mail, Diktat/Audio, Protokoll-Fachlogik, Restarbeiten-Fachlogik, Datenbankmigration, automatische DOM-Erkennung und neue Editor-Architekturentscheidungen blieben ausserhalb dieses Pakets.
 - Neue Doku: `docs/M35_UI_EDITOR_BEDIENHINWEISE_ABNAHMEGRENZEN.md`.
+
+### M36 UI-Editor Fixstand nach M29 bis M35 dokumentiert (neu)
+- Der globale UI-Editor-Fixstand ist als Abnahmestand dokumentiert.
+- Fixiert sind Speichern/Laden/Reset neutraler Layoutaenderungen, sichtbare App-Bedienung, Restarbeiten-Scope, Protokoll/TOPS-Scope, Scope-Wechsel und Bediengrenzen.
+- Angebundene Scopes bleiben `restarbeiten.screen` -> `restarbeiten.ui.main` und `protokoll.topsScreen` -> `protokoll.topsScreen`.
+- Weitere Themen wie zusaetzliche Scopes, neue bewusst registrierte Elemente, Usability-Ausbau oder fachliche Klick-Abnahme muessen nach diesem Fixstand separat beauftragt werden.
+- PDF, Druck, Mail, Diktat/Audio, Fachlogik, Datenbankmigration, automatische DOM-Erkennung, neue Modul-Anbindung und neue Editor-Architektur blieben ausserhalb dieses Pakets.
+- Neue Doku: `docs/M36_UI_EDITOR_FIXSTAND_ABNAHME.md`.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -3,7 +3,7 @@
 ## Projektstatus
 Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.16a abgeschlossen (neutraler BBM-UI-Editor-Aktivmodus zeigt festen Registry-Scope).
 
-Statusupdate: M35 abgeschlossen (UI-Editor Bedienhinweise und Abnahmegrenzen festgezogen).
+Statusupdate: M36 abgeschlossen (UI-Editor Fixstand nach M29 bis M35 dokumentiert).
 
 Aktueller Stand:
 - M1 bis M13.6a abgeschlossen.
@@ -17,6 +17,7 @@ Aktueller Stand:
 - M33 abgeschlossen: Der globale UI-Editor ist zusaetzlich fuer registrierte TOPS-Quicklane-Elemente im Scope `protokoll.topsScreen` bedienbar; Restarbeiten bleibt bedienbar.
 - M34 abgeschlossen: Aktiver UI-Scope, Auswahl und Layout-Scope sind beim Wechsel zwischen Restarbeiten und Protokoll/TOPS eindeutig; alte Auswahlen werden geloescht und unbekannte Scopes sichtbar blockiert.
 - M35 abgeschlossen: Bedienhinweise und Abnahmegrenzen sind sichtbar festgezogen; der Editor bleibt fachneutral und bearbeitet keine Fachwerte.
+- M36 abgeschlossen: Der globale UI-Editor-Fixstand nach M29 bis M35 ist als Abnahmestand dokumentiert.
 
 ## Haken-System
 - `[x]` erledigt
@@ -60,6 +61,14 @@ Aktueller Stand:
 - [x] M33 Globalen UI-Editor fuer den Protokoll-/TOPS-Scope sichtbar anbinden
 - [x] M34 UI-Editor Scope-Wechsel und Bedienfuehrung absichern
 - [x] M35 UI-Editor Bedienhinweise und Abnahmegrenzen festziehen
+- [x] M36 UI-Editor Fixstand nach M29 bis M35 dokumentieren und absichern
+
+## Statusupdate M36
+- Der globale UI-Editor-Fixstand nach M29 bis M35 ist dokumentiert.
+- Fixiert sind neutrale Layoutaenderungen, Speichern/Laden/Reset, sichtbare App-Bedienung, Restarbeiten-Scope, Protokoll/TOPS-Scope, Scope-Wechsel und Bediengrenzen.
+- Neue Doku: `docs/M36_UI_EDITOR_FIXSTAND_ABNAHME.md`.
+- Keine PDF-/Druck-/Mail-/Audio-, Protokoll- oder Restarbeiten-Fachlogik wurde geaendert.
+- Keine weitere Modul-Anbindung, keine UI-Umbauten und keine neue Editor-Architektur wurden eingefuehrt.
 
 ## Statusupdate M35
 - Die sichtbare UI-Editor-Bedienung ergaenzt klare Bediengrenzen: nur neutrale Layoutaenderungen, keine Fachwerte.


### PR DESCRIPTION
M36 dokumentiert den Fixstand des globalen UI-Editors nach M29 bis M35.

Umfang:
- neue Fixstand-Abnahme docs/M36_UI_EDITOR_FIXSTAND_ABNAHME.md
- dokumentiert, was der UI-Editor jetzt kann
- dokumentiert angebundene Scopes und Bediengrenzen
- dokumentiert ausdrücklich ausgeschlossene Bereiche
- STATUS, Modularisierungsplan und Aufgabenheft aktualisiert

Pruefung:
- git diff --check bestanden
- node scripts/ui-editor-contract-check.cjs --self-test bestanden
- npm test bestanden, endet mit Alle Tests bestanden

Keine Code-, UI-, Fachlogik- oder Architekturänderung.