### PR TITLE
M53: Visibility-only UI-Editor drafts (apply / reset)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ Status M51: Core-Vertrag technisch angebunden und testbar; noch keine vollständ
 ## M52: Sichtbarer UI-Editor-Startpunkt
 
 Ab M52 gibt es in BBM einen kleinen sichtbaren Einstieg `UI-Editor Status` in der bestehenden Navigation. Die Ansicht zeigt den Status der M51-Runtime, den aktiven Scope, das Layoutprofil, die explizit registrierten UI-Elemente und eine gepruefte Elementauswahl. Es ist noch keine vollstaendige Bearbeitung von Layout, Farben, Schrift, Drag-and-drop oder Resize. Details: [docs/M52_UI_EDITOR_SICHTBARER_STARTPUNKT.md](docs/M52_UI_EDITOR_SICHTBARER_STARTPUNKT.md).
+
+## M53 UI-Editor Sichtbarkeitsentwurf
+M53 erlaubt im bestehenden UI-Editor-Statuspanel erstmals kontrollierte Layoutaenderungen fuer registrierte BBM-Elemente. Der Umfang ist bewusst eng: nur `visible` true/false, nur als Entwurf, Apply/Discard/Load/Reset und nur im Sitzungsspeicher. Es gibt keine freie Layoutbearbeitung, keine Groessen-/Positions-/Styleaenderung und keine direkte DOM-Auswahl.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,3 +1,18 @@
+# M53 - UI-Editor Sichtbarkeitsentwurf / Apply / Reset
+
+Status: umgesetzt.
+
+- Draft moeglich fuer registrierte, in M53 freigegebene Elemente.
+- Apply moeglich fuer `visible` true/false ueber den bestehenden Runtime-/HostAdapter-Pfad.
+- Reset moeglich fuer das ausgewaehlte Element und Profil `default`.
+- Speicherung bleibt MemoryStore/Sitzungsspeicher; keine dauerhafte Speicherung.
+- Keine Groessen-, Positions-, Farb-, Schrift- oder Textbearbeitung.
+- Keine direkte DOM-Auswahl, kein DOM-Scan und keine automatische Registry.
+- Erlaubt: `bbm.main.header`, `bbm.main.actions`.
+- Gesperrt: `bbm.main.shell`, `bbm.main.navigation`, `bbm.main.content`.
+
+Naechster sinnvoller Schritt: M54 kann eine explizite sichere CoreShell-Bindung fuer sichtbare Anwendung des gespeicherten Layoutzustands klaeren.
+
 # STATUS.md â€” BBM-Produktiv
 
 ## Zweck

--- a/docs/M53_UI_EDITOR_VISIBILITY_DRAFT_APPLY_RESET.md
+++ b/docs/M53_UI_EDITOR_VISIBILITY_DRAFT_APPLY_RESET.md
@@ -1,0 +1,117 @@
+# M53 UI-Editor: Sichtbarkeits-Entwurf, Apply und Reset
+
+## Zweck
+M53 erweitert das bestehende M52-Statuspanel um die erste kontrollierte Layoutaenderung fuer registrierte BBM-Elemente. Es ist kein freier visueller Editor.
+
+## Erlaubter Funktionsumfang
+Erlaubt sind ausschliesslich:
+- Sichtbarkeit `visible: true`
+- Sichtbarkeit `visible: false`
+- Entwurf erstellen und anzeigen
+- Entwurf verwerfen
+- Entwurf anwenden
+- gespeicherten Layoutzustand laden
+- gespeicherten Layoutzustand fuer das ausgewaehlte Element zuruecksetzen
+
+Nicht erlaubt sind Position, Groesse, Abstaende, Farben, Schrift, Text, HTML, Children, Parent- oder Typaenderungen.
+
+## Oeffentliche UI-Editor-kit-Vertraege
+M53 nutzt nur `require("ui-editor-kit")`. Analysierte oeffentliche Exporte in v0.2.0:
+- `createTargetAppAdapterRuntime`
+- `createLayoutState`
+- `validateLayoutState`
+- `createMemoryLayoutStateStore`
+- `createEditorLayoutControlViewModel`
+- `assertCompatibleLayoutProfile`
+- `getLayoutStateProfileKey`
+- Runtime-/Status-/Selection-ViewModel-Factorys
+
+Der oeffentliche LayoutState-Vertrag verlangt mindestens `schemaVersion: 1`, `targetAppId`, `uiScope`, `layoutScope`, `layoutProfileId` und `version` oder `revision`. Die Layoutwerte liegen unter `elements` als Objekt. Fuer M53 wird `visible` ueber `allowedPayloadFields: ["visible"]` freigegeben.
+
+## ChangeDraft-Ablauf
+1. Element im M52/M53-Panel auswaehlen.
+2. Zielwert fuer `visible` waehlen.
+3. Main-Prozess erzeugt eine eng begrenzte ChangeRequest-Struktur.
+4. HostAdapter validiert Scope, Layout-Scope, Profil, Element, Operation, Property und Boolean-Wert.
+5. Das Panel zeigt den Entwurf mit altem Wert, neuem Wert, Operation, Validierungsstatus und Blockcode.
+6. Es wird noch nichts gespeichert.
+
+## Apply-Ablauf
+1. Bestehende Runtime verwenden.
+2. Entwurf erneut validieren.
+3. Element in der Registry pruefen.
+4. Scope `bbm.main`, Layout-Scope `bbm.main-layout` und Profil `default` pruefen.
+5. Operation `visibility.set` und Property `visible` pruefen.
+6. LayoutState per oeffentlichem UI-Editor-kit-Modell erzeugen.
+7. LayoutState im MemoryLayoutStateStore speichern.
+8. Gespeicherten Zustand zurueckgeben.
+9. Panel neu laden.
+
+## Reset-Ablauf
+Reset gilt nur fuer das ausgewaehlte Element und das aktive Profil `default`. Der gespeicherte Sitzungswert wird entfernt; anschliessend meldet das Panel den Registry-Default `visible: true`. Andere Elemente bleiben unveraendert.
+
+## Erlaubte und gesperrte Elemente
+In M53 umschaltbar:
+- `bbm.main.header`
+- `bbm.main.actions`
+
+In M53 sichtbar, aber gesperrt:
+- `bbm.main.shell` — Hauptrahmen darf nicht unbedienbar werden.
+- `bbm.main.navigation` — Rueckweg und Navigation bleiben erhalten.
+- `bbm.main.content` — Statuspanel und Inhalt duerfen nicht unbedienbar werden.
+
+## Blockcodes
+BBM-spezifische Blockcodes:
+- `BBM_UI_CHANGE_NO_SELECTION`
+- `BBM_UI_CHANGE_ELEMENT_LOCKED`
+- `BBM_UI_CHANGE_UNSUPPORTED_PROPERTY`
+- `BBM_UI_CHANGE_INVALID_VALUE`
+- `BBM_UI_CHANGE_SCOPE_MISMATCH`
+- `BBM_UI_CHANGE_PROFILE_MISMATCH`
+- `BBM_UI_CHANGE_DRAFT_INVALID`
+- `BBM_UI_CHANGE_APPLY_FAILED`
+
+## MemoryStore-Grenzen
+M53 speichert nur im Sitzungsspeicher. Nach einem vollstaendigen Neustart ist der Zustand nicht dauerhaft vorhanden. Es gibt keine Datenbank, keine JSON-Datei, keine LocalStorage-Persistenz und keine Migration.
+
+## IPC-Sicherheitsmodell
+Die Preload-Bruecke enthaelt nur eng benannte Methoden:
+- `uiEditorCreateChangeDraft`
+- `uiEditorGetChangeDraft`
+- `uiEditorDiscardChangeDraft`
+- `uiEditorApplyChangeDraft`
+- `uiEditorLoadLayoutState`
+- `uiEditorResetLayoutState`
+
+Es gibt keine generische Ausfuehrungsmethode, kein `eval`, keine beliebigen Operationsnamen und keinen direkten Renderer-Schreibzugriff auf den LayoutStore.
+
+## Testablauf
+Automatisiert:
+- `git diff --check`
+- `node scripts/tests/m51UiEditorKitIntegration.test.cjs`
+- `node scripts/tests/m52UiEditorVisibleEntry.test.cjs`
+- `node scripts/tests/m53UiEditorVisibilityDraft.test.cjs`
+- `node scripts/test.cjs`
+- `npm start`, soweit in der Umgebung moeglich
+
+Manuell unter Windows:
+1. UI-Editor Status oeffnen.
+2. Erlaubtes Element auswaehlen.
+3. Sichtbarkeit aendern.
+4. Entwurf erstellen.
+5. Entwurf pruefen.
+6. Anwenden.
+7. Layoutstatus neu laden.
+8. Gespeicherten Wert kontrollieren.
+9. Layout zuruecksetzen.
+10. Default-Zustand kontrollieren.
+11. Zurueck zur normalen BBM-Navigation.
+
+## Bekannte Einschraenkungen
+- Keine direkte sichtbare Ausblendung in der BBM-Arbeitsflaeche, solange keine explizite sichere CoreShell-Bindung vorhanden ist.
+- Keine dauerhafte Speicherung.
+- Keine Groessen-, Positions-, Style- oder Textbearbeitung.
+- Keine DOM-Auswahl und kein DOM-Scan.
+
+## Abgrenzung zu M54
+M54 kann eine explizite, sichere Bindung zwischen registrierten CoreShell-Elementen und LayoutState herstellen. Diese Bindung darf weiterhin keine DOM-Suche, keine automatische Registry und keine CSS-Selektor-Ableitung verwenden.

--- a/scripts/tests/m53UiEditorVisibilityDraft.test.cjs
+++ b/scripts/tests/m53UiEditorVisibilityDraft.test.cjs
@@ -1,0 +1,100 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const kit = require('ui-editor-kit');
+const { createBbmHostAdapter, createMemoryLayoutStateStore, validateM53ChangeRequest, createDefaultLayoutState } = require('../../src/ui-editor/bbm-host-adapter.cjs');
+const { _m52 } = require('../../src/main/ipc/uiEditorIpc.js');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+function test(name, fn) {
+  try { fn(); console.log(`ok - ${name}`); } catch (error) { console.error(`not ok - ${name}`); throw error; }
+}
+
+test('public ui-editor-kit API is used for LayoutState', () => {
+  assert.equal(typeof kit.createLayoutState, 'function');
+  assert.equal(typeof kit.validateLayoutState, 'function');
+  assert.equal(typeof kit.createMemoryLayoutStateStore, 'function');
+  const state = createDefaultLayoutState({ 'bbm.main.header': { visible: false } });
+  assert.equal(kit.validateLayoutState(state, { allowedPayloadFields: ['visible'] }).ok, true);
+  assert.equal(state.schemaVersion, 1);
+  assert.equal(state.elements['bbm.main.header'].visible, false);
+});
+
+test('selection and draft validation block unsafe cases', () => {
+  assert.equal(validateM53ChangeRequest({ value: false }).blockCode, 'BBM_UI_CHANGE_NO_SELECTION');
+  assert.equal(validateM53ChangeRequest({ elementId: 'bbm.main.unknown', value: false }).blockCode, 'BBM_UI_ELEMENT_UNKNOWN');
+  assert.equal(validateM53ChangeRequest({ elementId: 'bbm.main.navigation', value: false }).blockCode, 'BBM_UI_CHANGE_ELEMENT_LOCKED');
+  assert.equal(validateM53ChangeRequest({ elementId: 'bbm.main.header', value: false }).ok, true);
+  assert.equal(validateM53ChangeRequest({ elementId: 'bbm.main.actions', value: true }).ok, true);
+  assert.equal(validateM53ChangeRequest({ elementId: 'bbm.main.header', value: 'false' }).blockCode, 'BBM_UI_CHANGE_INVALID_VALUE');
+  assert.equal(validateM53ChangeRequest({ elementId: 'bbm.main.header', value: false, width: 100 }).blockCode, 'BBM_UI_CHANGE_UNSUPPORTED_PROPERTY');
+  assert.equal(validateM53ChangeRequest({ elementId: 'bbm.main.header', value: false, property: 'width' }).blockCode, 'BBM_UI_CHANGE_UNSUPPORTED_PROPERTY');
+});
+
+test('draft is not applied until apply and discard only removes draft', () => {
+  _m52.closeUiEditorSession();
+  const runtimeOptions = { layoutStore: createMemoryLayoutStateStore() };
+  _m52.ensureRuntime({ forceRestart: true, runtimeOptions });
+  assert.equal(_m52.createChangeDraft({ visible: false }).blockCode, 'BBM_UI_CHANGE_NO_SELECTION');
+  assert.equal(_m52.selectUiEditorElement({ elementId: 'bbm.main.header' }).ok, true);
+  const draft = _m52.createChangeDraft({ visible: false });
+  assert.equal(draft.ok, true);
+  assert.equal(_m52.loadLayoutState({ elementId: 'bbm.main.header' }).visible, true);
+  assert.equal(_m52.getChangeDraft().draft.nextValue, false);
+  assert.equal(_m52.discardChangeDraft().ok, true);
+  assert.equal(_m52.getChangeDraft().draft, null);
+  assert.equal(_m52.loadLayoutState({ elementId: 'bbm.main.header' }).visible, true);
+});
+
+test('apply validates again and stores session layout state', () => {
+  _m52.closeUiEditorSession();
+  const runtimeOptions = { layoutStore: createMemoryLayoutStateStore() };
+  _m52.ensureRuntime({ forceRestart: true, runtimeOptions });
+  _m52.selectUiEditorElement({ elementId: 'bbm.main.header' });
+  _m52.createChangeDraft({ visible: false });
+  const manipulated = _m52.applyChangeDraft({ elementId: 'bbm.main.header', value: false, uiScope: 'other' });
+  assert.equal(manipulated.ok, false);
+  assert.equal(manipulated.blockCode, 'BBM_UI_CHANGE_SCOPE_MISMATCH');
+  const applied = _m52.applyChangeDraft({});
+  assert.equal(applied.ok, true);
+  assert.equal(applied.visible, false);
+  assert.equal(_m52.loadLayoutState({ elementId: 'bbm.main.header' }).visible, false);
+  const adapter = _m52.ensureRuntime().hostAdapter;
+  assert.equal(adapter.getRegistry().elements.find((e) => e.elementId === 'bbm.main.header').layoutDefaults.visible, true);
+  assert.equal(_m52.applyChangeDraft({}).blockCode, 'BBM_UI_CHANGE_DRAFT_INVALID');
+});
+
+test('profile and scope mismatch are blocked in adapter path', () => {
+  const adapter = createBbmHostAdapter({ layoutStore: createMemoryLayoutStateStore() });
+  assert.equal(adapter.saveLayoutState({ elementId: 'bbm.main.header', layoutScope: 'bad', layoutValue: { visible: false } }).blockCode, 'BBM_UI_CHANGE_SCOPE_MISMATCH');
+  assert.equal(adapter.saveLayoutState({ elementId: 'bbm.main.header', layoutProfileId: 'other', layoutValue: { visible: false } }).blockCode, 'BBM_UI_CHANGE_PROFILE_MISMATCH');
+  assert.equal(adapter.saveLayoutState({ elementId: 'bbm.main.header', layoutValue: { color: 'red' } }).blockCode, 'BBM_UI_CHANGE_UNSUPPORTED_PROPERTY');
+});
+
+test('reset only selected element/profile and reports default visible true', () => {
+  const adapter = createBbmHostAdapter({ layoutStore: createMemoryLayoutStateStore() });
+  assert.equal(adapter.submitChangeRequest({ elementId: 'bbm.main.header', value: false }).ok, true);
+  assert.equal(adapter.submitChangeRequest({ elementId: 'bbm.main.actions', value: false }).ok, true);
+  assert.equal(adapter.resetLayoutState({ elementId: 'bbm.main.header' }).visible, true);
+  assert.equal(adapter.getElementLayoutState({ elementId: 'bbm.main.header' }).visible, true);
+  assert.equal(adapter.getElementLayoutState({ elementId: 'bbm.main.actions' }).visible, false);
+  assert.equal(adapter.resetLayoutState({ elementId: 'bbm.main.actions', layoutProfileId: 'other' }).blockCode, 'BBM_UI_CHANGE_PROFILE_MISMATCH');
+});
+
+test('security guardrails in M53 touched files', () => {
+  const files = [
+    'src/main/ipc/uiEditorIpc.js',
+    'src/main/preload.js',
+    'src/renderer/ui-editor/BbmUiEditorStatusPanel.js',
+    'src/ui-editor/bbm-host-adapter.cjs',
+  ];
+  const source = files.map((file) => fs.readFileSync(path.join(REPO_ROOT, file), 'utf8')).join('\n');
+  assert.equal(/querySelectorAll|getElementsBy|MutationObserver|eval\s*\(/.test(source), false);
+  assert.equal(/execute\s*[:=]|invokeAny|callMethod|runCommand/.test(source), false);
+  assert.equal(/localStorage|indexedDB|migrations|db\./i.test(source), false);
+  assert.equal(/\.\.\/\.\.\/node_modules\/ui-editor-kit/.test(source), false);
+  assert.match(source, /require\("ui-editor-kit"\)/);
+});
+
+console.log('TESTS OK: m53UiEditorVisibilityDraft');

--- a/src/main/ipc/uiEditorIpc.js
+++ b/src/main/ipc/uiEditorIpc.js
@@ -3,6 +3,7 @@ const { startBbmUiEditorRuntime, getBbmUiEditorIntegrationStatus } = require("..
 
 let session = null;
 let selectedElementId = null;
+let currentDraft = null;
 
 function getRuntimeBlockCode(result) {
   return result?.blockCode || result?.runtime?.blockCode || result?.runtime?.runtimeStatus?.blocked || result?.runtime?.status || null;
@@ -27,6 +28,9 @@ function cloneElement(element, selected = false) {
     parentId: element?.parentId == null ? null : String(element.parentId),
     capabilities: Array.isArray(element?.capabilities) ? element.capabilities.map(String) : [],
     allowedChanges: Array.isArray(element?.allowedChanges) ? element.allowedChanges.map(String) : [],
+    layoutDefaults: element?.layoutDefaults && typeof element.layoutDefaults === "object" ? { ...element.layoutDefaults } : {},
+    m53Editable: element?.elementId === "bbm.main.header" || element?.elementId === "bbm.main.actions",
+    m53LockReason: element?.elementId === "bbm.main.header" || element?.elementId === "bbm.main.actions" ? "" : "Dieses Element ist in M53 fuer Sichtbarkeitsaenderungen gesperrt.",
     selected: Boolean(selected),
   };
 }
@@ -124,8 +128,102 @@ function getSelectedUiEditorElementDetails() {
   return { ok: true, selectedElement: cloneElement(element, true) };
 }
 
+function getSelectedElement(runtimeResult) {
+  if (!selectedElementId) return null;
+  return (runtimeResult.registry.elements || []).find((entry) => entry.elementId === selectedElementId) || null;
+}
+
+function getElementVisible(runtimeResult, elementId) {
+  if (!elementId) return true;
+  const result = runtimeResult.hostAdapter.getElementLayoutState({
+    elementId,
+    layoutScope: runtimeResult.manifest.defaultLayoutScope,
+    layoutProfileId: runtimeResult.manifest.defaultLayoutProfileId,
+  });
+  return result?.ok ? result.visible : true;
+}
+
+function createDraftViewModel({ request, element, validation, currentVisible }) {
+  return {
+    elementId: request.elementId,
+    elementLabel: element?.label || request.elementId,
+    uiScope: request.uiScope,
+    layoutScope: request.layoutScope,
+    layoutProfileId: request.layoutProfileId,
+    previousValue: currentVisible,
+    nextValue: request.value,
+    operation: request.operation,
+    valid: Boolean(validation?.ok),
+    blockCode: validation?.ok ? null : String(validation?.blockCode || "BBM_UI_CHANGE_DRAFT_INVALID"),
+  };
+}
+
+function createChangeDraft(payload = {}) {
+  const runtimeResult = ensureRuntime();
+  if (!runtimeResult?.ok) return sanitizeError(runtimeResult);
+  const element = getSelectedElement(runtimeResult);
+  if (!element) return { ok: false, blockCode: "BBM_UI_CHANGE_NO_SELECTION", message: "Kein registriertes Element ausgewaehlt." };
+  const request = {
+    elementId: element.elementId,
+    uiScope: runtimeResult.manifest.defaultUiScope,
+    layoutScope: runtimeResult.manifest.defaultLayoutScope,
+    layoutProfileId: runtimeResult.manifest.defaultLayoutProfileId,
+    operation: "visibility.set",
+    property: "visible",
+    value: payload?.visible,
+  };
+  const validation = runtimeResult.hostAdapter.validateChangeRequest(request);
+  const draft = createDraftViewModel({ request, element, validation, currentVisible: getElementVisible(runtimeResult, element.elementId) });
+  currentDraft = { request, draft };
+  return { ok: validation.ok, draft, blockCode: validation.ok ? null : validation.blockCode, message: validation.message || null };
+}
+
+function getChangeDraft() {
+  return { ok: true, draft: currentDraft?.draft || null };
+}
+
+function discardChangeDraft() {
+  currentDraft = null;
+  return { ok: true, draft: null };
+}
+
+function applyChangeDraft(payload = {}) {
+  const runtimeResult = ensureRuntime();
+  if (!runtimeResult?.ok) return sanitizeError(runtimeResult);
+  if (!currentDraft?.request) return { ok: false, blockCode: "BBM_UI_CHANGE_DRAFT_INVALID", message: "Kein gueltiger Entwurf vorhanden." };
+  if (payload && typeof payload === "object" && Object.keys(payload).length > 0) {
+    const validation = runtimeResult.hostAdapter.validateChangeRequest(payload);
+    if (!validation.ok) return { ok: false, blockCode: validation.blockCode || "BBM_UI_CHANGE_DRAFT_INVALID", message: validation.message || "Manipulierte Payload wurde abgelehnt.", draft: currentDraft.draft };
+  }
+  const validation = runtimeResult.hostAdapter.validateChangeRequest(currentDraft.request);
+  if (!validation.ok) return { ok: false, blockCode: validation.blockCode || "BBM_UI_CHANGE_DRAFT_INVALID", message: validation.message || "Entwurf wurde abgelehnt.", draft: currentDraft.draft };
+  const result = runtimeResult.hostAdapter.submitChangeRequest(currentDraft.request);
+  if (!result?.ok) return { ok: false, blockCode: String(result?.blockCode || "BBM_UI_CHANGE_APPLY_FAILED"), message: "Layoutaenderung wurde nicht gespeichert.", draft: currentDraft.draft };
+  currentDraft = null;
+  return { ok: true, message: "Layoutaenderung angewendet", elementId: result.elementId, visible: result.visible, layoutProfileId: result.layoutProfileId, storage: "Sitzungsspeicher", layoutState: result.layoutState };
+}
+
+function loadLayoutState(payload = {}) {
+  const runtimeResult = ensureRuntime();
+  if (!runtimeResult?.ok) return sanitizeError(runtimeResult);
+  const elementId = String(payload?.elementId || selectedElementId || "").trim();
+  if (!elementId) return { ok: false, blockCode: "BBM_UI_CHANGE_NO_SELECTION", message: "Kein registriertes Element ausgewaehlt." };
+  return runtimeResult.hostAdapter.getElementLayoutState({ elementId, layoutScope: runtimeResult.manifest.defaultLayoutScope, layoutProfileId: runtimeResult.manifest.defaultLayoutProfileId });
+}
+
+function resetLayoutState(payload = {}) {
+  const runtimeResult = ensureRuntime();
+  if (!runtimeResult?.ok) return sanitizeError(runtimeResult);
+  const elementId = String(payload?.elementId || selectedElementId || "").trim();
+  if (!elementId) return { ok: false, blockCode: "BBM_UI_CHANGE_NO_SELECTION", message: "Kein registriertes Element ausgewaehlt." };
+  const result = runtimeResult.hostAdapter.resetLayoutState({ elementId, layoutScope: runtimeResult.manifest.defaultLayoutScope, layoutProfileId: runtimeResult.manifest.defaultLayoutProfileId });
+  if (currentDraft?.request?.elementId === elementId) currentDraft = null;
+  return result;
+}
+
 function closeUiEditorSession() {
   selectedElementId = null;
+  currentDraft = null;
   session = null;
   return { ok: true };
 }
@@ -137,6 +235,12 @@ function registerUiEditorIpc() {
   ipcMain.handle("uiEditor:getElements", async () => getUiEditorElements());
   ipcMain.handle("uiEditor:selectElement", async (_event, payload) => selectUiEditorElement(payload));
   ipcMain.handle("uiEditor:getSelectedElementDetails", async () => getSelectedUiEditorElementDetails());
+  ipcMain.handle("uiEditor:createChangeDraft", async (_event, payload) => createChangeDraft(payload));
+  ipcMain.handle("uiEditor:getChangeDraft", async () => getChangeDraft());
+  ipcMain.handle("uiEditor:discardChangeDraft", async () => discardChangeDraft());
+  ipcMain.handle("uiEditor:applyChangeDraft", async (_event, payload) => applyChangeDraft(payload));
+  ipcMain.handle("uiEditor:loadLayoutState", async (_event, payload) => loadLayoutState(payload));
+  ipcMain.handle("uiEditor:resetLayoutState", async (_event, payload) => resetLayoutState(payload));
 }
 
 module.exports = {
@@ -149,5 +253,11 @@ module.exports = {
     getUiEditorStatus,
     selectUiEditorElement,
     getSelectedUiEditorElementDetails,
+    createChangeDraft,
+    getChangeDraft,
+    discardChangeDraft,
+    applyChangeDraft,
+    loadLayoutState,
+    resetLayoutState,
   },
 };

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -265,6 +265,12 @@ contextBridge.exposeInMainWorld("bbmDb", {
   uiEditorGetElements: () => ipcRenderer.invoke("uiEditor:getElements"),
   uiEditorSelectElement: (data) => ipcRenderer.invoke("uiEditor:selectElement", data),
   uiEditorGetSelectedElementDetails: () => ipcRenderer.invoke("uiEditor:getSelectedElementDetails"),
+  uiEditorCreateChangeDraft: (data) => ipcRenderer.invoke("uiEditor:createChangeDraft", data),
+  uiEditorGetChangeDraft: () => ipcRenderer.invoke("uiEditor:getChangeDraft"),
+  uiEditorDiscardChangeDraft: () => ipcRenderer.invoke("uiEditor:discardChangeDraft"),
+  uiEditorApplyChangeDraft: (data) => ipcRenderer.invoke("uiEditor:applyChangeDraft", data),
+  uiEditorLoadLayoutState: (data) => ipcRenderer.invoke("uiEditor:loadLayoutState", data),
+  uiEditorResetLayoutState: (data) => ipcRenderer.invoke("uiEditor:resetLayoutState", data),
 });
 
 contextBridge.exposeInMainWorld("bbmPrint", {

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -40,10 +40,16 @@ export class BbmUiEditorStatusPanel {
     this.statusNode = null;
     this.elementsNode = null;
     this.detailsNode = null;
+    this.changeNode = null;
     this.errorNode = null;
     this.status = null;
     this.elements = [];
     this.selectedElement = null;
+    this.currentLayoutState = null;
+    this.currentDraft = null;
+    this.desiredVisible = true;
+    this.applyBusy = false;
+    this.resetBusy = false;
   }
 
   render() {
@@ -55,7 +61,7 @@ export class BbmUiEditorStatusPanel {
     const title = createNode("h1");
     title.textContent = "UI-Editor";
     const subtitle = createNode("p");
-    subtitle.textContent = "Technische Editor-Ansicht fuer BBM. Layoutaenderungen folgen in einem spaeteren Paket.";
+    subtitle.textContent = "Technische Editor-Ansicht fuer BBM. M53 erlaubt nur Sichtbarkeit als Entwurf im Sitzungsspeicher.";
     titleBox.append(title, subtitle);
 
     const closeButton = createNode("button", "bbm-ui-editor-panel__close");
@@ -77,7 +83,8 @@ export class BbmUiEditorStatusPanel {
     this.statusNode = createNode("section", "bbm-ui-editor-card");
     this.elementsNode = createNode("section", "bbm-ui-editor-card");
     this.detailsNode = createNode("section", "bbm-ui-editor-card");
-    grid.append(this.statusNode, this.elementsNode, this.detailsNode);
+    this.changeNode = createNode("section", "bbm-ui-editor-card");
+    grid.append(this.statusNode, this.elementsNode, this.detailsNode, this.changeNode);
 
     root.append(header, this.errorNode, intro, grid);
     this.root = root;
@@ -116,6 +123,14 @@ export class BbmUiEditorStatusPanel {
     this.status = status;
     this.elements = Array.isArray(elementsResult?.elements) ? elementsResult.elements : [];
     this.selectedElement = detailsResult?.selectedElement || null;
+    if (this.selectedElement && typeof api.uiEditorLoadLayoutState === "function") {
+      this.currentLayoutState = await api.uiEditorLoadLayoutState({ elementId: this.selectedElement.elementId });
+    } else {
+      this.currentLayoutState = null;
+    }
+    const draftResult = typeof api.uiEditorGetChangeDraft === "function" ? await api.uiEditorGetChangeDraft() : { ok: true, draft: null };
+    this.currentDraft = draftResult?.draft || null;
+    this.desiredVisible = this.currentDraft ? this.currentDraft.nextValue : this.currentLayoutState?.visible !== false;
     this.renderAll();
   }
 
@@ -130,6 +145,7 @@ export class BbmUiEditorStatusPanel {
     this.renderStatus();
     this.renderElements();
     this.renderDetails();
+    this.renderChange();
   }
 
   renderStatus() {
@@ -161,7 +177,8 @@ export class BbmUiEditorStatusPanel {
       createInfoRow("LayoutStore verfuegbar", yesNo(status.layoutStoreAvailable)),
       createInfoRow("Layoutzustand vorhanden", yesNo(layout.hasStateForScopeAndProfile)),
       createInfoRow("Load/Save/Reset technisch", `${yesNo(layout.canLoad)} / ${yesNo(layout.canSave)} / ${yesNo(layout.canReset)}`),
-      createInfoRow("Blockcode", status.blockCode || "kein Block")
+      createInfoRow("Blockcode", status.blockCode || "kein Block"),
+      createInfoRow("Speicherung", "nur Sitzungsspeicher")
     );
 
     const reloadButton = createNode("button", "bbm-ui-editor-panel__secondary");
@@ -235,9 +252,138 @@ export class BbmUiEditorStatusPanel {
       createInfoRow("Scope", element.scope),
       createInfoRow("Parent", element.parentId || "Root"),
       createInfoRow("Capabilities", formatList(element.capabilities)),
-      createInfoRow("Erlaubte Aenderungen", formatList(element.allowedChanges))
+      createInfoRow("Erlaubte Aenderungen", formatList(element.allowedChanges)),
+      createInfoRow("M53 aenderbar", element.m53Editable ? "Ja" : "Nein"),
+      createInfoRow("M53 Sperre", element.m53Editable ? "keine" : element.m53LockReason)
     );
     this.detailsNode.appendChild(list);
+  }
+
+
+  renderChange() {
+    if (!this.changeNode) return;
+    this.changeNode.innerHTML = "";
+    const title = createNode("h2");
+    title.textContent = "Layoutaenderung";
+    const notice = createNode("p", "bbm-ui-editor-panel__notice");
+    notice.textContent = "Layoutaenderungen werden in M53 nur fuer die aktuelle Sitzung gespeichert.";
+    this.changeNode.append(title, notice);
+
+    const element = this.selectedElement;
+    if (!element) {
+      const empty = createNode("p", "bbm-ui-editor-panel__empty");
+      empty.textContent = "Kein Element ausgewaehlt.";
+      this.changeNode.appendChild(empty);
+      return;
+    }
+
+    const currentVisible = this.currentLayoutState?.visible !== false;
+    const locked = !element.m53Editable || !this.status?.runtimeStarted || !this.status?.adapterValid;
+    const list = createNode("dl", "bbm-ui-editor-status-list");
+    list.append(
+      createInfoRow("Aktueller Zustand", currentVisible ? "Sichtbar" : "Ausgeblendet"),
+      createInfoRow("UI-Scope", element.scope),
+      createInfoRow("Layout-Scope", element.layoutScope),
+      createInfoRow("Layoutprofil", element.layoutProfileId),
+      createInfoRow("Speicher", "Sitzungsspeicher")
+    );
+
+    const select = createNode("select", "bbm-ui-editor-panel__select");
+    const visibleOption = createNode("option");
+    visibleOption.value = "true";
+    visibleOption.textContent = "Sichtbar";
+    const hiddenOption = createNode("option");
+    hiddenOption.value = "false";
+    hiddenOption.textContent = "Ausgeblendet";
+    select.append(visibleOption, hiddenOption);
+    select.value = String(this.desiredVisible !== false);
+    select.disabled = locked;
+    select.addEventListener("change", () => { this.desiredVisible = select.value === "true"; });
+
+    const fieldLabel = createNode("label", "bbm-ui-editor-panel__field");
+    fieldLabel.textContent = "Gewuenschter Zustand";
+    fieldLabel.appendChild(select);
+
+    const draftBox = createNode("div", "bbm-ui-editor-panel__draft");
+    if (this.currentDraft) {
+      const draft = this.currentDraft;
+      const draftList = createNode("dl", "bbm-ui-editor-status-list");
+      draftList.append(
+        createInfoRow("elementId", draft.elementId),
+        createInfoRow("Elementbezeichnung", draft.elementLabel),
+        createInfoRow("UI-Scope", draft.uiScope),
+        createInfoRow("Layout-Scope", draft.layoutScope),
+        createInfoRow("Layoutprofil", draft.layoutProfileId),
+        createInfoRow("Bisheriger Wert", String(draft.previousValue)),
+        createInfoRow("Neuer Wert", String(draft.nextValue)),
+        createInfoRow("Operation", draft.operation),
+        createInfoRow("Validierungsstatus", draft.valid ? "gueltig" : "abgelehnt"),
+        createInfoRow("Blockcode", draft.blockCode || "kein Block")
+      );
+      draftBox.appendChild(draftList);
+    } else {
+      draftBox.textContent = "Noch kein Entwurf erstellt.";
+    }
+
+    const createButton = createNode("button", "bbm-ui-editor-panel__secondary");
+    createButton.type = "button";
+    createButton.textContent = "Entwurf erstellen";
+    createButton.disabled = locked;
+    createButton.addEventListener("click", () => this.createDraft().catch((error) => this.showLoadError(error)));
+
+    const applyButton = createNode("button", "bbm-ui-editor-panel__secondary");
+    applyButton.type = "button";
+    applyButton.textContent = "Anwenden";
+    applyButton.disabled = locked || !this.currentDraft?.valid || this.applyBusy;
+    applyButton.addEventListener("click", () => this.applyDraft().catch((error) => this.showLoadError(error)));
+
+    const discardButton = createNode("button", "bbm-ui-editor-panel__secondary");
+    discardButton.type = "button";
+    discardButton.textContent = "Entwurf verwerfen";
+    discardButton.disabled = !this.currentDraft;
+    discardButton.addEventListener("click", () => this.discardDraft().catch((error) => this.showLoadError(error)));
+
+    const resetButton = createNode("button", "bbm-ui-editor-panel__secondary");
+    resetButton.type = "button";
+    resetButton.textContent = "Layout zuruecksetzen";
+    resetButton.disabled = !element || this.resetBusy;
+    resetButton.addEventListener("click", () => this.resetLayout().catch((error) => this.showLoadError(error)));
+
+    const reloadButton = createNode("button", "bbm-ui-editor-panel__secondary");
+    reloadButton.type = "button";
+    reloadButton.textContent = "Layoutstatus neu laden";
+    reloadButton.addEventListener("click", () => this.refresh().catch((error) => this.showLoadError(error)));
+
+    const actions = createNode("div", "bbm-ui-editor-panel__actions");
+    actions.append(createButton, applyButton, discardButton, resetButton, reloadButton);
+    this.changeNode.append(list, fieldLabel, draftBox, actions);
+  }
+
+  async createDraft() {
+    const result = await window.bbmDb?.uiEditorCreateChangeDraft?.({ visible: this.desiredVisible });
+    if (!result?.ok && this.errorNode) setNeutralError(this.errorNode, result);
+    await this.refresh();
+  }
+
+  async applyDraft() {
+    this.applyBusy = true;
+    const result = await window.bbmDb?.uiEditorApplyChangeDraft?.({});
+    this.applyBusy = false;
+    if (!result?.ok && this.errorNode) setNeutralError(this.errorNode, result);
+    await this.refresh();
+  }
+
+  async discardDraft() {
+    await window.bbmDb?.uiEditorDiscardChangeDraft?.();
+    await this.refresh();
+  }
+
+  async resetLayout() {
+    this.resetBusy = true;
+    const result = await window.bbmDb?.uiEditorResetLayoutState?.({ elementId: this.selectedElement?.elementId });
+    this.resetBusy = false;
+    if (!result?.ok && this.errorNode) setNeutralError(this.errorNode, result);
+    await this.refresh();
   }
 
   async selectElement(elementId) {

--- a/src/ui-editor/bbm-host-adapter.cjs
+++ b/src/ui-editor/bbm-host-adapter.cjs
@@ -1,7 +1,44 @@
 "use strict";
 
+const uiEditorKit = require("ui-editor-kit");
 const { getBbmUiEditorManifest, BBM_UI_SCOPE, BBM_LAYOUT_SCOPE, BBM_LAYOUT_PROFILE_ID } = require("./bbm-ui-editor-manifest.cjs");
 const { getBbmUiElementRegistry, findBbmUiElement } = require("./bbm-ui-element-registry.cjs");
+
+const M53_CHANGE_OPERATION = "visibility.set";
+const M53_ALLOWED_ELEMENTS = Object.freeze(["bbm.main.header", "bbm.main.actions"]);
+const M53_LOCKED_REASONS = Object.freeze({
+  "bbm.main.shell": "Der Hauptrahmen darf in M53 nicht ausgeblendet werden.",
+  "bbm.main.navigation": "Die Navigation bleibt gesperrt, damit ein Rueckweg erhalten bleibt.",
+  "bbm.main.content": "Der Inhaltsbereich bleibt gesperrt, damit das Statuspanel bedienbar bleibt.",
+});
+const M53_ALLOWED_CHANGE_FIELDS = Object.freeze([
+  "elementId",
+  "uiScope",
+  "layoutScope",
+  "layoutProfileId",
+  "operation",
+  "property",
+  "value",
+]);
+const M53_FORBIDDEN_PROPERTIES = Object.freeze([
+  "x",
+  "y",
+  "width",
+  "height",
+  "margin",
+  "padding",
+  "color",
+  "background",
+  "font",
+  "fontSize",
+  "className",
+  "style",
+  "text",
+  "html",
+  "children",
+  "parentId",
+  "type",
+]);
 
 function cloneValue(value) {
   if (Array.isArray(value)) return value.map(cloneValue);
@@ -16,18 +53,14 @@ function cloneValue(value) {
 }
 
 function createMemoryLayoutStateStore(initialState = []) {
-  const entries = new Map();
-  const layoutStates = new Map();
+  const entryStore = new Map();
+  const publicStore = uiEditorKit.createMemoryLayoutStateStore({ allowedPayloadFields: ["visible"] });
   for (const entry of initialState) {
-    if (entry?.elementId) entries.set(entry.elementId, { ...entry, layoutValue: { ...(entry.layoutValue || {}) } });
-  }
-
-  function selectorKey({ targetAppId = "bbm-produktiv", uiScope = BBM_UI_SCOPE, layoutScope = BBM_LAYOUT_SCOPE, layoutProfileId = BBM_LAYOUT_PROFILE_ID } = {}) {
-    return [targetAppId, uiScope, layoutScope, layoutProfileId].join("::");
+    if (entry?.elementId) entryStore.set(entry.elementId, { ...entry, layoutValue: { ...(entry.layoutValue || {}) } });
   }
 
   function cloneEntries({ layoutScope = BBM_LAYOUT_SCOPE, layoutProfileId = BBM_LAYOUT_PROFILE_ID } = {}) {
-    return [...entries.values()]
+    return [...entryStore.values()]
       .filter((entry) => entry.layoutScope === layoutScope && entry.layoutProfileId === layoutProfileId)
       .map((entry) => ({ ...entry, layoutValue: { ...entry.layoutValue } }));
   }
@@ -39,33 +72,25 @@ function createMemoryLayoutStateStore(initialState = []) {
       return cloneEntries({ layoutScope, layoutProfileId });
     },
     save(entry) {
-      entries.set(entry.elementId, { ...entry, layoutValue: { ...(entry.layoutValue || {}) } });
+      entryStore.set(entry.elementId, { ...entry, layoutValue: { ...(entry.layoutValue || {}) } });
       return { ok: true };
     },
     reset({ elementId } = {}) {
-      if (elementId) entries.delete(elementId);
-      else entries.clear();
+      if (elementId) entryStore.delete(elementId);
+      else entryStore.clear();
       return { ok: true };
     },
     saveLayoutState(layoutState) {
-      const state = cloneValue(layoutState || {});
-      layoutStates.set(selectorKey(state), state);
-      return { ok: true, status: "layout_state_saved", layoutState: cloneValue(state) };
+      return publicStore.saveLayoutState(layoutState);
     },
     loadLayoutState(selector) {
-      const key = selectorKey(selector || {});
-      if (!layoutStates.has(key)) {
-        return { ok: false, status: "layout_profile_not_found", errors: [{ code: "layout_profile_not_found", message: "Layout-Profil wurde nicht gefunden." }] };
-      }
-      return { ok: true, status: "layout_state_loaded", layoutState: cloneValue(layoutStates.get(key)) };
+      return publicStore.loadLayoutState(selector);
     },
     resetLayoutState(selector) {
-      const key = selectorKey(selector || {});
-      if (!layoutStates.has(key)) {
-        return { ok: false, status: "layout_profile_not_found", errors: [{ code: "layout_profile_not_found", message: "Layout-Profil wurde nicht gefunden." }] };
-      }
-      layoutStates.delete(key);
-      return { ok: true, status: "layout_state_reset", reset: "removed" };
+      return publicStore.resetLayoutState(selector);
+    },
+    listLayoutProfiles(selector) {
+      return publicStore.listLayoutProfiles(selector);
     },
   };
 }
@@ -74,25 +99,101 @@ function block(blockCode, message, extra = {}) {
   return { ok: false, blockCode, message, ...extra };
 }
 
+function createLayoutSelector() {
+  return {
+    targetAppId: "bbm-produktiv",
+    uiScope: BBM_UI_SCOPE,
+    layoutScope: BBM_LAYOUT_SCOPE,
+    layoutProfileId: BBM_LAYOUT_PROFILE_ID,
+  };
+}
+
+function createDefaultLayoutState(elementsMap = {}, version = 1) {
+  return uiEditorKit.createLayoutState({
+    schemaVersion: 1,
+    ...createLayoutSelector(),
+    version,
+    source: "saved",
+    elements: elementsMap,
+  });
+}
+
+function normalizeChangeRequest(input = {}) {
+  const payload = input && typeof input === "object" ? input : {};
+  return {
+    elementId: String(payload.elementId || "").trim(),
+    uiScope: String(payload.uiScope || BBM_UI_SCOPE).trim(),
+    layoutScope: String(payload.layoutScope || BBM_LAYOUT_SCOPE).trim(),
+    layoutProfileId: String(payload.layoutProfileId || BBM_LAYOUT_PROFILE_ID).trim(),
+    operation: String(payload.operation || M53_CHANGE_OPERATION).trim(),
+    property: String(payload.property || "visible").trim(),
+    value: payload.value,
+  };
+}
+
+function validateM53ChangeRequest(input = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return block("BBM_UI_CHANGE_DRAFT_INVALID", "ChangeRequest muss ein Objekt sein.");
+  const unknownField = Object.keys(input).find((field) => !M53_ALLOWED_CHANGE_FIELDS.includes(field));
+  if (unknownField) return block("BBM_UI_CHANGE_UNSUPPORTED_PROPERTY", "Diese Aenderung ist in M53 nicht erlaubt.", { field: unknownField });
+  const request = normalizeChangeRequest(input);
+  if (!request.elementId) return block("BBM_UI_CHANGE_NO_SELECTION", "Kein registriertes Element ausgewaehlt.");
+  if (request.uiScope !== BBM_UI_SCOPE) return block("BBM_UI_CHANGE_SCOPE_MISMATCH", "Dieser UI-Scope ist in M53 nicht erlaubt.");
+  if (request.layoutScope !== BBM_LAYOUT_SCOPE) return block("BBM_UI_CHANGE_SCOPE_MISMATCH", "Dieser Layout-Scope ist in M53 nicht erlaubt.");
+  if (request.layoutProfileId !== BBM_LAYOUT_PROFILE_ID) return block("BBM_UI_CHANGE_PROFILE_MISMATCH", "Dieses Layoutprofil ist in M53 nicht erlaubt.");
+  const element = findBbmUiElement(request.elementId, request.uiScope);
+  if (!element) return block("BBM_UI_ELEMENT_UNKNOWN", "Das UI-Element ist nicht registriert.");
+  if (request.operation !== M53_CHANGE_OPERATION || request.property !== "visible") {
+    return block("BBM_UI_CHANGE_UNSUPPORTED_PROPERTY", "M53 erlaubt ausschliesslich visible true/false.");
+  }
+  if (M53_FORBIDDEN_PROPERTIES.includes(request.property)) return block("BBM_UI_CHANGE_UNSUPPORTED_PROPERTY", "Diese Eigenschaft ist in M53 gesperrt.");
+  if (typeof request.value !== "boolean") return block("BBM_UI_CHANGE_INVALID_VALUE", "visible muss ein Boolean sein.");
+  if (!M53_ALLOWED_ELEMENTS.includes(request.elementId)) {
+    return block("BBM_UI_CHANGE_ELEMENT_LOCKED", M53_LOCKED_REASONS[request.elementId] || "Dieses Element ist in M53 fuer Layoutaenderungen gesperrt.", { element });
+  }
+  return { ok: true, request, element };
+}
+
 function createBbmHostAdapter(options = {}) {
   const manifest = getBbmUiEditorManifest();
   const layoutStore = options.layoutStore || createMemoryLayoutStateStore();
   let selectedElementId = null;
+  let layoutVersion = 1;
 
   function assertScope(uiScope = BBM_UI_SCOPE) {
-    if (!manifest.uiScopes.includes(uiScope)) {
-      return block("BBM_UI_SCOPE_UNKNOWN", `Unknown UI scope: ${String(uiScope)}`);
-    }
+    if (!manifest.uiScopes.includes(uiScope)) return block("BBM_UI_SCOPE_UNKNOWN", `Unknown UI scope: ${String(uiScope)}`);
     return { ok: true };
+  }
+
+  function loadPublicLayoutState() {
+    return layoutStore.loadLayoutState(createLayoutSelector());
+  }
+
+  function getVisible(elementId) {
+    const loaded = loadPublicLayoutState();
+    const value = loaded?.ok ? loaded.layoutState?.elements?.[elementId]?.visible : undefined;
+    if (typeof value === "boolean") return value;
+    const element = findBbmUiElement(elementId);
+    return element?.layoutDefaults?.visible !== false;
+  }
+
+  function saveVisible(elementId, visible) {
+    const existing = loadPublicLayoutState();
+    const elements = existing?.ok && existing.layoutState?.elements ? cloneValue(existing.layoutState.elements) : {};
+    elements[elementId] = { visible };
+    const state = createDefaultLayoutState(elements, ++layoutVersion);
+    const validation = uiEditorKit.validateLayoutState(state, { allowedPayloadFields: ["visible"] });
+    if (!validation.ok) return block("BBM_UI_CHANGE_DRAFT_INVALID", "LayoutState wurde vom UI-Editor-kit abgelehnt.", { validation });
+    const saved = layoutStore.saveLayoutState(state);
+    if (!saved?.ok) return block("BBM_UI_CHANGE_APPLY_FAILED", "Layoutzustand konnte nicht gespeichert werden.", { validation: saved });
+    layoutStore.save({ elementId, layoutScope: BBM_LAYOUT_SCOPE, layoutProfileId: BBM_LAYOUT_PROFILE_ID, layoutValue: { visible }, savedAt: "runtime" });
+    return { ok: true, layoutState: saved.layoutState, elementState: saved.layoutState.elements[elementId] };
   }
 
   return {
     manifest,
     adapterManifest: manifest,
     layoutStore,
-    getAdapterManifest() {
-      return getBbmUiEditorManifest();
-    },
+    getAdapterManifest() { return getBbmUiEditorManifest(); },
     getRegistry(uiScope = BBM_UI_SCOPE) {
       const scope = assertScope(uiScope);
       if (!scope.ok) return { ...scope, elements: [], listElements: () => [], getElementById: () => null, size: () => 0 };
@@ -101,9 +202,7 @@ function createBbmHostAdapter(options = {}) {
     validateScope(uiScope = BBM_UI_SCOPE, layoutScope = BBM_LAYOUT_SCOPE) {
       const scope = assertScope(uiScope);
       if (!scope.ok) return scope;
-      if (!manifest.layoutScopes.includes(layoutScope)) {
-        return block("BBM_LAYOUT_SCOPE_UNKNOWN", `Unknown layout scope: ${String(layoutScope)}`);
-      }
+      if (!manifest.layoutScopes.includes(layoutScope)) return block("BBM_LAYOUT_SCOPE_UNKNOWN", `Unknown layout scope: ${String(layoutScope)}`);
       return { ok: true, uiScope, layoutScope, layoutProfileId: BBM_LAYOUT_PROFILE_ID };
     },
     selectElement(elementId, uiScope = BBM_UI_SCOPE) {
@@ -123,29 +222,50 @@ function createBbmHostAdapter(options = {}) {
       if (!manifest.layoutScopes.includes(layoutScope)) return block("BBM_LAYOUT_SCOPE_UNKNOWN", `Unknown layout scope: ${String(layoutScope)}`);
       return { ok: true, layoutScope, layoutProfileId, entries: layoutStore.load({ layoutScope, layoutProfileId }) };
     },
+    getElementLayoutState({ elementId, layoutScope = BBM_LAYOUT_SCOPE, layoutProfileId = BBM_LAYOUT_PROFILE_ID } = {}) {
+      const element = findBbmUiElement(elementId);
+      if (!element) return block("BBM_UI_ELEMENT_UNKNOWN", "Das UI-Element ist nicht registriert.");
+      if (layoutScope !== BBM_LAYOUT_SCOPE) return block("BBM_UI_CHANGE_SCOPE_MISMATCH", "Dieser Layout-Scope ist in M53 nicht erlaubt.");
+      if (layoutProfileId !== BBM_LAYOUT_PROFILE_ID) return block("BBM_UI_CHANGE_PROFILE_MISMATCH", "Dieses Layoutprofil ist in M53 nicht erlaubt.");
+      return { ok: true, elementId, layoutScope, layoutProfileId, visible: getVisible(elementId), defaultVisible: element.layoutDefaults?.visible !== false, storage: "session-memory" };
+    },
     saveLayoutState({ elementId, layoutValue = {}, layoutScope = BBM_LAYOUT_SCOPE, layoutProfileId = BBM_LAYOUT_PROFILE_ID } = {}) {
       const element = findBbmUiElement(elementId);
       if (!element) return block("BBM_UI_ELEMENT_UNKNOWN", `Unknown UI element: ${String(elementId)}`);
-      if (!manifest.layoutScopes.includes(layoutScope)) return block("BBM_LAYOUT_SCOPE_UNKNOWN", `Unknown layout scope: ${String(layoutScope)}`);
-      layoutStore.save({ elementId, layoutScope, layoutProfileId, layoutValue, savedAt: "runtime" });
-      return { ok: true, elementId, layoutScope, layoutProfileId };
+      if (layoutScope !== BBM_LAYOUT_SCOPE) return block("BBM_UI_CHANGE_SCOPE_MISMATCH", "Dieser Layout-Scope ist in M53 nicht erlaubt.");
+      if (layoutProfileId !== BBM_LAYOUT_PROFILE_ID) return block("BBM_UI_CHANGE_PROFILE_MISMATCH", "Dieses Layoutprofil ist in M53 nicht erlaubt.");
+      const keys = Object.keys(layoutValue || {});
+      if (keys.length !== 1 || keys[0] !== "visible") return block("BBM_UI_CHANGE_UNSUPPORTED_PROPERTY", "M53 erlaubt ausschliesslich visible.");
+      if (typeof layoutValue.visible !== "boolean") return block("BBM_UI_CHANGE_INVALID_VALUE", "visible muss ein Boolean sein.");
+      return saveVisible(elementId, layoutValue.visible);
     },
     resetLayoutState({ elementId, layoutScope = BBM_LAYOUT_SCOPE, layoutProfileId = BBM_LAYOUT_PROFILE_ID } = {}) {
-      if (elementId && !findBbmUiElement(elementId)) return block("BBM_UI_ELEMENT_UNKNOWN", `Unknown UI element: ${String(elementId)}`);
-      if (!manifest.layoutScopes.includes(layoutScope)) return block("BBM_LAYOUT_SCOPE_UNKNOWN", `Unknown layout scope: ${String(layoutScope)}`);
+      const element = findBbmUiElement(elementId);
+      if (!element) return block("BBM_UI_ELEMENT_UNKNOWN", "Das UI-Element ist nicht registriert.");
+      if (layoutScope !== BBM_LAYOUT_SCOPE) return block("BBM_UI_CHANGE_SCOPE_MISMATCH", "Dieser Layout-Scope ist in M53 nicht erlaubt.");
+      if (layoutProfileId !== BBM_LAYOUT_PROFILE_ID) return block("BBM_UI_CHANGE_PROFILE_MISMATCH", "Dieses Layoutprofil ist in M53 nicht erlaubt.");
+      const existing = loadPublicLayoutState();
+      const elements = existing?.ok && existing.layoutState?.elements ? cloneValue(existing.layoutState.elements) : {};
+      delete elements[elementId];
       layoutStore.reset({ elementId, layoutScope, layoutProfileId });
-      return { ok: true, elementId: elementId || null, layoutScope, layoutProfileId };
+      if (Object.keys(elements).length === 0) {
+        const reset = layoutStore.resetLayoutState(createLayoutSelector());
+        if (!reset?.ok && reset?.status !== "layout_profile_not_found") return block("BBM_UI_CHANGE_APPLY_FAILED", "Layoutzustand konnte nicht zurueckgesetzt werden.");
+      } else {
+        const saved = layoutStore.saveLayoutState(createDefaultLayoutState(elements, ++layoutVersion));
+        if (!saved?.ok) return block("BBM_UI_CHANGE_APPLY_FAILED", "Layoutzustand konnte nicht zurueckgesetzt werden.");
+      }
+      return { ok: true, elementId, layoutScope, layoutProfileId, visible: element.layoutDefaults?.visible !== false, defaultVisible: element.layoutDefaults?.visible !== false, storage: "session-memory" };
     },
+    validateChangeRequest: validateM53ChangeRequest,
     submitChangeRequest(changeRequest) {
-      return {
-        ok: true,
-        accepted: true,
-        executed: false,
-        changeRequest: cloneValue(changeRequest || {}),
-        message: "M52 accepts only neutral technical UI-Editor requests; no BBM Fachaktion is executed.",
-      };
+      const validation = validateM53ChangeRequest(changeRequest);
+      if (!validation.ok) return validation;
+      const saved = saveVisible(validation.request.elementId, validation.request.value);
+      if (!saved.ok) return saved;
+      return { ok: true, accepted: true, executed: true, elementId: validation.request.elementId, visible: validation.request.value, layoutProfileId: BBM_LAYOUT_PROFILE_ID, storage: "session-memory", layoutState: saved.layoutState };
     },
   };
 }
 
-module.exports = { createBbmHostAdapter, createMemoryLayoutStateStore };
+module.exports = { createBbmHostAdapter, createMemoryLayoutStateStore, validateM53ChangeRequest, createDefaultLayoutState, M53_CHANGE_OPERATION, M53_ALLOWED_ELEMENTS };


### PR DESCRIPTION
### Motivation
- Implement the M53 mini‑milestone to allow a first safe, session-only layout change (visibility) for registered BBM elements from the existing M52 status panel. 
- Keep the change minimal and safe: use only the public `ui-editor-kit` API, limit allowed operations/fields to `visible` true/false, and avoid DOM scanning, persistence or broad editor features.

### Description
- Extend the BBM host adapter to validate and apply visibility change requests and to store/load/reset layout state in a `MemoryLayoutStateStore` using the public `ui-editor-kit` store with `allowedPayloadFields: ["visible"]`, and to expose `validateChangeRequest`/`submitChangeRequest`/`getElementLayoutState` paths; allowed elements in M53 are `bbm.main.header` and `bbm.main.actions` while critical elements are locked. 
- Add a controlled draft workflow in the main process IPC: `createChangeDraft`, `getChangeDraft`, `discardChangeDraft`, `applyChangeDraft`, `loadLayoutState`, `resetLayoutState`, and keep drafts in the main-process session state (no renderer-side persistence). 
- Expand the preload bridge with narrowly named renderer methods (`uiEditorCreateChangeDraft`, `uiEditorGetChangeDraft`, `uiEditorDiscardChangeDraft`, `uiEditorApplyChangeDraft`, `uiEditorLoadLayoutState`, `uiEditorResetLayoutState`) and avoid any generic invocation APIs. 
- Update the M52 status panel (`BbmUiEditorStatusPanel`) to show a new "Layoutaenderung" area with current state, desired state selector, draft summary, and buttons for `Entwurf erstellen`, `Anwenden`, `Entwurf verwerfen`, `Layout zuruecksetzen` and `Layoutstatus neu laden`, and clearly mark that storage is session-only. 
- Add a focused test `scripts/tests/m53UiEditorVisibilityDraft.test.cjs` that validates public `ui-editor-kit` usage, draft validation rules, apply/reset behavior and security guardrails. 
- Add documentation `docs/M53_UI_EDITOR_VISIBILITY_DRAFT_APPLY_RESET.md` and update `README.md` and `STATUS.md` to record M53 scope and limitations.

### Testing
- Ran `git diff --check` and static checks: passed. 
- Ran `node scripts/tests/m51UiEditorKitIntegration.test.cjs`: passed. 
- Ran `node scripts/tests/m52UiEditorVisibleEntry.test.cjs`: passed. 
- Ran `node scripts/tests/m53UiEditorVisibilityDraft.test.cjs`: passed (covers draft creation, validation, apply/discard, reset and security guardrails). 
- Ran `node scripts/test.cjs` under a 180s timeout where the suite produced long sequences of green test output but that particular timed invocation hit the timeout; a subsequent full test run showed broad passing output (see CI environment note). 
- `npm start` was attempted but failed in this Linux environment due to missing Electron system library `libatk-1.0.so.0` (environment limitation), so manual UI smoke test is pending on an environment with Electron runtime support.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a528602fc4c8322a8749b1998eaeb7f)