### PR TITLE
M54: Bind explicit CoreShell UI element refs to M51/M52 registry

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,15 @@
 # STATUS.md â€” BBM-Produktiv
 
+## M54 – Explizite UI-Element-Referenzen (2026-07-11)
+
+- CoreShell bindet vorhandene HTMLElement-Referenzen explizit an die M51/M52-Registry-IDs.
+- Referenzabbildung: `bbm.main.shell -> host`, `bbm.main.navigation -> sidebar`, `bbm.main.header -> headerEl`, `bbm.main.content -> content/contentRoot`.
+- `bbm.main.actions` bleibt bewusst ungebunden, weil kein einzelner vorhandener fachlich eindeutiger Aktionsbereich existiert.
+- Neue Doku: `docs/M54_EXPLIZITE_UI_ELEMENT_REFERENZEN.md`.
+- Der alte RuntimeLauncher wird in CoreShell nicht mehr automatisch parallel gestartet; `UI-Editor Status` bleibt erhalten.
+- Keine DOM-Suche, kein Overlay, kein Auswahlmodus, keine Layoutmutation und keine HTMLElement-Übertragung über IPC.
+- Naechster kleiner Schritt M55: fachlich eindeutigen Actions-Bereich klaeren, bevor `bbm.main.actions` gebunden wird.
+
 ## M53 – Bestand visuelle UI-Auswahl (2026-07-11)
 
 - Reines Analysepaket, kein Implementierungsversuch.

--- a/docs/M54_EXPLIZITE_UI_ELEMENT_REFERENZEN.md
+++ b/docs/M54_EXPLIZITE_UI_ELEMENT_REFERENZEN.md
@@ -1,0 +1,77 @@
+# M54 – Explizite UI-Element-Referenzen
+
+## Ziel
+
+M54 verbindet die aktuelle M51/M52-Registry gezielt mit den HTMLElement-Referenzen, die beim normalen Aufbau der BBM-CoreShell bereits entstehen. Der Schritt bleibt bewusst klein: Es gibt keinen Auswahlmodus, kein Overlay, keine Hover-Rahmen und keine Layoutmutation.
+
+## Bezug auf M53-Bestandsanalyse
+
+M53 hat gezeigt, dass historische UI-Inspector-, EditorV2- und TargetSelection-Pfade sichtbare Auswahl und Markierung kannten, aber DOM-Suche, Selector-Fallbacks, Attribute-Scanning oder parallele Legacy-Runtimes verwendeten. M54 übernimmt deshalb keine alte Runtime. Die neue Bindung nutzt ausschließlich vorhandene Variablen aus dem CoreShell-Aufbau.
+
+## Referenzspeicher
+
+Der neue Speicher liegt in `src/renderer/ui-editor/bbmUiElementRefs.js` und enthält nur diese Funktionen:
+
+- `registerBbmUiElementRef(elementId, element)`
+- `getBbmUiElementRef(elementId)`
+- `unregisterBbmUiElementRef(elementId)`
+- `clearBbmUiElementRefs()`
+- `getBbmUiElementRefStatus()`
+
+Der Speicher kennt nur `elementId -> HTMLElement`. Label, Typ, Scope, Parent, Fähigkeiten und erlaubte Operationen bleiben ausschließlich in der M51-Registry `src/ui-editor/bbm-ui-element-registry.cjs`.
+
+## ElementId-zu-Referenz-Tabelle
+
+| elementId | Referenz in M54 | Status | Begründung |
+|---|---|---:|---|
+| `bbm.main.shell` | `host` | gebunden | `host` ist der übergeordnete CoreShell-Container aus `createCoreShellLayout()`. |
+| `bbm.main.navigation` | `sidebar` | gebunden | `sidebar` ist der vorhandene Navigationscontainer. |
+| `bbm.main.header` | `headerEl` | gebunden | `MainHeader.render()` liefert diese konkrete Header-Referenz. |
+| `bbm.main.content` | `content` / `contentRoot` | gebunden | `contentRoot` und `content` zeigen auf den vorhandenen Inhaltscontainer. |
+| `bbm.main.actions` | ungebunden | bewusst ungebunden | Die Registry nennt als Parent `bbm.main.content`; im aktuellen CoreShell-Aufbau gibt es aber keinen einzelnen, fachlich eindeutigen Aktionsbereich im Content. `topBox` und `bottomBox` gehören zur Navigation/Sidebar; der Context-Control-Bereich erzeugt keinen eindeutigen bestehenden Actions-Container. |
+
+## Gebundene Elemente
+
+- bbm.main.shell -> host
+- bbm.main.navigation -> sidebar
+- bbm.main.header -> headerEl
+- bbm.main.content -> content/contentRoot
+- bbm.main.actions -> ungebunden
+
+M54 bindet vier von fünf Registry-Elementen: Shell, Navigation, Header und Content. Die Bindung erfolgt unmittelbar nach `createCoreShellLayout()` in `CoreShell.js` aus vorhandenen Variablen.
+
+## Bewusst ungebundene Elemente
+
+`bbm.main.actions` bleibt ungebunden. M54 erzeugt keinen künstlichen Wrapper und setzt keine falsche Referenz auf `topBox`, `bottomBox`, einen Buttoncontainer oder dynamische Aktionsschaltflächen.
+
+## Lifecycle
+
+Vor dem CoreShell-Aufbau werden alte Referenzen per `clearBbmUiElementRefs()` entfernt. Beim erneuten Aufbau ersetzt die kontrollierte Registrierung die alten Referenzen. Zusätzlich hat `CoreShell` einen minimalen `destroy()`-Pfad, der den Referenzspeicher leert und keine veralteten HTMLElement-Referenzen hält.
+
+## Registry-Abgrenzung
+
+Die Registry bleibt explizit und `autoDiscovery` bleibt `false`. Der Ref-Speicher übernimmt keine Registry-Metadaten, erzeugt keine zweite fachliche Registry und lässt nur IDs zu, die in der M51-Registry bekannt sind.
+
+## Sicherheitsgrenzen
+
+M54 verwendet keine Selector-Strings, keine CSS-Selektoren, kein `querySelector`, kein `querySelectorAll`, kein `getElementsBy*`, kein `getElementById`, kein `closest`, keinen `MutationObserver`, kein data-ui-Scanning und keine automatische Registrierung. Es werden keine HTMLElement-Objekte über IPC übertragen.
+
+## Ergebnis der Legacy-Runtime-Prüfung
+
+`BbmUiEditorRuntimeLauncher.js` ist der alte installierte Launcher-/TargetSelection-Pfad. Er lädt beziehungsweise nutzt `uiEditor/uiEditorLauncherButton.js` und `uiEditor/targetSelection.js`, kann einen alten sichtbaren Launcher erzeugen und wäre damit parallel zur gültigen M51/M52-Architektur. M54 entfernt deshalb die automatische Installation aus `CoreShell.js`. Die Legacy-Dateien bleiben als Historie/Artefakte im Repository, werden aber beim CoreShell-Start nicht mehr parallel gestartet.
+
+Die gültige Architektur bleibt:
+
+`UI-Editor-kit v0.2.0 -> M51-Manifest -> M51-Registry -> M51-HostAdapter -> M52-Statuspanel`.
+
+## Testabdeckung
+
+`scripts/tests/m54UiElementRefs.test.cjs` prüft den Ref-Speicher, die CoreShell-Bindung aus vorhandenen Variablen, das bewusst ungebundene `bbm.main.actions`, die Sicherheitsgrenzen, Legacy-Isolation und die Dokumentation. M51- und M52-Regressionstests bleiben unverändert relevant.
+
+## Einschränkungen
+
+M54 bietet noch keine direkte Auswahl, keinen Hover-Modus, keinen Rahmen, kein Overlay, keine Layoutvorschau und keine Persistenz. Die Statusanzeige darf nur neutrale Zahlen anzeigen, zum Beispiel `4/5` und die fehlende ID `bbm.main.actions`.
+
+## Nächster Schritt
+
+M55 sollte als kleinster nächster Schritt fachlich entscheiden, wie ein eindeutiger Aktionsbereich entstehen oder registriert werden soll. Erst danach darf `bbm.main.actions` gebunden werden; ein Auswahlmodus oder Overlay wäre ein separates späteres Paket.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -64,6 +64,15 @@ Aktueller Stand:
 - [x] M36 UI-Editor Fixstand nach M29 bis M35 dokumentieren und absichern
 
 
+## Statusupdate M54
+- M54 bindet die vorhandenen CoreShell-HTMLElement-Referenzen explizit an die M51/M52-Registry-IDs.
+- Gebunden sind `bbm.main.shell -> host`, `bbm.main.navigation -> sidebar`, `bbm.main.header -> headerEl` und `bbm.main.content -> content/contentRoot`.
+- `bbm.main.actions` bleibt bewusst ungebunden, weil aktuell kein einzelner vorhandener HTMLElement-Aktionsbereich fachlich eindeutig passt.
+- Neue Doku: `docs/M54_EXPLIZITE_UI_ELEMENT_REFERENZEN.md`.
+- Der alte RuntimeLauncher wird in `CoreShell` nicht mehr automatisch parallel gestartet; die M52-Navigation `UI-Editor Status` bleibt erhalten.
+- Kein Auswahlmodus, kein Overlay, kein Hover, keine Layoutmutation, keine DOM-Suche und keine IPC-Übertragung von HTMLElement-Objekten.
+- Naechster Schritt: M55 klein planen, insbesondere den fachlich eindeutigen Actions-Bereich klaeren, bevor `bbm.main.actions` gebunden wird.
+
 ## Statusupdate M53
 - M53 ist als reines Analysepaket dokumentiert.
 - Neue Bestandsdoku: `docs/M53_BESTAND_VISUELLE_UI_AUSWAHL.md`.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -83,6 +83,7 @@ const { runLicensePresentationTests } = require("./tests/licensePresentation.tes
 const { runNativeTestRuntimeTests } = require("./tests/nativeTestRuntime.test.cjs");
 const { runM51UiEditorKitIntegrationTests } = require("./tests/m51UiEditorKitIntegration.test.cjs");
 const { runM52UiEditorVisibleEntryTests } = require("./tests/m52UiEditorVisibleEntry.test.cjs");
+const { runM54UiElementRefsTests } = require("./tests/m54UiElementRefs.test.cjs");
 
 let failed = false;
 
@@ -213,6 +214,7 @@ async function main() {
   await runNativeTestRuntimeTests(run);
   await runM51UiEditorKitIntegrationTests(run);
   await runM52UiEditorVisibleEntryTests(run);
+  await runM54UiElementRefsTests(run);
 
   if (failed) {
     process.exitCode = 1;

--- a/scripts/tests/m54UiElementRefs.test.cjs
+++ b/scripts/tests/m54UiElementRefs.test.cjs
@@ -1,0 +1,151 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+const { getBbmUiElementRegistry } = require("../../src/ui-editor/bbm-ui-element-registry.cjs");
+
+const REPO_ROOT = path.join(__dirname, "../..");
+
+function read(file) {
+  return fs.readFileSync(path.join(REPO_ROOT, file), "utf8");
+}
+
+function createElementFactory() {
+  class TestHTMLElement {}
+  return {
+    TestHTMLElement,
+    element(name) {
+      const node = new TestHTMLElement();
+      node.name = name;
+      node.ownerDocument = { defaultView: { HTMLElement: TestHTMLElement } };
+      return node;
+    },
+  };
+}
+
+async function runM54UiElementRefsTests(run) {
+  await run("M54 Referenzspeicher: bekannte HTMLElement-Refs werden akzeptiert und exakt geliefert", async () => {
+    const refs = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiElementRefs.js"));
+    refs.clearBbmUiElementRefs();
+    const { element } = createElementFactory();
+    const first = element("content-1");
+    const second = element("content-2");
+
+    refs.registerBbmUiElementRef("bbm.main.content", first);
+    assert.equal(refs.getBbmUiElementRef("bbm.main.content"), first);
+    refs.registerBbmUiElementRef("bbm.main.content", second);
+    assert.equal(refs.getBbmUiElementRef("bbm.main.content"), second);
+
+    const status = refs.getBbmUiElementRefStatus();
+    assert.deepEqual(status.registeredIds, ["bbm.main.content"]);
+    assert.equal(status.count, 1);
+    assert.equal(status.expectedCount, 5);
+    refs.clearBbmUiElementRefs();
+  });
+
+  await run("M54 Referenzspeicher: unbekannte IDs und Nicht-HTMLElement-Werte werden blockiert", async () => {
+    const refs = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiElementRefs.js"));
+    refs.clearBbmUiElementRefs();
+    const { element } = createElementFactory();
+
+    assert.throws(() => refs.registerBbmUiElementRef("bbm.main.unknown", element("x")), /BBM_UI_ELEMENT_REF_UNKNOWN/);
+    assert.throws(() => refs.registerBbmUiElementRef("bbm.main.content", null), /BBM_UI_ELEMENT_REF_INVALID_ELEMENT/);
+    assert.throws(() => refs.registerBbmUiElementRef("bbm.main.content", "#content"), /BBM_UI_ELEMENT_REF_INVALID_ELEMENT/);
+    assert.throws(() => refs.registerBbmUiElementRef("bbm.main.content", {}), /BBM_UI_ELEMENT_REF_INVALID_ELEMENT/);
+    assert.equal(refs.getBbmUiElementRefStatus().count, 0);
+  });
+
+  await run("M54 Referenzspeicher: unregister und clear entfernen Referenzen", async () => {
+    const refs = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiElementRefs.js"));
+    refs.clearBbmUiElementRefs();
+    const { element } = createElementFactory();
+    refs.registerBbmUiElementRef("bbm.main.shell", element("shell"));
+    refs.registerBbmUiElementRef("bbm.main.header", element("header"));
+    refs.unregisterBbmUiElementRef("bbm.main.shell");
+    assert.equal(refs.getBbmUiElementRef("bbm.main.shell"), null);
+    assert.equal(refs.getBbmUiElementRefStatus().count, 1);
+    refs.clearBbmUiElementRefs();
+    assert.equal(refs.getBbmUiElementRefStatus().count, 0);
+  });
+
+  await run("M54 CoreShell: bindet nur vorhandene Variablen und laesst actions transparent ungebunden", () => {
+    const coreShell = read("src/renderer/app/CoreShell.js");
+    assert.match(coreShell, /bindCoreShellUiElementRefs/);
+    assert.match(coreShell, /registerBbmUiElementRef\("bbm\.main\.shell", host\)/);
+    assert.match(coreShell, /registerBbmUiElementRef\("bbm\.main\.navigation", sidebar\)/);
+    assert.match(coreShell, /registerBbmUiElementRef\("bbm\.main\.header", headerEl\)/);
+    assert.match(coreShell, /registerBbmUiElementRef\("bbm\.main\.content", content\)/);
+    assert.doesNotMatch(coreShell, /registerBbmUiElementRef\("bbm\.main\.actions"/);
+    assert.match(coreShell, /clearBbmUiElementRefs\(\)/);
+    assert.match(coreShell, /destroy\(\)/);
+    assert.doesNotMatch(coreShell, /querySelector|getElementById|getElementsBy|closest|MutationObserver|data-ui-/);
+  });
+
+  await run("M54 Legacy-Isolation: CoreShell startet den alten RuntimeLauncher nicht automatisch parallel", () => {
+    const coreShell = read("src/renderer/app/CoreShell.js");
+    assert.doesNotMatch(coreShell, /installBbmUiEditorRuntimeLauncher/);
+    assert.doesNotMatch(coreShell, /createEditorScopeInspector/);
+    assert.doesNotMatch(coreShell, /targetSelection/);
+    const navigation = read("src/renderer/app/coreShellNavigation.js");
+    assert.match(navigation, /UI-Editor Status/);
+    assert.match(navigation, /showUiEditor/);
+  });
+
+  await run("M54 Sicherheit: keine DOM-Suche, keine zweite Registry, kein IPC-DOM und Registry bleibt explicit", () => {
+    const files = [
+      "src/renderer/ui-editor/bbmUiElementRefs.js",
+      "src/renderer/app/CoreShell.js",
+      "src/renderer/ui-editor/BbmUiEditorStatusPanel.js",
+    ];
+    const combined = files.map(read).join("\n");
+    assert.doesNotMatch(combined, /querySelector|querySelectorAll|getElementsBy|getElementById|closest|MutationObserver|data-ui-Scanning/);
+    assert.doesNotMatch(combined, /ipcRenderer|ipcMain|HTMLElement.*send|send.*HTMLElement|invoke\(/);
+    assert.doesNotMatch(combined, /BBM_UI_ELEMENTS\s*=|capabilities:\s*Object\.freeze|allowedChanges:/);
+    const registry = getBbmUiElementRegistry("bbm.main");
+    assert.equal(registry.registryMode, "explicit");
+    assert.equal(registry.autoDiscovery, false);
+    assert.deepEqual(registry.elements.map((element) => element.elementId), [
+      "bbm.main.shell",
+      "bbm.main.navigation",
+      "bbm.main.header",
+      "bbm.main.content",
+      "bbm.main.actions",
+    ]);
+  });
+
+  await run("M54 Statuspanel: zeigt nur neutrale Referenzzahlen ohne Auswahlmodus oder Overlay", () => {
+    const panel = read("src/renderer/ui-editor/BbmUiEditorStatusPanel.js");
+    assert.match(panel, /UI-Referenzen gebunden/);
+    assert.match(panel, /Fehlende Referenzen/);
+    assert.doesNotMatch(panel, /Auswahlmodus|Overlay|Hover|Rahmen/);
+  });
+
+  await run("M54 Dokumentation: Referenzabbildung, Lifecycle und Legacy-Pruefung sind dokumentiert", () => {
+    const doc = read("docs/M54_EXPLIZITE_UI_ELEMENT_REFERENZEN.md");
+    assert.match(doc, /bbm\.main\.shell\s*->\s*host/);
+    assert.match(doc, /bbm\.main\.actions\s*->\s*ungebunden/);
+    assert.match(doc, /Lifecycle/);
+    assert.match(doc, /Legacy-Runtime/);
+    assert.match(read("STATUS.md"), /M54/);
+    assert.match(read("docs/UI_INSPEKTOR_AUFGABENHEFT.md"), /M54/);
+  });
+}
+
+if (require.main === module) {
+  let failed = false;
+  const run = async (name, fn) => {
+    try {
+      await fn();
+      console.log(`ok - ${name}`);
+    } catch (error) {
+      failed = true;
+      console.error(`not ok - ${name}`);
+      console.error(error?.stack || error);
+    }
+  };
+  runM54UiElementRefsTests(run).then(() => {
+    if (failed) process.exitCode = 1;
+  });
+}
+
+module.exports = { runM54UiElementRefsTests };

--- a/src/renderer/app/CoreShell.js
+++ b/src/renderer/app/CoreShell.js
@@ -20,38 +20,42 @@ import { registerCoreShellHeaderBridge } from "./coreShellHeaderBridge.js";
 import { registerCoreShellContextControls } from "./coreShellContextControls.js";
 import { registerCoreShellKeyboardHandling } from "./coreShellKeyboard.js";
 import { createCoreShellNavigationRuntime } from "./coreShellNavigationRuntime.js";
-import { installBbmUiEditorRuntimeLauncher } from "../uiEditor/BbmUiEditorRuntimeLauncher.js";
-import { getActiveUiScope, getAvailableUiScopes, getBbmUiEditorRegistry } from "../uiEditor/bbmUiEditorRegistry.js";
-import { createEditorScopeInspector } from "../editorRuntime/inspector/editorScopeInspector.js";
+import {
+  clearBbmUiElementRefs,
+  getBbmUiElementRefStatus,
+  registerBbmUiElementRef,
+  unregisterBbmUiElementRef,
+} from "../ui-editor/bbmUiElementRefs.js";
 
-const HOST_UI_SCOPE_BY_SECTION = Object.freeze({
-  restarbeiten: "restarbeiten.screen",
-});
+const CORE_SHELL_BOUND_UI_ELEMENT_IDS = Object.freeze([
+  "bbm.main.shell",
+  "bbm.main.navigation",
+  "bbm.main.header",
+  "bbm.main.content",
+]);
 
-const LAYOUT_SCOPE_BY_UI_SCOPE = Object.freeze({
-  "protokoll.topsScreen": "protokoll.topsScreen",
-  "restarbeiten.screen": "restarbeiten.ui.main",
-});
-
-function resolveActiveHostUiScope(router) {
-  const sectionScope = HOST_UI_SCOPE_BY_SECTION[String(router?.activeSection || "").trim()];
-  if (sectionScope) return sectionScope;
-
-  if (router?.context?.ui?.isTopsView) {
-    return "protokoll.topsScreen";
+export function bindCoreShellUiElementRefs({ host, sidebar, headerEl, content } = {}) {
+  for (const elementId of CORE_SHELL_BOUND_UI_ELEMENT_IDS) {
+    unregisterBbmUiElementRef(elementId);
   }
 
-  return getActiveUiScope();
-}
+  registerBbmUiElementRef("bbm.main.shell", host);
+  registerBbmUiElementRef("bbm.main.navigation", sidebar);
+  registerBbmUiElementRef("bbm.main.header", headerEl);
+  registerBbmUiElementRef("bbm.main.content", content);
 
-function resolveLayoutScopeForUiScope(uiScope) {
-  return LAYOUT_SCOPE_BY_UI_SCOPE[String(uiScope || "").trim()] || null;
+  return getBbmUiElementRefStatus();
 }
 
 export default class CoreShell {
   constructor({ router, version } = {}) {
     this.router = router || null;
     this.version = version || "";
+    this.header = null;
+  }
+
+  destroy() {
+    clearBbmUiElementRefs();
     this.header = null;
   }
 
@@ -82,7 +86,10 @@ export default class CoreShell {
     this.header = header;
     const headerEl = header.render();
 
-    const { contentRoot: content, topBox, bottomBox, sidebar, bodyRow } = createCoreShellLayout({ headerEl });
+    clearBbmUiElementRefs();
+    const { host, contentRoot: content, topBox, bottomBox, sidebar, bodyRow } = createCoreShellLayout({ headerEl });
+    const uiElementRefStatus = bindCoreShellUiElementRefs({ host, sidebar, headerEl, content });
+    router.uiElementRefStatus = uiElementRefStatus;
 
     router.contentRoot = content;
     router.shellLayout = { sidebar, bodyRow };
@@ -104,34 +111,8 @@ export default class CoreShell {
       getUpdateContextButtons: () => updateContextButtons,
     });
 
-    let uiEditorRuntimeRefreshToken = 0;
-    const uiEditorLayoutInspector = createEditorScopeInspector();
-    const refreshUiEditorRuntimeLauncher = () => {
-      const activeUiScope = resolveActiveHostUiScope(router);
-      const uiEditorRegistry = getBbmUiEditorRegistry(activeUiScope);
-      const refreshToken = ++uiEditorRuntimeRefreshToken;
-      Promise.resolve(
-        installBbmUiEditorRuntimeLauncher({
-          header,
-          devEnabled: true,
-          activeScopeId: activeUiScope,
-          activeUiScope,
-          registeredElements: uiEditorRegistry?.elements,
-          availableUiScopes: getAvailableUiScopes(),
-          registryResolver: getBbmUiEditorRegistry,
-          layoutInspector: uiEditorLayoutInspector,
-          layoutScopeResolver: resolveLayoutScopeForUiScope,
-        })
-      ).catch((error) => {
-        if (refreshToken === uiEditorRuntimeRefreshToken) {
-          console.warn("[CoreShell] UI-Editor Runtime-Launcher konnte nicht aktualisiert werden:", error);
-        }
-      });
-    };
-
     router.onSectionChange = (section) => {
       setActive(section);
-      refreshUiEditorRuntimeLauncher();
     };
 
     const shellNavigationRouteDefs = createCoreShellNavigationRouteDefs(router);
@@ -155,7 +136,6 @@ export default class CoreShell {
 
     router.showHome();
     header.refresh();
-    refreshUiEditorRuntimeLauncher();
     if (typeof updateContextButtons === "function") {
       updateContextButtons();
     }

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -1,3 +1,5 @@
+import { getBbmUiElementRefStatus } from "./bbmUiElementRefs.js";
+
 function createNode(tag, className = "") {
   const node = document.createElement(tag);
   if (className) node.className = className;
@@ -42,6 +44,7 @@ export class BbmUiEditorStatusPanel {
     this.detailsNode = null;
     this.errorNode = null;
     this.status = null;
+    this.refStatus = null;
     this.elements = [];
     this.selectedElement = null;
   }
@@ -114,6 +117,7 @@ export class BbmUiEditorStatusPanel {
       : { ok: true, selectedElement: null };
 
     this.status = status;
+    this.refStatus = getBbmUiElementRefStatus();
     this.elements = Array.isArray(elementsResult?.elements) ? elementsResult.elements : [];
     this.selectedElement = detailsResult?.selectedElement || null;
     this.renderAll();
@@ -121,6 +125,7 @@ export class BbmUiEditorStatusPanel {
 
   showLoadError(error) {
     this.status = { ok: false, blockCode: "BBM_UI_EDITOR_RENDERER_STATUS_FAILED", message: error?.message || "" };
+    this.refStatus = getBbmUiElementRefStatus();
     this.elements = [];
     this.selectedElement = null;
     this.renderAll();
@@ -158,6 +163,8 @@ export class BbmUiEditorStatusPanel {
       createInfoRow("Aktiver Layout-Scope", status.activeLayoutScope),
       createInfoRow("Layoutprofil", status.activeLayoutProfileId),
       createInfoRow("Registrierte Elemente", status.registeredElementCount),
+      createInfoRow("UI-Referenzen gebunden", this.refStatus ? `${this.refStatus.count}/${this.refStatus.expectedCount}` : "nicht verfuegbar"),
+      createInfoRow("Fehlende Referenzen", this.refStatus ? formatList(this.refStatus.missingIds) : "nicht verfuegbar"),
       createInfoRow("LayoutStore verfuegbar", yesNo(status.layoutStoreAvailable)),
       createInfoRow("Layoutzustand vorhanden", yesNo(layout.hasStateForScopeAndProfile)),
       createInfoRow("Load/Save/Reset technisch", `${yesNo(layout.canLoad)} / ${yesNo(layout.canSave)} / ${yesNo(layout.canReset)}`),

--- a/src/renderer/ui-editor/bbmUiElementRefs.js
+++ b/src/renderer/ui-editor/bbmUiElementRefs.js
@@ -1,0 +1,64 @@
+const elementRefs = new Map();
+const allowedElementIds = new Set([
+  "bbm.main.shell",
+  "bbm.main.navigation",
+  "bbm.main.header",
+  "bbm.main.content",
+  "bbm.main.actions",
+]);
+
+function normalizeElementId(elementId) {
+  return String(elementId == null ? "" : elementId).trim();
+}
+
+function assertKnownElementId(elementId) {
+  const normalizedElementId = normalizeElementId(elementId);
+  if (!allowedElementIds.has(normalizedElementId)) {
+    throw new Error(`BBM_UI_ELEMENT_REF_UNKNOWN: ${normalizedElementId || "<empty>"}`);
+  }
+  return normalizedElementId;
+}
+
+function isHTMLElementInstance(element) {
+  if (!element || typeof element !== "object") return false;
+  const HTMLElementCtor = element.ownerDocument?.defaultView?.HTMLElement || globalThis.HTMLElement;
+  return typeof HTMLElementCtor === "function" && element instanceof HTMLElementCtor;
+}
+
+function cloneStatus() {
+  const registeredIds = [...elementRefs.keys()];
+  const expectedIds = [...allowedElementIds];
+  return {
+    registeredIds,
+    missingIds: expectedIds.filter((elementId) => !elementRefs.has(elementId)),
+    count: registeredIds.length,
+    expectedCount: expectedIds.length,
+  };
+}
+
+export function registerBbmUiElementRef(elementId, element) {
+  const normalizedElementId = assertKnownElementId(elementId);
+  if (!isHTMLElementInstance(element)) {
+    throw new Error(`BBM_UI_ELEMENT_REF_INVALID_ELEMENT: ${normalizedElementId}`);
+  }
+  elementRefs.set(normalizedElementId, element);
+  return getBbmUiElementRef(normalizedElementId);
+}
+
+export function getBbmUiElementRef(elementId) {
+  const normalizedElementId = assertKnownElementId(elementId);
+  return elementRefs.get(normalizedElementId) || null;
+}
+
+export function unregisterBbmUiElementRef(elementId) {
+  const normalizedElementId = assertKnownElementId(elementId);
+  elementRefs.delete(normalizedElementId);
+}
+
+export function clearBbmUiElementRefs() {
+  elementRefs.clear();
+}
+
+export function getBbmUiElementRefStatus() {
+  return cloneStatus();
+}


### PR DESCRIPTION
### Motivation
- Ensure the UI-Editor reads only the explicit M51/M52 registry IDs by providing direct HTMLElement references created during CoreShell setup, avoiding any DOM scanning or selector-based discovery. 
- Provide a minimal, renderer-local reference store and a safe lifecycle so rebuilt shells do not retain stale DOM references and no legacy runtime is started in parallel.

### Description
- Add a thin renderer-local ref store `src/renderer/ui-editor/bbmUiElementRefs.js` that exposes `registerBbmUiElementRef`, `getBbmUiElementRef`, `unregisterBbmUiElementRef`, `clearBbmUiElementRefs` and `getBbmUiElementRefStatus` and only accepts known M51/M52 `elementId`s and real `HTMLElement` instances.  
- Update `CoreShell` (`src/renderer/app/CoreShell.js`) to `clear` refs before layout creation, bind the four explicit refs (`bbm.main.shell -> host`, `bbm.main.navigation -> sidebar`, `bbm.main.header -> headerEl`, `bbm.main.content -> content/contentRoot`) immediately after `createCoreShellLayout()`, expose a minimal `destroy()` that clears refs, and deliberately leave `bbm.main.actions` unbound because no single existing element is fachlich clearly the actions area.  
- Remove the automatic launcher/install path from CoreShell so the old installed runtime launcher is not started in parallel and keep legacy files as history only.  
- Surface the neutral ref status in the existing status panel by reading `getBbmUiElementRefStatus()` in `src/renderer/ui-editor/BbmUiEditorStatusPanel.js` and showing `UI-Referenzen gebunden` / `Fehlende Referenzen` without transmitting HTMLElement objects over IPC.  
- Add tests `scripts/tests/m54UiElementRefs.test.cjs` and wire it into `scripts/test.cjs`, and add documentation `docs/M54_EXPLIZITE_UI_ELEMENT_REFERENZEN.md` plus `STATUS.md` / taskbook updates describing the mapping and lifecycle.  

### Testing
- Ran `git diff --check` with no findings.  
- Ran `node scripts/tests/m51UiEditorKitIntegration.test.cjs` and it passed.  
- Ran `node scripts/tests/m52UiEditorVisibleEntry.test.cjs` and it passed.  
- Ran `node scripts/tests/m54UiElementRefs.test.cjs` (new) and it passed.  
- Executed the combined `node scripts/test.cjs` run which reached the long-running suite and was cut by the timeout in this environment, but the new M54 tests and the M51/M52 checks ran green; full CI should run the complete suite.  
- Attempted `npm start` but Electron could not launch in this environment due to missing system library `libatk-1.0.so.0`, so manual UI smoke checks are pending in a full desktop environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a8d1b7c48322b2a1a3aca79db2f0)