### PR TITLE
M55: Kontrollierter Hover- und Klick-Auswahlmodus für M54-Refs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,16 @@
 # STATUS.md â€” BBM-Produktiv
 
+## M55 – Visuelle UI-Auswahl ueber explizite Refs (2026-07-11)
+
+- Im bestehenden UI-Editor-Statuspanel gibt es einen kontrollierten Auswahlmodus fuer die vier in M54 gebundenen CoreShell-Refs.
+- Hover markiert genau ein explizit gebundenes Ziel mit Label und `elementId`; Klick waehlt ueber den bestehenden M52-Auswahlweg.
+- Zielaufloesung nutzt ausschliesslich M54-Refs und `contains(...)`; keine DOM-Suche, keine Selector-Fallbacks, keine Legacy-Runtime und keine zweite Registry.
+- `bbm.main.actions` bleibt bewusst ungebunden und nicht auswaehlbar.
+- Neue Dateien: `src/renderer/ui-editor/bbmUiElementSelection.js`, `src/renderer/ui-editor/bbmUiSelectionOverlay.js`, `scripts/tests/m55UiElementSelection.test.cjs`, `docs/M55_VISUELLE_UI_AUSWAHL_UEBER_EXPLIZITE_REFS.md`.
+- Geaendert: `src/renderer/ui-editor/BbmUiEditorStatusPanel.js`, `scripts/test.cjs`, `docs/UI_INSPEKTOR_AUFGABENHEFT.md`.
+- Pruefung: M51-, M52-, M54-, M55-Tests, `scripts/test.cjs`, `git diff --check`; `npm start` nur soweit Umgebung moeglich.
+- Naechster kleiner Schritt M56: fachlich eindeutigen Actions-Bereich klaeren, ohne `bbm.main.actions` zu raten.
+
 ## M54 – Explizite UI-Element-Referenzen (2026-07-11)
 
 - CoreShell bindet vorhandene HTMLElement-Referenzen explizit an die M51/M52-Registry-IDs.

--- a/docs/M55_VISUELLE_UI_AUSWAHL_UEBER_EXPLIZITE_REFS.md
+++ b/docs/M55_VISUELLE_UI_AUSWAHL_UEBER_EXPLIZITE_REFS.md
@@ -1,0 +1,74 @@
+# M55 – Visuelle UI-Auswahl ueber explizite Refs
+
+## Ziel und sichtbarer Bedienablauf
+
+M55 ergaenzt im bestehenden Bildschirm **UI-Editor Status** einen kontrollierten Auswahlmodus fuer die in M54 explizit gebundenen CoreShell-Bereiche. Der Nutzer startet den Modus ueber **Auswahlmodus starten**, bewegt die Maus ueber einen BBM-Bereich, sieht genau einen ruhigen Rahmen mit Bezeichnung und `elementId` und kann diesen Bereich anklicken. Die Auswahl laeuft ueber den bestehenden M52-Auswahlweg und aktualisiert danach die Elementdetails im Statuspanel.
+
+Escape, **Auswahlmodus beenden**, Schliessen des Statuspanels oder Panel-Destroy stoppen den Modus und entfernen Listener sowie Overlay.
+
+## Bezug zu M53 und M54
+
+M53 dokumentierte historische Auswahl- und Overlay-Loesungen. M54 band die aktuellen CoreShell-HTMLElement-Referenzen explizit an Registry-IDs. M55 nutzt diese M54-Referenzen als einzige Zielquelle und reaktiviert keine alte Runtime.
+
+## Wiederverwendete historische Konzepte
+
+Uebernommen wurde nur das sichtbare Grundprinzip eines `position: fixed`-Rahmens mit kleiner Beschriftung sowie der Lifecycle-Gedanke, dass Hover/Selection nur in einem ausdruecklich aktivierten Modus laufen.
+
+## Ausdruecklich nicht uebernommene Legacy-Teile
+
+Nicht uebernommen wurden DOM-Scan, Selector-Fallbacks, Trefferlisten, globale Dauer-Capture-Sperren, alte TargetSelection-Runtime, UI-Inspector-Core, EditorV2-Core, Drag/Resize, Vorschau, Speicherung und Layoutmutation.
+
+## Controller-Aufbau
+
+`src/renderer/ui-editor/bbmUiElementSelection.js` stellt `createBbmUiElementSelectionController(options)` bereit. Der Controller besitzt nur `start()`, `stop()`, `destroy()`, `isActive()` und `getState()`. Er verwaltet temporaere Listener, Hoverzustand und den Aufruf des bestehenden Auswahlcallbacks.
+
+## Overlay-Aufbau
+
+`src/renderer/ui-editor/bbmUiSelectionOverlay.js` erzeugt nur einen Overlay-Root, einen Hoverrahmen, eine Beschriftung und einen Bedienhinweis. Es sucht keine Ziele, kennt keine Registry und faengt keine Events ab.
+
+## Zielaufloesung ueber explizite Refs
+
+Die Zielaufloesung betrachtet ausschliesslich die aktuell registrierten M54-Refs fuer:
+
+- `bbm.main.navigation`
+- `bbm.main.header`
+- `bbm.main.content`
+- `bbm.main.shell`
+
+Fuer das Eventziel wird mit `HTMLElement.contains(...)` geprueft, welche gebundene Referenz passt. Wenn Shell und ein Kindbereich passen, gewinnt die kleinere gebundene Flaeche. Es gibt keine zweite Parent-Hierarchie und keine automatische DOM-Erkennung.
+
+## Event-Lifecycle
+
+Beim Start werden Listener einmalig am gebundenen Shell-Element sowie temporaer an dessen Dokument/Fenster fuer Escape, Scroll und Resize installiert. Beim Stop werden alle Listener entfernt, Hoverzustand und Overlay geloescht und keine alten HTMLElement-Referenzen gehalten.
+
+## Klickabfang nur im aktiven Modus
+
+Nur im aktiven Auswahlmodus wird der konkrete Zielklick per `preventDefault`, `stopPropagation` und `stopImmediatePropagation` abgefangen. Dadurch wechselt zum Beispiel ein Navigationsklick waehrend der Auswahl nicht gleichzeitig die Seite. Nach Stop bleiben Klicks unangetastet.
+
+## Panel-Ausschluss
+
+Das Statuspanel uebergibt seinen eigenen Root explizit an den Controller. Klicks innerhalb dieses Roots werden nicht als `bbm.main.content` oder Shell-Auswahl behandelt. Es gibt keine nachtraegliche DOM-Suche nach dem Panel.
+
+## Escape/Stop
+
+Escape stoppt den Modus. Gleiches gilt fuer den Button **Auswahlmodus beenden**, das Schliessen des Statuspanels und `destroy()`.
+
+## Scroll-/Resize-Verhalten
+
+Scroll und Resize aktualisieren nur den aktuellen Hoverrahmen. Die Listener existieren ausschliesslich waehrend aktivem Auswahlmodus. Es gibt keinen permanenten `requestAnimationFrame` und keinen `MutationObserver`.
+
+## Sicherheitsgrenzen
+
+M55 nutzt keine DOM-Suche, keine Selector-Strings, keine `data-ui-*`-Erkennung, keine automatische Registrierung, keine zweite Registry, keine Legacy-Imports, keine Fach- oder Nutzdaten-Aenderung, keine Speicherung und keine HTMLElement-Uebertragung ueber IPC.
+
+## Testabdeckung
+
+`scripts/tests/m55UiElementSelection.test.cjs` prueft Controller-Lifecycle, Zielaufloesung, Panel-Ausschluss, Hover-Overlay, Scroll/Resize-Aktualisierung, Klickauswahl, Klickfreiheit nach Stop und Sicherheitsgrenzen. `scripts/test.cjs` fuehrt den M55-Test als Regression mit aus.
+
+## Bekannte Einschraenkung `bbm.main.actions`
+
+`bbm.main.actions` bleibt absichtlich nicht auswaehlbar, solange M54 keine eindeutige HTMLElement-Referenz bindet. Das Statuspanel nennt diese ID als nicht verfuegbar.
+
+## Naechster Schritt
+
+M56 sollte als kleinstmoeglicher Schritt fachlich klaeren, ob und wo ein eindeutiger Actions-Bereich in der CoreShell existieren soll, bevor `bbm.main.actions` gebunden oder fuer Auswahl/Layout freigegeben wird.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -64,6 +64,14 @@ Aktueller Stand:
 - [x] M36 UI-Editor Fixstand nach M29 bis M35 dokumentieren und absichern
 
 
+## Statusupdate M55
+- M55 ergaenzt im bestehenden UI-Editor-Statuspanel einen ausdruecklich startbaren Auswahlmodus fuer die vier M54-Refs.
+- Gebundene auswählbare Ziele bleiben `bbm.main.shell`, `bbm.main.navigation`, `bbm.main.header` und `bbm.main.content`.
+- `bbm.main.actions` bleibt bewusst ungebunden und nicht auswaehlbar.
+- Zielaufloesung erfolgt nur ueber explizite HTMLElement-Refs und `contains(...)`; keine DOM-Suche, keine Legacy-Runtime, kein EditorV2-/UI-Inspector-Core.
+- Neue Doku: `docs/M55_VISUELLE_UI_AUSWAHL_UEBER_EXPLIZITE_REFS.md`.
+- Naechster Schritt: M56 klaert einen eindeutigen Actions-Bereich, bevor Actions gebunden werden kann.
+
 ## Statusupdate M54
 - M54 bindet die vorhandenen CoreShell-HTMLElement-Referenzen explizit an die M51/M52-Registry-IDs.
 - Gebunden sind `bbm.main.shell -> host`, `bbm.main.navigation -> sidebar`, `bbm.main.header -> headerEl` und `bbm.main.content -> content/contentRoot`.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -84,6 +84,7 @@ const { runNativeTestRuntimeTests } = require("./tests/nativeTestRuntime.test.cj
 const { runM51UiEditorKitIntegrationTests } = require("./tests/m51UiEditorKitIntegration.test.cjs");
 const { runM52UiEditorVisibleEntryTests } = require("./tests/m52UiEditorVisibleEntry.test.cjs");
 const { runM54UiElementRefsTests } = require("./tests/m54UiElementRefs.test.cjs");
+const { runM55UiElementSelectionTests } = require("./tests/m55UiElementSelection.test.cjs");
 
 let failed = false;
 
@@ -215,6 +216,7 @@ async function main() {
   await runM51UiEditorKitIntegrationTests(run);
   await runM52UiEditorVisibleEntryTests(run);
   await runM54UiElementRefsTests(run);
+  await runM55UiElementSelectionTests(run);
 
   if (failed) {
     process.exitCode = 1;

--- a/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
+++ b/scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs
@@ -1458,26 +1458,22 @@ async function runBbmUiEditorRuntimeLauncherTests(run) {
     assert.equal(source.includes("showEditorLabV2"), false);
     assert.equal(source.includes("showRestarbeitenV2"), false);
     assert.equal(coreShellSource.includes("showBbmUiEditorDemo"), false);
-    assert.equal(coreShellSource.includes("getAvailableUiScopes"), true);
-    assert.equal(coreShellSource.includes("registryResolver"), true);
-    assert.equal(coreShellSource.includes("resolveActiveHostUiScope"), true);
-    assert.equal(coreShellSource.includes('restarbeiten: "restarbeiten.screen"'), true);
-    assert.equal(coreShellSource.includes("if (sectionScope) return sectionScope;"), true);
-    assert.equal(coreShellSource.includes('return "protokoll.topsScreen"'), true);
-    assert.equal(coreShellSource.includes("return getActiveUiScope();"), true);
-    assert.equal(
-      coreShellSource.indexOf("if (sectionScope) return sectionScope;") <
-        coreShellSource.indexOf('return "protokoll.topsScreen"'),
-      true
-    );
-    assert.equal(coreShellSource.includes("activeScopeId: activeUiScope"), true);
+    assert.equal(coreShellSource.includes("installBbmUiEditorRuntimeLauncher"), false);
+    assert.equal(coreShellSource.includes("targetSelection"), false);
+    assert.equal(coreShellSource.includes("bindCoreShellUiElementRefs"), true);
+    assert.equal(coreShellSource.includes('registerBbmUiElementRef("bbm.main.shell", host)'), true);
+    assert.equal(coreShellSource.includes('registerBbmUiElementRef("bbm.main.navigation", sidebar)'), true);
+    assert.equal(coreShellSource.includes('registerBbmUiElementRef("bbm.main.header", headerEl)'), true);
+    assert.equal(coreShellSource.includes('registerBbmUiElementRef("bbm.main.content", content)'), true);
+    assert.equal(coreShellSource.includes('registerBbmUiElementRef("bbm.main.actions"'), false);
+    assert.equal(coreShellSource.includes("activeScopeId: activeUiScope"), false);
     assert.equal(source.includes("getStatusScopeLabel"), true);
     assert.equal(source.includes("activeUiScope"), true);
     assert.equal(source.includes("layoutInspector"), true);
     assert.equal(source.includes("layoutScopeResolver"), true);
-    assert.equal(coreShellSource.includes("createEditorScopeInspector"), true);
-    assert.equal(coreShellSource.includes('"protokoll.topsScreen": "protokoll.topsScreen"'), true);
-    assert.equal(coreShellSource.includes('"restarbeiten.screen": "restarbeiten.ui.main"'), true);
+    assert.equal(coreShellSource.includes("createEditorScopeInspector"), false);
+    assert.equal(coreShellSource.includes('"protokoll.topsScreen": "protokoll.topsScreen"'), false);
+    assert.equal(coreShellSource.includes('"restarbeiten.screen": "restarbeiten.ui.main"'), false);
   });
 
 }

--- a/scripts/tests/m54UiElementRefs.test.cjs
+++ b/scripts/tests/m54UiElementRefs.test.cjs
@@ -113,11 +113,11 @@ async function runM54UiElementRefsTests(run) {
     ]);
   });
 
-  await run("M54 Statuspanel: zeigt nur neutrale Referenzzahlen ohne Auswahlmodus oder Overlay", () => {
+  await run("M54 Statuspanel: zeigt Referenzzahlen und bleibt ohne Legacy-Runtime", () => {
     const panel = read("src/renderer/ui-editor/BbmUiEditorStatusPanel.js");
     assert.match(panel, /UI-Referenzen gebunden/);
     assert.match(panel, /Fehlende Referenzen/);
-    assert.doesNotMatch(panel, /Auswahlmodus|Overlay|Hover|Rahmen/);
+    assert.doesNotMatch(panel, /installBbmUiEditorRuntimeLauncher|targetSelection|editorV2Core|UiInspectorOverlay/);
   });
 
   await run("M54 Dokumentation: Referenzabbildung, Lifecycle und Legacy-Pruefung sind dokumentiert", () => {

--- a/scripts/tests/m55UiElementSelection.test.cjs
+++ b/scripts/tests/m55UiElementSelection.test.cjs
@@ -1,0 +1,248 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const REPO_ROOT = path.join(__dirname, "../..");
+
+function read(file) {
+  return fs.readFileSync(path.join(REPO_ROOT, file), "utf8");
+}
+
+class TestHTMLElement {
+  constructor(name, rect = {}) {
+    this.name = name;
+    this.parentNode = null;
+    this.children = [];
+    this.listeners = new Map();
+    this.ownerDocument = null;
+    this.rect = { left: 0, top: 0, width: 100, height: 100, ...rect };
+  }
+  appendChild(child) {
+    child.parentNode = this;
+    if (!child.ownerDocument) child.ownerDocument = this.ownerDocument;
+    this.children.push(child);
+    child.isConnected = true;
+    return child;
+  }
+  removeChild(child) {
+    this.children = this.children.filter((entry) => entry !== child);
+    child.parentNode = null;
+    child.isConnected = false;
+  }
+  contains(target) {
+    let node = target;
+    while (node) {
+      if (node === this) return true;
+      node = node.parentNode || null;
+    }
+    return false;
+  }
+  addEventListener(type, handler) {
+    const list = this.listeners.get(type) || [];
+    list.push(handler);
+    this.listeners.set(type, list);
+  }
+  removeEventListener(type, handler) {
+    const list = this.listeners.get(type) || [];
+    this.listeners.set(type, list.filter((entry) => entry !== handler));
+  }
+  dispatch(type, event) {
+    for (const handler of this.listeners.get(type) || []) handler(event);
+  }
+  getBoundingClientRect() {
+    return this.rect;
+  }
+}
+
+function createDoc() {
+  const doc = {
+    defaultView: { HTMLElement: TestHTMLElement, listeners: new Map() },
+    listeners: new Map(),
+    body: null,
+    createElement(name) {
+      const node = new TestHTMLElement(name);
+      node.ownerDocument = doc;
+      node.style = {};
+      node.attributes = new Map();
+      node.setAttribute = (key, value) => node.attributes.set(key, String(value));
+      node.firstChild = null;
+      const baseAppend = node.appendChild.bind(node);
+      node.appendChild = (child) => {
+        if (!node.firstChild) node.firstChild = child;
+        return baseAppend(child);
+      };
+      return node;
+    },
+    addEventListener(type, handler) {
+      const list = this.listeners.get(type) || [];
+      list.push(handler);
+      this.listeners.set(type, list);
+    },
+    removeEventListener(type, handler) {
+      const list = this.listeners.get(type) || [];
+      this.listeners.set(type, list.filter((entry) => entry !== handler));
+    },
+    dispatch(type, event) {
+      for (const handler of this.listeners.get(type) || []) handler(event);
+    },
+  };
+  doc.defaultView.addEventListener = function addEventListener(type, handler) {
+    const list = this.listeners.get(type) || [];
+    list.push(handler);
+    this.listeners.set(type, list);
+  };
+  doc.defaultView.removeEventListener = function removeEventListener(type, handler) {
+    const list = this.listeners.get(type) || [];
+    this.listeners.set(type, list.filter((entry) => entry !== handler));
+  };
+  doc.defaultView.dispatch = function dispatch(type, event) {
+    for (const handler of this.listeners.get(type) || []) handler(event);
+  };
+  doc.body = new TestHTMLElement("body");
+  doc.body.ownerDocument = doc;
+  return doc;
+}
+
+function eventFor(target) {
+  return {
+    target,
+    prevented: false,
+    stopped: false,
+    immediateStopped: false,
+    preventDefault() { this.prevented = true; },
+    stopPropagation() { this.stopped = true; },
+    stopImmediatePropagation() { this.immediateStopped = true; },
+  };
+}
+
+async function setupRefs() {
+  const refs = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiElementRefs.js"));
+  refs.clearBbmUiElementRefs();
+  const doc = createDoc();
+  const shell = new TestHTMLElement("shell", { width: 1000, height: 800 });
+  const nav = new TestHTMLElement("nav", { width: 200, height: 700 });
+  const header = new TestHTMLElement("header", { width: 800, height: 80 });
+  const content = new TestHTMLElement("content", { width: 800, height: 620 });
+  const panel = new TestHTMLElement("panel", { width: 300, height: 400 });
+  for (const node of [shell, nav, header, content, panel]) node.ownerDocument = doc;
+  shell.appendChild(nav);
+  shell.appendChild(header);
+  shell.appendChild(content);
+  content.appendChild(panel);
+  refs.registerBbmUiElementRef("bbm.main.shell", shell);
+  refs.registerBbmUiElementRef("bbm.main.navigation", nav);
+  refs.registerBbmUiElementRef("bbm.main.header", header);
+  refs.registerBbmUiElementRef("bbm.main.content", content);
+  return { refs, doc, shell, nav, header, content, panel };
+}
+
+async function runM55UiElementSelectionTests(run) {
+  await run("M55 Controller: Lifecycle, Listener und Escape sind zeitlich begrenzt", async () => {
+    const { shell, doc } = await setupRefs();
+    const { createBbmUiElementSelectionController } = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiElementSelection.js"));
+    let destroyCount = 0;
+    const controller = createBbmUiElementSelectionController({ overlay: { mount() {}, updateHover() {}, clearHover() {}, destroy() { destroyCount += 1; } } });
+    assert.equal(controller.isActive(), false);
+    controller.start();
+    controller.start();
+    assert.equal(controller.isActive(), true);
+    assert.equal(shell.listeners.get("pointermove").length, 1);
+    assert.equal(shell.listeners.get("click").length, 1);
+    assert.equal(doc.listeners.get("keydown").length, 1);
+    doc.dispatch("keydown", { key: "Escape" });
+    assert.equal(controller.isActive(), false);
+    assert.equal(shell.listeners.get("pointermove").length, 0);
+    assert.equal(shell.listeners.get("click").length, 0);
+    assert.equal(destroyCount, 1);
+  });
+
+  await run("M55 Zielaufloesung: explizite Refs, konkretestes Ziel und Panel-Ausschluss", async () => {
+    const { shell, nav, header, content, panel } = await setupRefs();
+    const { createBbmUiElementSelectionController } = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiElementSelection.js"));
+    const controller = createBbmUiElementSelectionController({ panelRoot: panel, overlay: { mount() {}, updateHover() {}, clearHover() {}, destroy() {} } });
+    controller.start();
+    assert.equal(controller.resolveTargetForTest(nav).elementId, "bbm.main.navigation");
+    assert.equal(controller.resolveTargetForTest(header).elementId, "bbm.main.header");
+    assert.equal(controller.resolveTargetForTest(content).elementId, "bbm.main.content");
+    assert.equal(controller.resolveTargetForTest(shell).elementId, "bbm.main.shell");
+    assert.equal(controller.resolveTargetForTest(panel), null);
+    assert.equal(controller.getState().unavailableIds.includes("bbm.main.actions"), true);
+    controller.stop();
+  });
+
+  await run("M55 Hover: ein Rahmen wird aktualisiert, Scroll/Resize erneuert, Stop entfernt Overlay", async () => {
+    const { shell, nav, header, doc } = await setupRefs();
+    const { createBbmUiElementSelectionController } = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiElementSelection.js"));
+    const calls = [];
+    let destroyed = false;
+    const controller = createBbmUiElementSelectionController({
+      getElementMeta: (elementId) => ({ label: elementId === "bbm.main.header" ? "Seitenkopf" : "Hauptnavigation" }),
+      overlay: { mount() {}, updateHover(payload) { calls.push(payload); }, clearHover() { calls.push({ clear: true }); }, destroy() { destroyed = true; } },
+    });
+    controller.start();
+    shell.dispatch("pointermove", eventFor(nav));
+    shell.dispatch("pointermove", eventFor(nav));
+    shell.dispatch("pointermove", eventFor(header));
+    doc.dispatch("scroll", {});
+    assert.equal(calls.filter((entry) => entry.targetElement).length, 3);
+    assert.match(calls[0].label, /Hauptnavigation · bbm\.main\.navigation/);
+    assert.match(calls[1].label, /Seitenkopf · bbm\.main\.header/);
+    shell.dispatch("pointermove", eventFor({}));
+    assert.equal(calls.some((entry) => entry.clear), true);
+    controller.stop();
+    assert.equal(destroyed, true);
+  });
+
+  await run("M55 Klick: Auswahlcallback nur aktiv und Panel-Klicks bleiben frei", async () => {
+    const { shell, nav, panel } = await setupRefs();
+    const { createBbmUiElementSelectionController } = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiElementSelection.js"));
+    const selected = [];
+    const controller = createBbmUiElementSelectionController({ panelRoot: panel, selectElement: ({ elementId }) => selected.push(elementId), overlay: { mount() {}, updateHover() {}, clearHover() {}, destroy() {} } });
+    const inactiveEvent = eventFor(nav);
+    shell.dispatch("click", inactiveEvent);
+    assert.equal(inactiveEvent.prevented, false);
+    controller.start();
+    const panelEvent = eventFor(panel);
+    shell.dispatch("click", panelEvent);
+    assert.equal(panelEvent.prevented, false);
+    const navEvent = eventFor(nav);
+    shell.dispatch("click", navEvent);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.deepEqual(selected, ["bbm.main.navigation"]);
+    assert.equal(navEvent.prevented, true);
+    controller.stop();
+    const afterStopEvent = eventFor(nav);
+    shell.dispatch("click", afterStopEvent);
+    assert.equal(afterStopEvent.prevented, false);
+  });
+
+  await run("M55 Sicherheit: keine DOM-Suche, keine Legacy-Imports, keine zweite Registry", () => {
+    const files = [
+      "src/renderer/ui-editor/bbmUiElementSelection.js",
+      "src/renderer/ui-editor/bbmUiSelectionOverlay.js",
+      "src/renderer/ui-editor/BbmUiEditorStatusPanel.js",
+    ];
+    const combined = files.map(read).join("\n");
+    assert.doesNotMatch(combined, /querySelector|querySelectorAll|getElementById|getElementsBy|closest\s*\(|matches\s*\(|MutationObserver|elementsFromPoint|elementFromPoint/);
+    assert.doesNotMatch(combined, /data-ui-|targetSelection|editorV2Core|UiInspectorOverlay|BBM_UI_ELEMENTS\s*=|ipcRenderer|ipcMain|HTMLElement.*send|send.*HTMLElement/);
+    assert.doesNotMatch(combined, /\.style\.(width|height|left|top|position)\s*=\s*[^;]*(target|ref|element)/);
+  });
+
+  await run("M55 Dokumentation und Status sind nachgezogen", () => {
+    assert.match(read("docs/M55_VISUELLE_UI_AUSWAHL_UEBER_EXPLIZITE_REFS.md"), /Zielaufloesung ueber explizite Refs/);
+    assert.match(read("STATUS.md"), /M55/);
+    assert.match(read("docs/UI_INSPEKTOR_AUFGABENHEFT.md"), /M55/);
+  });
+}
+
+if (require.main === module) {
+  let failed = false;
+  const run = async (name, fn) => {
+    try { await fn(); console.log(`ok - ${name}`); }
+    catch (error) { failed = true; console.error(`not ok - ${name}`); console.error(error?.stack || error); }
+  };
+  runM55UiElementSelectionTests(run).then(() => { if (failed) process.exitCode = 1; });
+}
+
+module.exports = { runM55UiElementSelectionTests };

--- a/scripts/tests/projektverwaltungModule.test.cjs
+++ b/scripts/tests/projektverwaltungModule.test.cjs
@@ -1059,24 +1059,17 @@ async function runProjektverwaltungModuleTests(run) {
   });
 
   await run("Projektverwaltung: MainHeader/CoreShell ohne alte DEV-Buttons und ohne Scanstatus", async () => {
-    assert.equal(coreShellSource.includes("installBbmUiEditorRuntimeLauncher"), true);
-    assert.equal(coreShellSource.includes("getActiveUiScope"), true);
-    assert.equal(coreShellSource.includes("getBbmUiEditorRegistry"), true);
-    assert.equal(coreShellSource.includes("resolveActiveHostUiScope"), true);
-    assert.equal(coreShellSource.includes('restarbeiten: "restarbeiten.screen"'), true);
-    assert.equal(coreShellSource.includes("if (sectionScope) return sectionScope;"), true);
-    assert.equal(coreShellSource.includes('return "protokoll.topsScreen"'), true);
-    assert.equal(coreShellSource.includes("return getActiveUiScope();"), true);
-    assert.equal(
-      coreShellSource.indexOf("if (sectionScope) return sectionScope;") <
-        coreShellSource.indexOf('return "protokoll.topsScreen"'),
-      true
-    );
-    assert.equal(coreShellSource.includes("refreshUiEditorRuntimeLauncher"), true);
-    assert.equal(coreShellSource.includes("activeScopeId: activeUiScope"), true);
-    assert.equal(coreShellSource.includes("activeUiScope,"), true);
-    assert.equal(coreShellSource.includes("registeredElements: uiEditorRegistry?.elements"), true);
-    assert.equal(coreShellSource.includes("activeUiScope: null"), false);
+    assert.equal(coreShellSource.includes("installBbmUiEditorRuntimeLauncher"), false);
+    assert.equal(coreShellSource.includes("refreshUiEditorRuntimeLauncher"), false);
+    assert.equal(coreShellSource.includes("getActiveUiScope"), false);
+    assert.equal(coreShellSource.includes("getBbmUiEditorRegistry"), false);
+    assert.equal(coreShellSource.includes("resolveActiveHostUiScope"), false);
+    assert.equal(coreShellSource.includes("bindCoreShellUiElementRefs"), true);
+    assert.equal(coreShellSource.includes('registerBbmUiElementRef("bbm.main.shell", host)'), true);
+    assert.equal(coreShellSource.includes('registerBbmUiElementRef("bbm.main.navigation", sidebar)'), true);
+    assert.equal(coreShellSource.includes('registerBbmUiElementRef("bbm.main.header", headerEl)'), true);
+    assert.equal(coreShellSource.includes('registerBbmUiElementRef("bbm.main.content", content)'), true);
+    assert.equal(coreShellSource.includes('registerBbmUiElementRef("bbm.main.actions"'), false);
     assert.equal(coreShellSource.includes("showEditorLabV2"), false);
     assert.equal(coreShellSource.includes("showRestarbeitenV2Dev"), false);
     assert.equal(coreShellSource.includes("scanUiInspectorTargets"), false);

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -1,4 +1,5 @@
 import { getBbmUiElementRefStatus } from "./bbmUiElementRefs.js";
+import { createBbmUiElementSelectionController } from "./bbmUiElementSelection.js";
 
 function createNode(tag, className = "") {
   const node = document.createElement(tag);
@@ -47,6 +48,9 @@ export class BbmUiEditorStatusPanel {
     this.refStatus = null;
     this.elements = [];
     this.selectedElement = null;
+    this.selectionController = null;
+    this.selectionMessage = "";
+    this.selectionModeActive = false;
   }
 
   render() {
@@ -84,11 +88,26 @@ export class BbmUiEditorStatusPanel {
 
     root.append(header, this.errorNode, intro, grid);
     this.root = root;
+    this.selectionController = createBbmUiElementSelectionController({
+      getPanelRoot: () => this.root,
+      getElementMeta: (elementId) => this.getElementMeta(elementId),
+      selectElement: ({ elementId }) => this.selectElement(elementId, { fromSelectionMode: true }),
+      onSelection: ({ elementId, meta }) => {
+        this.selectionMessage = `Ausgewaehlt: ${asText(meta?.label, elementId)}`;
+        this.selectionModeActive = this.selectionController?.isActive?.() || false;
+        this.renderAll();
+      },
+      onStateChange: (state) => {
+        this.selectionModeActive = Boolean(state?.active);
+        this.renderAll();
+      },
+    });
     this.refresh().catch((error) => this.showLoadError(error));
     return root;
   }
 
   async close() {
+    this.stopSelectionMode();
     try {
       await window.bbmDb?.uiEditorClose?.();
     } catch (_e) {
@@ -165,6 +184,9 @@ export class BbmUiEditorStatusPanel {
       createInfoRow("Registrierte Elemente", status.registeredElementCount),
       createInfoRow("UI-Referenzen gebunden", this.refStatus ? `${this.refStatus.count}/${this.refStatus.expectedCount}` : "nicht verfuegbar"),
       createInfoRow("Fehlende Referenzen", this.refStatus ? formatList(this.refStatus.missingIds) : "nicht verfuegbar"),
+      createInfoRow("Auswahlmodus", this.selectionModeActive ? "Aktiv" : "Inaktiv"),
+      createInfoRow("Gebundene Ziele", this.refStatus ? String(this.getSelectableBoundCount()) : "nicht verfuegbar"),
+      createInfoRow("Nicht verfuegbar", "bbm.main.actions"),
       createInfoRow("LayoutStore verfuegbar", yesNo(status.layoutStoreAvailable)),
       createInfoRow("Layoutzustand vorhanden", yesNo(layout.hasStateForScopeAndProfile)),
       createInfoRow("Load/Save/Reset technisch", `${yesNo(layout.canLoad)} / ${yesNo(layout.canSave)} / ${yesNo(layout.canReset)}`),
@@ -181,9 +203,32 @@ export class BbmUiEditorStatusPanel {
     resetSelection.textContent = "Auswahl zuruecksetzen";
     resetSelection.addEventListener("click", () => this.selectElement("").catch((error) => this.showLoadError(error)));
 
+    const startSelection = createNode("button", "bbm-ui-editor-panel__secondary");
+    startSelection.type = "button";
+    startSelection.textContent = "Auswahlmodus starten";
+    startSelection.disabled = !this.canStartSelectionMode();
+    startSelection.addEventListener("click", () => this.startSelectionMode());
+
+    const stopSelection = createNode("button", "bbm-ui-editor-panel__secondary");
+    stopSelection.type = "button";
+    stopSelection.textContent = "Auswahlmodus beenden";
+    stopSelection.disabled = !this.selectionModeActive;
+    stopSelection.addEventListener("click", () => this.stopSelectionMode());
+
     const actions = createNode("div", "bbm-ui-editor-panel__actions");
-    actions.append(reloadButton, resetSelection);
+    actions.append(reloadButton, resetSelection, startSelection, stopSelection);
     this.statusNode.append(title, list, actions);
+
+    if (this.selectionModeActive) {
+      const hint = createNode("p", "bbm-ui-editor-panel__notice");
+      hint.textContent = "Maus ueber einen BBM-Bereich bewegen und anklicken. Esc beendet den Auswahlmodus.";
+      this.statusNode.appendChild(hint);
+    }
+    if (this.selectionMessage) {
+      const selected = createNode("p", "bbm-ui-editor-panel__notice");
+      selected.textContent = this.selectionMessage;
+      this.statusNode.appendChild(selected);
+    }
   }
 
   renderElements() {
@@ -247,7 +292,41 @@ export class BbmUiEditorStatusPanel {
     this.detailsNode.appendChild(list);
   }
 
-  async selectElement(elementId) {
+  getElementMeta(elementId) {
+    return this.elements.find((element) => element.elementId === elementId) || null;
+  }
+
+  getSelectableBoundCount() {
+    const ids = new Set(this.refStatus?.registeredIds || []);
+    return ["bbm.main.navigation", "bbm.main.header", "bbm.main.content", "bbm.main.shell"].filter((elementId) => ids.has(elementId)).length;
+  }
+
+  canStartSelectionMode() {
+    if (this.selectionModeActive) return false;
+    if (!this.status?.runtimeStarted || !this.status?.adapterValid) return false;
+    return this.getSelectableBoundCount() > 0;
+  }
+
+  startSelectionMode() {
+    if (!this.canStartSelectionMode()) return;
+    this.selectionMessage = "";
+    this.selectionController?.start?.();
+    this.selectionModeActive = this.selectionController?.isActive?.() || false;
+    this.renderAll();
+  }
+
+  stopSelectionMode() {
+    this.selectionController?.stop?.();
+    this.selectionModeActive = false;
+    this.renderAll();
+  }
+
+  destroy() {
+    this.stopSelectionMode();
+    this.root = null;
+  }
+
+  async selectElement(elementId, options = {}) {
     const api = window.bbmDb || {};
     if (typeof api.uiEditorSelectElement !== "function") {
       this.status = { ok: false, blockCode: "BBM_UI_EDITOR_BRIDGE_MISSING" };
@@ -260,6 +339,12 @@ export class BbmUiEditorStatusPanel {
       return;
     }
     await this.refresh();
+    if (options.fromSelectionMode) {
+      const meta = this.getElementMeta(elementId);
+      this.selectionMessage = `Ausgewaehlt: ${asText(meta?.label, elementId)}`;
+      this.selectionModeActive = this.selectionController?.isActive?.() || false;
+      this.renderAll();
+    }
   }
 }
 

--- a/src/renderer/ui-editor/bbmUiElementSelection.js
+++ b/src/renderer/ui-editor/bbmUiElementSelection.js
@@ -1,0 +1,173 @@
+import { getBbmUiElementRef, getBbmUiElementRefStatus } from "./bbmUiElementRefs.js";
+import { createBbmUiSelectionOverlay } from "./bbmUiSelectionOverlay.js";
+
+const SELECTABLE_ELEMENT_IDS = Object.freeze([
+  "bbm.main.navigation",
+  "bbm.main.header",
+  "bbm.main.content",
+  "bbm.main.shell",
+]);
+
+function isEventInsidePanel(eventTarget, panelRoot) {
+  return Boolean(panelRoot && eventTarget && (eventTarget === panelRoot || panelRoot.contains?.(eventTarget)));
+}
+
+function rectArea(element) {
+  const rect = typeof element?.getBoundingClientRect === "function" ? element.getBoundingClientRect() : null;
+  const width = Math.max(0, Number(rect?.width) || 0);
+  const height = Math.max(0, Number(rect?.height) || 0);
+  return width * height;
+}
+
+function formatMetaLabel(elementId, getElementMeta) {
+  const meta = typeof getElementMeta === "function" ? getElementMeta(elementId) : null;
+  const label = String(meta?.label || elementId).trim();
+  return `${label} · ${elementId}`;
+}
+
+export function createBbmUiElementSelectionController(options = {}) {
+  const overlay = options.overlay || createBbmUiSelectionOverlay(options.overlayOptions || {});
+  const selectElement = typeof options.selectElement === "function" ? options.selectElement : async () => {};
+  const getElementMeta = typeof options.getElementMeta === "function" ? options.getElementMeta : () => null;
+  const onStateChange = typeof options.onStateChange === "function" ? options.onStateChange : () => {};
+  const onSelection = typeof options.onSelection === "function" ? options.onSelection : () => {};
+  let active = false;
+  let shellElement = null;
+  let ownerDocument = null;
+  let ownerWindow = null;
+  let hoveredElementId = "";
+  let hoveredElement = null;
+
+  function getPanelRoot() {
+    return typeof options.getPanelRoot === "function" ? options.getPanelRoot() : options.panelRoot || null;
+  }
+
+  function resolveTarget(eventTarget) {
+    if (!eventTarget || isEventInsidePanel(eventTarget, getPanelRoot())) return null;
+    const matches = [];
+    for (const elementId of SELECTABLE_ELEMENT_IDS) {
+      const ref = getBbmUiElementRef(elementId);
+      if (!ref || ref === getPanelRoot()) continue;
+      if (ref === eventTarget || ref.contains?.(eventTarget)) {
+        matches.push({ elementId, element: ref, area: rectArea(ref) });
+      }
+    }
+    matches.sort((a, b) => a.area - b.area || SELECTABLE_ELEMENT_IDS.indexOf(a.elementId) - SELECTABLE_ELEMENT_IDS.indexOf(b.elementId));
+    return matches[0] || null;
+  }
+
+  function clearHover() {
+    hoveredElementId = "";
+    hoveredElement = null;
+    overlay.clearHover();
+  }
+
+  function updateHoverForTarget(eventTarget) {
+    const hit = resolveTarget(eventTarget);
+    if (!hit) {
+      clearHover();
+      return;
+    }
+    if (hit.elementId === hoveredElementId && hit.element === hoveredElement) return;
+    hoveredElementId = hit.elementId;
+    hoveredElement = hit.element;
+    overlay.updateHover({ targetElement: hit.element, label: formatMetaLabel(hit.elementId, getElementMeta) });
+  }
+
+  function refreshHover() {
+    if (!hoveredElementId || !hoveredElement) return;
+    overlay.updateHover({ targetElement: hoveredElement, label: formatMetaLabel(hoveredElementId, getElementMeta) });
+  }
+
+  function stopInternal() {
+    if (!active) return;
+    shellElement?.removeEventListener?.("pointermove", handlePointerMove);
+    shellElement?.removeEventListener?.("click", handleClick, true);
+    ownerDocument?.removeEventListener?.("keydown", handleKeyDown, true);
+    ownerDocument?.removeEventListener?.("scroll", handleViewportChange, true);
+    ownerWindow?.removeEventListener?.("resize", handleViewportChange);
+    active = false;
+    shellElement = null;
+    ownerDocument = null;
+    ownerWindow = null;
+    clearHover();
+    overlay.destroy();
+    onStateChange(getState());
+  }
+
+  function handlePointerMove(event) {
+    try {
+      updateHoverForTarget(event?.target);
+    } catch (error) {
+      stopInternal();
+      throw error;
+    }
+  }
+
+  function handleClick(event) {
+    if (!active) return;
+    const hit = resolveTarget(event?.target);
+    if (!hit) return;
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    if (typeof event?.stopImmediatePropagation === "function") event.stopImmediatePropagation();
+    Promise.resolve(selectElement({ elementId: hit.elementId }))
+      .then(() => onSelection({ elementId: hit.elementId, meta: getElementMeta(hit.elementId) }))
+      .catch((error) => {
+        stopInternal();
+        throw error;
+      });
+  }
+
+  function handleKeyDown(event) {
+    if (event?.key === "Escape") stopInternal();
+  }
+
+  function handleViewportChange() {
+    refreshHover();
+  }
+
+  function getState() {
+    const refStatus = getBbmUiElementRefStatus();
+    return {
+      active,
+      hoveredElementId,
+      boundTargetCount: SELECTABLE_ELEMENT_IDS.filter((elementId) => refStatus.registeredIds.includes(elementId)).length,
+      unavailableIds: refStatus.missingIds,
+    };
+  }
+
+  return {
+    start() {
+      if (active) return getState();
+      shellElement = getBbmUiElementRef("bbm.main.shell");
+      if (!shellElement) return getState();
+      ownerDocument = shellElement.ownerDocument || null;
+      ownerWindow = ownerDocument?.defaultView || null;
+      hoveredElementId = "";
+      hoveredElement = null;
+      overlay.mount(ownerDocument);
+      shellElement.addEventListener("pointermove", handlePointerMove);
+      shellElement.addEventListener("click", handleClick, true);
+      ownerDocument?.addEventListener?.("keydown", handleKeyDown, true);
+      ownerDocument?.addEventListener?.("scroll", handleViewportChange, true);
+      ownerWindow?.addEventListener?.("resize", handleViewportChange);
+      active = true;
+      onStateChange(getState());
+      return getState();
+    },
+    stop() {
+      stopInternal();
+      return getState();
+    },
+    destroy() {
+      stopInternal();
+      return getState();
+    },
+    isActive() {
+      return active;
+    },
+    getState,
+    resolveTargetForTest: resolveTarget,
+  };
+}

--- a/src/renderer/ui-editor/bbmUiSelectionOverlay.js
+++ b/src/renderer/ui-editor/bbmUiSelectionOverlay.js
@@ -1,0 +1,128 @@
+const DEFAULT_Z_INDEX = 2147483200;
+
+function toNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function readRect(targetElement) {
+  const rect = typeof targetElement?.getBoundingClientRect === "function" ? targetElement.getBoundingClientRect() : null;
+  return {
+    left: toNumber(rect?.left),
+    top: toNumber(rect?.top),
+    width: Math.max(0, toNumber(rect?.width)),
+    height: Math.max(0, toNumber(rect?.height)),
+  };
+}
+
+export function createBbmUiSelectionOverlay(options = {}) {
+  const zIndex = Number.isFinite(options.zIndex) ? options.zIndex : DEFAULT_Z_INDEX;
+  let doc = null;
+  let root = null;
+  let frame = null;
+  let hint = null;
+
+  function ensureRoot(ownerDocument) {
+    doc = ownerDocument || doc;
+    if (!doc || typeof doc.createElement !== "function") return null;
+    if (root?.isConnected) return root;
+    root = doc.createElement("div");
+    root.setAttribute("data-bbm-ui-selection-overlay-root", "true");
+    root.style.position = "fixed";
+    root.style.inset = "0";
+    root.style.pointerEvents = "none";
+    root.style.zIndex = String(zIndex);
+    root.style.overflow = "hidden";
+    const mount = doc.body || doc.documentElement;
+    if (mount?.appendChild) mount.appendChild(root);
+    return root;
+  }
+
+  function ensureFrame() {
+    if (!root || !doc) return null;
+    if (frame?.isConnected) return frame;
+    frame = doc.createElement("div");
+    frame.setAttribute("data-bbm-ui-selection-hover-frame", "true");
+    frame.style.position = "fixed";
+    frame.style.boxSizing = "border-box";
+    frame.style.border = "2px solid rgba(37, 99, 235, 0.95)";
+    frame.style.background = "rgba(37, 99, 235, 0.08)";
+    frame.style.pointerEvents = "none";
+    frame.style.borderRadius = "6px";
+
+    const label = doc.createElement("div");
+    label.setAttribute("data-bbm-ui-selection-hover-label", "true");
+    label.style.position = "absolute";
+    label.style.left = "0";
+    label.style.top = "-24px";
+    label.style.maxWidth = "360px";
+    label.style.whiteSpace = "nowrap";
+    label.style.overflow = "hidden";
+    label.style.textOverflow = "ellipsis";
+    label.style.background = "rgba(30, 41, 59, 0.95)";
+    label.style.color = "#fff";
+    label.style.font = "12px/1.35 system-ui, sans-serif";
+    label.style.padding = "3px 6px";
+    label.style.borderRadius = "4px";
+    label.style.pointerEvents = "none";
+    frame.appendChild(label);
+    root.appendChild(frame);
+    return frame;
+  }
+
+  function showHint(text = "Maus ueber einen BBM-Bereich bewegen und anklicken. Esc beendet den Auswahlmodus.") {
+    if (!root || !doc) return;
+    if (!hint?.isConnected) {
+      hint = doc.createElement("div");
+      hint.setAttribute("data-bbm-ui-selection-hint", "true");
+      hint.style.position = "fixed";
+      hint.style.left = "50%";
+      hint.style.bottom = "18px";
+      hint.style.transform = "translateX(-50%)";
+      hint.style.background = "rgba(15, 23, 42, 0.94)";
+      hint.style.color = "#fff";
+      hint.style.font = "13px/1.4 system-ui, sans-serif";
+      hint.style.padding = "8px 10px";
+      hint.style.borderRadius = "8px";
+      hint.style.pointerEvents = "none";
+      root.appendChild(hint);
+    }
+    hint.textContent = text;
+  }
+
+  return {
+    mount(ownerDocument) {
+      ensureRoot(ownerDocument);
+      showHint();
+    },
+    updateHover({ targetElement, label }) {
+      if (!targetElement || !root) {
+        this.clearHover();
+        return;
+      }
+      const rect = readRect(targetElement);
+      const node = ensureFrame();
+      if (!node) return;
+      node.style.left = `${rect.left}px`;
+      node.style.top = `${rect.top}px`;
+      node.style.width = `${rect.width}px`;
+      node.style.height = `${rect.height}px`;
+      const labelNode = node.firstChild;
+      if (labelNode) labelNode.textContent = String(label || "");
+    },
+    clearHover() {
+      if (frame?.parentNode) frame.parentNode.removeChild(frame);
+      frame = null;
+    },
+    destroy() {
+      if (root?.parentNode) root.parentNode.removeChild(root);
+      root = null;
+      frame = null;
+      hint = null;
+      doc = null;
+    },
+    getState() {
+      return { mounted: Boolean(root?.isConnected), hovering: Boolean(frame?.isConnected) };
+    },
+  };
+}


### PR DESCRIPTION
### Motivation
- Sichtbare, kleine und sichere Auswahlsteuerung für die in M54 explizit gebundenen CoreShell-Elemente bereitstellen, ohne alte Runtime, DOM-Scan oder Registry-Änderung zu reaktivieren.
- Dem bestehenden UI-Editor-Statuspanel eine verständliche, ausdrückliche Bedienmöglichkeit zum Starten/Beenden des Auswahlmodus hinzufügen.
- Auswahl und Sichtbarkeit müssen ausschließlich über die M54-Element-Refs erfolgen und die normale BBM-Bedienung nach Beenden unverändert lassen.

### Description
- Neuer dünner Controller `createBbmUiElementSelectionController` in `src/renderer/ui-editor/bbmUiElementSelection.js` implementiert `start()`, `stop()`, `destroy()`, `isActive()` und `getState()` und löst Ziele ausschließlich über `getBbmUiElementRef(...)` und `HTMLElement.contains(...)` auf.
- Neues reines Overlay `src/renderer/ui-editor/bbmUiSelectionOverlay.js` erzeugt Root, Hoverrahmen und Beschriftung und positioniert Rahmen via `getBoundingClientRect()`; das Overlay kennt keine Registry und fängt keine Events ab.
- Das Statuspanel `src/renderer/ui-editor/BbmUiEditorStatusPanel.js` wurde erweitert und initialisiert den Controller, bietet `Auswahlmodus starten` / `Auswahlmodus beenden` Buttons, zeigt Auswahlmodus-Status, gebundene Ziele und die Hinweise sowie eine „Ausgewählt: …“-Bestätigung nach erfolgreicher Auswahl; Panel-Root wird als ausgeschlossener Bereich übergeben.
- Tests, Doku und Status wurden ergänzt: neue Testdatei `scripts/tests/m55UiElementSelection.test.cjs`, Dokumentation `docs/M55_VISUELLE_UI_AUSWAHL_UEBER_EXPLIZITE_REFS.md`, sowie `STATUS.md` und `docs/UI_INSPEKTOR_AUFGABENHEFT.md` aktualisiert; keine Bindung von `bbm.main.actions` und keine Legacy-Runtime-Reaktivierung.

### Testing
- Ausgeführt: `git diff --check` sowie Unit-Tests `node scripts/tests/m51UiEditorKitIntegration.test.cjs`, `node scripts/tests/m52UiEditorVisibleEntry.test.cjs`, `node scripts/tests/m54UiElementRefs.test.cjs`, `node scripts/tests/m55UiElementSelection.test.cjs`, `node scripts/tests/bbmUiEditorRuntimeLauncher.test.cjs` und `node scripts/tests/projektverwaltungModule.test.cjs`, alle genannten Tests liefen grün in dieser Umgebung.
- Die kombinierte Testsuite `node scripts/test.cjs` wurde mit erweitertem Lauf gestartet und lief bis zum Zeitlimit ohne neue M55-bezogene Fehler; die vollständige Suite benötigt in dieser Umgebung längere Laufzeit als das Test-Timeout.
- `npm start` (manuelle Electron-Sichtprüfung) konnte in dieser CI-Umgebung nicht ausgeführt werden, weil Electron wegen fehlender Systembibliothek `libatk-1.0.so.0` scheiterte; daher blieb die Windows/Electron UI-Sichtprüfung offen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52affe6e548322b27aaef4dc2a99f1)