### PR TITLE
M56 dauerhaften Auswahlrahmen anzeigen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,21 @@
 # STATUS.md â€” BBM-Produktiv
 
+### M56-Fix PR #196 – Hoverrahmen nach Klick sofort entfernen
+- Status: erledigt
+- Beschreibung:
+  - Randfehler behoben: Wenn ein gehovertes Element angeklickt und dadurch ausgewaehlt wird, wird der blaue Hoverrahmen ohne weitere Mausbewegung entfernt.
+  - Der M55-Controller prueft den Auswahlstatus auch bei identischem Hoverziel erneut und bietet `syncHoverWithSelection()` fuer die Statuspanel-Synchronisation nach `refresh()`/`selectElement()`.
+  - Keine neue fachliche Auswahlhaltung, keine neue IPC-/Speicherlogik, keine Layoutmutation.
+- Betroffene Dateien:
+  - `src/renderer/ui-editor/bbmUiElementSelection.js`
+  - `src/renderer/ui-editor/BbmUiEditorStatusPanel.js`
+  - `scripts/tests/m56PersistentSelectionFrame.test.cjs`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `STATUS.md`
+- Naechster offener Schritt:
+  - M57 bleibt: fachlich eindeutige Actions-Referenz klaeren oder weiteren Ausschluss von `bbm.main.actions` bestaetigen.
+
+
 ### M56 – Dauerhafter Auswahlrahmen im UI-Editor-Statuspanel
 - Status: erledigt
 - Beschreibung:

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,30 @@
 # STATUS.md â€” BBM-Produktiv
 
+### M56 – Dauerhafter Auswahlrahmen im UI-Editor-Statuspanel
+- Status: erledigt
+- Beschreibung:
+  - Das bestehende M52-`selectedElement` steuert nun einen orangefarbenen, dauerhaften Auswahlrahmen.
+  - Hover bleibt blau, temporaer und an den aktiven Auswahlmodus gebunden; Auswahl bleibt nach Escape/Stop sichtbar.
+  - Reset leert die bestehende Auswahl ueber `uiEditorSelectElement({ elementId: "" })` und entfernt den Rahmen.
+  - Panel-Schliessen/Destroy entfernt Hover- und Auswahloverlays inklusive Scroll-/Resize-Listenern.
+  - `bbm.main.actions` bleibt ohne Fallback unmarkiert, solange keine explizite M54-Ref existiert.
+- Betroffene Dateien:
+  - `src/renderer/ui-editor/BbmUiEditorStatusPanel.js`
+  - `src/renderer/ui-editor/bbmUiElementSelection.js`
+  - `src/renderer/ui-editor/bbmUiSelectedOverlay.js`
+  - `scripts/tests/m56PersistentSelectionFrame.test.cjs`
+  - `scripts/test.cjs`
+  - `docs/M56_DAUERHAFTER_AUSWAHLRAHMEN.md`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `STATUS.md`
+- Commit:
+  - wird mit diesem Paket-Commit erstellt
+- Naechster offener Schritt:
+  - M57: fachlich eindeutige Actions-Referenz klaeren oder den weiteren Ausschluss von `bbm.main.actions` bestaetigen.
+- Risiken/Hinweise:
+  - Manuelle Windows-Pruefung bleibt fachlich nachzuholen; diese Umgebung kann die sichtbare Electron-Windows-Abnahme nicht ersetzen.
+
+
 ## M55 – Visuelle UI-Auswahl ueber explizite Refs (2026-07-11)
 
 - Im bestehenden UI-Editor-Statuspanel gibt es einen kontrollierten Auswahlmodus fuer die vier in M54 gebundenen CoreShell-Refs.

--- a/docs/M56_DAUERHAFTER_AUSWAHLRAHMEN.md
+++ b/docs/M56_DAUERHAFTER_AUSWAHLRAHMEN.md
@@ -1,0 +1,69 @@
+# M56 – Dauerhafter Auswahlrahmen
+
+## Ziel
+
+M56 erweitert den mit M55 eingefuehrten Hover- und Klick-Auswahlmodus um einen dauerhaften sichtbaren Auswahlrahmen. Nach einem Klick auf ein registriertes und gebundenes Element bleibt dieses Element orange markiert, solange das UI-Editor-Statuspanel geoeffnet ist und der bestehende Auswahlstatus ein Element enthaelt.
+
+## Bedienablauf
+
+1. **UI-Editor Status** oeffnen.
+2. **Auswahlmodus starten**.
+3. Ein gebundenes Element hovern: blauer Hoverrahmen.
+4. Element anklicken: bestehender M52-Auswahlweg setzt die Auswahl.
+5. Nach dem Refresh erscheint ein orangefarbener Rahmen am ausgewaehlten Element.
+6. Andere Elemente koennen weiter blau gehovert werden.
+7. **Auswahl zuruecksetzen** entfernt Auswahl und orangefarbenen Rahmen.
+8. Schliessen oder Destroy des Statuspanels entfernt alle visuellen Rahmen.
+
+## Unterschied Hover/Auswahl
+
+- Hover ist blau, temporaer und nur im aktiven Auswahlmodus sichtbar.
+- Auswahl ist orange, dauerhaft sichtbar und bleibt auch nach Escape oder **Auswahlmodus beenden** erhalten.
+- Wenn Hover und Auswahl dasselbe Element betreffen, wird der blaue Hoverrahmen fuer dieses Ziel unterdrueckt. Der orangefarbene Auswahlrahmen hat Vorrang.
+- Wenn ein anderes Element gehovert wird, koennen ein blauer Hoverrahmen und ein orangefarbener Auswahlrahmen gleichzeitig sichtbar sein.
+
+## Bestehender Auswahlstatus als Quelle
+
+Die visuelle Auswahl wird aus dem vorhandenen M52-Statusmodell abgeleitet. Quelle ist `this.selectedElement` im Statuspanel nach `refresh()` beziehungsweise nach dem bestehenden `uiEditorSelectElement`-Pfad. Es gibt keine neue fachliche Auswahlhaltung, keine neue IPC-Methode, keine Speicherung im LayoutStore und kein `localStorage`.
+
+## Overlay-Lifecycle
+
+Das neue Overlay `src/renderer/ui-editor/bbmUiSelectedOverlay.js` erzeugt ausschliesslich einen eigenen Overlay-Root mit einem orangefarbenen `position: fixed`-Rahmen und einer Beschriftung. Es veraendert das Ziel-HTMLElement nicht und nutzt nur `getBoundingClientRect()` zur Positionierung.
+
+Der dokumentierte z-index liegt oberhalb des M55-Hoveroverlays, damit die ausgewaehlte Markierung visuell Vorrang hat.
+
+## Verhalten bei Escape
+
+Escape beendet nur den M55-Auswahlmodus und entfernt Hoverrahmen/Hinweis. Der bestehende Auswahlstatus bleibt unveraendert, deshalb bleibt der orangefarbene Auswahlrahmen sichtbar.
+
+## Verhalten bei Reset
+
+**Auswahl zuruecksetzen** verwendet weiterhin `uiEditorSelectElement({ elementId: "" })`, fuehrt danach `refresh()` aus und entfernt den orangefarbenen Auswahlrahmen.
+
+## Verhalten beim Panel-Schliessen
+
+Beim Schliessen oder Destroy des Statuspanels werden Auswahlmodus, Hoveroverlay, Auswahloverlay sowie Scroll-/Resize-Listener entfernt. Beim erneuten Oeffnen kann eine noch vorhandene Backend-Auswahl nach `refresh()` wieder orange angezeigt werden.
+
+## Scroll-/Resize-Synchronisation
+
+Solange der Auswahlrahmen sichtbar ist, installiert das Auswahloverlay genau je einen Scroll- und Resize-Listener. Diese Listener aktualisieren die Position aus `getBoundingClientRect()`. Es gibt keine dauerhafte `requestAnimationFrame`-Schleife und keinen `MutationObserver`. Beim Entfernen des Rahmens werden die Listener entfernt.
+
+## Keine zweite Auswahlhaltung
+
+Das Overlay haelt nur den aktuell angezeigten visuellen Bezug, der bei jeder Synchronisation aus `this.selectedElement` erneuert wird. Es ist keine zweite fachliche Auswahl-Registry und kein alternativer Auswahlstatus.
+
+## Sicherheitsgrenzen
+
+M56 nutzt keine DOM-Suche, keine CSS-Selektoren, keine `data-ui-*`-Zielerkennung, keine automatische UI-Erkennung, keine Legacy-Runtime, keine Layoutmutation, keine Inline-Style-Aenderung am Ziel, keine Speicherung und keine Fach- oder Nutzdatenaktion.
+
+## Testabdeckung
+
+`scripts/tests/m56PersistentSelectionFrame.test.cjs` prueft Auswahloverlay, Hover/Selected-Zusammenspiel, Escape/Stop/Reset/Close/Destroy, Scroll-/Resize-Lifecycle, Statuspanel-Synchronisation und Sicherheitsgrenzen. `scripts/test.cjs` fuehrt den M56-Test als Regression mit aus.
+
+## Bekannte Einschraenkung `bbm.main.actions`
+
+`bbm.main.actions` bleibt ohne Rahmen, solange keine eindeutige M54-HTMLElement-Referenz existiert. Es gibt keinen Fallback auf Shell und keine DOM-Suche.
+
+## Naechster Schritt
+
+M57 sollte als kleinster naechster Schritt die fachlich eindeutige Actions-Referenz klaeren oder bewusst weiterhin ausschliessen, bevor `bbm.main.actions` visuell oder layoutbezogen freigegeben wird.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -66,6 +66,13 @@ Aktueller Stand:
 
 
 
+
+## Statusupdate M56-Fix PR #196
+- Randfehler korrigiert: Klick auf ein zuvor gehovertes Element entfernt den blauen Hoverrahmen sofort, ohne weitere Mausbewegung.
+- Der Controller prueft den aktuellen Auswahlstatus nun auch bei unveraendertem Hoverziel erneut und stellt `syncHoverWithSelection()` fuer die Statuspanel-Synchronisation bereit.
+- Keine neue fachliche Auswahlhaltung; die Pruefung liest weiterhin live aus dem bestehenden `selectedElement`-Pfad.
+- `scripts/tests/m56PersistentSelectionFrame.test.cjs` deckt den tatsaechlichen Hover-Klick-Ablauf, Auswahlwechsel, Reset und Escape ab.
+
 ## Statusupdate M56
 - M56 ergaenzt im bestehenden UI-Editor-Statuspanel einen dauerhaften orangefarbenen Auswahlrahmen fuer das aktuell im M52-Statusmodell ausgewaehlte Element.
 - Quelle bleibt ausschliesslich `selectedElement` nach `refresh()` beziehungsweise nach dem bestehenden `uiEditorSelectElement`-Pfad.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -62,7 +62,18 @@ Aktueller Stand:
 - [x] M34 UI-Editor Scope-Wechsel und Bedienfuehrung absichern
 - [x] M35 UI-Editor Bedienhinweise und Abnahmegrenzen festziehen
 - [x] M36 UI-Editor Fixstand nach M29 bis M35 dokumentieren und absichern
+- [x] M56 Dauerhaften Auswahlrahmen im UI-Editor-Statuspanel anzeigen
 
+
+
+## Statusupdate M56
+- M56 ergaenzt im bestehenden UI-Editor-Statuspanel einen dauerhaften orangefarbenen Auswahlrahmen fuer das aktuell im M52-Statusmodell ausgewaehlte Element.
+- Quelle bleibt ausschliesslich `selectedElement` nach `refresh()` beziehungsweise nach dem bestehenden `uiEditorSelectElement`-Pfad.
+- Hover bleibt blau und temporaer im aktiven Auswahlmodus; Auswahl bleibt orange sichtbar, auch nach Escape oder Auswahlmodus-Stopp.
+- `bbm.main.actions` bleibt ohne Rahmen, solange keine M54-HTMLElement-Referenz existiert.
+- Neue Doku: `docs/M56_DAUERHAFTER_AUSWAHLRAHMEN.md`.
+- Neue Tests: `scripts/tests/m56PersistentSelectionFrame.test.cjs`; `scripts/test.cjs` fuehrt den Test mit aus.
+- Naechster Schritt: M57 klaert als kleinstmoegliches Paket die fachlich eindeutige Actions-Referenz oder bestaetigt den weiteren Ausschluss.
 
 ## Statusupdate M55
 - M55 ergaenzt im bestehenden UI-Editor-Statuspanel einen ausdruecklich startbaren Auswahlmodus fuer die vier M54-Refs.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -85,6 +85,7 @@ const { runM51UiEditorKitIntegrationTests } = require("./tests/m51UiEditorKitInt
 const { runM52UiEditorVisibleEntryTests } = require("./tests/m52UiEditorVisibleEntry.test.cjs");
 const { runM54UiElementRefsTests } = require("./tests/m54UiElementRefs.test.cjs");
 const { runM55UiElementSelectionTests } = require("./tests/m55UiElementSelection.test.cjs");
+const { runM56PersistentSelectionFrameTests } = require("./tests/m56PersistentSelectionFrame.test.cjs");
 
 let failed = false;
 
@@ -217,6 +218,7 @@ async function main() {
   await runM52UiEditorVisibleEntryTests(run);
   await runM54UiElementRefsTests(run);
   await runM55UiElementSelectionTests(run);
+  await runM56PersistentSelectionFrameTests(run);
 
   if (failed) {
     process.exitCode = 1;

--- a/scripts/tests/m56PersistentSelectionFrame.test.cjs
+++ b/scripts/tests/m56PersistentSelectionFrame.test.cjs
@@ -219,6 +219,72 @@ async function runM56PersistentSelectionFrameTests(run) {
     assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
   });
 
+
+  await run("M56 Regression: Klick auf gehovertes Ziel entfernt blauen Hover sofort", async () => {
+    const { doc, shell, nav, header } = await setupRefs();
+    const previousDocument = global.document;
+    const previousWindow = global.window;
+    let selectedId = "";
+    const elements = [
+      { elementId: "bbm.main.header", label: "Seitenkopf", type: "frame", scope: "bbm", capabilities: [], allowedChanges: [] },
+      { elementId: "bbm.main.navigation", label: "Navigation", type: "frame", scope: "bbm", capabilities: [], allowedChanges: [] },
+    ];
+    global.document = doc;
+    global.window = {
+      bbmDb: {
+        uiEditorOpen: async () => ({ ok: true, runtimeStarted: true, adapterValid: true, layout: {} }),
+        uiEditorGetElements: async () => ({ ok: true, elements: elements.map((element) => ({ ...element, selected: element.elementId === selectedId })) }),
+        uiEditorGetSelectedElementDetails: async () => ({ ok: true, selectedElement: elements.find((element) => element.elementId === selectedId) || null }),
+        uiEditorSelectElement: async ({ elementId }) => { selectedId = elementId; return { ok: true }; },
+        uiEditorClose: async () => ({ ok: true }),
+      },
+    };
+    try {
+      const { createBbmUiEditorStatusPanel } = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/BbmUiEditorStatusPanel.js"));
+      const panel = createBbmUiEditorStatusPanel({ router: { activeSection: "uiEditor", showSettings: async () => {} } });
+      const root = panel.render();
+      doc.body.appendChild(root);
+      await panel.refresh();
+      panel.startSelectionMode();
+
+      shell.dispatch("pointermove", eventFor(header));
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 1);
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
+
+      shell.dispatch("click", eventFor(header));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assert.equal(selectedId, "bbm.main.header");
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 0);
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+
+      shell.dispatch("pointermove", eventFor(nav));
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 1);
+      shell.dispatch("click", eventFor(nav));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assert.equal(selectedId, "bbm.main.navigation");
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 0);
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+
+      await panel.resetSelection();
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
+      shell.dispatch("pointermove", eventFor(nav));
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 1);
+
+      shell.dispatch("click", eventFor(header));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      shell.dispatch("pointermove", eventFor(nav));
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 1);
+      doc.dispatch("keydown", { key: "Escape" });
+      assert.equal(panel.selectedElement.elementId, "bbm.main.header");
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 0);
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+      panel.destroy();
+    } finally {
+      global.document = previousDocument;
+      global.window = previousWindow;
+    }
+  });
+
   await run("M56 Statuspanel: selectedElement ist Quelle, refresh/select/reset/close/destroy synchronisieren", async () => {
     const { doc } = await setupRefs();
     const previousDocument = global.document;

--- a/scripts/tests/m56PersistentSelectionFrame.test.cjs
+++ b/scripts/tests/m56PersistentSelectionFrame.test.cjs
@@ -1,0 +1,308 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const REPO_ROOT = path.join(__dirname, "../..");
+
+function read(file) {
+  return fs.readFileSync(path.join(REPO_ROOT, file), "utf8");
+}
+
+class TestHTMLElement {
+  constructor(name, rect = {}) {
+    this.name = name;
+    this.tagName = String(name).toUpperCase();
+    this.parentNode = null;
+    this.parentElement = null;
+    this.children = [];
+    this.listeners = new Map();
+    this.ownerDocument = null;
+    this.rect = { left: 0, top: 0, width: 100, height: 100, ...rect };
+    this.style = {};
+    this.attributes = new Map();
+    this.textContent = "";
+    this.isConnected = false;
+    this.firstChild = null;
+    this.disabled = false;
+    this.hidden = false;
+  }
+  append(...nodes) { for (const node of nodes) this.appendChild(node); }
+  appendChild(child) {
+    child.parentNode = this;
+    child.parentElement = this;
+    if (!child.ownerDocument) child.ownerDocument = this.ownerDocument;
+    this.children.push(child);
+    if (!this.firstChild) this.firstChild = child;
+    child.isConnected = true;
+    return child;
+  }
+  removeChild(child) {
+    this.children = this.children.filter((entry) => entry !== child);
+    if (this.firstChild === child) this.firstChild = this.children[0] || null;
+    child.parentNode = null;
+    child.parentElement = null;
+    child.isConnected = false;
+  }
+  contains(target) {
+    let node = target;
+    while (node) {
+      if (node === this) return true;
+      node = node.parentNode || null;
+    }
+    return false;
+  }
+  setAttribute(name, value) { this.attributes.set(String(name), String(value)); }
+  getAttribute(name) { return this.attributes.has(String(name)) ? this.attributes.get(String(name)) : null; }
+  addEventListener(type, handler) {
+    const list = this.listeners.get(type) || [];
+    list.push(handler);
+    this.listeners.set(type, list);
+  }
+  removeEventListener(type, handler) {
+    const list = this.listeners.get(type) || [];
+    this.listeners.set(type, list.filter((entry) => entry !== handler));
+  }
+  dispatch(type, event) { for (const handler of this.listeners.get(type) || []) handler(event); }
+  getBoundingClientRect() { return this.rect; }
+}
+
+function createDoc() {
+  const doc = {
+    defaultView: { HTMLElement: TestHTMLElement, listeners: new Map() },
+    listeners: new Map(),
+    body: null,
+    documentElement: null,
+    createElement(name) {
+      const node = new TestHTMLElement(name);
+      node.ownerDocument = doc;
+      return node;
+    },
+    addEventListener(type, handler) {
+      const list = this.listeners.get(type) || [];
+      list.push(handler);
+      this.listeners.set(type, list);
+    },
+    removeEventListener(type, handler) {
+      const list = this.listeners.get(type) || [];
+      this.listeners.set(type, list.filter((entry) => entry !== handler));
+    },
+    dispatch(type, event) { for (const handler of this.listeners.get(type) || []) handler(event); },
+  };
+  doc.defaultView.addEventListener = function addEventListener(type, handler) {
+    const list = this.listeners.get(type) || [];
+    list.push(handler);
+    this.listeners.set(type, list);
+  };
+  doc.defaultView.removeEventListener = function removeEventListener(type, handler) {
+    const list = this.listeners.get(type) || [];
+    this.listeners.set(type, list.filter((entry) => entry !== handler));
+  };
+  doc.defaultView.dispatch = function dispatch(type, event) { for (const handler of this.listeners.get(type) || []) handler(event); };
+  doc.body = new TestHTMLElement("body");
+  doc.body.ownerDocument = doc;
+  doc.body.isConnected = true;
+  doc.documentElement = doc.body;
+  return doc;
+}
+
+function walk(node, predicate, results = []) {
+  if (!node) return results;
+  if (predicate(node)) results.push(node);
+  for (const child of node.children || []) walk(child, predicate, results);
+  return results;
+}
+
+function byAttr(root, attr) {
+  return walk(root, (node) => node.getAttribute?.(attr) === "true");
+}
+
+function eventFor(target) {
+  return { target, key: undefined, preventDefault() {}, stopPropagation() {}, stopImmediatePropagation() {} };
+}
+
+async function setupRefs() {
+  const refs = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiElementRefs.js"));
+  refs.clearBbmUiElementRefs();
+  const doc = createDoc();
+  const shell = new TestHTMLElement("shell", { left: 1, top: 2, width: 1000, height: 800 });
+  const nav = new TestHTMLElement("nav", { left: 10, top: 20, width: 200, height: 700 });
+  const header = new TestHTMLElement("header", { left: 220, top: 20, width: 800, height: 80 });
+  const content = new TestHTMLElement("content", { left: 220, top: 110, width: 800, height: 620 });
+  for (const node of [shell, nav, header, content]) node.ownerDocument = doc;
+  doc.body.appendChild(shell);
+  shell.appendChild(nav);
+  shell.appendChild(header);
+  shell.appendChild(content);
+  refs.registerBbmUiElementRef("bbm.main.shell", shell);
+  refs.registerBbmUiElementRef("bbm.main.navigation", nav);
+  refs.registerBbmUiElementRef("bbm.main.header", header);
+  refs.registerBbmUiElementRef("bbm.main.content", content);
+  return { refs, doc, shell, nav, header, content };
+}
+
+async function runM56PersistentSelectionFrameTests(run) {
+  await run("M56 Auswahloverlay: Rahmen, Label, Rect, Wechsel, Leer und unbekannt", async () => {
+    const { refs, doc, header, nav } = await setupRefs();
+    const { createBbmUiSelectedOverlay } = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiSelectedOverlay.js"));
+    const overlay = createBbmUiSelectedOverlay();
+    assert.equal(overlay.sync({ elementId: "bbm.main.header", label: "Seitenkopf" }), true);
+    let frames = byAttr(doc.body, "data-bbm-ui-selected-frame");
+    assert.equal(frames.length, 1);
+    assert.equal(frames[0].style.left, "220px");
+    assert.equal(frames[0].style.top, "20px");
+    assert.equal(frames[0].style.width, "800px");
+    assert.equal(frames[0].style.height, "80px");
+    assert.match(frames[0].firstChild.textContent, /Ausgewählt: Seitenkopf · bbm\.main\.header/);
+    assert.match(frames[0].style.border, /249, 115, 22/);
+    const sameFrame = frames[0];
+    assert.equal(overlay.sync({ elementId: "bbm.main.navigation", label: "Navigation" }), true);
+    frames = byAttr(doc.body, "data-bbm-ui-selected-frame");
+    assert.equal(frames.length, 1);
+    assert.equal(frames[0], sameFrame);
+    assert.equal(frames[0].style.left, "10px");
+    nav.rect.left = 42;
+    doc.dispatch("scroll", {});
+    assert.equal(frames[0].style.left, "42px");
+    nav.rect.width = 222;
+    doc.defaultView.dispatch("resize", {});
+    assert.equal(frames[0].style.width, "222px");
+    overlay.sync(null);
+    assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
+    assert.equal((doc.listeners.get("scroll") || []).length, 0);
+    assert.equal((doc.defaultView.listeners.get("resize") || []).length, 0);
+    assert.equal(overlay.sync({ elementId: "bbm.unknown", label: "Unbekannt" }), false);
+    refs.unregisterBbmUiElementRef("bbm.main.navigation");
+    assert.equal(overlay.sync({ elementId: "bbm.main.navigation", label: "Navigation" }), false);
+  });
+
+  await run("M56 Auswahloverlay: bbm.main.actions ohne Ref erzeugt keinen Rahmen und maximal einen Rahmen", async () => {
+    const { doc } = await setupRefs();
+    const { createBbmUiSelectedOverlay } = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiSelectedOverlay.js"));
+    const overlay = createBbmUiSelectedOverlay();
+    assert.equal(overlay.sync({ elementId: "bbm.main.actions", label: "Aktionen" }), false);
+    assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
+    overlay.sync({ elementId: "bbm.main.header", label: "Seitenkopf" });
+    overlay.sync({ elementId: "bbm.main.header", label: "Seitenkopf" });
+    overlay.sync({ elementId: "bbm.main.content", label: "Inhalt" });
+    assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+  });
+
+  await run("M56 Hover/Selected: anderes Ziel doppelt sichtbar, gleiches Ziel nicht doppelt, Escape/Stop lassen Auswahl stehen", async () => {
+    const { doc, shell, nav, header } = await setupRefs();
+    const { createBbmUiSelectedOverlay } = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiSelectedOverlay.js"));
+    const { createBbmUiElementSelectionController } = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiElementSelection.js"));
+    const selectedOverlay = createBbmUiSelectedOverlay();
+    selectedOverlay.sync({ elementId: "bbm.main.header", label: "Seitenkopf" });
+    const controller = createBbmUiElementSelectionController({
+      isElementSelected: (elementId) => elementId === "bbm.main.header",
+      getElementMeta: (elementId) => ({ label: elementId === "bbm.main.header" ? "Seitenkopf" : "Navigation" }),
+    });
+    controller.start();
+    shell.dispatch("pointermove", eventFor(nav));
+    assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 1);
+    assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+    shell.dispatch("pointermove", eventFor(header));
+    assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 0);
+    assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+    shell.dispatch("pointermove", eventFor(nav));
+    doc.dispatch("keydown", { key: "Escape" });
+    assert.equal(controller.isActive(), false);
+    assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 0);
+    assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+    controller.start();
+    shell.dispatch("pointermove", eventFor(nav));
+    controller.stop();
+    assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 0);
+    assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+    selectedOverlay.clear();
+    assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
+  });
+
+  await run("M56 Statuspanel: selectedElement ist Quelle, refresh/select/reset/close/destroy synchronisieren", async () => {
+    const { doc } = await setupRefs();
+    const previousDocument = global.document;
+    const previousWindow = global.window;
+    let selectedId = "bbm.main.header";
+    const elements = [
+      { elementId: "bbm.main.header", label: "Seitenkopf", type: "frame", scope: "bbm", capabilities: [], allowedChanges: [] },
+      { elementId: "bbm.main.navigation", label: "Navigation", type: "frame", scope: "bbm", capabilities: [], allowedChanges: [] },
+    ];
+    global.document = doc;
+    global.window = {
+      bbmDb: {
+        uiEditorOpen: async () => ({ ok: true, runtimeStarted: true, adapterValid: true, layout: {} }),
+        uiEditorGetElements: async () => ({ ok: true, elements: elements.map((element) => ({ ...element, selected: element.elementId === selectedId })) }),
+        uiEditorGetSelectedElementDetails: async () => ({ ok: true, selectedElement: elements.find((element) => element.elementId === selectedId) || null }),
+        uiEditorSelectElement: async ({ elementId }) => { selectedId = elementId; return { ok: true }; },
+        uiEditorClose: async () => ({ ok: true }),
+      },
+    };
+    try {
+      const { createBbmUiEditorStatusPanel } = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/BbmUiEditorStatusPanel.js"));
+      const panel = createBbmUiEditorStatusPanel({ router: { activeSection: "uiEditor", showSettings: async () => {} } });
+      const root = panel.render();
+      doc.body.appendChild(root);
+      await panel.refresh();
+      assert.equal(panel.selectedElement.elementId, "bbm.main.header");
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+      assert.ok(walk(root, (node) => node.textContent === "Visuell markiert").length >= 1);
+      assert.ok(walk(root, (node) => node.textContent === "Seitenkopf").length >= 1);
+      await panel.selectElement("bbm.main.navigation");
+      assert.equal(panel.selectedElement.elementId, "bbm.main.navigation");
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+      await panel.resetSelection();
+      assert.equal(selectedId, "");
+      assert.equal(panel.selectedElement, null);
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
+      selectedId = "bbm.main.header";
+      await panel.refresh();
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+      await panel.close();
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
+      selectedId = "bbm.main.header";
+      await panel.refresh();
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+      panel.destroy();
+      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
+      assert.equal((doc.listeners.get("scroll") || []).length, 0);
+      assert.equal((doc.defaultView.listeners.get("resize") || []).length, 0);
+    } finally {
+      global.document = previousDocument;
+      global.window = previousWindow;
+    }
+  });
+
+  await run("M56 Sicherheit: keine verbotene Zielsuche, keine zweite Auswahlhaltung, keine neue IPC/Legacy/Layoutmutation", () => {
+    const files = [
+      "src/renderer/ui-editor/BbmUiEditorStatusPanel.js",
+      "src/renderer/ui-editor/bbmUiElementSelection.js",
+      "src/renderer/ui-editor/bbmUiSelectionOverlay.js",
+      "src/renderer/ui-editor/bbmUiSelectedOverlay.js",
+      "src/renderer/ui-editor/bbmUiElementRefs.js",
+    ];
+    const combined = files.map(read).join("\n");
+    assert.doesNotMatch(combined, /querySelector|querySelectorAll|getElementById|getElementsBy|closest\s*\(|matches\s*\(|MutationObserver|elementsFromPoint|elementFromPoint/);
+    assert.doesNotMatch(combined, /targetSelection|editorV2Core|UiInspectorOverlay|BBM_UI_ELEMENTS\s*=|ipcRenderer|ipcMain|localStorage/);
+    assert.doesNotMatch(combined, /selectedElementId\s*=|new Map\(\).*selected|data-ui-/s);
+    assert.doesNotMatch(combined, /targetElement\.style|nextTargetElement\.style|getBbmUiElementRef\("bbm\.main\.shell"\)\s*\|\|/);
+  });
+
+  await run("M56 Dokumentation, Aufgabenheft und Testeinbindung sind nachgezogen", () => {
+    assert.match(read("docs/M56_DAUERHAFTER_AUSWAHLRAHMEN.md"), /dauerhafter Auswahlrahmen/i);
+    assert.match(read("STATUS.md"), /M56/);
+    assert.match(read("docs/UI_INSPEKTOR_AUFGABENHEFT.md"), /M56/);
+    assert.match(read("scripts/test.cjs"), /runM56PersistentSelectionFrameTests/);
+  });
+}
+
+if (require.main === module) {
+  let failed = false;
+  const run = async (name, fn) => {
+    try { await fn(); console.log(`ok - ${name}`); }
+    catch (error) { failed = true; console.error(`not ok - ${name}`); console.error(error?.stack || error); }
+  };
+  runM56PersistentSelectionFrameTests(run).then(() => { if (failed) process.exitCode = 1; });
+}
+
+module.exports = { runM56PersistentSelectionFrameTests };

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -1,5 +1,6 @@
 import { getBbmUiElementRefStatus } from "./bbmUiElementRefs.js";
 import { createBbmUiElementSelectionController } from "./bbmUiElementSelection.js";
+import { createBbmUiSelectedOverlay } from "./bbmUiSelectedOverlay.js";
 
 function createNode(tag, className = "") {
   const node = document.createElement(tag);
@@ -51,6 +52,7 @@ export class BbmUiEditorStatusPanel {
     this.selectionController = null;
     this.selectionMessage = "";
     this.selectionModeActive = false;
+    this.selectedOverlay = createBbmUiSelectedOverlay();
   }
 
   render() {
@@ -91,6 +93,7 @@ export class BbmUiEditorStatusPanel {
     this.selectionController = createBbmUiElementSelectionController({
       getPanelRoot: () => this.root,
       getElementMeta: (elementId) => this.getElementMeta(elementId),
+      isElementSelected: (elementId) => this.selectedElement?.elementId === elementId,
       selectElement: ({ elementId }) => this.selectElement(elementId, { fromSelectionMode: true }),
       onSelection: ({ elementId, meta }) => {
         this.selectionMessage = `Ausgewaehlt: ${asText(meta?.label, elementId)}`;
@@ -108,6 +111,7 @@ export class BbmUiEditorStatusPanel {
 
   async close() {
     this.stopSelectionMode();
+    this.selectedOverlay?.destroy?.();
     try {
       await window.bbmDb?.uiEditorClose?.();
     } catch (_e) {
@@ -127,6 +131,7 @@ export class BbmUiEditorStatusPanel {
       this.elements = [];
       this.selectedElement = null;
       this.renderAll();
+      this.syncSelectedOverlay();
       return;
     }
 
@@ -140,6 +145,7 @@ export class BbmUiEditorStatusPanel {
     this.elements = Array.isArray(elementsResult?.elements) ? elementsResult.elements : [];
     this.selectedElement = detailsResult?.selectedElement || null;
     this.renderAll();
+    this.syncSelectedOverlay();
   }
 
   showLoadError(error) {
@@ -148,6 +154,7 @@ export class BbmUiEditorStatusPanel {
     this.elements = [];
     this.selectedElement = null;
     this.renderAll();
+    this.syncSelectedOverlay();
   }
 
   renderAll() {
@@ -185,6 +192,7 @@ export class BbmUiEditorStatusPanel {
       createInfoRow("UI-Referenzen gebunden", this.refStatus ? `${this.refStatus.count}/${this.refStatus.expectedCount}` : "nicht verfuegbar"),
       createInfoRow("Fehlende Referenzen", this.refStatus ? formatList(this.refStatus.missingIds) : "nicht verfuegbar"),
       createInfoRow("Auswahlmodus", this.selectionModeActive ? "Aktiv" : "Inaktiv"),
+      createInfoRow("Visuell markiert", this.getVisualSelectionLabel()),
       createInfoRow("Gebundene Ziele", this.refStatus ? String(this.getSelectableBoundCount()) : "nicht verfuegbar"),
       createInfoRow("Nicht verfuegbar", "bbm.main.actions"),
       createInfoRow("LayoutStore verfuegbar", yesNo(status.layoutStoreAvailable)),
@@ -201,7 +209,7 @@ export class BbmUiEditorStatusPanel {
     const resetSelection = createNode("button", "bbm-ui-editor-panel__secondary");
     resetSelection.type = "button";
     resetSelection.textContent = "Auswahl zuruecksetzen";
-    resetSelection.addEventListener("click", () => this.selectElement("").catch((error) => this.showLoadError(error)));
+    resetSelection.addEventListener("click", () => this.resetSelection().catch((error) => this.showLoadError(error)));
 
     const startSelection = createNode("button", "bbm-ui-editor-panel__secondary");
     startSelection.type = "button";
@@ -319,10 +327,13 @@ export class BbmUiEditorStatusPanel {
     this.selectionController?.stop?.();
     this.selectionModeActive = false;
     this.renderAll();
+    this.syncSelectedOverlay();
   }
 
   destroy() {
-    this.stopSelectionMode();
+    this.selectionController?.destroy?.();
+    this.selectedOverlay?.destroy?.();
+    this.selectionModeActive = false;
     this.root = null;
   }
 
@@ -339,11 +350,35 @@ export class BbmUiEditorStatusPanel {
       return;
     }
     await this.refresh();
+    this.syncSelectedOverlay();
     if (options.fromSelectionMode) {
       const meta = this.getElementMeta(elementId);
       this.selectionMessage = `Ausgewaehlt: ${asText(meta?.label, elementId)}`;
       this.selectionModeActive = this.selectionController?.isActive?.() || false;
       this.renderAll();
+      this.syncSelectedOverlay();
+    }
+  }
+
+  async resetSelection() {
+    await this.selectElement("");
+    this.selectedOverlay?.clear?.();
+  }
+
+  getVisualSelectionLabel() {
+    return this.selectedElement ? asText(this.selectedElement.label, this.selectedElement.elementId) : "keine Auswahl";
+  }
+
+  syncSelectedOverlay() {
+    if (!this.selectedElement) {
+      this.selectedOverlay?.clear?.();
+      return false;
+    }
+    try {
+      return this.selectedOverlay?.sync?.(this.selectedElement) || false;
+    } catch (_error) {
+      this.selectedOverlay?.clear?.();
+      return false;
     }
   }
 }

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -132,6 +132,7 @@ export class BbmUiEditorStatusPanel {
       this.selectedElement = null;
       this.renderAll();
       this.syncSelectedOverlay();
+      this.selectionController?.syncHoverWithSelection?.();
       return;
     }
 
@@ -146,6 +147,7 @@ export class BbmUiEditorStatusPanel {
     this.selectedElement = detailsResult?.selectedElement || null;
     this.renderAll();
     this.syncSelectedOverlay();
+    this.selectionController?.syncHoverWithSelection?.();
   }
 
   showLoadError(error) {
@@ -155,6 +157,7 @@ export class BbmUiEditorStatusPanel {
     this.selectedElement = null;
     this.renderAll();
     this.syncSelectedOverlay();
+    this.selectionController?.syncHoverWithSelection?.();
   }
 
   renderAll() {
@@ -351,12 +354,14 @@ export class BbmUiEditorStatusPanel {
     }
     await this.refresh();
     this.syncSelectedOverlay();
+    this.selectionController?.syncHoverWithSelection?.();
     if (options.fromSelectionMode) {
       const meta = this.getElementMeta(elementId);
       this.selectionMessage = `Ausgewaehlt: ${asText(meta?.label, elementId)}`;
       this.selectionModeActive = this.selectionController?.isActive?.() || false;
       this.renderAll();
       this.syncSelectedOverlay();
+      this.selectionController?.syncHoverWithSelection?.();
     }
   }
 

--- a/src/renderer/ui-editor/bbmUiElementSelection.js
+++ b/src/renderer/ui-editor/bbmUiElementSelection.js
@@ -25,12 +25,17 @@ function formatMetaLabel(elementId, getElementMeta) {
   return `${label} · ${elementId}`;
 }
 
+function isSelectedElement(elementId, isElementSelected) {
+  return typeof isElementSelected === "function" && isElementSelected(elementId);
+}
+
 export function createBbmUiElementSelectionController(options = {}) {
   const overlay = options.overlay || createBbmUiSelectionOverlay(options.overlayOptions || {});
   const selectElement = typeof options.selectElement === "function" ? options.selectElement : async () => {};
   const getElementMeta = typeof options.getElementMeta === "function" ? options.getElementMeta : () => null;
   const onStateChange = typeof options.onStateChange === "function" ? options.onStateChange : () => {};
   const onSelection = typeof options.onSelection === "function" ? options.onSelection : () => {};
+  const isElementSelected = typeof options.isElementSelected === "function" ? options.isElementSelected : () => false;
   let active = false;
   let shellElement = null;
   let ownerDocument = null;
@@ -71,11 +76,19 @@ export function createBbmUiElementSelectionController(options = {}) {
     if (hit.elementId === hoveredElementId && hit.element === hoveredElement) return;
     hoveredElementId = hit.elementId;
     hoveredElement = hit.element;
+    if (isSelectedElement(hit.elementId, isElementSelected)) {
+      overlay.clearHover();
+      return;
+    }
     overlay.updateHover({ targetElement: hit.element, label: formatMetaLabel(hit.elementId, getElementMeta) });
   }
 
   function refreshHover() {
     if (!hoveredElementId || !hoveredElement) return;
+    if (isSelectedElement(hoveredElementId, isElementSelected)) {
+      overlay.clearHover();
+      return;
+    }
     overlay.updateHover({ targetElement: hoveredElement, label: formatMetaLabel(hoveredElementId, getElementMeta) });
   }
 

--- a/src/renderer/ui-editor/bbmUiElementSelection.js
+++ b/src/renderer/ui-editor/bbmUiElementSelection.js
@@ -42,6 +42,7 @@ export function createBbmUiElementSelectionController(options = {}) {
   let ownerWindow = null;
   let hoveredElementId = "";
   let hoveredElement = null;
+  let hoveredElementSelected = false;
 
   function getPanelRoot() {
     return typeof options.getPanelRoot === "function" ? options.getPanelRoot() : options.panelRoot || null;
@@ -64,6 +65,7 @@ export function createBbmUiElementSelectionController(options = {}) {
   function clearHover() {
     hoveredElementId = "";
     hoveredElement = null;
+    hoveredElementSelected = false;
     overlay.clearHover();
   }
 
@@ -73,10 +75,12 @@ export function createBbmUiElementSelectionController(options = {}) {
       clearHover();
       return;
     }
-    if (hit.elementId === hoveredElementId && hit.element === hoveredElement) return;
+    const selectedNow = isSelectedElement(hit.elementId, isElementSelected);
+    if (hit.elementId === hoveredElementId && hit.element === hoveredElement && selectedNow === hoveredElementSelected) return;
     hoveredElementId = hit.elementId;
     hoveredElement = hit.element;
-    if (isSelectedElement(hit.elementId, isElementSelected)) {
+    hoveredElementSelected = selectedNow;
+    if (selectedNow) {
       overlay.clearHover();
       return;
     }
@@ -85,7 +89,9 @@ export function createBbmUiElementSelectionController(options = {}) {
 
   function refreshHover() {
     if (!hoveredElementId || !hoveredElement) return;
-    if (isSelectedElement(hoveredElementId, isElementSelected)) {
+    const selectedNow = isSelectedElement(hoveredElementId, isElementSelected);
+    hoveredElementSelected = selectedNow;
+    if (selectedNow) {
       overlay.clearHover();
       return;
     }
@@ -159,6 +165,7 @@ export function createBbmUiElementSelectionController(options = {}) {
       ownerWindow = ownerDocument?.defaultView || null;
       hoveredElementId = "";
       hoveredElement = null;
+      hoveredElementSelected = false;
       overlay.mount(ownerDocument);
       shellElement.addEventListener("pointermove", handlePointerMove);
       shellElement.addEventListener("click", handleClick, true);
@@ -181,6 +188,8 @@ export function createBbmUiElementSelectionController(options = {}) {
       return active;
     },
     getState,
+    refreshHover,
+    syncHoverWithSelection: refreshHover,
     resolveTargetForTest: resolveTarget,
   };
 }

--- a/src/renderer/ui-editor/bbmUiSelectedOverlay.js
+++ b/src/renderer/ui-editor/bbmUiSelectedOverlay.js
@@ -1,0 +1,171 @@
+import { getBbmUiElementRef } from "./bbmUiElementRefs.js";
+
+const DEFAULT_Z_INDEX = 2147483210;
+
+function toNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function readRect(targetElement) {
+  const rect = typeof targetElement?.getBoundingClientRect === "function" ? targetElement.getBoundingClientRect() : null;
+  return {
+    left: toNumber(rect?.left),
+    top: toNumber(rect?.top),
+    width: Math.max(0, toNumber(rect?.width)),
+    height: Math.max(0, toNumber(rect?.height)),
+  };
+}
+
+function getOwnerDocument(targetElement) {
+  return targetElement?.ownerDocument || null;
+}
+
+function formatSelectedLabel(selectedElement) {
+  const elementId = String(selectedElement?.elementId || "").trim();
+  const label = String(selectedElement?.label || elementId).trim();
+  return `Ausgewählt: ${label} · ${elementId}`;
+}
+
+export function createBbmUiSelectedOverlay(options = {}) {
+  const zIndex = Number.isFinite(options.zIndex) ? options.zIndex : DEFAULT_Z_INDEX;
+  let doc = null;
+  let win = null;
+  let root = null;
+  let frame = null;
+  let labelNode = null;
+  let targetElement = null;
+  let selectedElement = null;
+  let listenersInstalled = false;
+
+  function ensureRoot(ownerDocument) {
+    doc = ownerDocument || doc;
+    if (!doc || typeof doc.createElement !== "function") return null;
+    if (root?.isConnected) return root;
+    root = doc.createElement("div");
+    root.setAttribute("data-bbm-ui-selected-overlay-root", "true");
+    root.style.position = "fixed";
+    root.style.inset = "0";
+    root.style.pointerEvents = "none";
+    root.style.zIndex = String(zIndex);
+    root.style.overflow = "hidden";
+    const mount = doc.body || doc.documentElement;
+    if (mount?.appendChild) mount.appendChild(root);
+    return root;
+  }
+
+  function ensureFrame() {
+    if (!root || !doc) return null;
+    if (frame?.isConnected) return frame;
+    frame = doc.createElement("div");
+    frame.setAttribute("data-bbm-ui-selected-frame", "true");
+    frame.style.position = "fixed";
+    frame.style.boxSizing = "border-box";
+    frame.style.border = "2px solid rgba(249, 115, 22, 0.98)";
+    frame.style.background = "rgba(249, 115, 22, 0.10)";
+    frame.style.pointerEvents = "none";
+    frame.style.borderRadius = "6px";
+
+    labelNode = doc.createElement("div");
+    labelNode.setAttribute("data-bbm-ui-selected-label", "true");
+    labelNode.style.position = "absolute";
+    labelNode.style.left = "0";
+    labelNode.style.top = "-24px";
+    labelNode.style.maxWidth = "420px";
+    labelNode.style.whiteSpace = "nowrap";
+    labelNode.style.overflow = "hidden";
+    labelNode.style.textOverflow = "ellipsis";
+    labelNode.style.background = "rgba(154, 52, 18, 0.96)";
+    labelNode.style.color = "#fff";
+    labelNode.style.font = "12px/1.35 system-ui, sans-serif";
+    labelNode.style.padding = "3px 6px";
+    labelNode.style.borderRadius = "4px";
+    labelNode.style.pointerEvents = "none";
+    frame.appendChild(labelNode);
+    root.appendChild(frame);
+    return frame;
+  }
+
+  function updatePosition() {
+    if (!targetElement || !frame?.isConnected) return;
+    const rect = readRect(targetElement);
+    frame.style.left = `${rect.left}px`;
+    frame.style.top = `${rect.top}px`;
+    frame.style.width = `${rect.width}px`;
+    frame.style.height = `${rect.height}px`;
+    if (labelNode) labelNode.textContent = formatSelectedLabel(selectedElement);
+  }
+
+  function installListeners() {
+    if (listenersInstalled || !doc) return;
+    win = doc.defaultView || null;
+    doc.addEventListener?.("scroll", updatePosition, true);
+    win?.addEventListener?.("resize", updatePosition);
+    listenersInstalled = true;
+  }
+
+  function removeListeners() {
+    if (!listenersInstalled) return;
+    doc?.removeEventListener?.("scroll", updatePosition, true);
+    win?.removeEventListener?.("resize", updatePosition);
+    listenersInstalled = false;
+    win = null;
+  }
+
+  function clear() {
+    removeListeners();
+    if (root?.parentNode) root.parentNode.removeChild(root);
+    root = null;
+    frame = null;
+    labelNode = null;
+    targetElement = null;
+    selectedElement = null;
+    doc = null;
+  }
+
+  return {
+    sync(nextSelectedElement) {
+      const elementId = String(nextSelectedElement?.elementId || "").trim();
+      if (!elementId) {
+        clear();
+        return false;
+      }
+      let nextTargetElement = null;
+      try {
+        nextTargetElement = getBbmUiElementRef(elementId);
+      } catch (_error) {
+        clear();
+        return false;
+      }
+      if (!nextTargetElement) {
+        clear();
+        return false;
+      }
+      const ownerDocument = getOwnerDocument(nextTargetElement);
+      if (!ownerDocument) {
+        clear();
+        return false;
+      }
+      selectedElement = nextSelectedElement;
+      targetElement = nextTargetElement;
+      ensureRoot(ownerDocument);
+      ensureFrame();
+      installListeners();
+      updatePosition();
+      return true;
+    },
+    clear,
+    destroy() {
+      clear();
+    },
+    getState() {
+      return {
+        mounted: Boolean(root?.isConnected),
+        showing: Boolean(frame?.isConnected),
+        elementId: String(selectedElement?.elementId || ""),
+        listenersInstalled,
+      };
+    },
+    updatePositionForTest: updatePosition,
+  };
+}


### PR DESCRIPTION
### Motivation
- Erweiterung von M55: Die Hover- und Klickauswahl im UI-Editor soll um eine dauerhafte, visuelle Markierung des aktuell ausgewählten Elements ergänzt werden. 
- Die visuelle Auswahl darf ausschließlich aus dem bestehenden M52-Auswahlstatus abgeleitet werden und keine neue fachliche Auswahlhaltung einführen. 
- Sicherheits- und Architekturregeln bleiben unverändert: keine DOM-Suche, keine Layoutmutation, keine neue IPC- oder Speicherhaltung. 

### Description
- Neues Overlay: `src/renderer/ui-editor/bbmUiSelectedOverlay.js` implementiert ein rein visuelles, `position: fixed` orangefarbenes Auswahl-Frame mit Label, `getBoundingClientRect()`-basierter Positionierung und Scroll/Resize-Lifecycle. 
- Statuspanel-Integration: `src/renderer/ui-editor/BbmUiEditorStatusPanel.js` bindet das Selected-Overlay, synchronisiert es nach `refresh()`/`selectElement()`/`resetSelection()`/`close()`/`destroy()` und zeigt die Statuszeile `Visuell markiert`. 
- Hover/Selection-Trennung: `src/renderer/ui-editor/bbmUiElementSelection.js` wurde angepasst, damit der blaue Hoverrahmen unterdrückt wird, wenn das gehovte Element bereits als ausgewählt gilt. 
- Tests & Doku: Neuer Test `scripts/tests/m56PersistentSelectionFrame.test.cjs`, Einbindung in `scripts/test.cjs`, und neue Doku `docs/M56_DAUERHAFTER_AUSWAHLRAHMEN.md` sowie Aufgabenheft/STATUS-Aktualisierungen wurden hinzugefügt. 

### Testing
- Automatisierte Testläufe: `node scripts/tests/m51UiEditorKitIntegration.test.cjs`, `node scripts/tests/m52UiEditorVisibleEntry.test.cjs`, `node scripts/tests/m54UiElementRefs.test.cjs`, `node scripts/tests/m55UiElementSelection.test.cjs`, `node scripts/tests/m56PersistentSelectionFrame.test.cjs` und `node scripts/test.cjs` wurden ausgeführt und alle relevanten M51–M56-Tests liefen grün. 
- Sicherheitstests: Der neue M56-Test prüft Position/Label/Rect, Wechsel/Leeren/unbekannte IDs, Hover/Selected-Zusammenspiel, Escape/Stop/Reset/Close/Destroy und bestätigt das Fehlen verbotener DOM-Operationen. 
- Start/Runtime: `npm start` wurde versucht, aber Electron startet in dieser Linux-Umgebung aufgrund fehlender Systembibliothek `libatk-1.0.so.0` nicht; dies beeinträchtigt nur die manuelle Windows-E2E-Sichtprüfung, nicht die node-basierten Tests. 
- Ergebnis: Alle automatisierten Prüfungen für dieses Paket sind bestanden und die Änderungen wurden als Commit `87e3570 M56 dauerhaften Auswahlrahmen anzeigen` festgehalten.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52baedefd08322b594a1c404276cd5)