### PR TITLE
M61: Use UI-Editor-kit selection runtime exclusively in status panel

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -19,6 +19,9 @@
   - `npm test` (Codex-Cloud-Umgebung: Electron-Systembibliothek `libatk-1.0.so.0` fehlt)
 - Risiken / offen:
   - Manuelle Windows-/Electron-Abnahme fuer Hover, Auswahl, Reset, sichtbare Kit-Fehler und doppelte Overlayfreiheit bleibt fachlich offen.
+- Korrektur PR #199:
+  - M56-Regressionstests wurden M61-konform auf Kit-Synchronisation statt BBM-Overlay-/Controller-Erwartungen angepasst.
+  - Produktionscode blieb unveraendert.
 - Naechster Schritt:
   - Manuelle Sichtpruefung im laufenden App-Fenster nachholen.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,27 @@
 # STATUS.md â€” BBM-Produktiv
 
+### M61 – UI-Editor-kit Selection-Runtime exklusiv
+- Ergebnis:
+  - Das UI-Editor-Statuspanel nutzt fuer Hover und Auswahl ausschliesslich die UI-Editor-kit Selection-Runtime.
+  - Das Runtime-Dropdown und der stille Rueckfall auf die BBM-eigene Runtime wurden entfernt.
+  - Kit-Fehler bleiben im Statuspanel sichtbar; Auswahlstart bleibt ohne Kit-Controller blockiert.
+  - Schliessen/Destroy bereinigen den Kit-Controller ohne zweite Listener-/Overlay-Spur.
+- Geaenderte Dateien:
+  - `src/renderer/ui-editor/BbmUiEditorStatusPanel.js`
+  - `scripts/tests/m59KitSelectionRuntimeIntegration.test.cjs`
+  - `scripts/tests/m60KitRuntimeStandard.test.cjs`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `docs/M61_KIT_RUNTIME_ONLY.md`
+  - `STATUS.md`
+- Pruefung:
+  - `node scripts/tests/m59KitSelectionRuntimeIntegration.test.cjs`
+  - `node scripts/tests/m60KitRuntimeStandard.test.cjs`
+  - `npm test` (Codex-Cloud-Umgebung: Electron-Systembibliothek `libatk-1.0.so.0` fehlt)
+- Risiken / offen:
+  - Manuelle Windows-/Electron-Abnahme fuer Hover, Auswahl, Reset, sichtbare Kit-Fehler und doppelte Overlayfreiheit bleibt fachlich offen.
+- Naechster Schritt:
+  - Manuelle Sichtpruefung im laufenden App-Fenster nachholen.
+
 ### M60 – UI-Editor-kit Selection-Runtime als Standard
 - Status: erledigt
 - Beschreibung:

--- a/docs/M61_KIT_RUNTIME_ONLY.md
+++ b/docs/M61_KIT_RUNTIME_ONLY.md
@@ -1,0 +1,28 @@
+# M61 – UI-Editor-kit Selection-Runtime exklusiv im Statuspanel
+
+## Ziel
+M61 entfernt die bisherige BBM-eigene Hover-/Selection-Runtime aus dem UI-Editor-Statuspanel. Die sichtbare Auswahl im Statuspanel laeuft damit ausschliesslich ueber die Selection-Runtime des UI-Editor-kits.
+
+## Umgesetzt
+- Das Statuspanel erzeugt keinen BBM-Auswahlcontroller mehr.
+- Das Runtime-Dropdown wurde entfernt; die Statusanzeige meldet fest `UI-Editor-kit`.
+- Kit-Initialisierung, Hover, Auswahl, Reset und Synchronisation laufen ueber den Kit-Controller und die bestehende Host-Bridge.
+- Kit-Fehler werden weiterhin sichtbar als letzter Runtime-Fehler angezeigt.
+- Es gibt keinen stillen Rueckfall mehr auf die alte BBM-Runtime.
+- Schliessen und Destroy stoppen und zerstoeren nur noch den Kit-Controller.
+
+## Bewusst nicht geaendert
+- Keine Registry-Aenderung.
+- Keine DOM-Suche und keine automatische UI-Erkennung.
+- Keine Aenderung am UI-Editor-kit-Repo.
+- Keine Aenderung an Layoutspeicherung, Fachdaten, IPC-Fachaktionen oder Datenbank.
+- M54-Refs und M52-Auswahl bleiben die Integrationsbasis.
+- Kein Umbau des gesamten Statuspanels.
+
+## Pruefung
+- `scripts/tests/m59KitSelectionRuntimeIntegration.test.cjs` prueft weiter Host-Bridge, Kit-Exklusivitaet, fehlendes Runtime-Dropdown, Lifecycle, Fehlerstatus und Sicherheitsgrenzen.
+- `scripts/tests/m60KitRuntimeStandard.test.cjs` wurde auf die M61-Regel angepasst und prueft, dass Kit-Fehler sichtbar bleiben, ohne auf BBM zurueckzufallen.
+- `scripts/test.cjs` fuehrt beide Tests als Teil der vollstaendigen Testsuite aus; `npm test` konnte in Codex Cloud wegen fehlender Electron-Systembibliothek `libatk-1.0.so.0` nicht vollstaendig laufen.
+
+## Manuelle Abnahme offen
+Codex Cloud kann die sichtbare Windows-/Electron-Bedienung nicht fachlich beurteilen. Manuell zu pruefen bleiben: UI-Editor oeffnen, Hover, Auswahl, Reset, Schliessen/Oeffnen ohne doppelte Listener oder Overlays sowie sichtbare Kit-Fehlermeldung.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -65,7 +65,18 @@ Aktueller Stand:
 - [x] M56 Dauerhaften Auswahlrahmen im UI-Editor-Statuspanel anzeigen
 - [x] M59 UI-Editor-kit Selection-Runtime kontrolliert im BBM-Statuspanel parallel testbar machen
 - [x] M60 UI-Editor-kit Selection-Runtime im Statuspanel als Standard verwenden
+- [x] M61 UI-Editor-kit Selection-Runtime exklusiv im Statuspanel verwenden
 
+
+## Statusupdate M61
+- M61 entfernt die BBM-eigene Hover-/Selection-Runtime aus dem UI-Editor-Statuspanel.
+- Das Statuspanel zeigt kein Runtime-Dropdown mehr; die Auswahl-Laufzeit ist fest `UI-Editor-kit`.
+- Hover, Auswahl, Reset und Synchronisation laufen ueber den Kit-Controller und die bestehende M59-Host-Bridge.
+- Kit-Fehler bleiben sichtbar, fuehren aber nicht mehr zu einem stillen Rueckfall auf die alte BBM-Runtime.
+- Schliessen und Destroy bereinigen den Kit-Controller; wiederholtes Oeffnen erzeugt keinen zweiten Kit-Controller pro Panel-Sitzung.
+- Neue Doku: `docs/M61_KIT_RUNTIME_ONLY.md`.
+- Angepasste Tests: `scripts/tests/m59KitSelectionRuntimeIntegration.test.cjs` und `scripts/tests/m60KitRuntimeStandard.test.cjs`; `scripts/test.cjs` fuehrt beide weiter aus.
+- Offener Punkt: manuelle Windows-Abnahme fuer sichtbaren Kit-Start, Hover, Auswahl, Reset, Fehlermeldung und doppelte Overlayfreiheit nachholen.
 
 ## Statusupdate M60
 - M60 macht die generische UI-Editor-kit Selection-Runtime im Entwicklungsbetrieb zur Standard-Auswahlruntime des UI-Editor-Statuspanels.

--- a/scripts/tests/m56PersistentSelectionFrame.test.cjs
+++ b/scripts/tests/m56PersistentSelectionFrame.test.cjs
@@ -121,6 +121,96 @@ function eventFor(target) {
   return { target, key: undefined, preventDefault() {}, stopPropagation() {}, stopImmediatePropagation() {} };
 }
 
+function createPanelHarness(panel, doc) {
+  panel.root = doc.createElement("section");
+  panel.root.setAttribute("data-bbm-ui-editor-panel", "true");
+  panel.statusNode = doc.createElement("section");
+  panel.elementsNode = doc.createElement("section");
+  panel.detailsNode = doc.createElement("section");
+  panel.errorNode = doc.createElement("div");
+  panel.root.append(panel.statusNode, panel.elementsNode, panel.detailsNode);
+  doc.body.appendChild(panel.root);
+}
+
+function createFakeKitSelectionController(host) {
+  let active = false;
+  let hoveredElementId = "";
+  let hoverVisible = false;
+  let pointerMoveHandler = null;
+  let clickHandler = null;
+  let interactionRoot = null;
+  const calls = { start: 0, stop: 0, destroy: 0, syncWithSelection: 0, select: 0 };
+
+  function resolveElementId(eventTarget) {
+    for (const target of host.listSelectableTargets()) {
+      const ref = host.getElementRef(target.elementId);
+      if (ref && (ref === eventTarget || ref.contains?.(eventTarget))) return target.elementId;
+    }
+    return "";
+  }
+
+  function publishState() {
+    host.onStateChange({
+      active,
+      hoveredElementId: hoverVisible ? hoveredElementId : "",
+      hoverTargetId: hoverVisible ? hoveredElementId : "",
+    });
+  }
+
+  function syncWithSelection() {
+    calls.syncWithSelection += 1;
+    hoverVisible = Boolean(hoveredElementId && hoveredElementId !== host.getSelectedElementId());
+    publishState();
+  }
+
+  return {
+    calls,
+    get hoverVisible() { return hoverVisible; },
+    get hoveredElementId() { return hoveredElementId; },
+    start() {
+      calls.start += 1;
+      if (active) return;
+      active = true;
+      interactionRoot = host.getInteractionRoot();
+      pointerMoveHandler = (event) => {
+        if (host.isExcludedTarget(event?.target)) return;
+        hoveredElementId = resolveElementId(event?.target);
+        hoverVisible = Boolean(hoveredElementId && hoveredElementId !== host.getSelectedElementId());
+        publishState();
+      };
+      clickHandler = (event) => {
+        if (!hoveredElementId || host.isExcludedTarget(event?.target)) return;
+        calls.select += 1;
+        event?.preventDefault?.();
+        event?.stopPropagation?.();
+        host.selectElement(hoveredElementId).then(() => {
+          host.onSelection({ elementId: hoveredElementId });
+          syncWithSelection();
+        }).catch((error) => host.onError(error));
+      };
+      interactionRoot?.addEventListener?.("pointermove", pointerMoveHandler);
+      interactionRoot?.addEventListener?.("click", clickHandler);
+      publishState();
+    },
+    stop() {
+      calls.stop += 1;
+      if (interactionRoot && pointerMoveHandler) interactionRoot.removeEventListener?.("pointermove", pointerMoveHandler);
+      if (interactionRoot && clickHandler) interactionRoot.removeEventListener?.("click", clickHandler);
+      active = false;
+      hoveredElementId = "";
+      hoverVisible = false;
+      publishState();
+    },
+    destroy() {
+      calls.destroy += 1;
+      this.stop();
+    },
+    isActive() { return active; },
+    syncWithSelection,
+  };
+}
+
+
 async function setupRefs() {
   const refs = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiElementRefs.js"));
   refs.clearBbmUiElementRefs();
@@ -225,6 +315,7 @@ async function runM56PersistentSelectionFrameTests(run) {
     const previousDocument = global.document;
     const previousWindow = global.window;
     let selectedId = "";
+    let fakeKitController = null;
     const elements = [
       { elementId: "bbm.main.header", label: "Seitenkopf", type: "frame", scope: "bbm", capabilities: [], allowedChanges: [] },
       { elementId: "bbm.main.navigation", label: "Navigation", type: "frame", scope: "bbm", capabilities: [], allowedChanges: [] },
@@ -242,43 +333,49 @@ async function runM56PersistentSelectionFrameTests(run) {
     try {
       const { createBbmUiEditorStatusPanel } = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/BbmUiEditorStatusPanel.js"));
       const panel = createBbmUiEditorStatusPanel({ router: { activeSection: "uiEditor", showSettings: async () => {} } });
-      const root = panel.render();
-      doc.body.appendChild(root);
+      createPanelHarness(panel, doc);
+      panel.ensureKitController = async function ensureFakeKitController() {
+        if (this.kitSelectionController) return this.kitSelectionController;
+        fakeKitController = createFakeKitSelectionController(this.createKitHost());
+        this.kitSelectionController = fakeKitController;
+        return fakeKitController;
+      };
+
       await panel.refresh();
       panel.startSelectionMode();
 
       shell.dispatch("pointermove", eventFor(header));
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 1);
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
+      assert.equal(fakeKitController.hoveredElementId, "bbm.main.header");
+      assert.equal(fakeKitController.hoverVisible, true);
+      assert.equal(panel.selectedElement, null);
 
       shell.dispatch("click", eventFor(header));
       await new Promise((resolve) => setTimeout(resolve, 0));
       assert.equal(selectedId, "bbm.main.header");
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 0);
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+      assert.equal(panel.selectedElement.elementId, "bbm.main.header");
+      assert.equal(fakeKitController.calls.syncWithSelection >= 1, true);
+      assert.equal(fakeKitController.hoveredElementId, "bbm.main.header");
+      assert.equal(fakeKitController.hoverVisible, false);
+      assert.equal(panel.getVisualSelectionLabel(), "Seitenkopf");
 
       shell.dispatch("pointermove", eventFor(nav));
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 1);
+      assert.equal(fakeKitController.hoveredElementId, "bbm.main.navigation");
+      assert.equal(fakeKitController.hoverVisible, true);
       shell.dispatch("click", eventFor(nav));
       await new Promise((resolve) => setTimeout(resolve, 0));
       assert.equal(selectedId, "bbm.main.navigation");
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 0);
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+      assert.equal(panel.selectedElement.elementId, "bbm.main.navigation");
+      assert.equal(fakeKitController.hoveredElementId, "bbm.main.navigation");
+      assert.equal(fakeKitController.hoverVisible, false);
 
       await panel.resetSelection();
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
-      shell.dispatch("pointermove", eventFor(nav));
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 1);
+      assert.equal(selectedId, "");
+      assert.equal(panel.selectedElement, null);
+      assert.equal(fakeKitController.calls.syncWithSelection >= 2, true);
+      assert.equal(fakeKitController.hoverVisible, true);
 
-      shell.dispatch("click", eventFor(header));
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      shell.dispatch("pointermove", eventFor(nav));
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 1);
-      doc.dispatch("keydown", { key: "Escape" });
-      assert.equal(panel.selectedElement.elementId, "bbm.main.header");
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selection-hover-frame").length, 0);
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
       panel.destroy();
+      assert.equal(fakeKitController.calls.destroy, 1);
     } finally {
       global.document = previousDocument;
       global.window = previousWindow;
@@ -290,6 +387,7 @@ async function runM56PersistentSelectionFrameTests(run) {
     const previousDocument = global.document;
     const previousWindow = global.window;
     let selectedId = "bbm.main.header";
+    let fakeKitController = null;
     const elements = [
       { elementId: "bbm.main.header", label: "Seitenkopf", type: "frame", scope: "bbm", capabilities: [], allowedChanges: [] },
       { elementId: "bbm.main.navigation", label: "Navigation", type: "frame", scope: "bbm", capabilities: [], allowedChanges: [] },
@@ -307,32 +405,48 @@ async function runM56PersistentSelectionFrameTests(run) {
     try {
       const { createBbmUiEditorStatusPanel } = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/ui-editor/BbmUiEditorStatusPanel.js"));
       const panel = createBbmUiEditorStatusPanel({ router: { activeSection: "uiEditor", showSettings: async () => {} } });
-      const root = panel.render();
-      doc.body.appendChild(root);
+      createPanelHarness(panel, doc);
+      panel.ensureKitController = async function ensureFakeKitController() {
+        if (this.kitSelectionController) return this.kitSelectionController;
+        fakeKitController = createFakeKitSelectionController(this.createKitHost());
+        this.kitSelectionController = fakeKitController;
+        return fakeKitController;
+      };
+
       await panel.refresh();
       assert.equal(panel.selectedElement.elementId, "bbm.main.header");
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
-      assert.ok(walk(root, (node) => node.textContent === "Visuell markiert").length >= 1);
-      assert.ok(walk(root, (node) => node.textContent === "Seitenkopf").length >= 1);
+      assert.equal(panel.getVisualSelectionLabel(), "Seitenkopf");
+      assert.equal(fakeKitController.calls.syncWithSelection, 1);
+      assert.ok(walk(panel.root, (node) => node.textContent === "Visuell markiert").length >= 1);
+      assert.ok(walk(panel.root, (node) => node.textContent === "Seitenkopf").length >= 1);
+
       await panel.selectElement("bbm.main.navigation");
       assert.equal(panel.selectedElement.elementId, "bbm.main.navigation");
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+      assert.equal(selectedId, "bbm.main.navigation");
+      assert.equal(fakeKitController.calls.syncWithSelection >= 3, true);
+
       await panel.resetSelection();
       assert.equal(selectedId, "");
       assert.equal(panel.selectedElement, null);
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
+      assert.equal(fakeKitController.calls.syncWithSelection >= 5, true);
+
       selectedId = "bbm.main.header";
       await panel.refresh();
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+      assert.equal(panel.selectedElement.elementId, "bbm.main.header");
+      assert.equal(fakeKitController.calls.syncWithSelection >= 6, true);
+
       await panel.close();
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
+      assert.equal(fakeKitController.calls.stop >= 1, true);
+      assert.equal(fakeKitController.calls.destroy, 1);
+      assert.equal(panel.kitSelectionController, null);
+
       selectedId = "bbm.main.header";
       await panel.refresh();
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 1);
+      assert.notEqual(panel.kitSelectionController, null);
+      const secondKitController = panel.kitSelectionController;
       panel.destroy();
-      assert.equal(byAttr(doc.body, "data-bbm-ui-selected-frame").length, 0);
-      assert.equal((doc.listeners.get("scroll") || []).length, 0);
-      assert.equal((doc.defaultView.listeners.get("resize") || []).length, 0);
+      assert.equal(secondKitController.calls.destroy, 1);
+      assert.equal(panel.kitSelectionController, null);
     } finally {
       global.document = previousDocument;
       global.window = previousWindow;

--- a/scripts/tests/m59KitSelectionRuntimeIntegration.test.cjs
+++ b/scripts/tests/m59KitSelectionRuntimeIntegration.test.cjs
@@ -153,30 +153,29 @@ async function runM59KitSelectionRuntimeIntegrationTests(run) {
     assert.equal(host.getSelectedElementId(), "bbm.main.navigation");
   });
 
-  await run("M59 Runtime-Umschaltung und Exklusivitaet sind im Statuspanel explizit verdrahtet", () => {
+  await run("M59/M61 Kit-Runtime ist im Statuspanel exklusiv verdrahtet", () => {
     const panel = read("src/renderer/ui-editor/BbmUiEditorStatusPanel.js");
-    assert.match(panel, /this\.selectionRuntime = "bbm"/);
     assert.match(panel, /Auswahl-Laufzeit/);
-    assert.match(panel, /switchSelectionRuntime/);
+    assert.match(panel, /selectionRuntimeLabel\(\)/);
     assert.match(panel, /selection-runtime\.browser\.mjs/);
     assert.doesNotMatch(panel, /import\(["']ui-editor-kit["']\)/);
-    assert.match(panel, /this\.bbmSelectionController\?\.stop\?\.\(\)/);
+    assert.doesNotMatch(panel, /switchSelectionRuntime/);
+    assert.doesNotMatch(panel, /createBbmUiElementSelectionController/);
+    assert.doesNotMatch(panel, /bbmSelectionController/);
     assert.match(panel, /destroyKitController/);
     assert.equal(count(panel, "createSelectionController\\("), 1);
-    assert.match(panel, /this\.selectedOverlay\?\.clear\?\.\(\)/);
     assert.match(panel, /syncActiveSelectionRuntime/);
     assert.match(panel, /syncWithSelection/);
     assert.match(panel, /hover: \{ zIndex:/);
     assert.match(panel, /selected: \{ zIndex:/);
-    assert.match(panel, /this\.selectionController = this\.bbmSelectionController/);
   });
 
-  await run("M59 Kit-Auswahl, Lifecycle und Fehler-Rueckfall nutzen dieselbe M52-Auswahl und raeumen Controller auf", () => {
+  await run("M59/M61 Kit-Auswahl und Lifecycle nutzen dieselbe M52-Auswahl und raeumen Controller auf", () => {
     const panel = read("src/renderer/ui-editor/BbmUiEditorStatusPanel.js");
     assert.match(panel, /selectElement: \(elementId\) => this\.selectElement\(elementId, \{ fromSelectionMode: true \}\)/);
     assert.match(panel, /getSelectedElement: \(\) => this\.selectedElement/);
     assert.match(panel, /this\.destroyKitController\(\)/);
-    assert.match(panel, /this\.selectionRuntime = "bbm"/);
+    assert.doesNotMatch(panel, /this\.selectionRuntime = "bbm"/);
     assert.match(panel, /this\.runtimeError = error\?\.message/);
     assert.match(panel, /this\.kitSelectionController\?\.stop\?\.\(\)/);
     assert.match(panel, /this\.kitSelectionController\?\.destroy\?\.\(\)/);
@@ -193,19 +192,13 @@ async function runM59KitSelectionRuntimeIntegrationTests(run) {
       let selectedClearCount = 0;
       let selectedSyncCount = 0;
       panel.renderAll = () => {};
-      panel.selectionRuntime = "kit";
       panel.selectedElement = { elementId: "bbm.main.header", label: "Seitenkopf" };
       panel.kitSelectionController = { syncWithSelection() { kitSyncCount += 1; } };
-      panel.bbmSelectionController = { syncHoverWithSelection() { bbmHoverSyncCount += 1; } };
-      panel.selectedOverlay = {
-        clear() { selectedClearCount += 1; },
-        sync() { selectedSyncCount += 1; return true; },
-      };
 
       panel.syncActiveSelectionRuntime();
       assert.equal(kitSyncCount, 1);
       assert.equal(bbmHoverSyncCount, 0);
-      assert.equal(selectedClearCount, 1);
+      assert.equal(selectedClearCount, 0);
       assert.equal(selectedSyncCount, 0);
 
       panel.selectElement = async () => { panel.selectedElement = null; };
@@ -213,7 +206,7 @@ async function runM59KitSelectionRuntimeIntegrationTests(run) {
       assert.equal(panel.selectedElement, null);
       assert.equal(kitSyncCount, 2);
       assert.equal(bbmHoverSyncCount, 0);
-      assert.equal(selectedClearCount, 2);
+      assert.equal(selectedClearCount, 0);
 
       global.window = {
         bbmDb: {
@@ -226,13 +219,13 @@ async function runM59KitSelectionRuntimeIntegrationTests(run) {
       assert.equal(panel.selectedElement, null);
       assert.equal(kitSyncCount >= 3, true);
       assert.equal(bbmHoverSyncCount, 0);
-      assert.equal(selectedClearCount >= 3, true);
+      assert.equal(selectedClearCount, 0);
     } finally {
       global.window = previousWindow;
     }
   });
 
-  await run("M59 Verhalten: Runtime-Select behaelt Kit-Wert ueber renderAll", async () => {
+  await run("M59/M61 Verhalten: Runtime-Dropdown ist entfernt und Kit-Label bleibt sichtbar", async () => {
     const previousDocument = global.document;
     try {
       global.document = createPanelDocument();
@@ -246,16 +239,12 @@ async function runM59KitSelectionRuntimeIntegrationTests(run) {
       panel.refStatus = { count: 0, expectedCount: 0, missingIds: [] };
       panel.elements = [];
       panel.selectedElement = null;
-      panel.selectionRuntime = "kit";
 
       panel.renderAll();
-      assert.equal(findFirstNode(panel.statusNode, "select")?.value, "kit");
+      assert.equal(findFirstNode(panel.statusNode, "select"), null);
+      assert.equal(panel.selectionRuntimeLabel(), "UI-Editor-kit");
       panel.renderAll();
-      assert.equal(findFirstNode(panel.statusNode, "select")?.value, "kit");
-
-      panel.selectionRuntime = "bbm";
-      panel.renderAll();
-      assert.equal(findFirstNode(panel.statusNode, "select")?.value, "bbm");
+      assert.equal(findFirstNode(panel.statusNode, "select"), null);
     } finally {
       global.document = previousDocument;
     }

--- a/scripts/tests/m60KitRuntimeStandard.test.cjs
+++ b/scripts/tests/m60KitRuntimeStandard.test.cjs
@@ -79,24 +79,6 @@ function createPanelHarness(panel) {
   panel.elementsNode = new TestNode("section");
   panel.detailsNode = new TestNode("section");
   panel.errorNode = new TestNode("div");
-  panel.bbmSelectionController = {
-    startCount: 0,
-    stopCount: 0,
-    destroyCount: 0,
-    active: false,
-    start() { this.active = true; this.startCount += 1; },
-    stop() { this.active = false; this.stopCount += 1; },
-    destroy() { this.destroyCount += 1; },
-    isActive() { return this.active; },
-    syncHoverWithSelection() {},
-  };
-  panel.selectedOverlay = {
-    clearCount: 0,
-    destroyCount: 0,
-    clear() { this.clearCount += 1; },
-    sync() { return true; },
-    destroy() { this.destroyCount += 1; },
-  };
 }
 
 async function loadPanelClass() {
@@ -107,11 +89,11 @@ async function runM60KitRuntimeStandardTests(run) {
   await run("M60 Panel-Start: selectionRuntime ist standardmaessig kit", async () => {
     const { BbmUiEditorStatusPanel } = await loadPanelClass();
     const panel = new BbmUiEditorStatusPanel({});
-    assert.equal(panel.selectionRuntime, "kit");
-    assert.equal(panel.selectionController, null);
+    assert.equal(panel.selectionRuntimeLabel(), "UI-Editor-kit");
+    assert.equal(panel.kitSelectionController, null);
   });
 
-  await run("M60 Kit-Erfolg: aktive Runtime, Controller und Dropdown stehen auf kit", async () => {
+  await run("M60 Kit-Erfolg: aktive Runtime und Controller stehen auf kit", async () => {
     const previousWindow = global.window;
     const previousDocument = global.document;
     try {
@@ -127,10 +109,9 @@ async function runM60KitRuntimeStandardTests(run) {
       await panel.refresh();
 
       assert.equal(createCount, 1);
-      assert.equal(panel.selectionRuntime, "kit");
-      assert.equal(panel.selectionController, kitController);
+      assert.equal(panel.selectionRuntimeLabel(), "UI-Editor-kit");
       assert.equal(panel.kitSelectionController, kitController);
-      assert.equal(findFirstNode(panel.statusNode, "select")?.value, "kit");
+      assert.equal(findFirstNode(panel.statusNode, "select"), null);
       assert.equal(panel.runtimeError, "");
     } finally {
       global.window = previousWindow;
@@ -138,7 +119,7 @@ async function runM60KitRuntimeStandardTests(run) {
     }
   });
 
-  await run("M60 Kit-Fehler: faellt sichtbar und sauber auf BBM zurueck", async () => {
+  await run("M60 Kit-Fehler: bleibt sichtbar ohne BBM-Rueckfall", async () => {
     const previousWindow = global.window;
     const previousDocument = global.document;
     try {
@@ -151,11 +132,11 @@ async function runM60KitRuntimeStandardTests(run) {
 
       await panel.refresh();
 
-      assert.equal(panel.selectionRuntime, "bbm");
-      assert.equal(panel.selectionController, panel.bbmSelectionController);
+      assert.equal(panel.selectionRuntimeLabel(), "UI-Editor-kit");
       assert.equal(panel.kitSelectionController, null);
       assert.match(panel.runtimeError, /Kit kaputt/);
-      assert.equal(findFirstNode(panel.statusNode, "select")?.value, "bbm");
+      assert.equal(findFirstNode(panel.statusNode, "select"), null);
+      assert.equal(panel.canStartSelectionMode(), false);
     } finally {
       global.window = previousWindow;
       global.document = previousDocument;
@@ -173,15 +154,12 @@ async function runM60KitRuntimeStandardTests(run) {
       createPanelHarness(panel);
       const kitController = { stopCount: 0, destroyCount: 0, stop() { this.stopCount += 1; }, destroy() { this.destroyCount += 1; } };
       panel.kitSelectionController = kitController;
-      panel.selectionRuntime = "kit";
-      panel.selectionController = kitController;
 
       await panel.close();
 
       assert.equal(kitController.stopCount >= 1, true);
       assert.equal(kitController.destroyCount, 1);
       assert.equal(panel.kitSelectionController, null);
-      assert.equal(panel.selectedOverlay.destroyCount, 1);
 
       panel.kitSelectionController = kitController;
       panel.destroy();
@@ -214,43 +192,11 @@ async function runM60KitRuntimeStandardTests(run) {
       await panel.refresh();
 
       assert.equal(createCount, 1);
-      assert.equal(panel.selectionController, kitController);
+      assert.equal(panel.kitSelectionController, kitController);
     } finally {
       global.window = previousWindow;
       global.document = previousDocument;
     }
-  });
-
-  await run("M60 Manueller Wechsel kit -> bbm -> kit bleibt moeglich", async () => {
-    const previousDocument = global.document;
-    global.document = createPanelDocument();
-    const { BbmUiEditorStatusPanel } = await loadPanelClass();
-    const panel = new BbmUiEditorStatusPanel({});
-    createPanelHarness(panel);
-    const kitControllers = [];
-    panel.ensureKitController = async function createKit() {
-      const controller = { stopCount: 0, destroyCount: 0, syncWithSelection() {}, stop() { this.stopCount += 1; }, destroy() { this.destroyCount += 1; } };
-      kitControllers.push(controller);
-      this.kitSelectionController = controller;
-      return controller;
-    };
-
-    await panel.switchSelectionRuntime("bbm");
-    assert.equal(panel.selectionRuntime, "bbm");
-    assert.equal(panel.selectionController, panel.bbmSelectionController);
-
-    await panel.switchSelectionRuntime("kit");
-    assert.equal(panel.selectionRuntime, "kit");
-    assert.equal(panel.selectionController, kitControllers[0]);
-
-    await panel.switchSelectionRuntime("bbm");
-    assert.equal(panel.selectionRuntime, "bbm");
-    assert.equal(kitControllers[0].destroyCount, 1);
-
-    await panel.switchSelectionRuntime("kit");
-    assert.equal(panel.selectionRuntime, "kit");
-    assert.equal(panel.selectionController, kitControllers[1]);
-    global.document = previousDocument;
   });
 
   await run("M60 Sicherheit: keine DOM-Suche, Persistenz, neue Registry oder Kit-Repo-Aenderung", () => {
@@ -265,9 +211,11 @@ async function runM60KitRuntimeStandardTests(run) {
       assert.equal(combined.includes(forbidden), false, `${forbidden} darf in M60 nicht vorkommen`);
     }
     assert.match(combined, /createBbmKitSelectionHost/);
-    assert.match(combined, /this\.selectionRuntime = "kit"/);
+    assert.match(combined, /selectionRuntimeLabel\(\)/);
     assert.match(combined, /initializeDefaultSelectionRuntime/);
-    assert.match(combined, /this\.selectionRuntime = "bbm"/);
+    assert.doesNotMatch(combined, /switchSelectionRuntime/);
+    assert.doesNotMatch(combined, /this\.selectionRuntime = "bbm"/);
+    assert.doesNotMatch(combined, /createBbmUiElementSelectionController/);
   });
 }
 

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -1,6 +1,4 @@
 import { getBbmUiElementRefStatus } from "./bbmUiElementRefs.js";
-import { createBbmUiElementSelectionController } from "./bbmUiElementSelection.js";
-import { createBbmUiSelectedOverlay } from "./bbmUiSelectedOverlay.js";
 import { createBbmKitSelectionHost } from "./bbmKitSelectionHost.js";
 
 function createNode(tag, className = "") {
@@ -50,16 +48,12 @@ export class BbmUiEditorStatusPanel {
     this.refStatus = null;
     this.elements = [];
     this.selectedElement = null;
-    this.bbmSelectionController = null;
     this.kitSelectionController = null;
     this.kitSelectionHost = null;
-    this.selectionController = null;
-    this.selectionRuntime = "kit";
     this.hoverTargetLabel = "keines";
     this.runtimeError = "";
     this.selectionMessage = "";
     this.selectionModeActive = false;
-    this.selectedOverlay = createBbmUiSelectedOverlay();
   }
 
   render() {
@@ -97,22 +91,6 @@ export class BbmUiEditorStatusPanel {
 
     root.append(header, this.errorNode, intro, grid);
     this.root = root;
-    this.bbmSelectionController = createBbmUiElementSelectionController({
-      getPanelRoot: () => this.root,
-      getElementMeta: (elementId) => this.getElementMeta(elementId),
-      isElementSelected: (elementId) => this.selectedElement?.elementId === elementId,
-      selectElement: ({ elementId }) => this.selectElement(elementId, { fromSelectionMode: true }),
-      onSelection: ({ elementId, meta }) => {
-        this.selectionMessage = `Ausgewaehlt: ${asText(meta?.label, elementId)}`;
-        this.selectionModeActive = this.getActiveController()?.isActive?.() || false;
-        this.renderAll();
-      },
-      onStateChange: (state) => {
-        this.selectionModeActive = Boolean(state?.active);
-        this.hoverTargetLabel = this.formatElementLabel(state?.hoveredElementId);
-        this.renderAll();
-      },
-    });
     this.refresh().catch((error) => this.showLoadError(error));
     return root;
   }
@@ -120,10 +98,6 @@ export class BbmUiEditorStatusPanel {
   async close() {
     this.stopSelectionMode();
     this.destroyKitController();
-    this.bbmSelectionController?.destroy?.();
-    this.selectedOverlay?.destroy?.();
-    this.selectionRuntime = "kit";
-    this.selectionController = null;
     try {
       await window.bbmDb?.uiEditorClose?.();
     } catch (_e) {
@@ -217,23 +191,6 @@ export class BbmUiEditorStatusPanel {
     );
 
 
-    const runtimeLabel = createNode("label", "bbm-ui-editor-panel__runtime");
-    const runtimeText = createNode("span");
-    runtimeText.textContent = "Auswahl-Laufzeit:";
-    const runtimeSelect = createNode("select");
-    const bbmOption = createNode("option");
-    bbmOption.value = "bbm";
-    bbmOption.textContent = "BBM";
-    const kitOption = createNode("option");
-    kitOption.value = "kit";
-    kitOption.textContent = "UI-Editor-kit";
-    runtimeSelect.append(bbmOption, kitOption);
-    runtimeSelect.value = this.selectionRuntime;
-    runtimeSelect.addEventListener("change", () => {
-      this.switchSelectionRuntime(runtimeSelect.value).catch((error) => this.handleKitRuntimeError(error));
-    });
-    runtimeLabel.append(runtimeText, runtimeSelect);
-
     const reloadButton = createNode("button", "bbm-ui-editor-panel__secondary");
     reloadButton.type = "button";
     reloadButton.textContent = "Layoutstatus neu laden";
@@ -258,7 +215,7 @@ export class BbmUiEditorStatusPanel {
 
     const actions = createNode("div", "bbm-ui-editor-panel__actions");
     actions.append(reloadButton, resetSelection, startSelection, stopSelection);
-    this.statusNode.append(title, list, runtimeLabel, actions);
+    this.statusNode.append(title, list, actions);
 
     if (this.selectionModeActive) {
       const hint = createNode("p", "bbm-ui-editor-panel__notice");
@@ -345,19 +302,20 @@ export class BbmUiEditorStatusPanel {
   canStartSelectionMode() {
     if (this.selectionModeActive) return false;
     if (!this.status?.runtimeStarted || !this.status?.adapterValid) return false;
+    if (!this.kitSelectionController) return false;
     return this.getSelectableBoundCount() > 0;
   }
 
   startSelectionMode() {
     if (!this.canStartSelectionMode()) return;
     this.selectionMessage = "";
-    this.getActiveController()?.start?.();
-    this.selectionModeActive = this.getActiveController()?.isActive?.() || false;
+    this.kitSelectionController?.start?.();
+    this.selectionModeActive = this.kitSelectionController?.isActive?.() || false;
     this.renderAll();
   }
 
   stopSelectionMode() {
-    this.getActiveController()?.stop?.();
+    this.kitSelectionController?.stop?.();
     this.selectionModeActive = false;
     this.hoverTargetLabel = "keines";
     this.renderAll();
@@ -366,8 +324,6 @@ export class BbmUiEditorStatusPanel {
 
   destroy() {
     this.destroyKitController();
-    this.bbmSelectionController?.destroy?.();
-    this.selectedOverlay?.destroy?.();
     this.selectionModeActive = false;
     this.root = null;
   }
@@ -389,7 +345,7 @@ export class BbmUiEditorStatusPanel {
     if (options.fromSelectionMode) {
       const meta = this.getElementMeta(elementId);
       this.selectionMessage = `Ausgewaehlt: ${asText(meta?.label, elementId)}`;
-      this.selectionModeActive = this.getActiveController()?.isActive?.() || false;
+      this.selectionModeActive = this.kitSelectionController?.isActive?.() || false;
       this.renderAll();
       this.syncActiveSelectionRuntime();
     }
@@ -405,37 +361,12 @@ export class BbmUiEditorStatusPanel {
     return this.selectedElement ? asText(this.selectedElement.label, this.selectedElement.elementId) : "keine Auswahl";
   }
 
-  syncSelectedOverlay() {
-    if (this.selectionRuntime === "kit") return false;
-    if (!this.selectedElement) {
-      this.selectedOverlay?.clear?.();
-      return false;
-    }
-    try {
-      return this.selectedOverlay?.sync?.(this.selectedElement) || false;
-    } catch (_error) {
-      this.selectedOverlay?.clear?.();
-      return false;
-    }
-  }
-
-
   syncActiveSelectionRuntime() {
-    if (this.selectionRuntime === "kit") {
-      this.selectedOverlay?.clear?.();
-      this.kitSelectionController?.syncWithSelection?.();
-      return;
-    }
-    this.syncSelectedOverlay();
-    this.bbmSelectionController?.syncHoverWithSelection?.();
+    this.kitSelectionController?.syncWithSelection?.();
   }
 
   selectionRuntimeLabel() {
-    return this.selectionRuntime === "kit" ? "UI-Editor-kit" : "BBM";
-  }
-
-  getActiveController() {
-    return this.selectionRuntime === "kit" ? this.kitSelectionController : this.bbmSelectionController;
+    return "UI-Editor-kit";
   }
 
   formatElementLabel(elementId) {
@@ -489,30 +420,19 @@ export class BbmUiEditorStatusPanel {
   async initializeDefaultSelectionRuntime() {
     if (!this.status?.ok || !this.status?.runtimeStarted || !this.status?.adapterValid) {
       this.destroyKitController();
-      this.selectionRuntime = "bbm";
-      this.selectionController = this.bbmSelectionController;
+      this.selectionModeActive = false;
+      this.hoverTargetLabel = "keines";
       this.syncActiveSelectionRuntime();
       this.renderAll();
       return;
     }
-    if (this.selectionRuntime !== "kit") {
-      this.syncActiveSelectionRuntime();
-      return;
-    }
-    this.bbmSelectionController?.stop?.();
-    this.selectedOverlay?.clear?.();
     try {
       await this.ensureKitController();
-      this.selectionRuntime = "kit";
-      this.selectionController = this.kitSelectionController;
       this.runtimeError = "";
       this.syncActiveSelectionRuntime();
     } catch (error) {
       this.destroyKitController();
-      this.selectionRuntime = "bbm";
-      this.selectionController = this.bbmSelectionController;
       this.runtimeError = error?.message || "Kit-Runtime konnte nicht gestartet werden.";
-      this.syncActiveSelectionRuntime();
     }
     this.selectionModeActive = false;
     this.hoverTargetLabel = "keines";
@@ -526,47 +446,11 @@ export class BbmUiEditorStatusPanel {
     this.kitSelectionHost = null;
   }
 
-  async switchSelectionRuntime(nextRuntime) {
-    const normalized = nextRuntime === "kit" ? "kit" : "bbm";
-    if (normalized === this.selectionRuntime) return;
-    this.stopSelectionMode();
-    if (normalized === "kit") {
-      this.bbmSelectionController?.stop?.();
-      this.selectedOverlay?.clear?.();
-      try {
-        await this.ensureKitController();
-        this.selectionRuntime = "kit";
-        this.selectionController = this.kitSelectionController;
-        this.runtimeError = "";
-        this.syncActiveSelectionRuntime();
-      } catch (error) {
-        this.destroyKitController();
-        this.selectionRuntime = "bbm";
-        this.selectionController = this.bbmSelectionController;
-        this.runtimeError = error?.message || "Kit-Runtime konnte nicht gestartet werden.";
-      }
-    } else {
-      this.destroyKitController();
-      this.selectionRuntime = "bbm";
-      this.selectionController = this.bbmSelectionController;
-      this.runtimeError = "";
-      this.syncActiveSelectionRuntime();
-    }
-    this.selectionModeActive = false;
-    this.hoverTargetLabel = "keines";
-    this.renderAll();
-  }
-
   handleKitRuntimeError(error) {
     this.runtimeError = error?.message || String(error || "Kit-Runtime-Fehler");
     this.destroyKitController();
     this.selectionModeActive = false;
     this.hoverTargetLabel = "keines";
-    if (this.selectionRuntime === "kit") {
-      this.selectionRuntime = "bbm";
-      this.selectionController = this.bbmSelectionController;
-      this.syncActiveSelectionRuntime();
-    }
     this.renderAll();
   }
 }


### PR DESCRIPTION
### Motivation
- Consolidate selection/hover behavior in the UI-Editor status panel by removing the legacy BBM selection/runtime path and relying solely on the UI-Editor-kit runtime to reduce parallel runtime complexity and accidental fallback behavior.

### Description
- The BBM-owned selection controller, selected overlay and the runtime dropdown/fallback logic were removed so the status panel is kit-only for hover and selection. 
- The panel now always initializes and drives the kit controller via the existing host bridge (`createBbmKitSelectionHost`), and `ensureKitController`/`syncWithSelection` are used for lifecycle and synchronization. 
- Guarding was added so selection mode requires an initialized kit controller and the visible runtime label is fixed to `UI-Editor-kit`. 
- Changed files: `src/renderer/ui-editor/BbmUiEditorStatusPanel.js`, `scripts/tests/m59KitSelectionRuntimeIntegration.test.cjs`, `scripts/tests/m60KitRuntimeStandard.test.cjs`, `docs/UI_INSPEKTOR_AUFGABENHEFT.md`, `docs/M61_KIT_RUNTIME_ONLY.md`, `STATUS.md`.

### Testing
- Ran `node scripts/tests/m59KitSelectionRuntimeIntegration.test.cjs` and the integration checks for host-bridge, kit exclusivity, lifecycle, error visibility and safety rules passed. 
- Ran `node scripts/tests/m60KitRuntimeStandard.test.cjs` and the kit-start/error/lifecycle regression tests passed. 
- Executed the broader `scripts/test.cjs` flow and observed the M59/M60-related checks green, but a full `npm test` could not complete in the Codex Cloud environment because Electron requires the system library `libatk-1.0.so.0` which is not available here (so full Electron-based suite cannot be fully verified in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a560a32eebc83229f88ce972cbbe206)