### PR TITLE
M63A: Document editor runtime inventory and add integration audit (bridge proposal)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2824,3 +2824,23 @@ Wichtig:
 - Gemeinsame Auswahlwahrheit bleibt der bestehende M52-Auswahlstatus.
 - M55/M56-BBM-Runtime bleibt erhalten und wird nicht automatisch ersetzt.
 - Nächster Schritt: manueller Windows-Paralleltest und Entscheidung, ob M60 die Kit-Runtime weiter annähert oder als Standard vorbereitet.
+
+### M63A – Editor-Bestand und Integrationsplan
+- Status: erledigt
+- Beschreibung:
+  - Vorhandener EditorRuntime-/Inspector-/Layout-/Registry-/HostAdapter-Bestand wurde analysiert und in einem Integrationsplan dokumentiert.
+  - Empfehlung: M63B nutzt eine kleine BBM-spezifische Inspector-Bridge zwischen M52-Auswahl und vorhandenem `EditorScopeInspector`; keine zweite Registry, keine zweite Auswahlhaltung, keine neue Persistenz.
+  - Pilotoperation fuer M63B: `move`, da der vorhandene End-to-End-Test Apply/Load/Reset damit fuer Restarbeiten und Protokoll abdeckt.
+  - Keine produktive UI- oder Layoutfunktion wurde eingebaut.
+- Betroffene Dateien:
+  - `docs/M63A_EDITOR_BESTAND_UND_INTEGRATIONSPLAN.md`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `scripts/tests/m63aEditorIntegrationAudit.test.cjs`
+  - `STATUS.md`
+- Commit:
+  - wird mit diesem Paket-Commit erstellt
+- Naechster offener Schritt:
+  - M63B: kleine Bridge `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js` planen/umsetzen und zunaechst read-only an das vorhandene Statuspanel anbinden.
+- Risiken/Hinweise:
+  - M51-Hauptscope und editorRuntime-Modulscopes sind noch nicht deckungsgleich; die Bridge darf fehlende Metadaten nicht aus DOM oder Text erraten.
+  - Dauerhafte Persistenz bleibt gesondert zu entscheiden; M63A legt keinen neuen Persistenzweg an.

--- a/docs/M63A_EDITOR_BESTAND_UND_INTEGRATIONSPLAN.md
+++ b/docs/M63A_EDITOR_BESTAND_UND_INTEGRATIONSPLAN.md
@@ -1,0 +1,221 @@
+# M63A – Editor-Bestand und Integrationsplan M51–M62
+
+## 1. Aktueller M51–M62-Stand
+
+M51–M62 stellen bereits eine getrennte Kette aus `UI-Editor-kit`-Integration, sichtbarem BBM-Statuspanel, expliziten Element-Refs und Kit-Selection-Runtime bereit. M51 definiert den Zielweg `AdapterManifest -> HostAdapter -> UI-Element-Registry -> RuntimeLauncher -> ViewModels -> LayoutStateStore` und hält BBM auf Integrationsdaten, Host-Grenzen, Auswahl und neutralen LayoutStateStore begrenzt. M52 macht den Einstieg als Statuspanel sichtbar und führt `selectedElement` über die vorhandenen IPC-Funktionen `uiEditorGetElements`, `uiEditorSelectElement` und `uiEditorGetSelectedElementDetails`. M60 macht die Kit-Selection-Runtime zum Standard; M62 entfernt die alte BBM-eigene Hover-/Selection-Runtime.
+
+Für M63 gilt deshalb: Die Selection-Runtime und M52-Auswahl bleiben führend. Der vorhandene Inspector darf nur angebunden werden, wenn er diese Auswahl übernimmt und keine zweite Registry, keine zweite Auswahlhaltung und keinen neuen Persistenzweg eröffnet.
+
+## 2. Vorhandener EditorRuntime-Bestand
+
+| Baustein | Zweck | Nutzung | öffentliche Funktionen / Daten | Ein-/Ausgabe | Seiteneffekte / Persistenz | Abhängigkeiten | Tests | Wiederverwendung / Konflikte |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `editorLayoutControls.js` | Erzeugt Layout-Control-Panel, baut ChangeRequests, delegiert Apply/Load/Reset. | produktiv vorbereiteter Runtime-Bestand, aktuell nicht sichtbar im M52-Panel eingebaut. | `createEditorLayoutControlPanel`, `applyEditorLayoutChange`, `loadEditorLayoutState`, `resetEditorLayoutState`, `EDITOR_LAYOUT_CONTROL_IDS`. | Eingabe: `scope`, `registry`, `hostAdapter`, `elementId`, `operation`, `payload`; Ausgabe: neutrale `ok/blocked/status`-Objekte, Controls, LayoutEntry/-State. | Ruft `hostAdapter.submitChangeRequest()` und `hostAdapter.resetLayoutState()` auf; Persistenz nur über HostAdapter/LayoutStore. | `SAFE_LAYOUT_OPERATIONS`, `getEditorElementDetails`. | `editorScopeInspector.test.cjs`. | Sehr gut wiederverwendbar; Konflikt nur, wenn Panel eigene Operationen oder Persistenz parallel baut. |
+| `editorScopeInspector.js` | Öffentlicher Inspector-Facade für Module, Scopes, Registry, Baum, LayoutControls und Layoutoperationen. | produktiv vorbereiteter Bestand. | `createEditorScopeInspector`, Re-Exports `findEditorScope`, `listEditorModules`, `listEditorScopes`. Instanzmethoden: `getAvailableModules`, `getAvailableScopes`, `inspectScope`, `getLayoutControlPanel`, `applyLayoutChange`, `loadLayoutState`, `resetLayoutState`. | Eingabe: `scopeId`, optional `elementId/operation/payload`; Ausgabe: Scope-Inspection, RegistryValidation, TreeResult, LayoutState, Operationsergebnisse. | Cacht HostAdapter pro Scope in einer Map; persistiert nicht selbst. | Catalog, HostAdapterFactory, RegistryValidator, RegistryTree, LayoutControls. | `editorScopeInspector.test.cjs`. | Geeigneter öffentlicher Einstieg für M63; Konflikt: eigener Catalog (`bbm`) liegt neben M51-Ziel-App-Registry (`bbm-produktiv`) und braucht Adapterentscheidung. |
+| `editorLayoutPersistence.js` | Normalisiert sichere Layoutwerte und stellt neutralen LayoutStore bereit. | produktiv vorbereiteter Bestand, aktuell MemoryStorage. | `normalizeEditorLayoutValue`, `createEditorLayoutMemoryStorage`, `createEditorLayoutStore`, `SAFE_LAYOUT_OPERATIONS`. | Operationen `move`, `resize`, `hide`, `show`, `spacing`, `width`, `height`; Payloads: numerische `x/y`, Längen `width/height/gap/padding/margin`, Sichtbarkeit. | Storage-Objekt mit `read/write/clear`; Standard ist Memory, kein `localStorage`, keine DB. | keine externen Runtime-Abhängigkeiten. | `editorScopeInspector.test.cjs`, `editorRuntime.catalog.test.cjs` indirekt. | Wiederverwendbar; M63 darf keinen zweiten LayoutStateStore neben diesem und M51-Store bauen. |
+| `editorLayoutStateModel.js` | Dokumentiert Felder eines LayoutState-Eintrags. | Modellbestand. | `EDITOR_LAYOUT_STATE_FIELDS`. | Felder: `layoutProfileId`, `targetAppId`, `moduleId`, `scopeId`, `elementId`, `operation`, `layoutValue`, `createdAt`, `updatedAt`. | keine. | keine. | indirekt. | Wiederverwendbar als Vertragsanker. |
+| `editorChangeRequestModel.js` | Definiert Pflichtfelder und verbotene Begriffe für ChangeRequests. | Modellbestand. | `EDITOR_CHANGE_REQUEST_REQUIRED_FIELDS`, `EDITOR_FORBIDDEN_CHANGE_REQUEST_TERMS`. | Pflicht: `changeId`, `targetAppId`, `moduleId`, `scopeId`, `elementId`, `operation`, `payload`, `createdAt`, `source`. | keine. | keine. | `editorScopeInspector.test.cjs` indirekt. | Wiederverwendbar. |
+| `editorChangeRequestValidator.js` | Validiert ChangeRequests gegen Scope und Registry. | produktiv vorbereiteter Bestand. | `validateEditorChangeRequest`. | Eingabe: ChangeRequest + `{scope, registry}`; Ausgabe `{ok, errors, warnings}`. | keine. | ChangeRequestModel. | `editorScopeInspector.test.cjs`. | Zentral für M63; Konflikt, falls M63 Validierung im Panel dupliziert. |
+| `bbmEditorHostAdapterContract.js` | Prüft HostAdapter-Shape. | Vertragsbestand. | `REQUIRED_HOST_ADAPTER_METHODS`, `validateHostAdapterShape`. | Eingabe Adapter; Ausgabe `{ok, errors}`. | keine. | keine. | `editorRuntime.catalog.test.cjs`. | Wiederverwendbar. |
+| `bbmEditorHostAdapterFactory.js` | Wählt HostAdapter je Scope. | produktiv vorbereiteter Bestand. | `createBbmEditorHostAdapter(scopeId, options)`. | Unterstützt `protokoll.topsScreen`, `restarbeiten.ui.main`; unbekannt wirft `EDITOR_SCOPE_UNSUPPORTED`. | Erzeugt scope-spezifische Adapter mit MemoryLayoutStorage, falls nichts injiziert wird. | Protokoll-/Restarbeiten-Adapter. | `editorScopeInspector.test.cjs`. | Wiederverwendbar; M63B braucht gezielte BBM-Bridge, falls M51-Scope `bbm.main` angebunden werden soll. |
+| `editorRegistryModel.js` | Elementtypen, Rollen, erlaubte Operationen. | Vertragsbestand. | `EDITOR_ELEMENT_TYPES`, `EDITOR_ELEMENT_ROLES`, `EDITOR_ALLOWED_OPERATIONS`, `is...`. | Strings für Typ/Rolle/Operation. | keine. | keine. | `editorRuntime.catalog.test.cjs`. | Wiederverwendbar; M51-Feldnamen müssen angepasst werden. |
+| `editorRegistryValidator.js` | Validiert Runtime-Registry. | produktiv vorbereiteter Bestand. | `validateEditorRegistry`. | Eingabe Array von Elementen mit `id/name/type/role/parentId/order/visible/editable/allowedOps/lockedOps`; Ausgabe `{ok, errors, warnings}`. | keine. | RegistryModel. | `editorRuntime.catalog.test.cjs`, `editorScopeInspector.test.cjs`. | Führender Kandidat für M63-Vertrag; M51-Registry braucht Adapter für Feldnamen. |
+| `bbmEditorCatalog.js` | Bündelt editorRuntime-Module und Scopes. | produktiv vorbereiteter Bestand. | `BBM_EDITOR_CATALOG`, `listEditorModules`, `listEditorScopes`, `findEditorScope`. | Scope enthält `scopeId`, `scopeLabel`, `kind`, `registry`, `status`. | keine. | Modulregistries. | `editorRuntime.catalog.test.cjs`. | Wiederverwendbar; darf nicht als zweite M51-Registry neben Kit-Registry erweitert werden. |
+| `editorScopeTypes.js` | Scope-Kind-Vertrag. | Modellbestand. | `EDITOR_SCOPE_KINDS`, `isEditorScopeKind`. | `ui`, `pdf`. | keine. | keine. | `editorRuntime.catalog.test.cjs`. | Wiederverwendbar. |
+| `BbmUiEditorStatusPanel.js` | Sichtbares M52–M62 Statuspanel mit Registry-Liste, Details und Kit-Auswahl. | produktiv sichtbarer Bestand. | Klasse `BbmUiEditorStatusPanel`, `createBbmUiEditorStatusPanel`. | Nutzt IPC: `uiEditorOpen`, `uiEditorGetElements`, `uiEditorGetSelectedElementDetails`, `uiEditorSelectElement`. | Startet/stoppt Kit-Selection-Controller; keine Layoutänderung. | `bbmKitSelectionHost`, `bbmUiElementRefs`, `ui-editor-kit/dist/selection-runtime.browser.mjs`. | `m52`, `m54`, `m59`, `m60`, `m62` Tests. | Minimal zu ändern: nur Bridge einhängen, keine Inspector-Logik direkt duplizieren. |
+| `bbmKitSelectionHost.js` | Host-Bridge für Kit-Selection-Runtime. | produktiv genutzt seit M59/M60. | `createBbmKitSelectionHost`. | Eingang: Registry-Elemente, selectedElement Getter, selectElement Callback, PanelRoot; Ausgabe Kit-Host mit `listSelectableTargets`, `getSelectedElementId`, `selectElement`, `getElementMeta`, `getElementRef`. | Delegiert Auswahl an M52-Auswahl; liest explizite Refs. | `bbmUiElementRefs`. | `m59KitSelectionRuntime.test.cjs`, `m60KitRuntimeStandard.test.cjs`. | Führend für Auswahl; nicht ersetzen. |
+| `bbmUiElementRefs.js` | Expliziter Ref-Store für registrierte BBM-Hauptelemente. | produktiv genutzt für Kit-Auswahl. | `registerBbmUiElementRef`, `getBbmUiElementRef`, `unregisterBbmUiElementRef`, `clearBbmUiElementRefs`, `getBbmUiElementRefStatus`. | Erlaubte IDs sind statisch, nur HTMLElement-Instanzen. | In-Memory Map; keine DOM-Suche. | keine. | `m54UiElementRefs.test.cjs` und Selection-Tests. | Weiterverwenden; keine automatische DOM-Suche ergänzen. |
+| Modulregistries / HostAdapter | Scope-spezifische Registries und Adapter für `restarbeiten` und `protokoll`. | produktiv vorbereiteter Runtime-Bestand. | `getRestarbeitenMainUiRegistry`, `getProtokollTopsUiRegistry`, `create...HostAdapter`. | Runtime-Registry-Array; ChangeRequests gegen Scope/Registry. | MemoryLayoutStore je Adapter. | editorRuntime Validator/Persistence. | `editorRuntime.catalog.test.cjs`, `editorScopeInspector.test.cjs`. | Wiederverwendbar als Beispiel und ggf. später Scope-Quellen; nicht für M51-Hauptscope kopieren. |
+
+## 3. Registry-Vergleich
+
+### Gemeinsame Felder
+
+M51-Ziel-App-Registry und editorRuntime-Registry beschreiben jeweils explizite Elemente mit stabiler ID, lesbarem Namen/Label, Typ, Parent-Struktur, Editierbarkeit und erlaubten Operationen/Capabilities. Beide Verträge verbieten automatische Befüllung aus DOM-Scans und lassen unbekannte Elemente nicht zu.
+
+### Unterschiedliche Felder
+
+- M51/Kit-Registry laut Statuspanel/Host benutzt im Renderer die Form `elementId`, `label`, `type`, `scope`, `parentId`, `capabilities` beziehungsweise `allowedChanges`.
+- editorRuntime verlangt `id`, `name`, `type`, `role`, `parentId`, `order`, `visible`, `editable`, `allowedOps`, `lockedOps`.
+- editorRuntime hängt Scopes am `BBM_EDITOR_CATALOG` mit `targetAppId: bbm`; M51 nutzt `targetAppId: bbm-produktiv`, `uiScope: bbm.main`, `layoutScope: bbm.main-layout`.
+- TableLayoutRegistry ist tabellenspezifisch (`tableKey`, Modul, UI/PDF-Verfügbarkeit, Spalten, Defaultbreiten, `editorEnabled`) und darf nicht zur allgemeinen UI-Editor-Registry werden.
+
+### Fehlende Felder / Adapterbedarf
+
+Für die Übergabe eines M51-Elements an `EditorScopeInspector` fehlen in der Kit-Form mindestens `role`, `order`, `visible`, `allowedOps` und `lockedOps` in editorRuntime-Namen. Diese Werte können aus vorhandenen M51-Feldern deterministisch abgeleitet werden, sofern die BBM-Bridge keine neuen Elemente erfindet: `elementId -> id`, `label/name -> name`, `allowedChanges/capabilities.layout -> allowedOps`, fehlende `lockedOps -> []`, fehlende `visible -> true`, `order` aus Registry-Reihenfolge. `role` muss aus der Registry kommen oder als explizite, dokumentierte Bridge-Konstante pro Element ergänzt werden; er darf nicht aus DOM oder Text geraten werden.
+
+### Führende Registry
+
+Es darf keine zweite Registry entstehen. Führend bleibt die M51/Kit-Ziel-App-Registry für den aktiven sichtbaren BBM-Hauptscope. Die editorRuntime-RegistryValidator-Form ist ein interner Adaptervertrag für den vorhandenen Inspector. Ein kleiner Adapter genügt, wenn er ausschließlich die bestehende M51-Registry transformiert und keine zusätzlichen Elemente, Scopes oder Persistenzziele anlegt. Die bestehenden Modulregistries bleiben Bestand für ihre editorRuntime-Scopes, werden aber nicht parallel zum M51-Hauptscope aktiviert.
+
+## 4. Auswahlvertrag
+
+M52 hält die Auswahl als `selectedElement` im bestehenden UI-Editor-HostAdapter und liefert sie über `uiEditorGetSelectedElementDetails`. Die Kit-Host-Bridge liest genau diese Auswahl über `getSelectedElement()?.elementId` und delegiert neue Auswahl über `selectElement(elementId)`. `EditorScopeInspector` erwartet für LayoutControls keinen eigenen Auswahlzustand, sondern nur `scopeId` und `elementId`. Die ChangeRequest-Zielidentifikation nutzt ebenfalls `elementId` plus Scope-Felder.
+
+Damit kann M63B ohne zweite Auswahlhaltung arbeiten: Das Statuspanel liest das vorhandene `selectedElement.elementId`, die Bridge übersetzt nur Registry-/Scope-Metadaten und ruft `inspector.getLayoutControlPanel(scopeId, selectedElement.elementId)` beziehungsweise später `inspector.applyLayoutChange(scopeId, { elementId, operation, payload })` auf. Eigentümer der Auswahl bleibt M52/Kit-Host; der Inspector bekommt nur einen Snapshot der ausgewählten ID.
+
+## 5. Vorhandene Layoutoperationen
+
+Tatsächlich vorhandene, durch `SAFE_LAYOUT_OPERATIONS` und `normalizeEditorLayoutValue` unterstützte Operationen:
+
+| Operation | Datei / Funktion | Datenformat | zulässige Werte | Validierung | HostAdapter-Aufruf | Persistenz | bestehender Test |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `move` | `editorLayoutPersistence.normalizeEditorLayoutValue`; `editorLayoutControls.applyEditorLayoutChange` | Payload `{x, y}` | endliche Zahlen; mindestens ein Wert | ChangeRequestValidator + `pickNumericPayload`; verbotene Payload-Keys blockiert | `submitChangeRequest(changeRequest)` | LayoutStore speichert `{x, y}` je `elementId` | `editorScopeInspector.test.cjs` nutzt `move` für Restarbeiten und Protokoll. |
+| `resize` | wie oben | Payload `{width, height}` | endliche Zahl oder String mit `px`, `rem`, `em`, `%`; mindestens ein Wert | ChangeRequestValidator + `pickLengthPayload` | `submitChangeRequest` | LayoutStore speichert Breite/Höhe | indirekt über SafeOps/Validator; kein sichtbarer Panel-Pilot. |
+| `hide` | wie oben | Payload optional | keine Payloadwerte nötig | Operation muss erlaubt und nicht locked sein | `submitChangeRequest` | `{visible:false}` | indirekt über SafeOps/Validator. |
+| `show` | wie oben | Payload optional | keine Payloadwerte nötig | Operation muss erlaubt und nicht locked sein | `submitChangeRequest` | `{visible:true}` | indirekt über SafeOps/Validator. |
+| `spacing` | wie oben | Payload `{gap, padding, margin}` | endliche Zahl oder `px/rem/em/%`; mindestens ein Wert | ChangeRequestValidator + `pickLengthPayload` | `submitChangeRequest` | LayoutStore speichert neutrale Spacing-Werte | indirekt über SafeOps/Validator. |
+| `width` | wie oben | Payload `{width}` | endliche Zahl oder `px/rem/em/%` | ChangeRequestValidator + `toNeutralLength` | `submitChangeRequest` | `{width}` | indirekt; nicht als erster Pilot bevorzugt, da Nutzerauftrag ausdrücklich nicht automatisch Breite wählen. |
+| `height` | wie oben | Payload `{height}` | endliche Zahl oder `px/rem/em/%` | ChangeRequestValidator + `toNeutralLength` | `submitChangeRequest` | `{height}` | indirekt. |
+
+Zusätzlich vorhanden sind Control-/Lifecycle-Funktionen:
+
+- Preview: In editorRuntime nicht als separate dauerhafte Operation vorhanden. Historische UI-Inspector-M13-Preview war temporär und ist nicht Teil des M63-Zielwegs.
+- Apply: `applyEditorLayoutChange` baut ChangeRequest und ruft HostAdapter auf.
+- Save: Apply speichert über LayoutStore; es gibt keinen separaten `save`-Button als Fachoperation.
+- Load: `loadEditorLayoutState` liest `hostAdapter.getCurrentLayoutState()` und optional einen Eintrag.
+- Reset: `resetEditorLayoutState` validiert Element und ruft `hostAdapter.resetLayoutState({ elementId })` auf.
+
+Als Pilotoperation für M63B ist `move` am besten abgesichert, weil der vorhandene Inspector-Test `move` für beide Scopes vollständig durch Apply, Load und Reset führt. `width` ist zwar vorhanden, aber nicht der am stärksten belegte End-to-End-Pfad.
+
+## 6. Save/Load/Reset/Persistenz
+
+Der vorhandene Persistenzpfad ist:
+
+`EditorScopeInspector -> editorLayoutControls -> HostAdapter -> validateEditorChangeRequest -> normalizeEditorLayoutValue -> createEditorLayoutStore -> Storage(read/write)`.
+
+Der Standard-Storage ist `createEditorLayoutMemoryStorage`; er schreibt keine DB, kein `localStorage` und keine IPCs. HostAdapter für Restarbeiten und Protokoll besitzen `getCurrentLayoutState`, `submitChangeRequest` und `resetLayoutState`. LayoutStore-Einträge enthalten `layoutProfileId`, Scope-Felder, `elementId`, `operation`, `layoutValue`, `createdAt`, `updatedAt`.
+
+M63B darf keinen neuen Persistenzweg anlegen. Falls dauerhafte Speicherung später erforderlich ist, muss sie gezielt hinter denselben HostAdapter/LayoutStore-Vertrag gelegt werden und nicht im Statuspanel oder in einer Bridge entstehen.
+
+## 7. Alte UI-Wege und Abgrenzung
+
+Vorhandene Alt-/Lab-/V2-Wege:
+
+- `EditorLab` / `EditorLab V2`: historischer eigener Weg; Tests sichern, dass alte DEV-Header-/Router-Einstiege nicht sichtbar zurückkehren.
+- `Editor V2 Panel`: eigener Alt-/V2-Bestand und nicht Ziel der M63-Integration.
+- `TableLayoutEditor`: tabellenspezifischer Editor mit eigener TableLayoutRegistry und IPCs; relevant nur als Abgrenzung, nicht als allgemeiner UI-Editor.
+- alte DEV-Schalter/Header-Buttons: durch Tests wie `editorLabV2Access`, `restarbeitenV2DevAccess`, `projektverwaltungModule` abgesichert.
+- historische UI-Inspector-M13-Preview/DOM-Marker-Wege: laut Entscheidungslog historisch; keine automatische DOM-Erkennung und kein Scan als Zielrichtung.
+
+Diese Wege dürfen in M63B nicht parallel aktiviert und nicht als zweiter UI-Editor wiederbelebt werden.
+
+## 8. Bewertete Integrationsvarianten
+
+### A. `BbmUiEditorStatusPanel` importiert `EditorScopeInspector` direkt
+
+- Aufwand: gering im ersten Schritt.
+- Kopplung: hoch, weil sichtbares Panel Catalog-/HostAdapter-/Runtime-Details kennen würde.
+- Risiko zweite Registry: mittel bis hoch; Panel könnte M51-Elemente und editorRuntime-Catalog nebeneinander halten.
+- Risiko zweite Auswahlhaltung: mittel; Panel müsste Inspector-Auswahlstatus selbst koordinieren.
+- Wiederverwendung: nutzt Inspector, aber ohne saubere Grenze.
+- Testbarkeit: möglich, aber Paneltests würden Runtime-Verträge direkt mitschleppen.
+- Empfehlung: nicht bevorzugen.
+
+### B. Kleine BBM-spezifische Inspector-Bridge verbindet M52-Auswahl und vorhandenen `EditorScopeInspector`
+
+- Aufwand: klein und kontrollierbar.
+- Kopplung: niedrig bis mittel; Panel kennt nur Bridge-API.
+- Risiko zweite Registry: niedrig, wenn Bridge ausschließlich M51-Registry transformiert und keine eigenen Elemente enthält.
+- Risiko zweite Auswahlhaltung: niedrig, wenn Bridge `selectedElementId` nur als Parameter bekommt.
+- Wiederverwendung: hoch; Inspector, LayoutControls, ChangeRequest-Validierung, HostAdapter und LayoutPersistence bleiben unverändert.
+- Testbarkeit: gut; Bridge kann statisch und funktional isoliert geprüft werden.
+- Empfehlung: bevorzugt.
+
+### C. Vorhandene editorRuntime wird über bestehenden öffentlichen Einstieg verwendet
+
+- Aufwand: mittel; `createEditorScopeInspector` existiert bereits.
+- Kopplung: mittel; öffentlicher Einstieg ist sauber, aber Scope-/Registry-Unterschiede zu M51 bleiben ungelöst.
+- Risiko zweite Registry: mittel; bestehender `BBM_EDITOR_CATALOG` enthält andere Scopes als M51-Hauptscope.
+- Risiko zweite Auswahlhaltung: niedrig, wenn nur `elementId` übergeben wird.
+- Wiederverwendung: hoch für bestehende Module, aber nicht passend für `bbm.main` ohne Adapter.
+- Testbarkeit: sehr gut für vorhandene Scopes.
+- Empfehlung: als Ziel der Bridge nutzen, nicht direkt aus dem Panel ohne Registry-/Scope-Adapter.
+
+## 9. Empfohlene Architektur
+
+Empfohlen wird Variante B.
+
+Unverändert verwenden:
+
+- `src/renderer/ui-editor/BbmUiEditorStatusPanel.js` als sichtbarer M52–M62 Einstieg und Auswahl-Eigentümer.
+- `src/renderer/ui-editor/bbmKitSelectionHost.js` als Kit-Selection-Host.
+- `src/renderer/ui-editor/bbmUiElementRefs.js` als expliziter Ref-Store.
+- `src/renderer/editorRuntime/inspector/editorScopeInspector.js` als vorhandener Inspector-Facade.
+- `src/renderer/editorRuntime/inspector/editorLayoutControls.js` für Apply/Load/Reset-Control-Modelle.
+- `src/renderer/editorRuntime/changeRequests/editorChangeRequestValidator.js` und `editorLayoutPersistence.js` für Validierung und LayoutStore.
+- vorhandene HostAdapter-Verträge.
+
+Kleine neue Bridge-Datei für M63B:
+
+- Vorschlag: `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js`.
+- Aufgabe: M52/M51-Statuspanel-Daten (`elements`, `selectedElement`) in den vorhandenen Inspector-Vertrag durchreichen, Scope eindeutig mappen und ein read-only ControlPanel-Modell liefern.
+- Keine DOM-Suche, keine Registry-Erzeugung, keine Persistenz.
+
+Minimal zu ändernde bestehende Datei in M63B:
+
+- `BbmUiEditorStatusPanel.js`: nur Bridge importieren und das Bridge-Ergebnis im Detailbereich anzeigen beziehungsweise später eine einzelne Pilotoperation auslösen.
+
+Durchgereichte Daten:
+
+- `selectedElement.elementId` als einzige Auswahl-ID.
+- bestehende M51-Registry-Elemente aus `uiEditorGetElements()`.
+- aktiver UI-/Layout-Scope aus `uiEditorOpen()`/Status.
+- später Operation/Payload der Pilotoperation.
+
+Eigentümer:
+
+- Auswahl: M52/Kit-Selection-Runtime und M51-HostAdapter.
+- Layoutzustand: vorhandener HostAdapter/LayoutPersistence-Pfad, nicht das Statuspanel.
+- Registry: M51-Ziel-App-Registry bleibt führend; Bridge adaptiert nur für Inspector-Form.
+- HostAdapter: vorhandener M51-HostAdapter für `bbm.main` oder ein dünner Adapter auf denselben Vertrag; nicht die Modulregistries als Parallelquelle.
+- Persistenz: vorhandener LayoutStateStore/HostAdapter-Pfad; keine neue Storage-Schicht.
+
+Pilotoperation für M63B:
+
+- `move`, weil vorhandene Tests Apply/Load/Reset damit für Restarbeiten und Protokoll abdecken. M63B sollte zunächst nur das ControlPanel-/ChangeRequest-Modell für `move` prüfen und noch keine breite Bedienoberfläche bauen.
+
+## 10. Exakter Scope für M63B
+
+M63B sollte nur Folgendes tun:
+
+1. `bbmEditorRuntimeInspectorBridge.js` anlegen.
+2. Bridge-Test anlegen: M52-selectedElement-ID geht ohne zweite Auswahlhaltung in `getLayoutControlPanel`.
+3. `BbmUiEditorStatusPanel.js` minimal erweitern, um den vorhandenen Inspector-Status für das bereits ausgewählte Element read-only darzustellen.
+4. Keine Operation sichtbar ausführen, außer wenn ein separater M63B-Unterauftrag ausdrücklich den `move`-Pilot freigibt.
+5. Statische Guardrails gegen zweite Registry, zweite Auswahlhaltung, alte EditorLab-Einstiege und neue Persistenz beibehalten.
+
+## 11. Risiken und offene Punkte
+
+- M51-Hauptscope (`bbm.main`) und editorRuntime-Catalog-Scopes (`protokoll.topsScreen`, `restarbeiten.ui.main`) sind noch nicht deckungsgleich.
+- `role` und `order` fehlen möglicherweise in der M51-Renderer-Elementform; Bridge darf diese nicht aus DOM oder Text erraten.
+- Dauerhafte Persistenz ist nicht abschließend entschieden; aktuell ist der editorRuntime-Pfad Memory-basiert.
+- TableLayoutEditor bleibt separat und darf nicht als allgemeiner UI-Editor missverstanden werden.
+- Sichtbare Bedienbarkeit kann Codex Cloud nicht fachlich abnehmen; lokale Electron-Prüfung bleibt für spätere sichtbare Schritte nötig.
+
+## 12. Dateiliste: verwenden / adaptieren / nicht verwenden
+
+### Verwenden
+
+- `src/renderer/editorRuntime/inspector/editorScopeInspector.js`
+- `src/renderer/editorRuntime/inspector/editorLayoutControls.js`
+- `src/renderer/editorRuntime/layout/editorLayoutPersistence.js`
+- `src/renderer/editorRuntime/changeRequests/editorChangeRequestValidator.js`
+- `src/renderer/editorRuntime/host/bbmEditorHostAdapterContract.js`
+- `src/renderer/ui-editor/bbmKitSelectionHost.js`
+- `src/renderer/ui-editor/bbmUiElementRefs.js`
+- M51-HostAdapter/Registry als führender sichtbarer BBM-Hauptscope
+
+### Adaptieren
+
+- neue Bridge `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js`
+- minimal `src/renderer/ui-editor/BbmUiEditorStatusPanel.js`
+- Registry-Feldnamenadapter von M51-Form auf editorRuntime-Form
+
+### Nicht verwenden / nicht reaktivieren
+
+- EditorLab-/EditorLab-V2-/Editor-V2-Einstiege
+- TableLayoutEditor als allgemeiner UI-Editor
+- alte DEV-Header-Buttons
+- historische DOM-Scan-/Bestandserkennungswege
+- neue lokale Registry-, Selection- oder Persistenzobjekte im Statuspanel

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -580,3 +580,16 @@ Hinweis:
   - `npm test` (in dieser Umgebung durch fehlendes Electron-Systempaket `libatk-1.0.so.0` blockiert)
 - Nächster Schritt:
   - Lokale Sichtprüfung per `npm start`.
+
+## M63A Analysebefund – Editor-Bestand und Integrationsplan
+- M63A ist als reine Analyse- und Dokumentationsstufe abgeschlossen.
+- Der vorhandene Bestand unter `src/renderer/editorRuntime/`, `src/renderer/ui-editor/`, Modul-Editorregistries und relevante Tests wurde ausgewertet.
+- Befund: `EditorScopeInspector`, `editorLayoutControls`, `editorChangeRequestValidator`, HostAdapter-Vertrag und `editorLayoutPersistence` sind wiederverwendbar und duerfen fuer M63 nicht neu erfunden werden.
+- Fuehrend fuer die sichtbare Auswahl bleibt M52/M60: UI-Editor-kit Selection-Runtime -> `bbmKitSelectionHost` -> M52 `selectedElement`.
+- Fuehrend fuer die sichtbare Ziel-App-Registry bleibt die M51/Kit-Registry; keine zweite Registry und keine zweite Auswahlhaltung duerfen entstehen.
+- Empfehlung fuer M63B: kleine BBM-spezifische Inspector-Bridge, die die vorhandene Auswahl-ID und Registry-Metadaten an den vorhandenen Inspector weiterreicht.
+- Pilotoperation fuer spaetere Umsetzung: `move`, weil Apply/Load/Reset dafuer im vorhandenen Inspector-Test bereits end-to-end belegt sind.
+- Keine produktive UI-Erweiterung, keine Layoutoperation, keine Persistenz und kein alter EditorLab-/V2-Einstieg wurden in M63A aktiviert.
+- Dokumentation: `docs/M63A_EDITOR_BESTAND_UND_INTEGRATIONSPLAN.md`.
+- Neuer Guardrail-Test: `scripts/tests/m63aEditorIntegrationAudit.test.cjs`.
+- Naechster sinnvoller Schritt: M63B als read-only Bridge-Paket mit statischem/funktionalem Bridge-Test vorbereiten.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -89,6 +89,7 @@ const { runM56PersistentSelectionFrameTests } = require("./tests/m56PersistentSe
 const { runM59KitSelectionRuntimeIntegrationTests } = require("./tests/m59KitSelectionRuntimeIntegration.test.cjs");
 const { runM60KitRuntimeStandardTests } = require("./tests/m60KitRuntimeStandard.test.cjs");
 const { runM62BbmSelectionLegacyCleanupTests } = require("./tests/m62BbmSelectionLegacyCleanup.test.cjs");
+const { runM63aEditorIntegrationAuditTests } = require("./tests/m63aEditorIntegrationAudit.test.cjs");
 
 let failed = false;
 
@@ -225,6 +226,7 @@ async function main() {
   await runM59KitSelectionRuntimeIntegrationTests(run);
   await runM60KitRuntimeStandardTests(run);
   await runM62BbmSelectionLegacyCleanupTests(run);
+  await runM63aEditorIntegrationAuditTests(run);
 
   if (failed) {
     process.exitCode = 1;

--- a/scripts/tests/m63aEditorIntegrationAudit.test.cjs
+++ b/scripts/tests/m63aEditorIntegrationAudit.test.cjs
@@ -1,0 +1,91 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REPO_ROOT = path.join(__dirname, "../..");
+const DOC_PATH = path.join(REPO_ROOT, "docs/M63A_EDITOR_BESTAND_UND_INTEGRATIONSPLAN.md");
+const STATUS_PANEL_PATH = path.join(REPO_ROOT, "src/renderer/ui-editor/BbmUiEditorStatusPanel.js");
+const STATUS_PATH = path.join(REPO_ROOT, "STATUS.md");
+const AUFGABENHEFT_PATH = path.join(REPO_ROOT, "docs/UI_INSPEKTOR_AUFGABENHEFT.md");
+
+function read(relativeOrAbsolutePath) {
+  return fs.readFileSync(relativeOrAbsolutePath, "utf8");
+}
+
+async function runM63aEditorIntegrationAuditTests(run) {
+  const doc = read(DOC_PATH);
+  const statusPanel = read(STATUS_PANEL_PATH);
+  const status = read(STATUS_PATH);
+  const aufgabenheft = read(AUFGABENHEFT_PATH);
+
+  await run("M63A Audit: Dokument enthaelt alle Pflichtkapitel", () => {
+    [
+      "## 1. Aktueller M51–M62-Stand",
+      "## 2. Vorhandener EditorRuntime-Bestand",
+      "## 3. Registry-Vergleich",
+      "## 4. Auswahlvertrag",
+      "## 5. Vorhandene Layoutoperationen",
+      "## 6. Save/Load/Reset/Persistenz",
+      "## 7. Alte UI-Wege und Abgrenzung",
+      "## 8. Bewertete Integrationsvarianten",
+      "## 9. Empfohlene Architektur",
+      "## 10. Exakter Scope für M63B",
+      "## 11. Risiken und offene Punkte",
+      "## 12. Dateiliste: verwenden / adaptieren / nicht verwenden",
+    ].forEach((heading) => assert.equal(doc.includes(heading), true, heading));
+  });
+
+  await run("M63A Audit: empfiehlt keine zweite Registry und keine zweite Auswahlhaltung", () => {
+    assert.equal(doc.includes("Es darf keine zweite Registry entstehen."), true);
+    assert.equal(doc.includes("M52/Kit-Host"), true);
+    assert.equal(doc.includes("Eigentümer der Auswahl bleibt M52/Kit-Host"), true);
+    assert.equal(doc.includes("Führend bleibt die M51/Kit-Ziel-App-Registry"), true);
+  });
+
+  await run("M63A Audit: haelt M63B auf Bridge statt produktiver Direktintegration begrenzt", () => {
+    assert.equal(doc.includes("Empfohlen wird Variante B."), true);
+    assert.equal(doc.includes("bbmEditorRuntimeInspectorBridge.js"), true);
+    assert.equal(doc.includes("read-only"), true);
+    assert.equal(doc.includes("Keine Operation sichtbar ausführen"), true);
+  });
+
+  await run("M63A Audit: legt keinen neuen Persistenzweg nahe", () => {
+    assert.equal(doc.includes("M63B darf keinen neuen Persistenzweg anlegen."), true);
+    assert.equal(doc.includes("kein `localStorage`"), true);
+    assert.equal(doc.includes("keine DB"), true);
+  });
+
+  await run("M63A Audit: alter EditorLab-/V2-Einstieg bleibt abgegrenzt", () => {
+    assert.equal(doc.includes("EditorLab"), true);
+    assert.equal(doc.includes("nicht parallel aktiviert"), true);
+    assert.equal(statusPanel.includes("showEditorLabV2"), false);
+    assert.equal(statusPanel.includes("EditorLab V2"), false);
+  });
+
+  await run("M63A Audit: Status und Aufgabenheft enthalten Analysebefund", () => {
+    assert.equal(status.includes("M63A – Editor-Bestand und Integrationsplan"), true);
+    assert.equal(aufgabenheft.includes("M63A Analysebefund"), true);
+    assert.equal(aufgabenheft.includes("keine zweite Registry"), true);
+    assert.equal(aufgabenheft.includes("keine zweite Auswahlhaltung"), true);
+  });
+}
+
+if (require.main === module) {
+  const run = async (name, fn) => {
+    try {
+      const out = fn();
+      if (out && typeof out.then === "function") await out;
+      console.log(`ok - ${name}`);
+    } catch (err) {
+      console.error(`not ok - ${name}`);
+      console.error(err?.stack || err?.message || err);
+      process.exitCode = 1;
+    }
+  };
+
+  runM63aEditorIntegrationAuditTests(run).then(() => {
+    if (!process.exitCode) console.log("m63aEditorIntegrationAudit.test.cjs passed");
+  });
+}
+
+module.exports = { runM63aEditorIntegrationAuditTests };


### PR DESCRIPTION
### Motivation
- Capture a complete inventory of the existing editor/inspector/layout/registry/host-adapter stack (M51–M62) to avoid reimplementing already working parts and to define a safe minimal integration path for M63.
- Ensure the visible `BbmUiEditorStatusPanel` and the UI-Editor-kit selection runtime remain the single source of truth for selection and registry, and prevent accidental creation of a second registry, second selection state, or a new persistence path.
- Provide a compact, testable recommendation for M63B (a small BBM-specific inspector bridge) so follow-up work is limited, reviewable and low-risk.

### Description
- Added the integration analysis and plan as `docs/M63A_EDITOR_BESTAND_UND_INTEGRATIONSPLAN.md` describing current state, registry comparison, selection contract, supported layout operations, variants evaluation and a concrete M63B scope recommending a small bridge (`bbmEditorRuntimeInspectorBridge.js`).
- Added a static guardrail audit test `scripts/tests/m63aEditorIntegrationAudit.test.cjs` and wired it into the central runner by updating `scripts/test.cjs` so the audit runs with the other editor tests.
- Updated repository documentation and status: appended the M63A summary to `docs/UI_INSPEKTOR_AUFGABENHEFT.md` and `STATUS.md` (no runtime or production code changed), and committed the changes on branch `codex/m63a-editor-bestand-und-integrationsplan`.
- No productive UI, layout operation, registry, persistence, DOM-scan, or selection runtime implementation was added; the PR only documents, audits and prepares the minimal integration path.

### Testing
- Ran targeted editor/runtime tests: `node scripts/tests/editorRuntime.catalog.test.cjs`, `node scripts/tests/editorScopeInspector.test.cjs`, `node scripts/tests/m59KitSelectionRuntimeIntegration.test.cjs`, `node scripts/tests/m60KitRuntimeStandard.test.cjs`, `node scripts/tests/m62BbmSelectionLegacyCleanup.test.cjs`, `node scripts/tests/editorLabV2Access.test.cjs`, `node scripts/tests/restarbeitenV2DevAccess.test.cjs`, and the new audit `node scripts/tests/m63aEditorIntegrationAudit.test.cjs`, all of which passed in this environment.
- Integrated the audit into the central `scripts/test.cjs` runner and executed the composed sequence above successfully (audit confirms presence of required chapters and guardrails).
- Attempted `npm test` (full suite) but it is blocked in this environment due to a missing system dependency for Electron (`libatk-1.0.so.0`), so the full Electron-backed test run could not be completed here.
- Performed `git diff --check` and basic repo status checks; commits were created on `codex/m63a-editor-bestand-und-integrationsplan` (commit `61c9102`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a592720d8588322b4f4382325fdb0e9)