### PR TITLE
M63B: Read-only bridge from M51/M52 to EditorScopeInspector and statuspanel read-only controls

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2849,8 +2849,9 @@ Wichtig:
 - Status: erledigt
 - Beschreibung:
   - Neue Bridge `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js` verbindet die fuehrende M51-Registry und M52-Auswahl read-only mit dem vorhandenen `EditorScopeInspector`-Layout-Control-Pfad.
-  - Das Statuspanel zeigt im Elementdetail jetzt `Layout-Steuerung` mit Inspector-Status, read-only Hinweis, konkret freigegebenen Layoutoperationen und Control-IDs.
-  - Korrektur PR #202: `layout.read`, `layout.save` und `layout.reset` werden nicht mehr in konkrete EditorRuntime-Operationen uebersetzt; ohne explizites `allowedOps` bleibt die Anzeige bei `allowedOps: []`.
+  - M63B.1 korrigiert die sichtbare Statuspanel-Oberflaeche: Der Detailbereich zeigt hoechstens den lesbaren Elementnamen und den neutralen Platzhalter `Bearbeitung wird vorbereitet.`.
+  - Technische Inspector-/Bridge-/Runtime-Daten, Control-IDs, interne Operationsnamen, `allowedOps` und Fehlercodes bleiben intern und werden nicht sichtbar ausgegeben.
+  - `layout.read`, `layout.save` und `layout.reset` werden nicht mehr in konkrete EditorRuntime-Operationen uebersetzt; ohne explizites `allowedOps` bleibt die interne Anzeige bei `allowedOps: []`.
   - Keine Layoutoperation, keine Speicherung, kein Reset, keine DOM-Suche, kein IPC und keine zweite Auswahlhaltung wurden eingebaut.
 - Betroffene Dateien:
   - `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js`

--- a/STATUS.md
+++ b/STATUS.md
@@ -2844,3 +2844,24 @@ Wichtig:
 - Risiken/Hinweise:
   - M51-Hauptscope und editorRuntime-Modulscopes sind noch nicht deckungsgleich; die Bridge darf fehlende Metadaten nicht aus DOM oder Text erraten.
   - Dauerhafte Persistenz bleibt gesondert zu entscheiden; M63A legt keinen neuen Persistenzweg an.
+
+### M63B – Read-only Inspector-Bridge
+- Status: erledigt
+- Beschreibung:
+  - Neue Bridge `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js` verbindet die fuehrende M51-Registry und M52-Auswahl read-only mit dem vorhandenen `EditorScopeInspector`-Layout-Control-Pfad.
+  - Das Statuspanel zeigt im Elementdetail jetzt `Layout-Steuerung` mit Inspector-Status, read-only Hinweis, erlaubten Layoutoperationen und Control-IDs.
+  - Keine Layoutoperation, keine Speicherung, kein Reset, keine DOM-Suche, kein IPC und keine zweite Auswahlhaltung wurden eingebaut.
+- Betroffene Dateien:
+  - `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js`
+  - `src/renderer/ui-editor/BbmUiEditorStatusPanel.js`
+  - `scripts/tests/m63bReadonlyInspectorBridge.test.cjs`
+  - `scripts/test.cjs`
+  - `docs/M63B_READONLY_INSPECTOR_BRIDGE.md`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `STATUS.md`
+- Commit:
+  - wird mit diesem Paket-Commit erstellt
+- Naechster offener Schritt:
+  - M63C darf spaeter genau eine vorhandene Inspector-Control-Operation sichtbar ausfuehrbar machen; keine neue Operation erfinden.
+- Risiken/Hinweise:
+  - Manuelle Windows-Abnahme fuer die sichtbare Statuspanel-Darstellung bleibt offen.

--- a/STATUS.md
+++ b/STATUS.md
@@ -2849,7 +2849,8 @@ Wichtig:
 - Status: erledigt
 - Beschreibung:
   - Neue Bridge `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js` verbindet die fuehrende M51-Registry und M52-Auswahl read-only mit dem vorhandenen `EditorScopeInspector`-Layout-Control-Pfad.
-  - Das Statuspanel zeigt im Elementdetail jetzt `Layout-Steuerung` mit Inspector-Status, read-only Hinweis, erlaubten Layoutoperationen und Control-IDs.
+  - Das Statuspanel zeigt im Elementdetail jetzt `Layout-Steuerung` mit Inspector-Status, read-only Hinweis, konkret freigegebenen Layoutoperationen und Control-IDs.
+  - Korrektur PR #202: `layout.read`, `layout.save` und `layout.reset` werden nicht mehr in konkrete EditorRuntime-Operationen uebersetzt; ohne explizites `allowedOps` bleibt die Anzeige bei `allowedOps: []`.
   - Keine Layoutoperation, keine Speicherung, kein Reset, keine DOM-Suche, kein IPC und keine zweite Auswahlhaltung wurden eingebaut.
 - Betroffene Dateien:
   - `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js`

--- a/docs/M63B_READONLY_INSPECTOR_BRIDGE.md
+++ b/docs/M63B_READONLY_INSPECTOR_BRIDGE.md
@@ -1,0 +1,62 @@
+# M63B – Read-only Inspector-Bridge
+
+## Zweck
+M63B verbindet die vorhandene BBM-M51/M52-Auswahl read-only mit dem bestehenden `EditorScopeInspector`-Pfad. Die Bridge zeigt im Statuspanel neutrale Layout-Control-Metadaten fuer das aktuell ausgewaehlte Registry-Element, ohne eine Layoutoperation auszufuehren.
+
+## Fuehrende Registry
+Fuehrend bleibt die M51/Kit-Ziel-App-Registry. Die Bridge erzeugt keine fachlich neue Registry, keine zusaetzlichen Elemente und keine parallele Modulregistry. Sie transformiert die aktuelle Elementliste nur pro Aufruf in die editorRuntime-Form, die der bestehende Inspector erwartet.
+
+## Fuehrende Auswahl
+Fuehrend bleibt M52 `selectedElement`, geliefert ueber das bestehende Statuspanel und die UI-Editor-kit Selection-Runtime. Die Bridge haelt keine eigene Auswahlwahrheit und liest bei jedem Aufruf die aktuelle Auswahl.
+
+## Registry-Feldabbildung
+Die Bridge bildet die M51-Felder deterministisch ab:
+
+| M51/Kit-Feld | editorRuntime-Feld | Regel |
+| --- | --- | --- |
+| `elementId` | `id` | unveraendert |
+| `label`/`name` | `name` | unveraendert, Fallback nur auf gleiche ID |
+| bekannte M51-ID | `type` | statische explizite Zuordnung fuer die bestehenden BBM-Hauptbereich-IDs |
+| bekannte M51-ID | `role` | statische explizite Zuordnung fuer die bestehenden BBM-Hauptbereich-IDs |
+| `parentId` | `parentId` | unveraendert |
+| Reihenfolge in der M51-Liste | `order` | numerischer Listenindex |
+| `editable`/`capabilities`/`allowedChanges` | `editable` | nur aus vorhandenen Capabilities/Aenderungsvertraegen |
+| `allowedOps` oder `allowedChanges` | `allowedOps` | vorhandene runtime-faehige Ops; `layout.read` wird fuer die read-only Inspector-Anzeige auf den dokumentierten M63A-Pilotpfad `move` abgebildet |
+| `lockedOps` | `lockedOps` | vorhandene Werte, sonst `[]` |
+| `visible`/`layoutDefaults.visible` | `visible` | vorhandener Wert, sonst `true` |
+
+## Umgang mit `role` und fehlenden Feldern
+`role` wird nicht aus Label, CSS, Tagname, DOM-Struktur oder sichtbarer Ueberschrift abgeleitet. Die Bridge kennt nur eine kleine explizite statische Zuordnung fuer die bestehenden BBM-Hauptbereich-IDs. Elemente ohne kompatiblen Vertrag werden als `unsupported`/`blocked` sichtbar gemeldet.
+
+## Read-only Status
+- Keine Auswahl: neutraler leerer Status ohne Controls.
+- Bekannte Auswahl: Inspector-/Control-Metadaten werden read-only angezeigt.
+- Unbekannte ID: blockierter Status ohne Controls.
+- Fehlender Vertrag: `unsupported`/`blocked`, ohne Raten fehlender Pflichtfelder.
+
+## Sichtbare Informationen im Statuspanel
+Im Detailbereich erscheint `Layout-Steuerung` mit:
+- Inspector-Status,
+- Read-only-Hinweis,
+- Editierbar/Gesperrt-Status,
+- Liste der erlaubten Layoutoperationen,
+- Control-IDs und Control-Metadaten,
+- Hinweis, dass M63B keine Operation ausfuehrt.
+
+## Bewusst nicht aktive Operationen
+M63B ruft nicht auf:
+- `applyLayoutChange`,
+- `submitChangeRequest`,
+- Save/Write,
+- Load-Anwendung,
+- `resetLayoutState`,
+- `clear`,
+- direkte `HTMLElement.style`-Mutation.
+
+Es gibt keine neuen IPCs, keine Datenbanktabellen, kein `localStorage`, keine DOM-Suche und keine dynamische CSS-/JS-Ausfuehrung.
+
+## Fehlerverhalten
+Inspector-/Adapterfehler werden als blockierter Status im Panel sichtbar. Die Auswahlruntime wird dadurch nicht gestoppt, die vorhandenen Statuspanel-Informationen bleiben nutzbar, und es wird keine Fallback-Registry aufgebaut.
+
+## Scope fuer M63C
+M63C darf spaeter genau eine bereits vorhandene Operation aus dem EditorLayoutControls-Pfad sichtbar ausfuehrbar machen. Die Pilotoperation ist aus dem bestehenden Inspector-Control-Panel und den vorhandenen Tests zu waehlen; M63A dokumentiert `move` als naheliegenden Pilot. M63C darf keine neue Operation erfinden und muss vor jeder Ausfuehrung die bestehenden Validator-/HostAdapter-Grenzen nutzen.

--- a/docs/M63B_READONLY_INSPECTOR_BRIDGE.md
+++ b/docs/M63B_READONLY_INSPECTOR_BRIDGE.md
@@ -1,15 +1,15 @@
-# M63B – Read-only Inspector-Bridge
+# M63B.1 – Read-only Inspector-Bridge intern, sichtbare Konsole vorbereitet
 
 ## Zweck
-M63B verbindet die vorhandene BBM-M51/M52-Auswahl read-only mit dem bestehenden `EditorScopeInspector`-Pfad. Die Bridge zeigt im Statuspanel neutrale Layout-Control-Metadaten fuer das aktuell ausgewaehlte Registry-Element, ohne eine Layoutoperation auszufuehren.
+M63B.1 verbindet die vorhandene BBM-M51/M52-Auswahl intern read-only mit dem bestehenden `EditorScopeInspector`-Pfad. Die technische Bridge bleibt testbar und liefert interne Inspector-/Control-Metadaten, aber die sichtbare Statuspanel-Oberflaeche zeigt diese technischen Vertragsdaten nicht mehr direkt an.
 
 ## Fuehrende Registry
-Fuehrend bleibt die M51/Kit-Ziel-App-Registry. Die Bridge erzeugt keine fachlich neue Registry, keine zusaetzlichen Elemente und keine parallele Modulregistry. Sie transformiert die aktuelle Elementliste nur pro Aufruf in die editorRuntime-Form, die der bestehende Inspector erwartet.
+Fuehrend bleibt die M51/Kit-Ziel-App-Registry. Die Bridge erzeugt keine fachlich neue Registry, keine zusaetzlichen Elemente und keine parallele Modulregistry. Sie transformiert die aktuelle Elementliste nur pro Aufruf in die editorRuntime-Form, die der bestehende Inspector intern erwartet.
 
 ## Fuehrende Auswahl
 Fuehrend bleibt M52 `selectedElement`, geliefert ueber das bestehende Statuspanel und die UI-Editor-kit Selection-Runtime. Die Bridge haelt keine eigene Auswahlwahrheit und liest bei jedem Aufruf die aktuelle Auswahl.
 
-## Registry-Feldabbildung
+## Interne Registry-Feldabbildung
 Die Bridge bildet die M51-Felder deterministisch ab:
 
 | M51/Kit-Feld | editorRuntime-Feld | Regel |
@@ -26,25 +26,20 @@ Die Bridge bildet die M51-Felder deterministisch ab:
 | `visible`/`layoutDefaults.visible` | `visible` | vorhandener Wert, sonst `true` |
 
 ## Umgang mit `role` und fehlenden Feldern
-`role` wird nicht aus Label, CSS, Tagname, DOM-Struktur oder sichtbarer Ueberschrift abgeleitet. Die Bridge kennt nur eine kleine explizite statische Zuordnung fuer die bestehenden BBM-Hauptbereich-IDs. Elemente ohne kompatiblen Vertrag werden als `unsupported`/`blocked` sichtbar gemeldet.
+`role` wird nicht aus Label, CSS, Tagname, DOM-Struktur oder sichtbarer Ueberschrift abgeleitet. Die Bridge kennt nur eine kleine explizite statische Zuordnung fuer die bestehenden BBM-Hauptbereich-IDs. Elemente ohne kompatiblen Vertrag werden intern als `unsupported`/`blocked` gemeldet.
 
-## Read-only Status
-- Keine Auswahl: neutraler leerer Status ohne Controls.
-- Bekannte Auswahl: Inspector-/Control-Metadaten werden read-only angezeigt; ohne konkret freigegebene Operationen bleibt `allowedOps: []`.
-- Unbekannte ID: blockierter Status ohne Controls.
-- Fehlender Vertrag: `unsupported`/`blocked`, ohne Raten fehlender Pflichtfelder.
+## Sichtbare Oberflaeche in M63B.1
+Im Statuspanel-Detailbereich werden keine technischen Vertragsdaten angezeigt. Sichtbar ist hoechstens:
 
-## Sichtbare Informationen im Statuspanel
-Im Detailbereich erscheint `Layout-Steuerung` mit:
-- Inspector-Status,
-- Read-only-Hinweis,
-- Editierbar/Gesperrt-Status,
-- Liste der erlaubten Layoutoperationen,
-- Control-IDs und Control-Metadaten,
-- Hinweis: In M63B werden keine Layoutaenderungen ausgefuehrt.
+- der lesbare Name des ausgewaehlten Elements,
+- der kurze neutrale Platzhalter `Bearbeitung wird vorbereitet.`,
+- bei internem Fehler hoechstens `Bearbeitungsfunktionen sind derzeit nicht verfuegbar.`
+
+Nicht sichtbar sind insbesondere Inspector-Status, `read_only`, technische Control-IDs, interne Operationsnamen, `allowedOps`, Bridge-/Runtime-Begriffe oder technische Fehlercodes.
 
 ## Bewusst nicht aktive Operationen
-M63B ruft nicht auf:
+M63B.1 erzeugt keine aktiven Bedienelemente und ruft nicht auf:
+
 - `applyLayoutChange`,
 - `submitChangeRequest`,
 - Save/Write,
@@ -55,8 +50,26 @@ M63B ruft nicht auf:
 
 Es gibt keine neuen IPCs, keine Datenbanktabellen, kein `localStorage`, keine DOM-Suche und keine dynamische CSS-/JS-Ausfuehrung.
 
-## Fehlerverhalten
-Inspector-/Adapterfehler werden als blockierter Status im Panel sichtbar. Die Auswahlruntime wird dadurch nicht gestoppt, die vorhandenen Statuspanel-Informationen bleiben nutzbar, und es wird keine Fallback-Registry aufgebaut.
+## Zielbild fuer die fertige Bedienkonsole
+Der fertige UI-Editor soll keine technische Diagnoseansicht sein, sondern eine kleine praktische Bedienkonsole. M63C soll die sichtbare Struktur kompakt erweitern, ohne neue Operationen zu erfinden.
 
-## Scope fuer M63C
-M63C darf spaeter genau eine bereits vorhandene Operation aus dem EditorLayoutControls-Pfad sichtbar ausfuehrbar machen. Die Pilotoperation ist aus dem bestehenden Inspector-Control-Panel, der fuehrenden Registry und den vorhandenen Tests zu waehlen. M63C darf keine neue Operation erfinden und muss vor jeder Ausfuehrung die bestehenden Validator-/HostAdapter-Grenzen nutzen.
+Geplante sichtbare Modi fuer M63C:
+
+- Move
+- Breite
+- Hoehe
+- Text
+- Textposition
+
+Geplantes Bedienmuster fuer M63C:
+
+```text
+        ▲
+     ◀  •  ▶
+        ▼
+```
+
+Diese Modusauswahl und das Steuerkreuz werden in M63B.1 noch nicht erzeugt.
+
+## Fehlerverhalten
+Inspector-/Adapterfehler duerfen intern Details enthalten. Sichtbar bleibt nur der nutzerfreundliche Hinweis, dass Bearbeitungsfunktionen derzeit nicht verfuegbar sind. Die Auswahlruntime, Elementauswahl und der orange Auswahlrahmen bleiben davon unberuehrt.

--- a/docs/M63B_READONLY_INSPECTOR_BRIDGE.md
+++ b/docs/M63B_READONLY_INSPECTOR_BRIDGE.md
@@ -21,7 +21,7 @@ Die Bridge bildet die M51-Felder deterministisch ab:
 | `parentId` | `parentId` | unveraendert |
 | Reihenfolge in der M51-Liste | `order` | numerischer Listenindex |
 | `editable`/`capabilities`/`allowedChanges` | `editable` | nur aus vorhandenen Capabilities/Aenderungsvertraegen |
-| `allowedOps` oder `allowedChanges` | `allowedOps` | vorhandene runtime-faehige Ops; `layout.read` wird fuer die read-only Inspector-Anzeige auf den dokumentierten M63A-Pilotpfad `move` abgebildet |
+| `allowedOps` oder explizite konkrete Operationsfelder in `capabilities` | `allowedOps` | nur bereits konkret benannte EditorRuntime-Operationen; `layout.read`, `layout.save` und `layout.reset` werden nicht in konkrete Operationen uebersetzt |
 | `lockedOps` | `lockedOps` | vorhandene Werte, sonst `[]` |
 | `visible`/`layoutDefaults.visible` | `visible` | vorhandener Wert, sonst `true` |
 
@@ -30,7 +30,7 @@ Die Bridge bildet die M51-Felder deterministisch ab:
 
 ## Read-only Status
 - Keine Auswahl: neutraler leerer Status ohne Controls.
-- Bekannte Auswahl: Inspector-/Control-Metadaten werden read-only angezeigt.
+- Bekannte Auswahl: Inspector-/Control-Metadaten werden read-only angezeigt; ohne konkret freigegebene Operationen bleibt `allowedOps: []`.
 - Unbekannte ID: blockierter Status ohne Controls.
 - Fehlender Vertrag: `unsupported`/`blocked`, ohne Raten fehlender Pflichtfelder.
 
@@ -41,7 +41,7 @@ Im Detailbereich erscheint `Layout-Steuerung` mit:
 - Editierbar/Gesperrt-Status,
 - Liste der erlaubten Layoutoperationen,
 - Control-IDs und Control-Metadaten,
-- Hinweis, dass M63B keine Operation ausfuehrt.
+- Hinweis: In M63B werden keine Layoutaenderungen ausgefuehrt.
 
 ## Bewusst nicht aktive Operationen
 M63B ruft nicht auf:
@@ -59,4 +59,4 @@ Es gibt keine neuen IPCs, keine Datenbanktabellen, kein `localStorage`, keine DO
 Inspector-/Adapterfehler werden als blockierter Status im Panel sichtbar. Die Auswahlruntime wird dadurch nicht gestoppt, die vorhandenen Statuspanel-Informationen bleiben nutzbar, und es wird keine Fallback-Registry aufgebaut.
 
 ## Scope fuer M63C
-M63C darf spaeter genau eine bereits vorhandene Operation aus dem EditorLayoutControls-Pfad sichtbar ausfuehrbar machen. Die Pilotoperation ist aus dem bestehenden Inspector-Control-Panel und den vorhandenen Tests zu waehlen; M63A dokumentiert `move` als naheliegenden Pilot. M63C darf keine neue Operation erfinden und muss vor jeder Ausfuehrung die bestehenden Validator-/HostAdapter-Grenzen nutzen.
+M63C darf spaeter genau eine bereits vorhandene Operation aus dem EditorLayoutControls-Pfad sichtbar ausfuehrbar machen. Die Pilotoperation ist aus dem bestehenden Inspector-Control-Panel, der fuehrenden Registry und den vorhandenen Tests zu waehlen. M63C darf keine neue Operation erfinden und muss vor jeder Ausfuehrung die bestehenden Validator-/HostAdapter-Grenzen nutzen.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -1,7 +1,7 @@
 # UI-Inspektor Aufgabenheft
 
 ## Projektstatus
-Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.16a abgeschlossen (neutraler BBM-UI-Editor-Aktivmodus zeigt festen Registry-Scope). M62 abgeschlossen (alte BBM-Auswahlruntime entfernt; Statuspanel nutzt ausschliesslich Kit-Runtime). M63B abgeschlossen (read-only Inspector-Bridge im Statuspanel).
+Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.16a abgeschlossen (neutraler BBM-UI-Editor-Aktivmodus zeigt festen Registry-Scope). M62 abgeschlossen (alte BBM-Auswahlruntime entfernt; Statuspanel nutzt ausschliesslich Kit-Runtime). M63B.1 abgeschlossen (interne read-only Inspector-Bridge, sichtbare Konsole vorbereitet).
 
 Statusupdate: M36 abgeschlossen (UI-Editor Fixstand nach M29 bis M35 dokumentiert).
 
@@ -74,13 +74,14 @@ Aktueller Stand:
 - M63B bindet die bestehende M51/M52-Auswahl read-only an den vorhandenen `EditorScopeInspector`-Layout-Control-Pfad an.
 - Neue Bridge: `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js`.
 - Fuehrend bleiben M51/Kit-Ziel-App-Registry und M52 `selectedElement`; die Bridge haelt keine eigene Auswahlwahrheit und erzeugt keine zusaetzlichen Registry-Elemente.
-- Das Statuspanel zeigt im Elementdetail `Layout-Steuerung` mit Inspector-Status, read-only Hinweis, konkret freigegebenen Layoutoperationen und Control-IDs.
-- Korrektur PR #202: `layout.read`, `layout.save` und `layout.reset` werden nicht in konkrete EditorRuntime-Operationen uebersetzt; ohne explizites `allowedOps` bleibt die Anzeige bei `allowedOps: []`.
-- Fehlende `role`-/Pflichtvertraege werden sichtbar als `unsupported`/`blocked` behandelt; es wird nichts aus Label, CSS, Tagname oder DOM-Struktur geraten.
+- M63B.1 korrigiert die sichtbare Statuspanel-Oberflaeche: Der Detailbereich zeigt hoechstens den lesbaren Elementnamen und den neutralen Platzhalter `Bearbeitung wird vorbereitet.`.
+- Technische Inspector-/Bridge-/Runtime-Daten, Control-IDs, interne Operationsnamen, `allowedOps` und Fehlercodes bleiben intern und werden nicht sichtbar ausgegeben.
+- `layout.read`, `layout.save` und `layout.reset` werden weiterhin nicht in konkrete EditorRuntime-Operationen uebersetzt; ohne explizites `allowedOps` bleibt die interne Anzeige bei `allowedOps: []`.
+- Fehlende `role`-/Pflichtvertraege werden intern als `unsupported`/`blocked` behandelt; es wird nichts aus Label, CSS, Tagname oder DOM-Struktur geraten.
 - Keine Apply-/Save-/Load-/Reset-Ausfuehrung, keine LayoutStore-Schreiboperation, keine DOM-Suche, keine IPC-Erweiterung und keine direkte Style-Mutation.
 - Neue Doku: `docs/M63B_READONLY_INSPECTOR_BRIDGE.md`.
 - Neuer Guardrail-Test: `scripts/tests/m63bReadonlyInspectorBridge.test.cjs`; `scripts/test.cjs` fuehrt ihn mit aus.
-- Naechster sinnvoller Schritt: M63C darf spaeter genau eine vorhandene Inspector-Control-Operation sichtbar ausfuehrbar machen; Pilot aus vorhandenen Controls/Tests waehlen, keine neue Operation erfinden.
+- Naechster sinnvoller Schritt: M63C darf die kompakte Bedienkonsole mit Modusauswahl und Steuerkreuz vorbereiten; Pilot aus vorhandenen Controls/Tests waehlen, keine neue Operation erfinden.
 - Offener Punkt: manuelle Windows-Abnahme fuer die sichtbare Statuspanel-Darstellung nachholen.
 
 ## Statusupdate M62

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -1,7 +1,7 @@
 # UI-Inspektor Aufgabenheft
 
 ## Projektstatus
-Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.16a abgeschlossen (neutraler BBM-UI-Editor-Aktivmodus zeigt festen Registry-Scope). M62 abgeschlossen (alte BBM-Auswahlruntime entfernt; Statuspanel nutzt ausschliesslich Kit-Runtime).
+Status: M13.6a abgeschlossen (Panel ist aus dem Header gelöst und bleibt verschiebbar). K19.16a abgeschlossen (neutraler BBM-UI-Editor-Aktivmodus zeigt festen Registry-Scope). M62 abgeschlossen (alte BBM-Auswahlruntime entfernt; Statuspanel nutzt ausschliesslich Kit-Runtime). M63B abgeschlossen (read-only Inspector-Bridge im Statuspanel).
 
 Statusupdate: M36 abgeschlossen (UI-Editor Fixstand nach M29 bis M35 dokumentiert).
 
@@ -67,7 +67,20 @@ Aktueller Stand:
 - [x] M60 UI-Editor-kit Selection-Runtime im Statuspanel als Standard verwenden
 - [x] M61 UI-Editor-kit Selection-Runtime exklusiv im Statuspanel verwenden
 - [x] M62 Alte BBM-Auswahlruntime sicher entfernen und Kit-Vertraege weiter pruefen
+- [x] M63A Editor-Bestand und Integrationsplan dokumentieren
+- [x] M63B M51/M52-Auswahl read-only an EditorScopeInspector anbinden
 
+## Statusupdate M63B
+- M63B bindet die bestehende M51/M52-Auswahl read-only an den vorhandenen `EditorScopeInspector`-Layout-Control-Pfad an.
+- Neue Bridge: `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js`.
+- Fuehrend bleiben M51/Kit-Ziel-App-Registry und M52 `selectedElement`; die Bridge haelt keine eigene Auswahlwahrheit und erzeugt keine zusaetzlichen Registry-Elemente.
+- Das Statuspanel zeigt im Elementdetail `Layout-Steuerung` mit Inspector-Status, read-only Hinweis, erlaubten Layoutoperationen und Control-IDs.
+- Fehlende `role`-/Pflichtvertraege werden sichtbar als `unsupported`/`blocked` behandelt; es wird nichts aus Label, CSS, Tagname oder DOM-Struktur geraten.
+- Keine Apply-/Save-/Load-/Reset-Ausfuehrung, keine LayoutStore-Schreiboperation, keine DOM-Suche, keine IPC-Erweiterung und keine direkte Style-Mutation.
+- Neue Doku: `docs/M63B_READONLY_INSPECTOR_BRIDGE.md`.
+- Neuer Guardrail-Test: `scripts/tests/m63bReadonlyInspectorBridge.test.cjs`; `scripts/test.cjs` fuehrt ihn mit aus.
+- Naechster sinnvoller Schritt: M63C darf spaeter genau eine vorhandene Inspector-Control-Operation sichtbar ausfuehrbar machen; Pilot aus vorhandenen Controls/Tests waehlen, keine neue Operation erfinden.
+- Offener Punkt: manuelle Windows-Abnahme fuer die sichtbare Statuspanel-Darstellung nachholen.
 
 ## Statusupdate M62
 - M62 entfernt die nicht mehr produktiv genutzte BBM-eigene Hover-/Selection-Runtime aus `src/renderer/ui-editor/`.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -74,7 +74,8 @@ Aktueller Stand:
 - M63B bindet die bestehende M51/M52-Auswahl read-only an den vorhandenen `EditorScopeInspector`-Layout-Control-Pfad an.
 - Neue Bridge: `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js`.
 - Fuehrend bleiben M51/Kit-Ziel-App-Registry und M52 `selectedElement`; die Bridge haelt keine eigene Auswahlwahrheit und erzeugt keine zusaetzlichen Registry-Elemente.
-- Das Statuspanel zeigt im Elementdetail `Layout-Steuerung` mit Inspector-Status, read-only Hinweis, erlaubten Layoutoperationen und Control-IDs.
+- Das Statuspanel zeigt im Elementdetail `Layout-Steuerung` mit Inspector-Status, read-only Hinweis, konkret freigegebenen Layoutoperationen und Control-IDs.
+- Korrektur PR #202: `layout.read`, `layout.save` und `layout.reset` werden nicht in konkrete EditorRuntime-Operationen uebersetzt; ohne explizites `allowedOps` bleibt die Anzeige bei `allowedOps: []`.
 - Fehlende `role`-/Pflichtvertraege werden sichtbar als `unsupported`/`blocked` behandelt; es wird nichts aus Label, CSS, Tagname oder DOM-Struktur geraten.
 - Keine Apply-/Save-/Load-/Reset-Ausfuehrung, keine LayoutStore-Schreiboperation, keine DOM-Suche, keine IPC-Erweiterung und keine direkte Style-Mutation.
 - Neue Doku: `docs/M63B_READONLY_INSPECTOR_BRIDGE.md`.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -90,6 +90,7 @@ const { runM59KitSelectionRuntimeIntegrationTests } = require("./tests/m59KitSel
 const { runM60KitRuntimeStandardTests } = require("./tests/m60KitRuntimeStandard.test.cjs");
 const { runM62BbmSelectionLegacyCleanupTests } = require("./tests/m62BbmSelectionLegacyCleanup.test.cjs");
 const { runM63aEditorIntegrationAuditTests } = require("./tests/m63aEditorIntegrationAudit.test.cjs");
+const { runM63bReadonlyInspectorBridgeTests } = require("./tests/m63bReadonlyInspectorBridge.test.cjs");
 
 let failed = false;
 
@@ -227,6 +228,7 @@ async function main() {
   await runM60KitRuntimeStandardTests(run);
   await runM62BbmSelectionLegacyCleanupTests(run);
   await runM63aEditorIntegrationAuditTests(run);
+  await runM63bReadonlyInspectorBridgeTests(run);
 
   if (failed) {
     process.exitCode = 1;

--- a/scripts/tests/m63bReadonlyInspectorBridge.test.cjs
+++ b/scripts/tests/m63bReadonlyInspectorBridge.test.cjs
@@ -48,6 +48,7 @@ class TestNode {
   set innerHTML(_value) { this.children = []; }
 }
 function collectText(node) { return [node?.textContent || "", ...(node?.children || []).flatMap(collectText)].join("\n"); }
+function collectTags(node) { return [node?.tagName || "", ...(node?.children || []).flatMap(collectTags)].filter(Boolean); }
 
 async function runM63bReadonlyInspectorBridgeTests(run) {
   const { createBbmEditorRuntimeInspectorBridge } = await importEsmFromFile(BRIDGE_PATH);
@@ -107,7 +108,7 @@ async function runM63bReadonlyInspectorBridgeTests(run) {
     assert.equal(bridge.inspectSelectedElement().reason, "ROLE_MISSING");
   });
 
-  await run("M63B Statuspanel: zeigt Layout-Steuerung und read-only Informationen", async () => {
+  await run("M63B Statuspanel: zeigt nur Elementname und neutralen Platzhalter", async () => {
     const oldDocument = global.document;
     const oldWindow = global.window;
     global.document = { createElement: (tagName) => new TestNode(tagName) };
@@ -120,14 +121,21 @@ async function runM63bReadonlyInspectorBridgeTests(run) {
       panel.selectedElement = elements[1];
       panel.renderDetails();
       const text = collectText(panel.detailsNode);
-      assert.match(text, /Layout-Steuerung/);
-      assert.match(text, /Read-only/);
-      assert.match(text, /Freigegebene Layoutoperationen/);
-      assert.match(text, /keine/);
-      assert.match(text, /In M63B werden keine Layoutaenderungen ausgefuehrt/);
-      assert.match(text, /editor\.layout\.applySave/);
-      assert.match(text, /in M63B nicht aktiv/);
-      assert.doesNotMatch(text, /vorhanden/);
+      const tags = collectTags(panel.detailsNode);
+      assert.match(text, /Header/);
+      assert.match(text, /Bearbeitung wird vorbereitet\./);
+      assert.doesNotMatch(text, /Layout-Steuerung/);
+      assert.doesNotMatch(text, /Inspector-Status/);
+      assert.doesNotMatch(text, /read_only/);
+      assert.doesNotMatch(text, /Inspector/);
+      assert.doesNotMatch(text, /Control-IDs/);
+      assert.doesNotMatch(text, /allowedOps/);
+      assert.doesNotMatch(text, /Freigegebene Layoutoperationen/);
+      assert.doesNotMatch(text, /editor\.layout\./);
+      assert.doesNotMatch(text, /move|resize|spacing|width|height/);
+      assert.equal(tags.includes("button"), false);
+      assert.equal(tags.includes("input"), false);
+      assert.equal(tags.includes("select"), false);
     } finally {
       global.document = oldDocument;
       global.window = oldWindow;

--- a/scripts/tests/m63bReadonlyInspectorBridge.test.cjs
+++ b/scripts/tests/m63bReadonlyInspectorBridge.test.cjs
@@ -75,14 +75,26 @@ async function runM63bReadonlyInspectorBridgeTests(run) {
     assert.equal(bridge.inspectSelectedElement().kind, "empty");
   });
 
-  await run("M63B Bridge: gueltiges Element liefert Inspector- und Control-Metadaten sowie vorhandene Operationen", () => {
+  await run("M63B Bridge: gueltiges M51-Element mit nur allowedChanges bleibt ohne konkrete Operationen", () => {
     const spy = createSpyInspector();
     const bridge = createBbmEditorRuntimeInspectorBridge({ registryElements: elements, selectedElement: elements[1], inspectorFactory: spy.inspectorFactory });
     const result = bridge.inspectSelectedElement();
     assert.equal(result.ok, true);
+    assert.equal(result.inspectorStatus, "read_only");
     assert.equal(result.inspectorElement.id, "bbm.main.header");
-    assert.deepEqual(result.allowedOps, ["move"]);
+    assert.deepEqual(result.allowedOps, []);
     assert.equal(result.controls[0].id, "editor.layout.applySave");
+    assert.equal(result.controls[0].enabled, false);
+    assert.equal(result.controls[0].m63bStatus, "in M63B nicht aktiv");
+  });
+
+  await run("M63B Bridge: explizites allowedOps uebernimmt genau diese Operation", () => {
+    const spy = createSpyInspector();
+    const explicit = [{ ...elements[0], allowedOps: ["move"] }];
+    const bridge = createBbmEditorRuntimeInspectorBridge({ registryElements: explicit, selectedElement: explicit[0], inspectorFactory: spy.inspectorFactory });
+    const result = bridge.inspectSelectedElement();
+    assert.deepEqual(result.allowedOps, ["move"]);
+    assert.deepEqual(result.registry[0].allowedOps, ["move"]);
   });
 
   await run("M63B Bridge: unbekannte ID und fehlende role/Pflichtfelder werden blockiert statt geraten", () => {
@@ -110,8 +122,12 @@ async function runM63bReadonlyInspectorBridgeTests(run) {
       const text = collectText(panel.detailsNode);
       assert.match(text, /Layout-Steuerung/);
       assert.match(text, /Read-only/);
-      assert.match(text, /Erlaubte Layoutoperationen/);
+      assert.match(text, /Freigegebene Layoutoperationen/);
+      assert.match(text, /keine/);
+      assert.match(text, /In M63B werden keine Layoutaenderungen ausgefuehrt/);
       assert.match(text, /editor\.layout\.applySave/);
+      assert.match(text, /in M63B nicht aktiv/);
+      assert.doesNotMatch(text, /vorhanden/);
     } finally {
       global.document = oldDocument;
       global.window = oldWindow;

--- a/scripts/tests/m63bReadonlyInspectorBridge.test.cjs
+++ b/scripts/tests/m63bReadonlyInspectorBridge.test.cjs
@@ -1,0 +1,139 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const REPO_ROOT = path.join(__dirname, "../..");
+const BRIDGE_PATH = path.join(REPO_ROOT, "src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js");
+const PANEL_PATH = path.join(REPO_ROOT, "src/renderer/ui-editor/BbmUiEditorStatusPanel.js");
+
+function read(file) { return fs.readFileSync(path.join(REPO_ROOT, file), "utf8"); }
+
+const elements = [
+  { elementId: "bbm.main.shell", label: "Shell", type: "frame", parentId: null, capabilities: ["select", "layout"], allowedChanges: ["layout.read", "layout.save", "layout.reset"], layoutDefaults: { visible: true } },
+  { elementId: "bbm.main.header", label: "Header", type: "header", parentId: "bbm.main.shell", capabilities: ["select", "layout"], allowedChanges: ["layout.read"] },
+];
+
+function createSpyInspector() {
+  const calls = { applyLayoutChange: 0, submitChangeRequest: 0, save: 0, write: 0, resetLayoutState: 0, clear: 0 };
+  return {
+    calls,
+    inspectorFactory({ hostAdapterFactory }) {
+      const host = hostAdapterFactory();
+      return {
+        getLayoutControlPanel(_scopeId, elementId) {
+          const registry = host.getRegistry();
+          const selectedElement = registry.find((entry) => entry.id === elementId) || null;
+          return {
+            ok: Boolean(selectedElement),
+            selectedElement: selectedElement && { ...selectedElement, effectiveOps: [...selectedElement.allowedOps] },
+            controls: selectedElement ? [{ id: "editor.layout.applySave", label: "Aenderung anwenden/speichern", enabled: true, allowedOps: [...selectedElement.allowedOps] }] : [],
+            status: { kind: selectedElement ? "ready" : "blocked" },
+            errors: [],
+            warnings: [],
+          };
+        },
+        applyLayoutChange() { calls.applyLayoutChange += 1; },
+      };
+    },
+  };
+}
+
+class TestNode {
+  constructor(tagName) { this.tagName = tagName; this.children = []; this.attributes = {}; this.className = ""; this.hidden = false; this.textContent = ""; this.type = ""; this.disabled = false; }
+  append(...children) { this.children.push(...children); }
+  appendChild(child) { this.children.push(child); return child; }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  addEventListener() {}
+  set innerHTML(_value) { this.children = []; }
+}
+function collectText(node) { return [node?.textContent || "", ...(node?.children || []).flatMap(collectText)].join("\n"); }
+
+async function runM63bReadonlyInspectorBridgeTests(run) {
+  const { createBbmEditorRuntimeInspectorBridge } = await importEsmFromFile(BRIDGE_PATH);
+
+  await run("M63B Bridge: transformiert nur vorhandene M51-Elemente und behaelt IDs/Parents", () => {
+    const spy = createSpyInspector();
+    const bridge = createBbmEditorRuntimeInspectorBridge({ registryElements: elements, selectedElement: elements[1], inspectorFactory: spy.inspectorFactory });
+    const result = bridge.inspectSelectedElement();
+    assert.equal(result.registry.length, elements.length);
+    assert.deepEqual(result.registry.map((entry) => entry.id), elements.map((entry) => entry.elementId));
+    assert.equal(result.registry[1].parentId, "bbm.main.shell");
+    assert.equal(result.registry[1].order, 1);
+  });
+
+  await run("M63B Bridge: selectedElement bleibt externe M52-Quelle, Auswahlwechsel und Reset wirken live", () => {
+    const spy = createSpyInspector();
+    let selectedElement = null;
+    const bridge = createBbmEditorRuntimeInspectorBridge({ registryElements: elements, getSelectedElement: () => selectedElement, inspectorFactory: spy.inspectorFactory });
+    assert.equal(bridge.inspectSelectedElement().kind, "empty");
+    selectedElement = elements[0];
+    assert.equal(bridge.inspectSelectedElement().elementId, "bbm.main.shell");
+    selectedElement = elements[1];
+    assert.equal(bridge.inspectSelectedElement().elementId, "bbm.main.header");
+    selectedElement = null;
+    assert.equal(bridge.inspectSelectedElement().kind, "empty");
+  });
+
+  await run("M63B Bridge: gueltiges Element liefert Inspector- und Control-Metadaten sowie vorhandene Operationen", () => {
+    const spy = createSpyInspector();
+    const bridge = createBbmEditorRuntimeInspectorBridge({ registryElements: elements, selectedElement: elements[1], inspectorFactory: spy.inspectorFactory });
+    const result = bridge.inspectSelectedElement();
+    assert.equal(result.ok, true);
+    assert.equal(result.inspectorElement.id, "bbm.main.header");
+    assert.deepEqual(result.allowedOps, ["move"]);
+    assert.equal(result.controls[0].id, "editor.layout.applySave");
+  });
+
+  await run("M63B Bridge: unbekannte ID und fehlende role/Pflichtfelder werden blockiert statt geraten", () => {
+    const spy = createSpyInspector();
+    let bridge = createBbmEditorRuntimeInspectorBridge({ registryElements: elements, selectedElement: { elementId: "bbm.main.unknown" }, inspectorFactory: spy.inspectorFactory });
+    assert.equal(bridge.inspectSelectedElement().reason, "UNKNOWN_SELECTED_ELEMENT");
+    const custom = [{ elementId: "custom.no.role", label: "Custom", type: "custom", parentId: null, allowedChanges: ["layout.read"] }];
+    bridge = createBbmEditorRuntimeInspectorBridge({ registryElements: custom, selectedElement: custom[0], inspectorFactory: spy.inspectorFactory });
+    assert.equal(bridge.inspectSelectedElement().kind, "unsupported");
+    assert.equal(bridge.inspectSelectedElement().reason, "ROLE_MISSING");
+  });
+
+  await run("M63B Statuspanel: zeigt Layout-Steuerung und read-only Informationen", async () => {
+    const oldDocument = global.document;
+    const oldWindow = global.window;
+    global.document = { createElement: (tagName) => new TestNode(tagName) };
+    global.window = { bbmDb: {} };
+    try {
+      const { BbmUiEditorStatusPanel } = await importEsmFromFile(PANEL_PATH);
+      const panel = new BbmUiEditorStatusPanel({});
+      panel.detailsNode = new TestNode("section");
+      panel.elements = elements;
+      panel.selectedElement = elements[1];
+      panel.renderDetails();
+      const text = collectText(panel.detailsNode);
+      assert.match(text, /Layout-Steuerung/);
+      assert.match(text, /Read-only/);
+      assert.match(text, /Erlaubte Layoutoperationen/);
+      assert.match(text, /editor\.layout\.applySave/);
+    } finally {
+      global.document = oldDocument;
+      global.window = oldWindow;
+    }
+  });
+
+  await run("M63B Guardrails: keine Apply-/Save-/Load-/Reset-Ausfuehrung, kein LayoutStore-Write, keine DOM-Suche/IPC/zweite Registry", () => {
+    const bridgeSource = read("src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js");
+    const panelSource = read("src/renderer/ui-editor/BbmUiEditorStatusPanel.js");
+    const combined = `${bridgeSource}\n${panelSource}`;
+    assert.doesNotMatch(bridgeSource, /\.applyLayoutChange\(|\.submitChangeRequest\(|\.resetLayoutState\(|\.write\(|\.clear\(|\.save\(/);
+    assert.doesNotMatch(combined, /querySelector|querySelectorAll|getElementById|getElementsBy|closest\(|matches\(|elementFromPoint|elementsFromPoint|MutationObserver|localStorage|ipcRenderer|\.style\s*=/);
+    assert.doesNotMatch(bridgeSource, /let\s+selectedElement|this\.selectedElement|let\s+selectedElementId|this\.selectedElementId/);
+  });
+}
+
+if (require.main === module) {
+  const run = async (name, fn) => {
+    try { const out = fn(); if (out && typeof out.then === "function") await out; console.log(`ok - ${name}`); }
+    catch (err) { console.error(`not ok - ${name}`); console.error(err?.stack || err); process.exitCode = 1; }
+  };
+  runM63bReadonlyInspectorBridgeTests(run).then(() => { if (!process.exitCode) console.log("m63bReadonlyInspectorBridge.test.cjs passed"); });
+}
+
+module.exports = { runM63bReadonlyInspectorBridgeTests };

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -282,48 +282,21 @@ export class BbmUiEditorStatusPanel {
       return;
     }
 
-    const list = createNode("dl", "bbm-ui-editor-status-list");
-    list.append(
-      createInfoRow("Element-ID", element.elementId),
-      createInfoRow("Bezeichnung", element.label),
-      createInfoRow("Typ", element.type),
-      createInfoRow("Scope", element.scope),
-      createInfoRow("Parent", element.parentId || "Root"),
-      createInfoRow("Capabilities", formatList(element.capabilities)),
-      createInfoRow("Erlaubte Aenderungen", formatList(element.allowedChanges))
-    );
-    this.detailsNode.appendChild(list);
-    this.renderReadonlyLayoutControls();
+    this.renderReadonlyLayoutControls(element);
   }
 
-  renderReadonlyLayoutControls() {
-    if (!this.detailsNode) return;
+  renderReadonlyLayoutControls(element) {
+    if (!this.detailsNode || !element) return;
     const section = createNode("section", "bbm-ui-editor-layout-controls");
-    const title = createNode("h3");
-    title.textContent = "Layout-Steuerung";
-    section.appendChild(title);
 
-    const result = this.inspectorBridge?.inspectSelectedElement?.() || { ok: true, kind: "empty", controls: [], allowedOps: [] };
-    const list = createNode("dl", "bbm-ui-editor-status-list");
-    list.append(
-      createInfoRow("Inspector-Status", result.inspectorStatus || result.kind || "read_only"),
-      createInfoRow("Read-only", "Ja"),
-      createInfoRow("Editierbar", result.inspectorElement?.editable ? "Ja" : "Nein"),
-      createInfoRow("Freigegebene Layoutoperationen", formatList(result.allowedOps)),
-      createInfoRow("Control-IDs", formatList((result.controls || []).map((control) => control.id))),
-      createInfoRow("Hinweis", result.message || "In M63B werden keine Layoutaenderungen ausgefuehrt.")
-    );
-    section.appendChild(list);
+    const name = createNode("p", "bbm-ui-editor-panel__selected-name");
+    name.textContent = asText(element.label || element.name, element.elementId);
+    section.appendChild(name);
 
-    if (Array.isArray(result.controls) && result.controls.length > 0) {
-      const controls = createNode("ul", "bbm-ui-editor-control-list");
-      for (const control of result.controls) {
-        const item = createNode("li");
-        item.textContent = `${asText(control.id)} · ${asText(control.label)} · ${asText(control.m63bStatus, "in M63B nicht aktiv")}`;
-        controls.appendChild(item);
-      }
-      section.appendChild(controls);
-    }
+    const result = this.inspectorBridge?.inspectSelectedElement?.() || { ok: true };
+    const hint = createNode("p", "bbm-ui-editor-panel__notice");
+    hint.textContent = result.ok ? "Bearbeitung wird vorbereitet." : "Bearbeitungsfunktionen sind derzeit nicht verfuegbar.";
+    section.appendChild(hint);
 
     this.detailsNode.appendChild(section);
   }

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -309,9 +309,9 @@ export class BbmUiEditorStatusPanel {
       createInfoRow("Inspector-Status", result.inspectorStatus || result.kind || "read_only"),
       createInfoRow("Read-only", "Ja"),
       createInfoRow("Editierbar", result.inspectorElement?.editable ? "Ja" : "Nein"),
-      createInfoRow("Erlaubte Layoutoperationen", formatList(result.allowedOps)),
+      createInfoRow("Freigegebene Layoutoperationen", formatList(result.allowedOps)),
       createInfoRow("Control-IDs", formatList((result.controls || []).map((control) => control.id))),
-      createInfoRow("Hinweis", result.message || "Keine Operationen werden in M63B ausgefuehrt.")
+      createInfoRow("Hinweis", result.message || "In M63B werden keine Layoutaenderungen ausgefuehrt.")
     );
     section.appendChild(list);
 
@@ -319,7 +319,7 @@ export class BbmUiEditorStatusPanel {
       const controls = createNode("ul", "bbm-ui-editor-control-list");
       for (const control of result.controls) {
         const item = createNode("li");
-        item.textContent = `${asText(control.id)} · ${asText(control.label)} · ${control.enabled ? "vorhanden" : "gesperrt"}`;
+        item.textContent = `${asText(control.id)} · ${asText(control.label)} · ${asText(control.m63bStatus, "in M63B nicht aktiv")}`;
         controls.appendChild(item);
       }
       section.appendChild(controls);

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -1,5 +1,6 @@
 import { getBbmUiElementRefStatus } from "./bbmUiElementRefs.js";
 import { createBbmKitSelectionHost } from "./bbmKitSelectionHost.js";
+import { createBbmEditorRuntimeInspectorBridge } from "./bbmEditorRuntimeInspectorBridge.js";
 
 function createNode(tag, className = "") {
   const node = document.createElement(tag);
@@ -54,6 +55,10 @@ export class BbmUiEditorStatusPanel {
     this.runtimeError = "";
     this.selectionMessage = "";
     this.selectionModeActive = false;
+    this.inspectorBridge = createBbmEditorRuntimeInspectorBridge({
+      getRegistryElements: () => this.elements,
+      getSelectedElement: () => this.selectedElement,
+    });
   }
 
   render() {
@@ -288,6 +293,39 @@ export class BbmUiEditorStatusPanel {
       createInfoRow("Erlaubte Aenderungen", formatList(element.allowedChanges))
     );
     this.detailsNode.appendChild(list);
+    this.renderReadonlyLayoutControls();
+  }
+
+  renderReadonlyLayoutControls() {
+    if (!this.detailsNode) return;
+    const section = createNode("section", "bbm-ui-editor-layout-controls");
+    const title = createNode("h3");
+    title.textContent = "Layout-Steuerung";
+    section.appendChild(title);
+
+    const result = this.inspectorBridge?.inspectSelectedElement?.() || { ok: true, kind: "empty", controls: [], allowedOps: [] };
+    const list = createNode("dl", "bbm-ui-editor-status-list");
+    list.append(
+      createInfoRow("Inspector-Status", result.inspectorStatus || result.kind || "read_only"),
+      createInfoRow("Read-only", "Ja"),
+      createInfoRow("Editierbar", result.inspectorElement?.editable ? "Ja" : "Nein"),
+      createInfoRow("Erlaubte Layoutoperationen", formatList(result.allowedOps)),
+      createInfoRow("Control-IDs", formatList((result.controls || []).map((control) => control.id))),
+      createInfoRow("Hinweis", result.message || "Keine Operationen werden in M63B ausgefuehrt.")
+    );
+    section.appendChild(list);
+
+    if (Array.isArray(result.controls) && result.controls.length > 0) {
+      const controls = createNode("ul", "bbm-ui-editor-control-list");
+      for (const control of result.controls) {
+        const item = createNode("li");
+        item.textContent = `${asText(control.id)} · ${asText(control.label)} · ${control.enabled ? "vorhanden" : "gesperrt"}`;
+        controls.appendChild(item);
+      }
+      section.appendChild(controls);
+    }
+
+    this.detailsNode.appendChild(section);
   }
 
   getElementMeta(elementId) {

--- a/src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js
+++ b/src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js
@@ -20,12 +20,6 @@ const ROLE_BY_ELEMENT_ID = Object.freeze({
   "bbm.main.actions": "action",
 });
 
-const RUNTIME_OPS_BY_ALLOWED_CHANGE = Object.freeze({
-  "layout.read": ["move"],
-  "layout.save": [],
-  "layout.reset": [],
-});
-
 function normalizeId(value) {
   return String(value ?? "").trim();
 }
@@ -44,8 +38,26 @@ function getSelectedElementId(selectedElement) {
 
 function toRuntimeAllowedOps(element) {
   if (Array.isArray(element?.allowedOps)) return unique(cloneList(element.allowedOps));
-  const fromAllowedChanges = cloneList(element?.allowedChanges).flatMap((change) => RUNTIME_OPS_BY_ALLOWED_CHANGE[change] || []);
-  return unique(fromAllowedChanges);
+
+  const capabilities = element?.capabilities;
+  if (capabilities && typeof capabilities === "object" && !Array.isArray(capabilities)) {
+    if (Array.isArray(capabilities.allowedOps)) return unique(cloneList(capabilities.allowedOps));
+    if (Array.isArray(capabilities.operations)) return unique(cloneList(capabilities.operations));
+    if (Array.isArray(capabilities.layoutOps)) return unique(cloneList(capabilities.layoutOps));
+  }
+
+  if (Array.isArray(capabilities)) {
+    const explicitOps = capabilities.flatMap((capability) => {
+      if (!capability || typeof capability !== "object" || Array.isArray(capability)) return [];
+      if (Array.isArray(capability.allowedOps)) return cloneList(capability.allowedOps);
+      if (Array.isArray(capability.operations)) return cloneList(capability.operations);
+      if (Array.isArray(capability.layoutOps)) return cloneList(capability.layoutOps);
+      return [];
+    });
+    return unique(explicitOps);
+  }
+
+  return [];
 }
 
 function isEditable(element) {
@@ -127,6 +139,17 @@ function createReadonlyCatalog({ scopeId, moduleId, targetAppId }) {
   };
 }
 
+function toReadonlyControls(controls) {
+  return Array.isArray(controls)
+    ? controls.map((control) => ({
+        ...control,
+        enabled: false,
+        readOnly: true,
+        m63bStatus: "in M63B nicht aktiv",
+      }))
+    : [];
+}
+
 function createReadonlyInspector({ inspector, inspectorFactory, registry, scopeId, moduleId, targetAppId }) {
   if (inspector) return inspector;
   const catalog = createReadonlyCatalog({ scopeId, moduleId, targetAppId });
@@ -176,10 +199,10 @@ export function createBbmEditorRuntimeInspectorBridge(options = {}) {
       return {
         ...status,
         scopeId,
-        inspectorStatus: panel?.status?.kind || "read_only",
+        inspectorStatus: "read_only",
         inspectorElement: panel?.selectedElement || null,
-        controlPanel: panel,
-        controls: Array.isArray(panel?.controls) ? panel.controls : [],
+        controlPanel: panel ? { ...panel, controls: toReadonlyControls(panel.controls) } : null,
+        controls: toReadonlyControls(panel?.controls),
         allowedOps: Array.isArray(panel?.selectedElement?.effectiveOps) ? [...panel.selectedElement.effectiveOps] : [],
         registry: snapshot.transformed.registry,
         errors: panel?.errors || [],

--- a/src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js
+++ b/src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js
@@ -1,0 +1,200 @@
+import { createEditorScopeInspector } from "../editorRuntime/inspector/editorScopeInspector.js";
+
+const DEFAULT_SCOPE_ID = "bbm.main.readonly";
+const DEFAULT_MODULE_ID = "bbm.main";
+const DEFAULT_TARGET_APP_ID = "bbm-produktiv";
+
+const TYPE_BY_ELEMENT_ID = Object.freeze({
+  "bbm.main.shell": "root",
+  "bbm.main.navigation": "area",
+  "bbm.main.header": "area",
+  "bbm.main.content": "area",
+  "bbm.main.actions": "area",
+});
+
+const ROLE_BY_ELEMENT_ID = Object.freeze({
+  "bbm.main.shell": "layout",
+  "bbm.main.navigation": "navigation",
+  "bbm.main.header": "layout",
+  "bbm.main.content": "content",
+  "bbm.main.actions": "action",
+});
+
+const RUNTIME_OPS_BY_ALLOWED_CHANGE = Object.freeze({
+  "layout.read": ["move"],
+  "layout.save": [],
+  "layout.reset": [],
+});
+
+function normalizeId(value) {
+  return String(value ?? "").trim();
+}
+
+function cloneList(value) {
+  return Array.isArray(value) ? value.map((entry) => String(entry ?? "").trim()).filter(Boolean) : [];
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function getSelectedElementId(selectedElement) {
+  return normalizeId(selectedElement?.elementId || selectedElement?.id || selectedElement?.selectedElementId);
+}
+
+function toRuntimeAllowedOps(element) {
+  if (Array.isArray(element?.allowedOps)) return unique(cloneList(element.allowedOps));
+  const fromAllowedChanges = cloneList(element?.allowedChanges).flatMap((change) => RUNTIME_OPS_BY_ALLOWED_CHANGE[change] || []);
+  return unique(fromAllowedChanges);
+}
+
+function isEditable(element) {
+  if (typeof element?.editable === "boolean") return element.editable;
+  const capabilities = cloneList(element?.capabilities);
+  const allowedChanges = cloneList(element?.allowedChanges);
+  return capabilities.includes("layout") || allowedChanges.length > 0;
+}
+
+function transformRegistryElement(element, order) {
+  const id = normalizeId(element?.elementId || element?.id);
+  const role = element?.role || ROLE_BY_ELEMENT_ID[id];
+  const type = TYPE_BY_ELEMENT_ID[id] || element?.runtimeType || element?.editorRuntimeType;
+
+  if (!id || !role || !type) {
+    return {
+      ok: false,
+      sourceElement: element,
+      elementId: id,
+      reason: !id ? "ELEMENT_ID_MISSING" : !role ? "ROLE_MISSING" : "TYPE_MISSING",
+    };
+  }
+
+  return {
+    ok: true,
+    sourceElement: element,
+    element: {
+      id,
+      name: normalizeId(element?.label || element?.name || id),
+      type,
+      role,
+      parentId: element?.parentId ?? null,
+      order,
+      visible: element?.visible !== undefined ? Boolean(element.visible) : element?.layoutDefaults?.visible !== false,
+      editable: isEditable(element),
+      allowedOps: toRuntimeAllowedOps(element),
+      lockedOps: cloneList(element?.lockedOps),
+    },
+  };
+}
+
+function transformRegistry(elements) {
+  const input = Array.isArray(elements) ? elements : [];
+  const transformed = input.map((element, index) => transformRegistryElement(element, index));
+  return {
+    registry: transformed.filter((entry) => entry.ok).map((entry) => entry.element),
+    unsupported: transformed.filter((entry) => !entry.ok),
+    sourceCount: input.length,
+  };
+}
+
+function createReadonlyHostAdapter(registry) {
+  return {
+    getRegistry() {
+      return registry.map((element) => ({ ...element, allowedOps: [...element.allowedOps], lockedOps: [...element.lockedOps] }));
+    },
+    getCurrentLayoutState() {
+      return [];
+    },
+  };
+}
+
+function createReadonlyCatalog({ scopeId, moduleId, targetAppId }) {
+  return {
+    targetAppId,
+    modules: [
+      {
+        moduleId,
+        moduleLabel: "BBM Hauptbereich",
+        scopes: [
+          {
+            scopeId,
+            scopeLabel: "BBM Hauptbereich read-only",
+            layoutProfileId: "bbm.main.readonly",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function createReadonlyInspector({ inspector, inspectorFactory, registry, scopeId, moduleId, targetAppId }) {
+  if (inspector) return inspector;
+  const catalog = createReadonlyCatalog({ scopeId, moduleId, targetAppId });
+  const hostAdapter = createReadonlyHostAdapter(registry);
+  const factory = inspectorFactory || createEditorScopeInspector;
+  return factory({ catalog, hostAdapterFactory: () => hostAdapter });
+}
+
+export function createBbmEditorRuntimeInspectorBridge(options = {}) {
+  const scopeId = normalizeId(options.scopeId) || DEFAULT_SCOPE_ID;
+  const moduleId = normalizeId(options.moduleId) || DEFAULT_MODULE_ID;
+  const targetAppId = normalizeId(options.targetAppId) || DEFAULT_TARGET_APP_ID;
+  const getRegistryElements = typeof options.getRegistryElements === "function" ? options.getRegistryElements : () => options.registryElements || [];
+  const getSelectedElement = typeof options.getSelectedElement === "function" ? options.getSelectedElement : () => options.selectedElement || null;
+
+  function getSnapshot() {
+    const registryElements = getRegistryElements() || [];
+    const selectedElement = getSelectedElement() || null;
+    const selectedElementId = getSelectedElementId(selectedElement);
+    const transformed = transformRegistry(registryElements);
+    return { registryElements, selectedElement, selectedElementId, transformed };
+  }
+
+  function getStatus() {
+    const snapshot = getSnapshot();
+    if (!snapshot.selectedElementId) {
+      return { ok: true, kind: "empty", selectedElement: null, inspectorStatus: "read_only", controls: [], allowedOps: [], message: "Keine Auswahl." };
+    }
+    const sourceElement = snapshot.registryElements.find((element) => normalizeId(element?.elementId || element?.id) === snapshot.selectedElementId) || null;
+    if (!sourceElement) {
+      return { ok: false, kind: "blocked", selectedElement: null, elementId: snapshot.selectedElementId, controls: [], allowedOps: [], message: "Ausgewaehlte Element-ID ist nicht in der fuehrenden M51-Registry vorhanden.", reason: "UNKNOWN_SELECTED_ELEMENT" };
+    }
+    const unsupported = snapshot.transformed.unsupported.find((entry) => entry.elementId === snapshot.selectedElementId);
+    if (unsupported) {
+      return { ok: false, kind: "unsupported", selectedElement: sourceElement, elementId: snapshot.selectedElementId, controls: [], allowedOps: [], message: "Element ist ohne expliziten Inspector-Vertrag nicht kompatibel.", reason: unsupported.reason };
+    }
+    return { ok: true, kind: "ready", selectedElement: sourceElement, elementId: snapshot.selectedElementId, sourceCount: snapshot.transformed.sourceCount, registryCount: snapshot.transformed.registry.length, inspectorStatus: "read_only" };
+  }
+
+  function inspectSelectedElement() {
+    const snapshot = getSnapshot();
+    const status = getStatus();
+    if (!status.ok || status.kind === "empty") return { ...status, registry: snapshot.transformed.registry };
+    try {
+      const inspector = createReadonlyInspector({ inspector: options.inspector, inspectorFactory: options.inspectorFactory, registry: snapshot.transformed.registry, scopeId, moduleId, targetAppId });
+      const panel = inspector.getLayoutControlPanel(scopeId, snapshot.selectedElementId);
+      return {
+        ...status,
+        scopeId,
+        inspectorStatus: panel?.status?.kind || "read_only",
+        inspectorElement: panel?.selectedElement || null,
+        controlPanel: panel,
+        controls: Array.isArray(panel?.controls) ? panel.controls : [],
+        allowedOps: Array.isArray(panel?.selectedElement?.effectiveOps) ? [...panel.selectedElement.effectiveOps] : [],
+        registry: snapshot.transformed.registry,
+        errors: panel?.errors || [],
+        warnings: panel?.warnings || [],
+      };
+    } catch (error) {
+      return { ok: false, kind: "blocked", selectedElement: status.selectedElement || null, elementId: snapshot.selectedElementId, controls: [], allowedOps: [], message: error?.message || "Inspector-Fehler", reason: "INSPECTOR_ERROR", errors: [{ code: "INSPECTOR_ERROR", message: error?.message || String(error || "Inspector-Fehler") }] };
+    }
+  }
+
+  function getSelectedElementControlPanel() {
+    return inspectSelectedElement().controlPanel || null;
+  }
+
+  return { inspectSelectedElement, getSelectedElementControlPanel, getStatus };
+}
+
+export const BBM_EDITOR_RUNTIME_INSPECTOR_BRIDGE_ROLE_BY_ID = ROLE_BY_ELEMENT_ID;


### PR DESCRIPTION
### Motivation
- Connect the existing M51/M52 selection and registry to the existing `EditorScopeInspector` so the UI status panel can show neutral layout-control metadata without enabling any layout operations. 
- Keep the integration strictly read-only: no layout apply/save/load/reset, no HostAdapter submits, no LayoutStore writes and no DOM scanning.
- Follow M63A recommendation to implement a small BBM-specific bridge rather than duplicating or inventing inspector/runtime registries.

### Description
- Added a small bridge API `createBbmEditorRuntimeInspectorBridge(options)` in `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js` that: transforms injected M51 registry entries deterministically into the editor-runtime shape, exposes `inspectSelectedElement()`, `getSelectedElementControlPanel()` and `getStatus()`, uses injected getters for registry + selectedElement, and creates a read-only inspector facade for the existing `createEditorScopeInspector` when needed.
- Deterministic field mapping implemented (examples): `elementId -> id`, `label/name -> name`, list index -> `order`, `parentId -> parentId`, `allowedChanges/capabilities -> allowedOps`, missing `lockedOps -> []`, missing `visible -> true`; `role` is provided only by explicit static map for known BBM IDs and otherwise the element is reported `unsupported`/`blocked` (no guessing from DOM/labels).
- Extended the visible status panel `src/renderer/ui-editor/BbmUiEditorStatusPanel.js` to render a new read-only detail section titled "Layout-Steuerung" that displays inspector status, read-only hint, whether the element is editable, allowed layout operations, control IDs and control metadata; the section calls the bridge but never performs any operation.
- Added a guardrail test suite `scripts/tests/m63bReadonlyInspectorBridge.test.cjs` validating transformation rules, ID/parent preservation, selection as external M52 source, behavior for unknown IDs and missing role, statuspanel rendering of read-only info, and absence of mutation/DOM-search/persistence code paths.
- Hooked the new test into the central `scripts/test.cjs` runner and added documentation `docs/M63B_READONLY_INSPECTOR_BRIDGE.md` and updated `docs/UI_INSPEKTOR_AUFGABENHEFT.md` and `STATUS.md` to record the change and next steps (M63C pilot).

### Testing
- Ran targeted node tests and they passed: `node scripts/tests/m63aEditorIntegrationAudit.test.cjs` (M63A audit), `node scripts/tests/m63bReadonlyInspectorBridge.test.cjs` (new guardrail tests), `node scripts/tests/m59KitSelectionRuntimeIntegration.test.cjs`, `node scripts/tests/m60KitRuntimeStandard.test.cjs`, `node scripts/tests/m62BbmSelectionLegacyCleanup.test.cjs`, and `node scripts/tests/editorScopeInspector.test.cjs` and `node scripts/tests/editorRuntime.catalog.test.cjs` (executed; their runners are library-style and produced no errors in this flow).
- Executed the repo-wide test runner `node scripts/test.cjs`; the M63B tests ran green as part of that run.
- `npm test` (full Electron-based suite) is blocked in this environment by missing system library `libatk-1.0.so.0` (Electron cannot start) and the complete Node/Electron DB suite later in `node scripts/test.cjs` encountered `better-sqlite3` native module version mismatch in this environment (binary compiled against a different Node version); these are environment issues and not regressions introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a593f038f5083228f6b15fa5e56230c)