### PR TITLE
M65: UI-Editor — Layout speichern, laden und dauerhaft wiederherstellen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2908,6 +2908,7 @@ Wichtig:
   - `src/main/ipc/uiEditorIpc.js`
   - `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js`
   - `src/renderer/ui-editor/bbmMainUiHostAdapter.js`
+  - `src/renderer/ui-editor/bbmMainUiLayoutStorage.js`
   - `src/renderer/ui-editor/BbmUiEditorStatusPanel.js`
   - `scripts/tests/m63cRealRegistryPanelIntegration.test.cjs`
   - `scripts/test.cjs`
@@ -2933,6 +2934,7 @@ Wichtig:
   - `src/renderer/ui-editor/bbmUiElementRefs.js`
   - `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js`
   - `src/renderer/ui-editor/bbmMainUiHostAdapter.js`
+  - `src/renderer/ui-editor/bbmMainUiLayoutStorage.js`
   - `src/renderer/ui-editor/BbmUiEditorStatusPanel.js`
   - `src/renderer/ui-editor/bbmUiEditorStatusPanel.css.js`
   - `scripts/tests/m63cRealRegistryPanelIntegration.test.cjs`
@@ -3129,3 +3131,37 @@ Wichtig:
   - `STATUS.md`
 - Naechster offener Schritt:
   - Lokale Windows-Abnahme für PR #204 erneut durchführen.
+
+### M65 – UI-Editor Layout speichern, laden und dauerhaft wiederherstellen
+- Status: umgesetzt im automatisierten Adapter-/Panelpfad; praktische Windows-Neustartprüfung in Cloud nicht verfügbar.
+- Beschreibung:
+  - `EditorScopeInspector` stellt öffentliche `saveLayoutSession`- und `loadSavedLayout`-Methoden bereit und setzt die Sitzungsbaseline nach erfolgreichem Speichern/Laden neu.
+  - Die Renderer-Bridge reicht diese Methoden ohne HostAdapter-Hintertür an das Steuerpanel durch.
+  - Der BBM-Main-HostAdapter trennt Sitzungs-LayoutStore und gespeicherten LayoutStore auf Basis des vorhandenen Storage-Adapter-Vertrags.
+  - Das M64-Steuerpanel zeigt Speicherstatus und den neuen Button „Änderungen speichern“; Bedienpanel-Elemente bleiben nicht editorfähig.
+  - Ein neuer M65-Roundtrip-Test prüft Speichern, Laden in neuer Instanz, Verwerfen einzelner Elemente, alle verwerfen, ausgeschlossene UI-Zustände und Fehlerfall.
+- Betroffene Dateien:
+  - `src/renderer/editorRuntime/inspector/editorScopeInspector.js`
+  - `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js`
+  - `src/renderer/ui-editor/bbmMainUiHostAdapter.js`
+  - `src/renderer/ui-editor/bbmMainUiLayoutStorage.js`
+  - `src/renderer/ui-editor/BbmUiEditorStatusPanel.js`
+  - `scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs`
+  - `scripts/test.cjs`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `STATUS.md`
+- Pruefung:
+  - `node scripts/ui-editor-contract-check.cjs` OK
+  - `node scripts/ui-editor-contract-check.cjs --self-test` OK
+  - `node scripts/tests/m63cRealRegistryPanelIntegration.test.cjs` OK
+  - `node scripts/tests/m63cLayoutControlConsole.test.cjs` OK
+  - `node scripts/tests/m64UiEditorTestSurface.test.cjs` OK
+  - `node scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs` OK
+  - `node scripts/test.cjs` in dieser Umgebung wegen `better-sqlite3`/Node-Modulversionskonflikt nicht vollstaendig gruen
+  - `npm test` in dieser Umgebung wegen fehlender Electron-Systembibliothek `libatk-1.0.so.0` nicht ausführbar
+- Naechster offener Schritt:
+  - Lokale Windows-Abnahme: BBM starten, UI-Editor öffnen, Testkarte/Tabelle ändern, speichern, BBM neu starten, gespeichertes Layout sichtbar prüfen.
+  - Lokale Prüfung bestätigt den separaten nichtflüchtigen Storage-Adapter in der echten Windows-/Electron-Umgebung; keine Panel- oder DOM-/UI-Scan-Persistenz ergänzen.
+- Risiken/Hinweise:
+  - Kein neuer Bestätigungsdialog, kein Autosave, keine Layoutprofile und keine PDF-/Fachmaskenänderung.
+  - Die Cloud kann die praktische Neustartprüfung nicht ersetzen.

--- a/STATUS.md
+++ b/STATUS.md
@@ -3165,3 +3165,29 @@ Wichtig:
 - Risiken/Hinweise:
   - Kein neuer Bestätigungsdialog, kein Autosave, keine Layoutprofile und keine PDF-/Fachmaskenänderung.
   - Die Cloud kann die praktische Neustartprüfung nicht ersetzen.
+
+### M65 Korrektur – persistente Speicherung ohne stillen Memory-Fallback
+- Status: umgesetzt in diesem Arbeitsstand.
+- Beschreibung:
+  - Der produktive BBM-Main-Layout-Storage meldet `available` und `persistent` explizit und verwendet keinen stillen Memory-Fallback mehr, wenn Browser-Storage fehlt.
+  - Lesefälle werden unterschieden: kein gespeichertes Layout, gespeichertes Layout gefunden, und Lesefehler wie beschädigtes JSON.
+  - `saveLayoutSession()` liefert nur bei verfügbarer persistenter Speicherung und erfolgreicher Verifikation `ok: true`; bei Fehler bleibt die bisherige Session-Baseline erhalten.
+  - `loadSavedLayout()` liefert `savedLayoutFound` und aktualisiert die Baseline nur bei tatsächlich gefundenem/geladenem Layout.
+  - Das UI-Editor-Steuerpanel zeigt präzise neutrale Statusmeldungen und deaktiviert Speichern bei nicht verfügbarer Persistenz.
+- Betroffene Dateien:
+  - `src/renderer/ui-editor/bbmMainUiLayoutStorage.js`
+  - `src/renderer/ui-editor/bbmMainUiHostAdapter.js`
+  - `src/renderer/editorRuntime/inspector/editorScopeInspector.js`
+  - `src/renderer/ui-editor/BbmUiEditorStatusPanel.js`
+  - `scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs`
+  - `docs/UI_INSPEKTOR_AUFGABENHEFT.md`
+  - `STATUS.md`
+- Pruefung:
+  - `node scripts/ui-editor-contract-check.cjs` OK
+  - `node scripts/ui-editor-contract-check.cjs --self-test` OK
+  - `node scripts/tests/m64UiEditorTestSurface.test.cjs` OK
+  - `node scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs` OK
+- Naechster offener Schritt:
+  - Lokale Windows-/Electron-Abnahme von Speichern, Neustart-Laden und Fehlerstatus durchführen.
+- Risiken/Hinweise:
+  - Memory-Storage bleibt nur für Tests oder ausdrücklich injizierte Laufzeiten erlaubt, nicht als stiller produktiver Ersatz.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -684,3 +684,12 @@ Hinweis:
 - Neuer Guardrail-/Roundtrip-Test: `scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs`.
 - Nicht umgesetzt: keine Profilverwaltung, kein Autosave, keine direkte Panel- oder DOM-Persistenz, keine produktive Fachmaske und keine PDF-Änderung.
 - Hinweis: Die Cloud-Umgebung erlaubt keine praktische Windows-/Electron-Neustartprüfung; der Roundtrip ist automatisiert über einen injizierten persistenten Storage-Adapter sowie den separaten BBM-Main-Storage-Adapter abgesichert.
+
+## M65 Korrektur – dauerhafte Speicherung ehrlich melden
+- Der produktive BBM-Main-Storage-Adapter fällt bei fehlendem Browser-Storage nicht mehr still auf Memory zurück.
+- `createBbmMainUiLayoutStorage()` meldet `available` und `persistent` explizit und unterscheidet kein gespeichertes Layout, erfolgreich gelesenen Payload und Lesefehler.
+- `saveLayoutSession()` meldet Erfolg nur noch bei verfügbarer persistenter Speicherung und erfolgreicher Verifikation; bei Fehler bleibt die Session-Baseline unverändert.
+- `loadSavedLayout()` unterscheidet `savedLayoutFound: true`, `savedLayoutFound: false` und Ladefehler.
+- Das Panel zeigt „Noch kein Layout gespeichert“, „Gespeichertes Layout geladen“, „Gespeichertes Layout konnte nicht geladen werden.“ und „Layout konnte nicht dauerhaft gespeichert werden.“ passend zum Ergebnis.
+- Der Speichern-Button berücksichtigt `persistenceAvailable` und `persistencePersistent` aus dem öffentlichen Inspector-/Bridge-Status.
+- M65-Tests decken nun leeren Storage, fehlenden produktiven Browser-Storage, beschädigtes JSON, Schreibfehler und erfolgreichen Browser-Storage-Roundtrip ab.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -674,3 +674,13 @@ Hinweis:
 - Der IPC-Elementklon überträgt `editable` und `lockedOps` explizit aus der führenden Registry.
 - Die Kreuzmitte bleibt im Panel weiterhin von `selectedElement.editable` abhängig; keine Ableitung aus IDs, DOM oder allowedOps.
 - Der M64-Test prüft den echten IPC-Auswahl-/Detailpfad und die Aktivierung der Kreuzmitte nach einer Layoutänderung.
+
+## M65 Abschlussnotiz – Layout speichern, laden und wiederherstellen
+- M65 ergänzt den M64-Sitzungsablauf um explizites Speichern und Laden über öffentliche Inspector-/Bridge-Methoden.
+- Der BBM-Main-HostAdapter trennt aktuelle Sitzungswerte von gespeicherten Layoutwerten: Layoutschritte ändern zuerst die aktuelle Darstellung, `saveLayoutSession` übernimmt diese Werte in den vorhandenen Storage-Adapter.
+- Beim Öffnen des Panels wird ein gespeicherter Layoutzustand über `loadSavedLayout` geladen und danach als Sitzungsbaseline verwendet.
+- Das rechte Steuerpanel zeigt Speicherstatus und den neuen Button „Änderungen speichern“; Bedienbuttons bleiben vom Editor ausgeschlossen und erhalten keine Registry-ID.
+- Verwerfen nach dem Speichern kehrt zum zuletzt gespeicherten Zustand zurück, nicht zum ursprünglichen Registry-Default.
+- Neuer Guardrail-/Roundtrip-Test: `scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs`.
+- Nicht umgesetzt: keine Profilverwaltung, kein Autosave, keine direkte Panel- oder DOM-Persistenz, keine produktive Fachmaske und keine PDF-Änderung.
+- Hinweis: Die Cloud-Umgebung erlaubt keine praktische Windows-/Electron-Neustartprüfung; der Roundtrip ist automatisiert über einen injizierten persistenten Storage-Adapter sowie den separaten BBM-Main-Storage-Adapter abgesichert.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -94,6 +94,7 @@ const { runM63bReadonlyInspectorBridgeTests } = require("./tests/m63bReadonlyIns
 const { runM63cLayoutControlConsoleTests } = require("./tests/m63cLayoutControlConsole.test.cjs");
 const { runM63cRealRegistryPanelIntegrationTests } = require("./tests/m63cRealRegistryPanelIntegration.test.cjs");
 const { runM64UiEditorTestSurfaceTests } = require("./tests/m64UiEditorTestSurface.test.cjs");
+const { runM65LayoutPersistenceRoundtripTests } = require("./tests/m65LayoutPersistenceRoundtrip.test.cjs");
 
 let failed = false;
 
@@ -235,6 +236,7 @@ async function main() {
   await runM63cLayoutControlConsoleTests(run);
   await runM63cRealRegistryPanelIntegrationTests(run);
   await runM64UiEditorTestSurfaceTests(run);
+  await runM65LayoutPersistenceRoundtripTests(run);
 
   if (failed) {
     process.exitCode = 1;

--- a/scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs
+++ b/scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs
@@ -1,0 +1,183 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+const { getBbmUiElementRegistry } = require("../../src/ui-editor/bbm-ui-element-registry.cjs");
+
+const REPO_ROOT = path.join(__dirname, "../..");
+const HOST_ADAPTER_PATH = path.join(REPO_ROOT, "src/renderer/ui-editor/bbmMainUiHostAdapter.js");
+const INSPECTOR_PATH = path.join(REPO_ROOT, "src/renderer/editorRuntime/inspector/editorScopeInspector.js");
+const REFS_PATH = path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiElementRefs.js");
+const LAYOUT_PERSISTENCE_PATH = path.join(REPO_ROOT, "src/renderer/editorRuntime/layout/editorLayoutPersistence.js");
+const DEFAULT_STORAGE_PATH = path.join(REPO_ROOT, "src/renderer/ui-editor/bbmMainUiLayoutStorage.js");
+const PANEL_PATH = path.join(REPO_ROOT, "src/renderer/ui-editor/BbmUiEditorStatusPanel.js");
+
+class TestRef {
+  constructor(width = 300, height = 180) {
+    this.style = { values: {}, setProperty: (k, v) => { this.style.values[k] = String(v); }, removeProperty: (k) => { delete this.style.values[k]; } };
+    this.rect = { width, height, left: 0, top: 0 };
+  }
+  getBoundingClientRect() { return { ...this.rect }; }
+}
+
+let changeCounter = 0;
+function request(elementId, operation, payload) {
+  changeCounter += 1;
+  return {
+    changeId: `m65-test-${changeCounter}`,
+    targetAppId: "bbm-produktiv",
+    moduleId: "bbm.main",
+    scopeId: "bbm.main-layout",
+    elementId,
+    operation,
+    payload,
+    createdAt: "2026-07-19T00:00:00.000Z",
+    source: "m65-test",
+  };
+}
+
+async function createHarness(layoutStorage) {
+  const [{ createBbmMainUiHostAdapter }, { createEditorScopeInspector }, refs] = await Promise.all([
+    importEsmFromFile(HOST_ADAPTER_PATH),
+    importEsmFromFile(INSPECTOR_PATH),
+    importEsmFromFile(REFS_PATH),
+  ]);
+  refs.clearBbmUiElementRefs();
+  global.HTMLElement = TestRef;
+  const sourceElements = getBbmUiElementRegistry().elements;
+  assert.ok(sourceElements.some((element) => element.elementId === "bbm.uiEditorTest.card"), "echte M64-Registry muss die Testkarte enthalten");
+  const registryElements = [
+    { id: "bbm.main.content", elementId: "bbm.main.content", name: "Inhalt", label: "Inhalt", type: "root", role: "layout", parentId: null, order: 1, visible: true, editable: false, allowedOps: [], lockedOps: [] },
+    { id: "bbm.uiEditorTest.card", elementId: "bbm.uiEditorTest.card", name: "Testkarte", label: "Testkarte", type: "card", role: "content", parentId: "bbm.main.content", order: 2, visible: true, editable: true, allowedOps: ["move", "resize"], lockedOps: [] },
+    { id: "bbm.uiEditorTest.table", elementId: "bbm.uiEditorTest.table", name: "Beispieltabelle", label: "Beispieltabelle", type: "table", role: "content", parentId: "bbm.main.content", order: 3, visible: true, editable: true, allowedOps: ["move", "resize"], lockedOps: [] },
+    { id: "bbm.uiEditorTest.card.title", elementId: "bbm.uiEditorTest.card.title", name: "Überschrift", label: "Überschrift", type: "label", role: "content", parentId: "bbm.uiEditorTest.card", order: 4, visible: true, editable: true, allowedOps: ["move", "resize"], lockedOps: [] },
+  ];
+  for (const id of ["bbm.uiEditorTest.card", "bbm.uiEditorTest.table", "bbm.uiEditorTest.card.title"]) {
+    refs.registerBbmUiElementRef(id, new TestRef(id.includes("table") ? 420 : 300, id.includes("table") ? 160 : 180));
+  }
+  const adapter = createBbmMainUiHostAdapter({ registry: registryElements, layoutStorage });
+  const inspector = createEditorScopeInspector({ hostAdapterFactory: () => adapter, catalog: { targetAppId: "bbm-produktiv", modules: [{ moduleId: "bbm.main", moduleLabel: "BBM", scopes: [{ scopeId: "bbm.main-layout", uiScope: "bbm.main", label: "BBM Main" }] }] } });
+  return { adapter, inspector, refs };
+}
+
+async function runM65LayoutPersistenceRoundtripTests(run) {
+  const { createEditorLayoutMemoryStorage } = await importEsmFromFile(LAYOUT_PERSISTENCE_PATH);
+
+  await run("M65 Speichern: echte M64-Registry schreibt erst per expliziter Session-Speicherung dauerhaft", async () => {
+    const layoutStorage = createEditorLayoutMemoryStorage();
+    const { adapter, inspector } = await createHarness(layoutStorage);
+    assert.equal(inspector.beginLayoutSession("bbm.main-layout").ok, true);
+    assert.equal(adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 10, y: 15 })).ok, true);
+    assert.equal(adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "resize", { width: 25, height: 20 })).ok, true);
+    assert.equal(inspector.getLayoutSessionStatus("bbm.main-layout").changedCount, 1);
+    const saved = inspector.saveLayoutSession("bbm.main-layout");
+    assert.equal(saved.ok, true);
+    assert.equal(saved.status.changedCount, 0);
+    const persisted = layoutStorage.read();
+    assert.deepEqual(persisted.entries["bbm.uiEditorTest.card"].layoutValue, { x: 10, y: 15, width: 325, height: 200 });
+    assert.equal(persisted.entries["bbm.uiEditorTest.card"].targetAppId, "bbm-produktiv");
+    assert.equal(persisted.entries["bbm.uiEditorTest.card"].moduleId, "bbm.main");
+    assert.equal(persisted.entries["bbm.uiEditorTest.card"].scopeId, "bbm.main-layout");
+    assert.equal(persisted.entries["bbm.uiEditorTest.card"].layoutProfileId, "default");
+    assert.ok(persisted.entries["bbm.uiEditorTest.card"].updatedAt);
+  });
+
+  await run("M65 Laden: neue Runtime lädt gespeicherte Werte und beginnt Baseline auf gespeichertem Zustand", async () => {
+    const layoutStorage = createEditorLayoutMemoryStorage();
+    let harness = await createHarness(layoutStorage);
+    harness.inspector.beginLayoutSession("bbm.main-layout");
+    harness.adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 20, y: 5 }));
+    harness.adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "resize", { width: 30, height: 10 }));
+    harness.inspector.saveLayoutSession("bbm.main-layout");
+
+    harness = await createHarness(layoutStorage);
+    const loaded = harness.inspector.loadSavedLayout("bbm.main-layout");
+    assert.equal(loaded.ok, true);
+    harness.inspector.beginLayoutSession("bbm.main-layout");
+    assert.equal(harness.inspector.getLayoutSessionStatus("bbm.main-layout").changedCount, 0);
+    const ref = harness.refs.getBbmUiElementRef("bbm.uiEditorTest.card");
+    assert.equal(ref.style.values.transform, "translate(20px, 5px)");
+    assert.equal(ref.style.values.width, "330px");
+    assert.equal(ref.style.values.height, "190px");
+  });
+
+  await run("M65 Verwerfen nach Speichern: einzelnes Element kehrt zum gespeicherten Zustand zurück", async () => {
+    const layoutStorage = createEditorLayoutMemoryStorage();
+    const { adapter, inspector, refs } = await createHarness(layoutStorage);
+    inspector.beginLayoutSession("bbm.main-layout");
+    adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 10, y: 0 }));
+    inspector.saveLayoutSession("bbm.main-layout");
+    adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 5, y: 0 }));
+    assert.equal(inspector.getLayoutSessionStatus("bbm.main-layout").changedCount, 1);
+    assert.equal(inspector.discardLayoutSessionElement("bbm.main-layout", "bbm.uiEditorTest.card").ok, true);
+    assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card").style.values.transform, "translate(10px, 0px)");
+    assert.equal(inspector.getLayoutSessionStatus("bbm.main-layout").changedCount, 0);
+  });
+
+  await run("M65 Alle verwerfen: mehrere Änderungen kehren zum gespeicherten Zustand zurück ohne Storage zu löschen", async () => {
+    const layoutStorage = createEditorLayoutMemoryStorage();
+    const { adapter, inspector, refs } = await createHarness(layoutStorage);
+    inspector.beginLayoutSession("bbm.main-layout");
+    adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 10, y: 0 }));
+    adapter.submitChangeRequest(request("bbm.uiEditorTest.table", "resize", { width: 20, height: 20 }));
+    inspector.saveLayoutSession("bbm.main-layout");
+    adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 5, y: 0 }));
+    adapter.submitChangeRequest(request("bbm.uiEditorTest.table", "move", { x: 5, y: 5 }));
+    assert.equal(inspector.discardLayoutSession("bbm.main-layout").ok, true);
+    assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card").style.values.transform, "translate(10px, 0px)");
+    assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.table").style.values.transform, "translate(0px, 0px)");
+    assert.ok(layoutStorage.read().entries["bbm.uiEditorTest.card"]);
+    assert.ok(layoutStorage.read().entries["bbm.uiEditorTest.table"]);
+  });
+
+  await run("M65 Guardrail: UI-Zustände und Registry-Metadaten werden nicht persistiert", async () => {
+    const layoutStorage = createEditorLayoutMemoryStorage();
+    const { adapter, inspector } = await createHarness(layoutStorage);
+    inspector.beginLayoutSession("bbm.main-layout");
+    adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 1 }));
+    assert.equal(inspector.saveLayoutSession("bbm.main-layout").ok, true);
+    const serialized = JSON.stringify(layoutStorage.read());
+    for (const forbidden of ["selectedElement", "selectionModeActive", "editorActive", "activeLayoutControlMode", "Meldung", "DOM", "ref", "registry", "metadata"]) {
+      assert.equal(serialized.includes(forbidden), false, `${forbidden} darf nicht im Layoutspeicher stehen`);
+    }
+  });
+
+  await run("M65 Default-Storage: separater Adapter nutzt Browser-Storage, falls vorhanden", async () => {
+    const previousStorage = global.localStorage;
+    const memory = new Map();
+    global.localStorage = {
+      getItem: (key) => memory.has(key) ? memory.get(key) : null,
+      setItem: (key, value) => memory.set(key, String(value)),
+      removeItem: (key) => memory.delete(key),
+    };
+    try {
+      const { createBbmMainUiLayoutStorage, BBM_MAIN_UI_LAYOUT_STORAGE_KEY } = await importEsmFromFile(DEFAULT_STORAGE_PATH);
+      const storage = createBbmMainUiLayoutStorage("m65.default.storage");
+      storage.write({ version: 1, entries: { sample: { layoutValue: { x: 1 } } } });
+      assert.equal(JSON.parse(global.localStorage.getItem("m65.default.storage")).entries.sample.layoutValue.x, 1);
+      assert.equal(BBM_MAIN_UI_LAYOUT_STORAGE_KEY.includes("bbm.uiEditor.layout"), true);
+    } finally {
+      global.localStorage = previousStorage;
+    }
+  });
+
+  await run("M65 Fehlerfall: fehlschlagender Storage liefert ok false und Panel zeigt keine Erfolgsmeldung", async () => {
+    const failingStorage = { read: () => null, write: () => { throw new Error("write failed"); }, clear() {} };
+    const { adapter, inspector } = await createHarness(failingStorage);
+    inspector.beginLayoutSession("bbm.main-layout");
+    adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 5 }));
+    const result = inspector.saveLayoutSession("bbm.main-layout");
+    assert.equal(result.ok, false);
+    assert.equal(inspector.getLayoutSessionStatus("bbm.main-layout").active, true);
+    const panelSource = fs.readFileSync(PANEL_PATH, "utf8");
+    assert.match(panelSource, /Layout konnte nicht gespeichert werden\./);
+    assert.doesNotMatch(panelSource, /localStorage/);
+  });
+}
+
+if (require.main === module) {
+  const run = async (name, fn) => { try { await fn(); console.log(`ok - ${name}`); } catch (error) { console.error(`not ok - ${name}`); console.error(error); process.exitCode = 1; } };
+  runM65LayoutPersistenceRoundtripTests(run).then(() => { if (!process.exitCode) console.log("m65LayoutPersistenceRoundtrip.test.cjs passed"); });
+}
+
+module.exports = { runM65LayoutPersistenceRoundtripTests };

--- a/scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs
+++ b/scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs
@@ -60,11 +60,26 @@ async function createHarness(layoutStorage) {
   return { adapter, inspector, refs };
 }
 
+function createPersistentTestStorage(createEditorLayoutMemoryStorage, initialPayload = null) {
+  const storage = createEditorLayoutMemoryStorage(initialPayload);
+  return {
+    available: true,
+    persistent: true,
+    readResult() {
+      const payload = storage.read();
+      return payload ? { ok: true, found: true, payload } : { ok: true, found: false, payload: null };
+    },
+    read: storage.read,
+    write: storage.write,
+    clear: storage.clear,
+  };
+}
+
 async function runM65LayoutPersistenceRoundtripTests(run) {
   const { createEditorLayoutMemoryStorage } = await importEsmFromFile(LAYOUT_PERSISTENCE_PATH);
 
   await run("M65 Speichern: echte M64-Registry schreibt erst per expliziter Session-Speicherung dauerhaft", async () => {
-    const layoutStorage = createEditorLayoutMemoryStorage();
+    const layoutStorage = createPersistentTestStorage(createEditorLayoutMemoryStorage);
     const { adapter, inspector } = await createHarness(layoutStorage);
     assert.equal(inspector.beginLayoutSession("bbm.main-layout").ok, true);
     assert.equal(adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 10, y: 15 })).ok, true);
@@ -83,7 +98,7 @@ async function runM65LayoutPersistenceRoundtripTests(run) {
   });
 
   await run("M65 Laden: neue Runtime lädt gespeicherte Werte und beginnt Baseline auf gespeichertem Zustand", async () => {
-    const layoutStorage = createEditorLayoutMemoryStorage();
+    const layoutStorage = createPersistentTestStorage(createEditorLayoutMemoryStorage);
     let harness = await createHarness(layoutStorage);
     harness.inspector.beginLayoutSession("bbm.main-layout");
     harness.adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 20, y: 5 }));
@@ -102,7 +117,7 @@ async function runM65LayoutPersistenceRoundtripTests(run) {
   });
 
   await run("M65 Verwerfen nach Speichern: einzelnes Element kehrt zum gespeicherten Zustand zurück", async () => {
-    const layoutStorage = createEditorLayoutMemoryStorage();
+    const layoutStorage = createPersistentTestStorage(createEditorLayoutMemoryStorage);
     const { adapter, inspector, refs } = await createHarness(layoutStorage);
     inspector.beginLayoutSession("bbm.main-layout");
     adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 10, y: 0 }));
@@ -115,7 +130,7 @@ async function runM65LayoutPersistenceRoundtripTests(run) {
   });
 
   await run("M65 Alle verwerfen: mehrere Änderungen kehren zum gespeicherten Zustand zurück ohne Storage zu löschen", async () => {
-    const layoutStorage = createEditorLayoutMemoryStorage();
+    const layoutStorage = createPersistentTestStorage(createEditorLayoutMemoryStorage);
     const { adapter, inspector, refs } = await createHarness(layoutStorage);
     inspector.beginLayoutSession("bbm.main-layout");
     adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 10, y: 0 }));
@@ -131,7 +146,7 @@ async function runM65LayoutPersistenceRoundtripTests(run) {
   });
 
   await run("M65 Guardrail: UI-Zustände und Registry-Metadaten werden nicht persistiert", async () => {
-    const layoutStorage = createEditorLayoutMemoryStorage();
+    const layoutStorage = createPersistentTestStorage(createEditorLayoutMemoryStorage);
     const { adapter, inspector } = await createHarness(layoutStorage);
     inspector.beginLayoutSession("bbm.main-layout");
     adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 1 }));
@@ -140,6 +155,71 @@ async function runM65LayoutPersistenceRoundtripTests(run) {
     for (const forbidden of ["selectedElement", "selectionModeActive", "editorActive", "activeLayoutControlMode", "Meldung", "DOM", "ref", "registry", "metadata"]) {
       assert.equal(serialized.includes(forbidden), false, `${forbidden} darf nicht im Layoutspeicher stehen`);
     }
+  });
+
+  await run("M65 Kein gespeichertes Layout: Load meldet found false und Paneltext ist neutral", async () => {
+    const layoutStorage = createPersistentTestStorage(createEditorLayoutMemoryStorage);
+    const { inspector } = await createHarness(layoutStorage);
+    const loaded = inspector.loadSavedLayout("bbm.main-layout");
+    assert.equal(loaded.ok, true);
+    assert.equal(loaded.savedLayoutFound, false);
+    const panelSource = fs.readFileSync(PANEL_PATH, "utf8");
+    assert.match(panelSource, /Noch kein Layout gespeichert/);
+    assert.doesNotMatch(panelSource, /loadResult\?\.ok \? "Gespeichertes Layout geladen"/);
+  });
+
+  await run("M65 Default-Storage: ohne Browser-Storage nicht persistent und Save bleibt Fehler", async () => {
+    const previousStorage = global.localStorage;
+    delete global.localStorage;
+    try {
+      const [{ createBbmMainUiHostAdapter }, refs] = await Promise.all([importEsmFromFile(HOST_ADAPTER_PATH), importEsmFromFile(REFS_PATH)]);
+      refs.clearBbmUiElementRefs();
+      global.HTMLElement = TestRef;
+      refs.registerBbmUiElementRef("bbm.uiEditorTest.card", new TestRef());
+      const adapter = createBbmMainUiHostAdapter({ registry: [{ id: "bbm.uiEditorTest.card", elementId: "bbm.uiEditorTest.card", name: "Testkarte", type: "card", role: "content", parentId: null, order: 1, visible: true, editable: true, allowedOps: ["move"], lockedOps: [] }] });
+      assert.deepEqual(adapter.getPersistenceStatus(), { persistenceAvailable: false, persistencePersistent: false });
+      assert.equal(adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 5 })).ok, true);
+      const result = adapter.saveLayoutSession();
+      assert.equal(result.ok, false);
+      assert.equal(result.reason, "LAYOUT_STORAGE_NOT_PERSISTENT");
+    } finally {
+      global.localStorage = previousStorage;
+    }
+  });
+
+  await run("M65 Beschädigtes JSON: Load meldet Fehler und wendet nichts an", async () => {
+    const previousStorage = global.localStorage;
+    global.localStorage = { getItem: () => "{ kaputt", setItem() {}, removeItem() {} };
+    try {
+      const [{ createBbmMainUiHostAdapter }, { createBbmMainUiLayoutStorage }, refs] = await Promise.all([importEsmFromFile(HOST_ADAPTER_PATH), importEsmFromFile(DEFAULT_STORAGE_PATH), importEsmFromFile(REFS_PATH)]);
+      refs.clearBbmUiElementRefs();
+      global.HTMLElement = TestRef;
+      const ref = new TestRef();
+      refs.registerBbmUiElementRef("bbm.uiEditorTest.card", ref);
+      const layoutStorage = createBbmMainUiLayoutStorage("m65.corrupt.storage");
+      const adapter = createBbmMainUiHostAdapter({ registry: [{ id: "bbm.uiEditorTest.card", elementId: "bbm.uiEditorTest.card", name: "Testkarte", type: "card", role: "content", parentId: null, order: 1, visible: true, editable: true, allowedOps: ["move"], lockedOps: [] }], layoutStorage });
+      const result = adapter.loadSavedLayout();
+      assert.equal(result.ok, false);
+      assert.equal(result.reason, "LAYOUT_STORAGE_READ_FAILED");
+      assert.equal(ref.style.values.transform, undefined);
+      const panelSource = fs.readFileSync(PANEL_PATH, "utf8");
+      assert.match(panelSource, /Gespeichertes Layout konnte nicht geladen werden\./);
+    } finally {
+      global.localStorage = previousStorage;
+    }
+  });
+
+  await run("M65 Schreibfehler: Save bleibt Fehler, Änderungen bleiben offen und Verwerfen funktioniert", async () => {
+    const failingStorage = { available: true, persistent: true, readResult: () => ({ ok: true, found: false, payload: null }), read: () => null, write: () => { const error = new Error("write failed"); error.code = "LAYOUT_STORAGE_WRITE_FAILED"; throw error; }, clear() {} };
+    const { adapter, inspector, refs } = await createHarness(failingStorage);
+    inspector.beginLayoutSession("bbm.main-layout");
+    adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 5 }));
+    const result = inspector.saveLayoutSession("bbm.main-layout");
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "LAYOUT_STORAGE_WRITE_FAILED");
+    assert.equal(inspector.getLayoutSessionStatus("bbm.main-layout").changedCount, 1);
+    assert.equal(inspector.discardLayoutSessionElement("bbm.main-layout", "bbm.uiEditorTest.card").ok, true);
+    assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card").style.values.transform, "translate(0px, 0px)");
   });
 
   await run("M65 Default-Storage: separater Adapter nutzt Browser-Storage, falls vorhanden", async () => {
@@ -170,7 +250,7 @@ async function runM65LayoutPersistenceRoundtripTests(run) {
     assert.equal(result.ok, false);
     assert.equal(inspector.getLayoutSessionStatus("bbm.main-layout").active, true);
     const panelSource = fs.readFileSync(PANEL_PATH, "utf8");
-    assert.match(panelSource, /Layout konnte nicht gespeichert werden\./);
+    assert.match(panelSource, /Layout konnte nicht dauerhaft gespeichert werden\./);
     assert.doesNotMatch(panelSource, /localStorage/);
   });
 }

--- a/src/renderer/editorRuntime/inspector/editorScopeInspector.js
+++ b/src/renderer/editorRuntime/inspector/editorScopeInspector.js
@@ -281,11 +281,14 @@ export function createEditorScopeInspector({
   function buildLayoutSessionStatus(scopeId, context) {
     const normalizedScopeId = normalizeId(scopeId);
     const session = layoutSessions.get(normalizedScopeId) || null;
+    const persistenceStatus = typeof context.hostAdapter?.getPersistenceStatus === "function"
+      ? context.hostAdapter.getPersistenceStatus()
+      : { persistenceAvailable: false, persistencePersistent: false };
     if (!context.ok) {
-      return { ok: false, active: Boolean(session), changedElementIds: [], changedCount: 0, changedByElementId: {}, errors: context.inspection.errors || [] };
+      return { ...persistenceStatus, ok: false, active: Boolean(session), changedElementIds: [], changedCount: 0, changedByElementId: {}, errors: context.inspection.errors || [] };
     }
     if (!session) {
-      return { ok: true, active: false, changedElementIds: [], changedCount: 0, changedByElementId: {} };
+      return { ...persistenceStatus, ok: true, active: false, changedElementIds: [], changedCount: 0, changedByElementId: {} };
     }
     const currentLayoutState = typeof context.hostAdapter.getCurrentLayoutState === "function" ? context.hostAdapter.getCurrentLayoutState() : [];
     const changedElementIds = context.registry
@@ -296,6 +299,7 @@ export function createEditorScopeInspector({
         session.baselineByElementId.get(elementId)?.layoutValue || null
       ));
     return {
+      ...persistenceStatus,
       ok: true,
       active: true,
       changedElementIds,
@@ -367,6 +371,7 @@ export function createEditorScopeInspector({
     }
     const result = context.hostAdapter.loadSavedLayout();
     if (!result?.ok) return { ...result, status: buildLayoutSessionStatus(scopeId, context) };
+    if (!result.savedLayoutFound) return { ...result, status: buildLayoutSessionStatus(scopeId, context) };
     return { ...result, status: resetSessionBaseline(scopeId, context) };
   }
 

--- a/src/renderer/editorRuntime/inspector/editorScopeInspector.js
+++ b/src/renderer/editorRuntime/inspector/editorScopeInspector.js
@@ -329,6 +329,47 @@ export function createEditorScopeInspector({
     return buildLayoutSessionStatus(scopeId, context);
   }
 
+
+  function resetSessionBaseline(scopeId, context) {
+    const normalizedScopeId = normalizeId(context.scope.scopeId);
+    const layoutState = typeof context.hostAdapter.getCurrentLayoutState === "function" ? context.hostAdapter.getCurrentLayoutState() : [];
+    const byElementId = new Map(layoutState.map((entry) => [normalizeId(entry?.elementId), cloneLayoutEntry(entry)]));
+    layoutSessions.set(normalizedScopeId, {
+      startedAt: new Date().toISOString(),
+      baselineByElementId: new Map(context.registry.map((element) => {
+        const elementId = normalizeId(element?.id || element?.elementId);
+        return [elementId, byElementId.get(elementId) || null];
+      })),
+    });
+    return buildLayoutSessionStatus(normalizedScopeId, context);
+  }
+
+  function saveLayoutSession(scopeId) {
+    const context = prepareScopeContext(scopeId);
+    if (!context.ok) {
+      return { ok: false, blocked: true, reason: context.inspection.errors?.[0]?.code || "SCOPE_UNAVAILABLE", status: buildLayoutSessionStatus(scopeId, context) };
+    }
+    if (typeof context.hostAdapter.saveLayoutSession !== "function") {
+      return { ok: false, blocked: true, reason: "HOST_SAVE_LAYOUT_SESSION_MISSING", status: buildLayoutSessionStatus(scopeId, context) };
+    }
+    const result = context.hostAdapter.saveLayoutSession();
+    if (!result?.ok) return { ...result, status: buildLayoutSessionStatus(scopeId, context) };
+    return { ...result, status: resetSessionBaseline(scopeId, context) };
+  }
+
+  function loadSavedLayout(scopeId) {
+    const context = prepareScopeContext(scopeId);
+    if (!context.ok) {
+      return { ok: false, blocked: true, reason: context.inspection.errors?.[0]?.code || "SCOPE_UNAVAILABLE", status: buildLayoutSessionStatus(scopeId, context) };
+    }
+    if (typeof context.hostAdapter.loadSavedLayout !== "function") {
+      return { ok: false, blocked: true, reason: "HOST_LOAD_SAVED_LAYOUT_MISSING", status: buildLayoutSessionStatus(scopeId, context) };
+    }
+    const result = context.hostAdapter.loadSavedLayout();
+    if (!result?.ok) return { ...result, status: buildLayoutSessionStatus(scopeId, context) };
+    return { ...result, status: resetSessionBaseline(scopeId, context) };
+  }
+
   function restoreBaselineForElementIds(scopeId, elementIds) {
     const context = prepareScopeContext(scopeId);
     if (!context.ok) {
@@ -374,6 +415,8 @@ export function createEditorScopeInspector({
     resetLayoutState,
     beginLayoutSession,
     getLayoutSessionStatus,
+    saveLayoutSession,
+    loadSavedLayout,
     discardLayoutSessionElement,
     discardLayoutSession,
     endLayoutSession,

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -166,9 +166,15 @@ export class BbmUiEditorStatusPanel {
     if (!this.savedLayoutLoadedForSession) {
       const loadResult = this.inspectorBridge?.loadSavedLayout?.();
       this.layoutSessionStatus = loadResult?.status || this.layoutSessionStatus;
-      this.layoutPersistenceStatus = loadResult?.ok ? "Gespeichertes Layout geladen" : "Noch nicht gespeichert";
+      this.layoutPersistenceStatus = loadResult?.ok
+        ? (loadResult.savedLayoutFound ? "Gespeichertes Layout geladen" : "Noch kein Layout gespeichert")
+        : "Gespeichertes Layout konnte nicht geladen werden.";
       this.savedLayoutLoadedForSession = true;
-      this.beginLayoutSession();
+      if (loadResult?.ok && loadResult.savedLayoutFound) {
+        this.layoutSessionStatus = loadResult?.status || this.layoutSessionStatus;
+      } else {
+        this.beginLayoutSession();
+      }
     } else {
       this.refreshLayoutSessionStatus();
     }
@@ -490,7 +496,9 @@ export class BbmUiEditorStatusPanel {
     const save = createNode("button", "bbm-ui-editor-panel__secondary");
     save.type = "button";
     save.textContent = "Änderungen speichern";
-    save.disabled = !this.editorActive || changeCount === 0 || !this.status?.layoutStoreAvailable;
+    const persistenceAvailable = this.layoutSessionStatus?.persistenceAvailable !== false;
+    const persistencePersistent = this.layoutSessionStatus?.persistencePersistent !== false;
+    save.disabled = !this.editorActive || changeCount === 0 || !persistenceAvailable || !persistencePersistent;
     save.addEventListener("click", () => this.saveLayoutSession());
     const toggle = createNode("button", "bbm-ui-editor-panel__secondary");
     toggle.type = "button";
@@ -630,8 +638,8 @@ export class BbmUiEditorStatusPanel {
     if (!this.editorActive || this.getOpenChangeCount() === 0) return;
     const result = this.inspectorBridge?.saveLayoutSession?.();
     this.layoutSessionStatus = result?.status || this.layoutSessionStatus;
-    this.layoutPersistenceStatus = result?.ok ? "Layout gespeichert" : "Layout konnte nicht gespeichert werden.";
-    this.selectionMessage = result?.ok ? "Layout gespeichert." : "Layout konnte nicht gespeichert werden.";
+    this.layoutPersistenceStatus = result?.ok ? "Layout gespeichert" : "Layout konnte nicht dauerhaft gespeichert werden.";
+    this.selectionMessage = result?.ok ? "Layout gespeichert." : "Layout konnte nicht dauerhaft gespeichert werden.";
     this.renderAll();
     this.syncActiveSelectionRuntime();
   }

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -61,6 +61,8 @@ export class BbmUiEditorStatusPanel {
     this.lastRenderedLayoutControlElementId = "";
     this.editorActive = true;
     this.layoutSessionStatus = { ok: true, active: false, changedElementIds: [], changedCount: 0, changedByElementId: {} };
+    this.layoutPersistenceStatus = "Noch nicht gespeichert";
+    this.savedLayoutLoadedForSession = false;
     this.inspectorBridge = createBbmEditorRuntimeInspectorBridge({
       getRegistryElements: () => this.elements,
       getSelectedElement: () => this.selectedElement,
@@ -128,6 +130,7 @@ export class BbmUiEditorStatusPanel {
     this.stopSelectionMode();
     this.destroyKitController();
     this.inspectorBridge?.endLayoutSession?.();
+    this.savedLayoutLoadedForSession = false;
     try {
       await window.bbmDb?.uiEditorClose?.();
     } catch (_e) {
@@ -160,7 +163,15 @@ export class BbmUiEditorStatusPanel {
     this.refStatus = getBbmUiElementRefStatus();
     this.elements = Array.isArray(elementsResult?.elements) ? elementsResult.elements : [];
     this.selectedElement = detailsResult?.selectedElement || null;
-    this.beginLayoutSession();
+    if (!this.savedLayoutLoadedForSession) {
+      const loadResult = this.inspectorBridge?.loadSavedLayout?.();
+      this.layoutSessionStatus = loadResult?.status || this.layoutSessionStatus;
+      this.layoutPersistenceStatus = loadResult?.ok ? "Gespeichertes Layout geladen" : "Noch nicht gespeichert";
+      this.savedLayoutLoadedForSession = true;
+      this.beginLayoutSession();
+    } else {
+      this.refreshLayoutSessionStatus();
+    }
     this.renderAll();
     await this.initializeDefaultSelectionRuntime();
   }
@@ -474,6 +485,13 @@ export class BbmUiEditorStatusPanel {
     const changeCount = this.getOpenChangeCount();
     const status = createNode("p", "bbm-ui-editor-panel__empty");
     status.textContent = changeCount > 0 ? `Änderungen offen: ${changeCount}` : "Keine offenen Änderungen";
+    const persistence = createNode("p", "bbm-ui-editor-panel__empty");
+    persistence.textContent = this.layoutPersistenceStatus || "Noch nicht gespeichert";
+    const save = createNode("button", "bbm-ui-editor-panel__secondary");
+    save.type = "button";
+    save.textContent = "Änderungen speichern";
+    save.disabled = !this.editorActive || changeCount === 0 || !this.status?.layoutStoreAvailable;
+    save.addEventListener("click", () => this.saveLayoutSession());
     const toggle = createNode("button", "bbm-ui-editor-panel__secondary");
     toggle.type = "button";
     toggle.textContent = this.editorActive ? "Editor ausschalten" : "Editor einschalten";
@@ -483,7 +501,7 @@ export class BbmUiEditorStatusPanel {
     discardAll.textContent = "Alle Änderungen verwerfen";
     discardAll.disabled = changeCount === 0;
     discardAll.addEventListener("click", () => this.discardAllSessionChanges());
-    box.append(status, toggle, discardAll);
+    box.append(status, persistence, save, toggle, discardAll);
     this.detailsNode.appendChild(box);
   }
 
@@ -608,6 +626,16 @@ export class BbmUiEditorStatusPanel {
     this.renderAll();
   }
 
+  saveLayoutSession() {
+    if (!this.editorActive || this.getOpenChangeCount() === 0) return;
+    const result = this.inspectorBridge?.saveLayoutSession?.();
+    this.layoutSessionStatus = result?.status || this.layoutSessionStatus;
+    this.layoutPersistenceStatus = result?.ok ? "Layout gespeichert" : "Layout konnte nicht gespeichert werden.";
+    this.selectionMessage = result?.ok ? "Layout gespeichert." : "Layout konnte nicht gespeichert werden.";
+    this.renderAll();
+    this.syncActiveSelectionRuntime();
+  }
+
   discardSelectedElementChanges() {
     const elementId = String(this.selectedElement?.elementId || this.selectedElement?.id || "").trim();
     if (!elementId || !this.selectedElement?.editable || !this.hasSessionChange(elementId)) return;
@@ -615,6 +643,7 @@ export class BbmUiEditorStatusPanel {
     this.layoutSessionStatus = result?.status || this.layoutSessionStatus;
     const label = asText(this.selectedElement?.label || this.selectedElement?.name, elementId);
     this.selectionMessage = result?.ok ? `Änderungen für ${label} verworfen.` : "Änderungen konnten nicht verworfen werden.";
+    if (!result?.ok) this.layoutPersistenceStatus = "Speichern fehlgeschlagen";
     this.renderAll();
     this.syncActiveSelectionRuntime();
   }
@@ -624,6 +653,7 @@ export class BbmUiEditorStatusPanel {
     const result = this.inspectorBridge?.discardAllSessionChanges?.();
     this.layoutSessionStatus = result?.status || this.layoutSessionStatus;
     this.selectionMessage = result?.ok ? "Alle Änderungen dieser Sitzung wurden verworfen." : "Änderungen konnten nicht verworfen werden.";
+    if (!result?.ok) this.layoutPersistenceStatus = "Speichern fehlgeschlagen";
     this.renderAll();
     this.syncActiveSelectionRuntime();
   }
@@ -682,6 +712,7 @@ export class BbmUiEditorStatusPanel {
     this.editorActive = false;
     this.destroyKitController();
     this.inspectorBridge?.endLayoutSession?.();
+    this.savedLayoutLoadedForSession = false;
     this.selectionModeActive = false;
     for (const elementId of ["bbm.uiEditorTest.workspace", "bbm.uiEditorTest.card", "bbm.uiEditorTest.card.title", "bbm.uiEditorTest.card.text", "bbm.uiEditorTest.card.button", "bbm.uiEditorTest.card.input", "bbm.uiEditorTest.card.select", "bbm.uiEditorTest.table"]) { try { unregisterBbmUiElementRef(elementId); } catch (_error) {} }
     this.panelRoot = null;
@@ -810,6 +841,7 @@ export class BbmUiEditorStatusPanel {
     this.runtimeError = error?.message || String(error || "Kit-Runtime-Fehler");
     this.destroyKitController();
     this.inspectorBridge?.endLayoutSession?.();
+    this.savedLayoutLoadedForSession = false;
     this.selectionModeActive = false;
     this.hoverTargetLabel = "keines";
     this.renderAll();

--- a/src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js
+++ b/src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js
@@ -296,6 +296,14 @@ export function createBbmEditorRuntimeInspectorBridge(options = {}) {
     return callLayoutSessionMethod("getLayoutSessionStatus");
   }
 
+  function saveLayoutSession() {
+    return callLayoutSessionMethod("saveLayoutSession");
+  }
+
+  function loadSavedLayout() {
+    return callLayoutSessionMethod("loadSavedLayout");
+  }
+
   function discardSelectedElementChanges(elementId) {
     return callLayoutSessionMethod("discardLayoutSessionElement", normalizeId(elementId));
   }
@@ -308,7 +316,7 @@ export function createBbmEditorRuntimeInspectorBridge(options = {}) {
     return callLayoutSessionMethod("endLayoutSession");
   }
 
-  return { inspectSelectedElement, getSelectedElementControlPanel, applySelectedElementLayoutAction, beginLayoutSession, getLayoutSessionStatus, discardSelectedElementChanges, discardAllSessionChanges, endLayoutSession, getStatus };
+  return { inspectSelectedElement, getSelectedElementControlPanel, applySelectedElementLayoutAction, beginLayoutSession, getLayoutSessionStatus, saveLayoutSession, loadSavedLayout, discardSelectedElementChanges, discardAllSessionChanges, endLayoutSession, getStatus };
 }
 
 export const BBM_EDITOR_RUNTIME_INSPECTOR_BRIDGE_ROLE_BY_ID = ROLE_BY_ELEMENT_ID;

--- a/src/renderer/ui-editor/bbmMainUiHostAdapter.js
+++ b/src/renderer/ui-editor/bbmMainUiHostAdapter.js
@@ -153,13 +153,38 @@ export function createBbmMainUiHostAdapter({ registry = [], layoutStorage = shar
     return { ok: true, applied: true };
   }
 
-  function loadPersistentEntriesIntoSession() {
-    const savedEntries = persistentLayoutStore.list();
-    layoutStore.replace(savedEntries, runtimeRegistry.map((entry) => normalizeId(entry.id)).filter(Boolean));
-    return savedEntries;
+  function getPersistenceStatus() {
+    return {
+      persistenceAvailable: Boolean(layoutStorage?.available),
+      persistencePersistent: Boolean(layoutStorage?.persistent),
+    };
   }
 
-  loadPersistentEntriesIntoSession();
+  function readPersistentStorage() {
+    if (typeof layoutStorage?.readResult === "function") {
+      return layoutStorage.readResult();
+    }
+    try {
+      const payload = typeof layoutStorage?.read === "function" ? layoutStorage.read() : null;
+      return payload ? { ok: true, found: true, payload } : { ok: true, found: false, payload: null };
+    } catch (error) {
+      return { ok: false, found: false, payload: null, reason: error?.code || "LAYOUT_STORAGE_READ_FAILED" };
+    }
+  }
+
+  function loadPersistentEntriesIntoSession() {
+    const readResult = readPersistentStorage();
+    if (!readResult.ok) return { ok: false, savedLayoutFound: false, reason: readResult.reason || "LAYOUT_STORAGE_READ_FAILED", entries: [] };
+    if (!readResult.found) return { ok: true, savedLayoutFound: false, entries: [] };
+    const savedEntries = persistentLayoutStore.list();
+    layoutStore.replace(savedEntries, runtimeRegistry.map((entry) => normalizeId(entry.id)).filter(Boolean));
+    return { ok: true, savedLayoutFound: savedEntries.length > 0, entries: savedEntries };
+  }
+
+  const initialLoad = loadPersistentEntriesIntoSession();
+  if (!initialLoad.ok && initialLoad.reason !== "LAYOUT_STORAGE_UNAVAILABLE") {
+    // Der Fehler wird erst beim expliziten Laden sichtbar gemeldet.
+  }
 
   const adapter = {
     getRegistry() {
@@ -174,25 +199,40 @@ export function createBbmMainUiHostAdapter({ registry = [], layoutStorage = shar
       return persistentLayoutStore.list();
     },
 
+    getPersistenceStatus() {
+      return getPersistenceStatus();
+    },
+
     loadSavedLayout() {
       try {
-        const savedEntries = loadPersistentEntriesIntoSession();
-        const applyResult = applyEntries(savedEntries, { resetMissingSize: true });
-        if (!applyResult.ok) return { ok: false, blocked: true, reason: applyResult.reason, elementId: applyResult.elementId, layoutState: layoutStore.list() };
-        return { ok: true, blocked: false, reason: null, layoutState: layoutStore.list(), savedLayoutState: persistentLayoutStore.list() };
+        const loadResult = loadPersistentEntriesIntoSession();
+        if (!loadResult.ok) return { ...getPersistenceStatus(), ok: false, blocked: true, reason: loadResult.reason || "LAYOUT_LOAD_FAILED", savedLayoutFound: false, layoutState: layoutStore.list() };
+        if (!loadResult.savedLayoutFound) return { ...getPersistenceStatus(), ok: true, blocked: false, reason: null, savedLayoutFound: false, layoutState: layoutStore.list(), savedLayoutState: [] };
+        const applyResult = applyEntries(loadResult.entries, { resetMissingSize: true });
+        if (!applyResult.ok) return { ...getPersistenceStatus(), ok: false, blocked: true, reason: applyResult.reason, elementId: applyResult.elementId, savedLayoutFound: true, layoutState: layoutStore.list() };
+        return { ...getPersistenceStatus(), ok: true, blocked: false, reason: null, savedLayoutFound: true, layoutState: layoutStore.list(), savedLayoutState: persistentLayoutStore.list() };
       } catch (_error) {
-        return { ok: false, blocked: true, reason: "LAYOUT_LOAD_FAILED", layoutState: layoutStore.list() };
+        return { ...getPersistenceStatus(), ok: false, blocked: true, reason: "LAYOUT_LOAD_FAILED", savedLayoutFound: false, layoutState: layoutStore.list() };
       }
     },
 
     saveLayoutSession() {
+      const persistence = getPersistenceStatus();
+      if (!persistence.persistenceAvailable || !persistence.persistencePersistent) {
+        return { ...persistence, ok: false, blocked: true, reason: "LAYOUT_STORAGE_NOT_PERSISTENT", layoutState: layoutStore.list() };
+      }
       try {
         const ids = runtimeRegistry.map((entry) => normalizeId(entry.id)).filter(Boolean);
         const layoutState = layoutStore.list();
         persistentLayoutStore.replace(layoutState, ids);
-        return { ok: true, blocked: false, reason: null, layoutState: layoutStore.list(), savedLayoutState: persistentLayoutStore.list() };
-      } catch (_error) {
-        return { ok: false, blocked: true, reason: "LAYOUT_SAVE_FAILED", layoutState: layoutStore.list() };
+        const verify = readPersistentStorage();
+        if (!verify.ok || !verify.found) {
+          return { ...persistence, ok: false, blocked: true, reason: verify.reason || "LAYOUT_STORAGE_VERIFY_FAILED", layoutState: layoutStore.list() };
+        }
+        const savedLayoutState = persistentLayoutStore.list();
+        return { ...persistence, ok: true, blocked: false, reason: null, savedLayoutFound: savedLayoutState.length > 0, layoutState: layoutStore.list(), savedLayoutState };
+      } catch (error) {
+        return { ...persistence, ok: false, blocked: true, reason: error?.code || "LAYOUT_SAVE_FAILED", layoutState: layoutStore.list() };
       }
     },
 

--- a/src/renderer/ui-editor/bbmMainUiHostAdapter.js
+++ b/src/renderer/ui-editor/bbmMainUiHostAdapter.js
@@ -6,6 +6,7 @@ import {
   normalizeEditorLayoutValue,
 } from "../editorRuntime/layout/editorLayoutPersistence.js";
 import { getBbmUiElementRef } from "./bbmUiElementRefs.js";
+import { createBbmMainUiLayoutStorage } from "./bbmMainUiLayoutStorage.js";
 
 const SCOPE = Object.freeze({
   targetAppId: "bbm-produktiv",
@@ -13,7 +14,7 @@ const SCOPE = Object.freeze({
   scopeId: "bbm.main-layout",
 });
 
-const sharedLayoutStorage = createEditorLayoutMemoryStorage();
+const sharedLayoutStorage = createBbmMainUiLayoutStorage();
 const DEFAULT_MIN_WIDTH = 20;
 const DEFAULT_MIN_HEIGHT = 20;
 
@@ -132,10 +133,33 @@ function applyLayoutValueToRegisteredTarget(elementId, layoutValue, { resetMissi
 
 export function createBbmMainUiHostAdapter({ registry = [], layoutStorage = sharedLayoutStorage, onChangeRequest = null } = {}) {
   const runtimeRegistry = cloneRegistry(registry);
-  const layoutStore = createEditorLayoutStore({
+  const persistentLayoutStore = createEditorLayoutStore({
     scope: SCOPE,
     storage: layoutStorage,
   });
+  const sessionLayoutStorage = createEditorLayoutMemoryStorage();
+  const layoutStore = createEditorLayoutStore({
+    scope: SCOPE,
+    storage: sessionLayoutStorage,
+  });
+
+  function applyEntries(entries = [], { resetMissingSize = false } = {}) {
+    for (const entry of Array.isArray(entries) ? entries : []) {
+      const elementId = normalizeId(entry?.elementId);
+      if (!elementId) continue;
+      const applyResult = applyLayoutValueToRegisteredTarget(elementId, entry?.layoutValue || {}, { resetMissingSize });
+      if (!applyResult.ok) return { ok: false, reason: applyResult.reason, elementId };
+    }
+    return { ok: true, applied: true };
+  }
+
+  function loadPersistentEntriesIntoSession() {
+    const savedEntries = persistentLayoutStore.list();
+    layoutStore.replace(savedEntries, runtimeRegistry.map((entry) => normalizeId(entry.id)).filter(Boolean));
+    return savedEntries;
+  }
+
+  loadPersistentEntriesIntoSession();
 
   const adapter = {
     getRegistry() {
@@ -144,6 +168,32 @@ export function createBbmMainUiHostAdapter({ registry = [], layoutStorage = shar
 
     getCurrentLayoutState() {
       return layoutStore.list();
+    },
+
+    getSavedLayoutState() {
+      return persistentLayoutStore.list();
+    },
+
+    loadSavedLayout() {
+      try {
+        const savedEntries = loadPersistentEntriesIntoSession();
+        const applyResult = applyEntries(savedEntries, { resetMissingSize: true });
+        if (!applyResult.ok) return { ok: false, blocked: true, reason: applyResult.reason, elementId: applyResult.elementId, layoutState: layoutStore.list() };
+        return { ok: true, blocked: false, reason: null, layoutState: layoutStore.list(), savedLayoutState: persistentLayoutStore.list() };
+      } catch (_error) {
+        return { ok: false, blocked: true, reason: "LAYOUT_LOAD_FAILED", layoutState: layoutStore.list() };
+      }
+    },
+
+    saveLayoutSession() {
+      try {
+        const ids = runtimeRegistry.map((entry) => normalizeId(entry.id)).filter(Boolean);
+        const layoutState = layoutStore.list();
+        persistentLayoutStore.replace(layoutState, ids);
+        return { ok: true, blocked: false, reason: null, layoutState: layoutStore.list(), savedLayoutState: persistentLayoutStore.list() };
+      } catch (_error) {
+        return { ok: false, blocked: true, reason: "LAYOUT_SAVE_FAILED", layoutState: layoutStore.list() };
+      }
     },
 
     submitChangeRequest(changeRequest) {

--- a/src/renderer/ui-editor/bbmMainUiLayoutStorage.js
+++ b/src/renderer/ui-editor/bbmMainUiLayoutStorage.js
@@ -10,29 +10,75 @@ function getBrowserStorage() {
   }
 }
 
+function clonePayload(payload) {
+  return payload && typeof payload === "object" && !Array.isArray(payload) ? structuredClone(payload) : null;
+}
+
 export function createBbmMainUiLayoutStorage(key = BBM_MAIN_UI_LAYOUT_STORAGE_KEY) {
   const storage = getBrowserStorage();
-  if (!storage || typeof storage.getItem !== "function" || typeof storage.setItem !== "function") {
-    return createEditorLayoutMemoryStorage();
+  const available = Boolean(storage && typeof storage.getItem === "function" && typeof storage.setItem === "function");
+
+  function readResult() {
+    if (!available) {
+      return { ok: false, found: false, payload: null, reason: "LAYOUT_STORAGE_UNAVAILABLE" };
+    }
+    try {
+      const raw = storage.getItem(key);
+      if (raw === null) return { ok: true, found: false, payload: null };
+      return { ok: true, found: true, payload: JSON.parse(raw) };
+    } catch (_error) {
+      return { ok: false, found: false, payload: null, reason: "LAYOUT_STORAGE_READ_FAILED" };
+    }
   }
 
   return {
+    available,
+    persistent: available,
+    readResult,
     read() {
-      try {
-        const raw = storage.getItem(key);
-        return raw ? JSON.parse(raw) : null;
-      } catch (_error) {
-        return null;
+      const result = readResult();
+      if (!result.ok) {
+        const error = new Error(result.reason || "LAYOUT_STORAGE_READ_FAILED");
+        error.code = result.reason || "LAYOUT_STORAGE_READ_FAILED";
+        throw error;
       }
+      return result.found ? clonePayload(result.payload) : null;
     },
     write(nextPayload) {
-      const payload = nextPayload && typeof nextPayload === "object" && !Array.isArray(nextPayload) ? structuredClone(nextPayload) : null;
-      storage.setItem(key, JSON.stringify(payload));
+      if (!available) {
+        const error = new Error("LAYOUT_STORAGE_UNAVAILABLE");
+        error.code = "LAYOUT_STORAGE_UNAVAILABLE";
+        throw error;
+      }
+      const payload = clonePayload(nextPayload);
+      try {
+        storage.setItem(key, JSON.stringify(payload));
+      } catch (_error) {
+        const error = new Error("LAYOUT_STORAGE_WRITE_FAILED");
+        error.code = "LAYOUT_STORAGE_WRITE_FAILED";
+        throw error;
+      }
       return payload;
     },
     clear() {
+      if (!available) return;
       storage.removeItem(key);
     },
+  };
+}
+
+export function createBbmMainUiMemoryLayoutStorage(initialPayload = null) {
+  const storage = createEditorLayoutMemoryStorage(initialPayload);
+  return {
+    available: true,
+    persistent: false,
+    readResult() {
+      const payload = storage.read();
+      return payload ? { ok: true, found: true, payload } : { ok: true, found: false, payload: null };
+    },
+    read: storage.read,
+    write: storage.write,
+    clear: storage.clear,
   };
 }
 

--- a/src/renderer/ui-editor/bbmMainUiLayoutStorage.js
+++ b/src/renderer/ui-editor/bbmMainUiLayoutStorage.js
@@ -1,0 +1,39 @@
+import { createEditorLayoutMemoryStorage } from "../editorRuntime/layout/editorLayoutPersistence.js";
+
+const BBM_MAIN_UI_LAYOUT_STORAGE_KEY = "bbm.uiEditor.layout.bbm-main.v1";
+
+function getBrowserStorage() {
+  try {
+    return globalThis?.localStorage || null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+export function createBbmMainUiLayoutStorage(key = BBM_MAIN_UI_LAYOUT_STORAGE_KEY) {
+  const storage = getBrowserStorage();
+  if (!storage || typeof storage.getItem !== "function" || typeof storage.setItem !== "function") {
+    return createEditorLayoutMemoryStorage();
+  }
+
+  return {
+    read() {
+      try {
+        const raw = storage.getItem(key);
+        return raw ? JSON.parse(raw) : null;
+      } catch (_error) {
+        return null;
+      }
+    },
+    write(nextPayload) {
+      const payload = nextPayload && typeof nextPayload === "object" && !Array.isArray(nextPayload) ? structuredClone(nextPayload) : null;
+      storage.setItem(key, JSON.stringify(payload));
+      return payload;
+    },
+    clear() {
+      storage.removeItem(key);
+    },
+  };
+}
+
+export { BBM_MAIN_UI_LAYOUT_STORAGE_KEY };


### PR DESCRIPTION
### Motivation
- Ermöglichen, dass in M64 bearbeitete Layoutwerte explizit gespeichert und nach einem Neustart wiederhergestellt werden können.  
- Klarer Arbeitsablauf: Layout ändern → speichern → App/Editor schließen → erneut öffnen → gespeichertes Layout ist wieder da.  
- Keine DOM- oder Panel‑Persistenz, keine Layoutprofile oder Autosave; die Persistenz soll über vorhandene Storage‑Adapter laufen.  

### Description
- Öffentliches Session-API/Flows ergänzt: `saveLayoutSession(scopeId)` und `loadSavedLayout(scopeId)` in `editorScopeInspector.js` und durchgereicht über `bbmEditorRuntimeInspectorBridge.js`.  
- HostAdapter: `bbmMainUiHostAdapter.js` trennt Session‑LayoutStore und persistenten Store; `saveLayoutSession()` schreibt persistent, `loadSavedLayout()` lädt persistent in die Sitzung und wendet Werte auf registrierte Refs an.  
- Separater, kapselnder Storage‑Adapter `src/renderer/ui-editor/bbmMainUiLayoutStorage.js` wurde eingeführt, der Browser‑Storage (localStorage) nutzt, aber mit Memory‑Fallback; dadurch bleibt keine direkte localStorage‑Logik im Panel.  
- UI: das Statuspanel (`BbmUiEditorStatusPanel.js`) zeigt Persistenzstatus, lädt gespeichertes Layout beim Öffnen einmalig und bietet den Button „Änderungen speichern“ mit neutraler Erfolgs-/Fehleranzeige.  
- Tests: neuer Roundtrip‑Test `scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs` hinzugefügt und in `scripts/test.cjs` eingebunden.  
- Dokumentation/Status: `docs/UI_INSPEKTOR_AUFGABENHEFT.md` und `STATUS.md` aktualisiert.  

### Testing
- Automatisierte Prüfungen ausgeführt:  
  - `node scripts/ui-editor-contract-check.cjs` — OK.  
  - `node scripts/ui-editor-contract-check.cjs --self-test` — OK.  
  - `node scripts/tests/m63cRealRegistryPanelIntegration.test.cjs` — OK.  
  - `node scripts/tests/m63cLayoutControlConsole.test.cjs` — OK.  
  - `node scripts/tests/m64UiEditorTestSurface.test.cjs` — OK.  
  - `node scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs` — OK (Speichern, Laden, Verwerfen einzeln, Alle verwerfen, Guardrails, Default‑Storage und Fehlerfall getestet).  
  - `node scripts/test.cjs` — in dieser Cloud‑Umgebung teilweise fehlgeschlagen wegen native Abhängigkeiten (`better-sqlite3` Node‑ABI‑Konflikt); die ui‑editor‑bezogenen Tests sind grün.  
  - `npm test` — in dieser Cloud‑Umgebung nicht ausführbar wegen fehlender Electron Systembibliothek (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ce66cf2408322b11d0d715aa3eda7)