### PR TITLE
M67: UI-Editor — Ausgewähltes Element dauerhaft auf Standard zurücksetzen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -3337,3 +3337,22 @@ Wichtig:
   - `npm test` in dieser Umgebung wegen fehlender Electron-Systembibliothek `libatk-1.0.so.0` nicht ausführbar
 - Nächster offener Schritt:
   - Lokale Windows-/Electron-Abnahme des Dialogablaufs auf dem Zielsystem wiederholen; die Tabelle darf beim Öffnen, Abbrechen oder Bestätigen nicht springen.
+
+## M67 Korrektur 4 – M63C-Operationspfad bei fehlender Persistenz
+- Status: umgesetzt im Korrekturcommit zu PR #207.
+- Beschreibung:
+  - Der elementbezogene M67-Persistenzstatus blockiert den Inspector-/Bridge-Pfad nicht mehr, wenn kein persistenter Browser-Storage verfügbar ist.
+  - `getSavedEntry(elementId)` behandelt nicht verfügbare Persistenz als „kein gespeicherter Eintrag“ statt den Inspector mit `LAYOUT_STORAGE_UNAVAILABLE` abbrechen zu lassen.
+  - Damit bleiben M63C-`allowedOps`/`effectiveOps`, Schrittweite 5 und Richtungspfeil-Aktivierung vollständig registry-/inspectorgeführt.
+- Prüfung:
+  - `node scripts/tests/m63cLayoutControlConsole.test.cjs` OK
+  - `node scripts/tests/m67ResetElementToDefaults.test.cjs` OK
+  - `git diff --check` OK
+  - `node scripts/ui-editor-contract-check.cjs` OK
+  - `node scripts/ui-editor-contract-check.cjs --self-test` OK
+  - `node scripts/tests/m66ResetLayoutToDefaults.test.cjs` OK
+  - `node scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs` OK
+  - `node scripts/tests/m64UiEditorTestSurface.test.cjs` OK
+  - `npm test` in dieser Umgebung wegen fehlender Electron-Systembibliothek `libatk-1.0.so.0` nicht ausführbar
+- Nächster offener Schritt:
+  - Vollständigen `npm test` lokal/CI mit vorhandenen Electron-Systembibliotheken erneut ausführen.

--- a/STATUS.md
+++ b/STATUS.md
@@ -3258,3 +3258,24 @@ Wichtig:
 - Nach erfolgreichem Standardreset ist der Session-LayoutStore wieder ein leerer Abweichungszustand; der persistente Default-Scope enthält keine Layoutentries.
 - M66-Tests prüfen den ursprünglichen Inline-Zustand, den Reset auf fehlende Inlinewerte, CSS-Quellen für Karte/Tabelle, Neustart, Abbrechen, Scope-/Profil-Isolation und Rollbackfälle.
 - Nächster offener Schritt: praktische Windows-Prüfung des UI-Editor-Ablaufs bleibt fachlich durchzuführen.
+
+## M67 Abschlussnotiz – ausgewähltes Element auf Standard zurücksetzen
+- M67 ergänzt den vierten klar getrennten Rücksetzweg „Element auf Standard …“ im Bereich des aktuell ausgewählten Elements.
+- Der Button öffnet einen Bestätigungsdialog mit lesbarem Elementnamen und ohne technische ID; „Abbrechen“ führt keine API- oder Layoutänderung aus.
+- Der Erfolgsweg läuft Panel → Inspector-Bridge → Inspector → BBM-Main-HostAdapter → Session- und persistenter LayoutStore → expliziter HTMLElement-Ref.
+- Aus dem persistenten Defaultprofil wird nur der Eintrag des ausgewählten Elements entfernt; andere Elemente, fremde Profile und fremde Scopes bleiben erhalten.
+- Aus dem Session-LayoutStore und aus der Sitzungsbaseline wird ebenfalls nur das ausgewählte Element auf CSS-/Registry-Standard aktualisiert; Kind- und Elternelemente bleiben isoliert.
+- Sichtbar entfernt der HostAdapter nur Editor-Inlinewerte (`transform`, `width`, `height`) und setzt `hidden` gemäß Registry-/Layout-Default; Fachinhalte bleiben unverändert.
+- Strukturierte Statusfelder (`selectedElementHasSavedLayout`, `selectedElementDeviatesFromDefaults`, `selectedElementCanResetToDefaults`) steuern die Button-Aktivierung ohne Textvergleich oder ID-Sonderfall im Panel.
+- Neuer Guardrail-/Regressionstest: `scripts/tests/m67ResetElementToDefaults.test.cjs`; `scripts/test.cjs` bindet den M67-Test ein.
+- Prüfung in Codex Cloud:
+  - `node scripts/ui-editor-contract-check.cjs` OK
+  - `node scripts/ui-editor-contract-check.cjs --self-test` OK
+  - `node scripts/tests/m64UiEditorTestSurface.test.cjs` OK
+  - `node scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs` OK
+  - `node scripts/tests/m66ResetLayoutToDefaults.test.cjs` OK
+  - `node scripts/tests/m67ResetElementToDefaults.test.cjs` OK
+  - `timeout 180s node scripts/test.cjs` erreicht nur OK-Ausgaben, beendet aber nicht innerhalb des Cloud-Zeitfensters
+  - `npm test` in dieser Umgebung wegen fehlender Electron-Systembibliothek `libatk-1.0.so.0` nicht ausführbar
+- Nächster offener Schritt:
+  - Praktische Windows-/Electron-Abnahme des vollständigen M67-Nutzerablaufs lokal durchführen; in Codex Cloud nicht verfügbar.

--- a/STATUS.md
+++ b/STATUS.md
@@ -3279,3 +3279,22 @@ Wichtig:
   - `npm test` in dieser Umgebung wegen fehlender Electron-Systembibliothek `libatk-1.0.so.0` nicht ausführbar
 - Nächster offener Schritt:
   - Praktische Windows-/Electron-Abnahme des vollständigen M67-Nutzerablaufs lokal durchführen; in Codex Cloud nicht verfügbar.
+
+## M67 Korrektur – strukturierter Elementstatus erreicht echten Bridge-Pfad
+- Status: umgesetzt im Korrekturcommit nach Reviewbefund.
+- Beschreibung:
+  - Der BBM-Main-HostAdapter reicht `getPersistenceStatus({ elementId })` jetzt bis in die interne Statusberechnung durch, statt das ausgewählte Elementargument zu verwerfen.
+  - Dadurch erreichen `selectedElementHasSavedLayout`, `selectedElementDeviatesFromDefaults` und `selectedElementCanResetToDefaults` den echten `EditorLayoutControls`-/Bridge-/Panelpfad.
+  - Der M67-Test prüft nun zusätzlich den echten Bridge-Statuspfad mit gespeichertem Layout und aktivierbarem Einzelreset.
+- Prüfung:
+  - `node scripts/tests/m67ResetElementToDefaults.test.cjs` OK
+  - `git diff --check` OK
+  - `node scripts/ui-editor-contract-check.cjs` OK
+  - `node scripts/ui-editor-contract-check.cjs --self-test` OK
+  - `node scripts/tests/m64UiEditorTestSurface.test.cjs` OK
+  - `node scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs` OK
+  - `node scripts/tests/m66ResetLayoutToDefaults.test.cjs` OK
+  - `npm test` in dieser Umgebung wegen fehlender Electron-Systembibliothek `libatk-1.0.so.0` nicht ausführbar
+  - `timeout 30s npm start` in dieser Umgebung aus demselben Grund nicht ausführbar
+- Nächster offener Schritt:
+  - Lokale Windows-/Electron-Prüfung nach Nutzerliste auf dem Zielsystem durchführen.

--- a/STATUS.md
+++ b/STATUS.md
@@ -3318,3 +3318,22 @@ Wichtig:
   - `npm test` in dieser Umgebung wegen fehlender Electron-Systembibliothek `libatk-1.0.so.0` nicht ausführbar
 - Nächster offener Schritt:
   - Lokale Windows-/Electron-Abnahme auf dem Zielsystem: Testkarte und Tabelle verändern/speichern, Testkarte einzeln zurücksetzen, Tabelle darf sichtbar nicht springen.
+
+## M67 Korrektur 3 – Elementdialog ohne Testflächen-Neuaufbau
+- Status: umgesetzt im Korrekturcommit zu PR #207.
+- Beschreibung:
+  - `openResetElementDefaultsDialog()` und `closeResetElementDefaultsDialog()` aktualisieren nur noch den Detailbereich und rufen kein `renderAll()` mehr auf.
+  - Der Bestätigungspfad bleibt ohne `renderAll()` und ohne `renderTestSurface()`; er aktualisiert nur Status, Details und Auswahl-/Overlay-Synchronisation.
+  - Der Reapply-Pfad bleibt als Absicherung für tatsächlich notwendige Ref-Neuaufbauten erhalten, wird aber nicht als Ersatz für unnötiges Dialog-Rendering genutzt.
+  - Der M67-Paneltest prüft nun explizit, dass Karten-, Überschrift- und Tabellen-Refs beim Öffnen, Abbrechen und Bestätigen identisch bleiben.
+- Prüfung:
+  - `git diff --check` OK
+  - `node scripts/tests/m67ResetElementToDefaults.test.cjs` OK
+  - `node scripts/tests/m66ResetLayoutToDefaults.test.cjs` OK
+  - `node scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs` OK
+  - `node scripts/tests/m64UiEditorTestSurface.test.cjs` OK
+  - `node scripts/ui-editor-contract-check.cjs` OK
+  - `node scripts/ui-editor-contract-check.cjs --self-test` OK
+  - `npm test` in dieser Umgebung wegen fehlender Electron-Systembibliothek `libatk-1.0.so.0` nicht ausführbar
+- Nächster offener Schritt:
+  - Lokale Windows-/Electron-Abnahme des Dialogablaufs auf dem Zielsystem wiederholen; die Tabelle darf beim Öffnen, Abbrechen oder Bestätigen nicht springen.

--- a/STATUS.md
+++ b/STATUS.md
@@ -3298,3 +3298,23 @@ Wichtig:
   - `timeout 30s npm start` in dieser Umgebung aus demselben Grund nicht ausführbar
 - Nächster offener Schritt:
   - Lokale Windows-/Electron-Prüfung nach Nutzerliste auf dem Zielsystem durchführen.
+
+## M67 Korrektur 2 – sichtbare Isolation nach Testflächen-Ref-Neuaufbau
+- Status: umgesetzt im Korrekturcommit zu PR #207.
+- Beschreibung:
+  - Nach dem Neuregistrieren der UI-Editor-Testflächen-Refs wird der aktuelle Session-Layoutzustand über eine öffentliche Runtime-Kette erneut auf die expliziten Refs angewendet.
+  - Die neue Reapply-Kette läuft Panel/Testflächen-Ref-Neuaufbau → Inspector-Bridge → Inspector → HostAdapter → aktueller Session-LayoutStore → explizite Refs.
+  - Reapply speichert nichts, lädt keinen persistenten Zustand, löscht keine Einträge und verändert keine Sessionbaseline.
+  - `confirmResetSelectedElementToDefaults()` aktualisiert nach dem Einzelreset nur Status und Detailbereich statt pauschal `renderAll()` aufzurufen.
+  - Dadurch bleibt die zurückgesetzte Testkarte standardmäßig, während Tabelle und Kindelemente ihre aktuellen Sessionwerte auch nach Ref-Neuaufbau sichtbar behalten.
+- Prüfung:
+  - `git diff --check` OK
+  - `node scripts/ui-editor-contract-check.cjs` OK
+  - `node scripts/ui-editor-contract-check.cjs --self-test` OK
+  - `node scripts/tests/m67ResetElementToDefaults.test.cjs` OK
+  - `node scripts/tests/m66ResetLayoutToDefaults.test.cjs` OK
+  - `node scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs` OK
+  - `node scripts/tests/m64UiEditorTestSurface.test.cjs` OK
+  - `npm test` in dieser Umgebung wegen fehlender Electron-Systembibliothek `libatk-1.0.so.0` nicht ausführbar
+- Nächster offener Schritt:
+  - Lokale Windows-/Electron-Abnahme auf dem Zielsystem: Testkarte und Tabelle verändern/speichern, Testkarte einzeln zurücksetzen, Tabelle darf sichtbar nicht springen.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -714,3 +714,18 @@ Hinweis:
 ### M66-Korrektur: Standardreset auf CSS-/Registry-Ursprung
 
 Für die M64-Testfläche bedeutet „Auf Standard zurücksetzen“ nicht das Schreiben gemessener oder erfundener Pixelwerte. Der HostAdapter löscht Editor-Inlinewerte (`transform`, `width`, `height`) und setzt nur freigegebene Zustände wie `visible` gemäß Registry/Layout-Default. Fehlen Layoutentries, gilt dies als Standardzustand; CSS und natürlicher Dokumentfluss liefern dann Breite, Höhe und Anordnung. Das Bedienpanel darf daraus keine eigene Default-Wahrheit ableiten.
+
+## M67 Abschlussnotiz – ausgewähltes Element dauerhaft auf Standard
+- Status: umgesetzt im automatisierten Runtime-/Panelpfad; praktische Windows-/Electron-Prüfung in Codex Cloud nicht verfügbar.
+- Umgesetzt:
+  - Neuer Panelbutton „Element auf Standard …“ nahe beim ↶-Einzelverwerfen.
+  - Zweistufiger Bestätigungsdialog mit „Abbrechen“ und „Element zurücksetzen“.
+  - Öffentliche Bridge-/Inspector-Operation für den Einzelreset des ausgewählten Elements.
+  - HostAdapter-Reset löscht nur den persistenten Defaultprofil-Eintrag des Elements, entfernt nur dessen Sessioneintrag und setzt nur dessen sichtbare Editor-Inlinewerte zurück.
+  - Baseline wird nach Erfolg nur für dieses Element auf Standard aktualisiert.
+  - Andere Elemente, Kind-/Elternelemente, fremde Profile und fremde Scopes bleiben unverändert.
+- Tests/Prüfung:
+  - Neuer Test `scripts/tests/m67ResetElementToDefaults.test.cjs` deckt Einzelreset, Kind-Isolation, Session-Isolation, Baseline-Verhalten, Abbrechen, fehlenden Ref, Persistenzfehler, Scope-/Profil-Isolation, nicht editierbares Element und Guardrails ab.
+  - M64/M65/M66/M67 Einzeltests laufen in Codex Cloud grün.
+- Offen:
+  - Lokale Windows-/Electron-Bedienprüfung: speichern, neu starten, Elementreset abbrechen/bestätigen, erneutes Verschieben und ↶, erneuter Neustart.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -729,3 +729,13 @@ Für die M64-Testfläche bedeutet „Auf Standard zurücksetzen“ nicht das Sch
   - M64/M65/M66/M67 Einzeltests laufen in Codex Cloud grün.
 - Offen:
   - Lokale Windows-/Electron-Bedienprüfung: speichern, neu starten, Elementreset abbrechen/bestätigen, erneutes Verschieben und ↶, erneuter Neustart.
+
+## M67 Korrektur – Elementstatus im echten Runtimepfad
+- Status: umgesetzt.
+- Korrektur:
+  - `getPersistenceStatus({ elementId })` wird im BBM-Main-HostAdapter nicht mehr ohne Argument ausgewertet.
+  - Der echte Bridge-/Inspector-Status liefert damit die elementbezogenen Felder für die Aktivierung von „Element auf Standard …“.
+- Testergänzung:
+  - `scripts/tests/m67ResetElementToDefaults.test.cjs` prüft jetzt zusätzlich den echten Bridge-Pfad für `selectedElementHasSavedLayout` und `selectedElementCanResetToDefaults`.
+- Offen:
+  - Praktische Windows-/Electron-Abnahme bleibt außerhalb der Cloud durchzuführen.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -761,3 +761,13 @@ Für die M64-Testfläche bedeutet „Auf Standard zurücksetzen“ nicht das Sch
   - Der M67-Test prüft jetzt explizit die Objektidentität von Karten-, Überschrift- und Tabellen-Refs bei Öffnen, Abbrechen und Bestätigen.
 - Offen:
   - Praktische Windows-/Electron-Abnahme des manuellen Fehlerfalls bleibt auf dem Zielsystem durchzuführen.
+
+## M67 Korrektur 4 – M63C-Kompatibilität
+- Status: umgesetzt.
+- Korrektur:
+  - Fehlende Persistenz blockiert die M63C-Bridge-/Inspector-Ermittlung der erlaubten Layoutoperationen nicht mehr.
+  - Der M67-Status behandelt nicht verfügbaren Storage für den Elementstatus neutral und deaktiviert nur den Element-Standard-Reset, nicht die Layoutpfeile.
+- Testergänzung:
+  - `scripts/tests/m63cLayoutControlConsole.test.cjs` läuft wieder grün und sichert `allowedOps`, Schrittweite 5 und Richtungspfeile ab.
+- Offen:
+  - Vollständiger `npm test` bleibt in der Cloud wegen fehlender Electron-Systembibliothek blockiert.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -750,3 +750,14 @@ Für die M64-Testfläche bedeutet „Auf Standard zurücksetzen“ nicht das Sch
   - `scripts/tests/m67ResetElementToDefaults.test.cjs` enthält einen echten Panelintegrationstest, der neue Refs erzwingt und prüft, dass Tabelle und Kindelemente ihre sichtbaren Layoutwerte behalten.
 - Offen:
   - Praktische Windows-/Electron-Abnahme nach manuellem Fehlerbefund bleibt auf dem Zielsystem durchzuführen.
+
+## M67 Korrektur 3 – Dialog ohne Ref-Ersatz
+- Status: umgesetzt.
+- Korrektur:
+  - Öffnen und Schließen des Element-Resetdialogs aktualisieren ausschließlich den Detailbereich.
+  - Bestätigen bleibt ohne vollständiges Rendering und ohne Testflächen-Neuaufbau.
+  - Reapply bleibt nur Absicherung für notwendige Neuaufbauten, nicht als Dialog-Workaround.
+- Testergänzung:
+  - Der M67-Test prüft jetzt explizit die Objektidentität von Karten-, Überschrift- und Tabellen-Refs bei Öffnen, Abbrechen und Bestätigen.
+- Offen:
+  - Praktische Windows-/Electron-Abnahme des manuellen Fehlerfalls bleibt auf dem Zielsystem durchzuführen.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -739,3 +739,14 @@ Für die M64-Testfläche bedeutet „Auf Standard zurücksetzen“ nicht das Sch
   - `scripts/tests/m67ResetElementToDefaults.test.cjs` prüft jetzt zusätzlich den echten Bridge-Pfad für `selectedElementHasSavedLayout` und `selectedElementCanResetToDefaults`.
 - Offen:
   - Praktische Windows-/Electron-Abnahme bleibt außerhalb der Cloud durchzuführen.
+
+## M67 Korrektur 2 – sichtbare Isolation bei neuen Refs
+- Status: umgesetzt.
+- Korrektur:
+  - Der aktuelle Session-Layoutzustand wird nach Testflächen-Ref-Neuaufbau erneut über eine öffentliche Runtime-/HostAdapter-Funktion angewendet.
+  - Beim Einzelreset wird kein `loadSavedLayout()` ausgeführt und keine globale Sessionbaseline neu begonnen.
+  - Der Einzelreset aktualisiert im Panel nur Status und Details; die Testfläche wird nicht wegen der Erfolgsmeldung vollständig neu aufgebaut.
+- Testergänzung:
+  - `scripts/tests/m67ResetElementToDefaults.test.cjs` enthält einen echten Panelintegrationstest, der neue Refs erzwingt und prüft, dass Tabelle und Kindelemente ihre sichtbaren Layoutwerte behalten.
+- Offen:
+  - Praktische Windows-/Electron-Abnahme nach manuellem Fehlerbefund bleibt auf dem Zielsystem durchzuführen.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -96,6 +96,7 @@ const { runM63cRealRegistryPanelIntegrationTests } = require("./tests/m63cRealRe
 const { runM64UiEditorTestSurfaceTests } = require("./tests/m64UiEditorTestSurface.test.cjs");
 const { runM65LayoutPersistenceRoundtripTests } = require("./tests/m65LayoutPersistenceRoundtrip.test.cjs");
 const { runM66ResetLayoutToDefaultsTests } = require("./tests/m66ResetLayoutToDefaults.test.cjs");
+const { runM67ResetElementToDefaultsTests } = require("./tests/m67ResetElementToDefaults.test.cjs");
 
 let failed = false;
 
@@ -239,6 +240,7 @@ async function main() {
   await runM64UiEditorTestSurfaceTests(run);
   await runM65LayoutPersistenceRoundtripTests(run);
   await runM66ResetLayoutToDefaultsTests(run);
+  await runM67ResetElementToDefaultsTests(run);
 
   if (failed) {
     process.exitCode = 1;

--- a/scripts/tests/m67ResetElementToDefaults.test.cjs
+++ b/scripts/tests/m67ResetElementToDefaults.test.cjs
@@ -117,6 +117,85 @@ async function runM67ResetElementToDefaultsTests(run) {
   });
 
 
+  await run("M67 Paneldialog: Öffnen, Abbrechen und Bestätigen ersetzen keine Testflächen-Refs", async () => {
+    const oldDocument = global.document;
+    const oldWindow = global.window;
+    const oldHTMLElement = global.HTMLElement;
+    try {
+      const doc = { defaultView: { HTMLElement: TestNode }, createElement: (tagName) => new TestNode(tagName) };
+      const win = { HTMLElement: TestNode, addEventListener() {}, removeEventListener() {} };
+      global.document = doc;
+      global.window = win;
+      global.HTMLElement = TestNode;
+      const [{ createBbmMainUiHostAdapter }, { createBbmEditorRuntimeInspectorBridge }, { BbmUiEditorStatusPanel }, refs] = await Promise.all([
+        importEsmFromFile(HOST_ADAPTER_PATH),
+        importEsmFromFile(BRIDGE_PATH),
+        importEsmFromFile(PANEL_PATH),
+        importEsmFromFile(REFS_PATH),
+      ]);
+      const storage = persistentStorage(createEditorLayoutMemoryStorage);
+      refs.clearBbmUiElementRefs();
+      const panel = new BbmUiEditorStatusPanel();
+      panel.statusNode = new TestNode("section");
+      panel.elementsNode = new TestNode("section");
+      panel.detailsNode = new TestNode("section");
+      panel.testSurfaceNode = new TestNode("section");
+      panel.status = { ok: true };
+      panel.elements = registry.map((entry) => ({ ...entry, label: entry.name, elementId: entry.id }));
+      panel.selectedElement = panel.elements.find((entry) => entry.elementId === "bbm.uiEditorTest.card");
+      const adapter = createBbmMainUiHostAdapter({ registry, layoutStorage: storage });
+      panel.inspectorBridge = createBbmEditorRuntimeInspectorBridge({
+        registryElements: panel.elements,
+        getSelectedElement: () => panel.selectedElement,
+        hostAdapterFactory: () => adapter,
+      });
+      panel.renderTestSurface();
+      panel.inspectorBridge.beginLayoutSession();
+      adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 10, y: 15 }));
+      adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "resize", { width: 25, height: 20 }));
+      adapter.submitChangeRequest(request("bbm.uiEditorTest.card.title", "move", { x: 5 }));
+      adapter.submitChangeRequest(request("bbm.uiEditorTest.table", "move", { x: 20 }));
+      adapter.submitChangeRequest(request("bbm.uiEditorTest.table", "resize", { width: 15, height: 10 }));
+      assert.equal(panel.inspectorBridge.saveLayoutSession().ok, true);
+      const cardRefBefore = refs.getBbmUiElementRef("bbm.uiEditorTest.card");
+      const titleRefBefore = refs.getBbmUiElementRef("bbm.uiEditorTest.card.title");
+      const tableRefBefore = refs.getBbmUiElementRef("bbm.uiEditorTest.table");
+      panel.renderDetails();
+      const openFirst = findNode(panel.detailsNode, (node) => node.tagName === "button" && node.textContent === "Element auf Standard …");
+      assert.equal(openFirst.disabled, false);
+      openFirst.click();
+      assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card"), cardRefBefore);
+      assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.table"), tableRefBefore);
+      const cancel = findNode(panel.detailsNode, (node) => node.tagName === "button" && node.textContent === "Abbrechen");
+      assert.ok(cancel);
+      cancel.click();
+      assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card"), cardRefBefore);
+      assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.table"), tableRefBefore);
+      const openSecond = findNode(panel.detailsNode, (node) => node.tagName === "button" && node.textContent === "Element auf Standard …");
+      openSecond.click();
+      const confirm = findNode(panel.detailsNode, (node) => node.tagName === "button" && node.textContent === "Element zurücksetzen");
+      assert.ok(confirm);
+      confirm.click();
+      assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card"), cardRefBefore);
+      assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card.title"), titleRefBefore);
+      assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.table"), tableRefBefore);
+      assert.equal(cardRefBefore.style.values.transform, undefined);
+      assert.equal(cardRefBefore.style.values.width, undefined);
+      assert.equal(cardRefBefore.style.values.height, undefined);
+      assert.equal(titleRefBefore.style.values.transform, "translate(5px, 0px)");
+      assert.equal(tableRefBefore.style.values.transform, "translate(20px, 0px)");
+      assert.equal(tableRefBefore.style.values.width, "435px");
+      assert.equal(tableRefBefore.style.values.height, "190px");
+      assert.equal(storage.read().entries["bbm.uiEditorTest.card"], undefined);
+      assert.ok(storage.read().entries["bbm.uiEditorTest.table"]);
+      assert.ok(adapter.getCurrentLayoutState().some((entry) => entry.elementId === "bbm.uiEditorTest.table"));
+    } finally {
+      global.document = oldDocument;
+      global.window = oldWindow;
+      global.HTMLElement = oldHTMLElement;
+    }
+  });
+
   await run("M67 Panelintegration: Ref-Neuaufbau übernimmt aktuelle Sessionwerte anderer Elemente", async () => {
     const oldDocument = global.document;
     const oldWindow = global.window;

--- a/scripts/tests/m67ResetElementToDefaults.test.cjs
+++ b/scripts/tests/m67ResetElementToDefaults.test.cjs
@@ -20,12 +20,25 @@ class TestRef {
   getBoundingClientRect() { return { ...this.rect }; }
 }
 class TestNode {
-  constructor(tagName) { this.tagName = tagName; this.children = []; this.textContent = ""; this.type = ""; this.disabled = false; this.hidden = false; this.className = ""; this.attributes = {}; this.listeners = {}; }
+  constructor(tagName) {
+    this.tagName = tagName;
+    this.children = [];
+    this.textContent = "";
+    this.type = "";
+    this.disabled = false;
+    this.hidden = false;
+    this.className = "";
+    this.attributes = {};
+    this.listeners = {};
+    this.style = { values: {}, setProperty: (k, v) => { this.style.values[k] = String(v); }, removeProperty: (k) => { delete this.style.values[k]; } };
+    this.rect = { width: tagName === "table" ? 420 : 300, height: 180, left: 0, top: 0 };
+  }
   append(...children) { children.forEach((child) => this.appendChild(child)); }
   appendChild(child) { this.children.push(child); return child; }
   setAttribute(name, value) { this.attributes[name] = String(value); }
   addEventListener(name, handler) { this.listeners[name] = [...(this.listeners[name] || []), handler]; }
   click() { if (!this.disabled) return this.listeners.click?.[0]?.({ target: this, preventDefault() {}, stopPropagation() {} }); return undefined; }
+  getBoundingClientRect() { return { ...this.rect }; }
   set innerHTML(_value) { this.children = []; }
 }
 function findNode(node, predicate) { if (!node) return null; if (predicate(node)) return node; for (const child of node.children || []) { const found = findNode(child, predicate); if (found) return found; } return null; }
@@ -101,6 +114,79 @@ async function runM67ResetElementToDefaultsTests(run) {
 
   await run("M67 E: Panel-Abbrechen ruft keine API auf", async () => {
     const oldDocument = global.document; try { global.document = { createElement: (tagName) => new TestNode(tagName) }; const { BbmUiEditorStatusPanel } = await importEsmFromFile(PANEL_PATH); const panel = new BbmUiEditorStatusPanel(); let calls = 0; panel.detailsNode = new TestNode("section"); panel.editorActive = true; panel.selectedElement = { elementId: "bbm.uiEditorTest.card", label: "Testkarte", editable: true }; panel.inspectorBridge = { inspectSelectedElement: () => ({ ok: true, allowedOps: ["move", "resize"], selectedElementCanResetToDefaults: true }), resetSelectedElementToDefaults: () => { calls += 1; return { ok: true }; } }; panel.renderReadonlyLayoutControls(panel.selectedElement); findNode(panel.detailsNode, (n) => n.tagName === "button" && n.textContent === "Element auf Standard …").click(); panel.detailsNode = new TestNode("section"); panel.renderReadonlyLayoutControls(panel.selectedElement); assert.match(collectText(panel.detailsNode), /Element auf Standard zurücksetzen\?/); assert.doesNotMatch(collectText(panel.detailsNode), /bbm\.uiEditorTest\.card/); findNode(panel.detailsNode, (n) => n.tagName === "button" && n.textContent === "Abbrechen").click(); assert.equal(calls, 0); } finally { global.document = oldDocument; }
+  });
+
+
+  await run("M67 Panelintegration: Ref-Neuaufbau übernimmt aktuelle Sessionwerte anderer Elemente", async () => {
+    const oldDocument = global.document;
+    const oldWindow = global.window;
+    const oldHTMLElement = global.HTMLElement;
+    try {
+      const doc = { defaultView: { HTMLElement: TestNode }, createElement: (tagName) => new TestNode(tagName) };
+      const win = { HTMLElement: TestNode, addEventListener() {}, removeEventListener() {} };
+      global.document = doc;
+      global.window = win;
+      global.HTMLElement = TestNode;
+      const [{ createBbmMainUiHostAdapter }, { createBbmEditorRuntimeInspectorBridge }, { BbmUiEditorStatusPanel }, refs] = await Promise.all([
+        importEsmFromFile(HOST_ADAPTER_PATH),
+        importEsmFromFile(BRIDGE_PATH),
+        importEsmFromFile(PANEL_PATH),
+        importEsmFromFile(REFS_PATH),
+      ]);
+      const storage = persistentStorage(createEditorLayoutMemoryStorage);
+      refs.clearBbmUiElementRefs();
+      const panel = new BbmUiEditorStatusPanel();
+      panel.statusNode = new TestNode("section");
+      panel.elementsNode = new TestNode("section");
+      panel.detailsNode = new TestNode("section");
+      panel.testSurfaceNode = new TestNode("section");
+      panel.status = { ok: true };
+      panel.elements = registry.map((entry) => ({ ...entry, label: entry.name, elementId: entry.id }));
+      panel.selectedElement = panel.elements.find((entry) => entry.elementId === "bbm.uiEditorTest.card");
+      const adapter = createBbmMainUiHostAdapter({ registry, layoutStorage: storage });
+      panel.inspectorBridge = createBbmEditorRuntimeInspectorBridge({
+        registryElements: panel.elements,
+        getSelectedElement: () => panel.selectedElement,
+        hostAdapterFactory: () => adapter,
+      });
+      panel.renderTestSurface();
+      panel.inspectorBridge.beginLayoutSession();
+      adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 10, y: 15 }));
+      adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "resize", { width: 25, height: 20 }));
+      adapter.submitChangeRequest(request("bbm.uiEditorTest.card.title", "move", { x: 5 }));
+      adapter.submitChangeRequest(request("bbm.uiEditorTest.table", "move", { x: 20 }));
+      adapter.submitChangeRequest(request("bbm.uiEditorTest.table", "resize", { width: 15, height: 10 }));
+      assert.equal(panel.inspectorBridge.saveLayoutSession().ok, true);
+      const oldTableRef = refs.getBbmUiElementRef("bbm.uiEditorTest.table");
+      panel.renderDetails();
+      const open = findNode(panel.detailsNode, (node) => node.tagName === "button" && node.textContent === "Element auf Standard …");
+      assert.equal(open.disabled, false);
+      open.click();
+      const confirm = findNode(panel.detailsNode, (node) => node.tagName === "button" && node.textContent === "Element zurücksetzen");
+      assert.ok(confirm);
+      confirm.click();
+      panel.renderTestSurface();
+      const cardRef = refs.getBbmUiElementRef("bbm.uiEditorTest.card");
+      const titleRef = refs.getBbmUiElementRef("bbm.uiEditorTest.card.title");
+      const tableRef = refs.getBbmUiElementRef("bbm.uiEditorTest.table");
+      assert.notEqual(tableRef, oldTableRef);
+      assert.equal(cardRef.style.values.transform, undefined);
+      assert.equal(cardRef.style.values.width, undefined);
+      assert.equal(cardRef.style.values.height, undefined);
+      assert.equal(titleRef.style.values.transform, "translate(5px, 0px)");
+      assert.equal(tableRef.style.values.transform, "translate(20px, 0px)");
+      assert.equal(tableRef.style.values.width, "435px");
+      assert.equal(tableRef.style.values.height, "190px");
+      assert.equal(storage.read().entries["bbm.uiEditorTest.card"], undefined);
+      assert.ok(storage.read().entries["bbm.uiEditorTest.table"]);
+      assert.ok(adapter.getCurrentLayoutState().some((entry) => entry.elementId === "bbm.uiEditorTest.table"));
+      assert.equal(panel.inspectorBridge.getLayoutSessionStatus().changedCount, 0);
+      assert.equal(panel.selectedElement?.elementId, "bbm.uiEditorTest.card");
+    } finally {
+      global.document = oldDocument;
+      global.window = oldWindow;
+      global.HTMLElement = oldHTMLElement;
+    }
   });
 
   await run("M67 F/G/I: fehlender Ref, Persistenzfehler und nicht editierbar blockieren/rollen zurück", async () => {

--- a/scripts/tests/m67ResetElementToDefaults.test.cjs
+++ b/scripts/tests/m67ResetElementToDefaults.test.cjs
@@ -1,0 +1,111 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const REPO_ROOT = path.join(__dirname, "../..");
+const HOST_ADAPTER_PATH = path.join(REPO_ROOT, "src/renderer/ui-editor/bbmMainUiHostAdapter.js");
+const INSPECTOR_PATH = path.join(REPO_ROOT, "src/renderer/editorRuntime/inspector/editorScopeInspector.js");
+const REFS_PATH = path.join(REPO_ROOT, "src/renderer/ui-editor/bbmUiElementRefs.js");
+const PANEL_PATH = path.join(REPO_ROOT, "src/renderer/ui-editor/BbmUiEditorStatusPanel.js");
+const BRIDGE_PATH = path.join(REPO_ROOT, "src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js");
+const LAYOUT_PERSISTENCE_PATH = path.join(REPO_ROOT, "src/renderer/editorRuntime/layout/editorLayoutPersistence.js");
+
+class TestRef {
+  constructor(width = 300, height = 180) {
+    this.hidden = false;
+    this.style = { values: {}, setProperty: (k, v) => { this.style.values[k] = String(v); }, removeProperty: (k) => { delete this.style.values[k]; } };
+    this.rect = { width, height, left: 0, top: 0 };
+  }
+  getBoundingClientRect() { return { ...this.rect }; }
+}
+class TestNode {
+  constructor(tagName) { this.tagName = tagName; this.children = []; this.textContent = ""; this.type = ""; this.disabled = false; this.hidden = false; this.className = ""; this.attributes = {}; this.listeners = {}; }
+  append(...children) { children.forEach((child) => this.appendChild(child)); }
+  appendChild(child) { this.children.push(child); return child; }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  addEventListener(name, handler) { this.listeners[name] = [...(this.listeners[name] || []), handler]; }
+  click() { if (!this.disabled) return this.listeners.click?.[0]?.({ target: this, preventDefault() {}, stopPropagation() {} }); return undefined; }
+  set innerHTML(_value) { this.children = []; }
+}
+function findNode(node, predicate) { if (!node) return null; if (predicate(node)) return node; for (const child of node.children || []) { const found = findNode(child, predicate); if (found) return found; } return null; }
+function collectText(node) { return [node?.textContent || "", ...(node?.children || []).flatMap(collectText)].join("\n"); }
+function clone(value) { return value && typeof value === "object" ? structuredClone(value) : null; }
+let counter = 0;
+function request(elementId, operation, payload) { counter += 1; return { changeId: `m67-${counter}`, targetAppId: "bbm-produktiv", moduleId: "bbm.main", scopeId: "bbm.main-layout", elementId, operation, payload, createdAt: "2026-07-19T00:00:00.000Z", source: "m67-test" }; }
+function persistentStorage(createEditorLayoutMemoryStorage, options = {}) {
+  const storage = createEditorLayoutMemoryStorage();
+  return { available: true, persistent: true, readResult() { const payload = storage.read(); return payload ? { ok: true, found: true, payload } : { ok: true, found: false, payload: null }; }, read: storage.read, write(nextPayload) { if (options.failDeletingCard && !nextPayload?.entries?.["bbm.uiEditorTest.card"]) { const error = new Error("write failed"); error.code = "LAYOUT_STORAGE_WRITE_FAILED"; throw error; } return storage.write(nextPayload); }, clear: storage.clear };
+}
+function scopedContainerStorage(container, scopeKey = "bbm-produktiv|bbm.main|bbm.main-layout") { return { available: true, persistent: true, readResult() { const payload = container[scopeKey] || null; return payload ? { ok: true, found: true, payload: clone(payload) } : { ok: true, found: false, payload: null }; }, read() { return clone(container[scopeKey] || null); }, write(nextPayload) { container[scopeKey] = clone(nextPayload); return clone(container[scopeKey]); }, clear() { delete container[scopeKey]; } }; }
+const registry = [
+  { id: "bbm.main.content", elementId: "bbm.main.content", name: "Inhalt", type: "root", role: "layout", parentId: null, order: 1, visible: true, editable: false, allowedOps: [], lockedOps: [], layoutDefaults: { visible: true } },
+  { id: "bbm.uiEditorTest.card", elementId: "bbm.uiEditorTest.card", name: "Testkarte", type: "card", role: "content", parentId: "bbm.main.content", order: 2, visible: true, editable: true, allowedOps: ["move", "resize"], lockedOps: [], layoutDefaults: { visible: true, minWidth: 80, minHeight: 80 } },
+  { id: "bbm.uiEditorTest.card.title", elementId: "bbm.uiEditorTest.card.title", name: "Überschrift", type: "label", role: "content", parentId: "bbm.uiEditorTest.card", order: 3, visible: true, editable: true, allowedOps: ["move", "resize"], lockedOps: [], layoutDefaults: { visible: true, minWidth: 80, minHeight: 24 } },
+  { id: "bbm.uiEditorTest.table", elementId: "bbm.uiEditorTest.table", name: "Beispieltabelle", type: "table", role: "content", parentId: "bbm.main.content", order: 8, visible: true, editable: true, allowedOps: ["move", "resize", "hide", "show"], lockedOps: [], layoutDefaults: { visible: true, minWidth: 160, minHeight: 80 } },
+];
+async function createHarness(layoutStorage, options = {}) {
+  const [{ createBbmMainUiHostAdapter }, { createEditorScopeInspector }, refs] = await Promise.all([importEsmFromFile(HOST_ADAPTER_PATH), importEsmFromFile(INSPECTOR_PATH), importEsmFromFile(REFS_PATH)]);
+  refs.clearBbmUiElementRefs(); global.HTMLElement = TestRef;
+  for (const entry of registry) if (entry.editable && !options.missingRefIds?.includes(entry.id)) refs.registerBbmUiElementRef(entry.id, new TestRef(entry.id.includes("table") ? 420 : 300, 180));
+  const adapter = createBbmMainUiHostAdapter({ registry, layoutStorage });
+  const inspector = createEditorScopeInspector({ hostAdapterFactory: () => adapter, catalog: { targetAppId: "bbm-produktiv", modules: [{ moduleId: "bbm.main", moduleLabel: "BBM", scopes: [{ scopeId: "bbm.main-layout" }] }] } });
+  return { adapter, inspector, refs };
+}
+async function saveTwo(storage) { const { adapter, inspector } = await createHarness(storage); inspector.beginLayoutSession("bbm.main-layout"); adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 10, y: 15 })); adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "resize", { width: 25, height: 20 })); adapter.submitChangeRequest(request("bbm.uiEditorTest.table", "move", { x: 20 })); assert.equal(inspector.saveLayoutSession("bbm.main-layout").ok, true); }
+
+async function runM67ResetElementToDefaultsTests(run) {
+  const { createEditorLayoutMemoryStorage } = await importEsmFromFile(LAYOUT_PERSISTENCE_PATH);
+
+  await run("M67 A: nur einzelnes gespeichertes Element wird dauerhaft zurückgesetzt", async () => {
+    const storage = persistentStorage(createEditorLayoutMemoryStorage); await saveTwo(storage);
+    const { inspector, refs } = await createHarness(storage); inspector.loadSavedLayout("bbm.main-layout"); inspector.beginLayoutSession("bbm.main-layout");
+    const result = inspector.resetLayoutElementToDefaults("bbm.main-layout", "bbm.uiEditorTest.card");
+    assert.equal(result.ok, true); assert.equal(result.status.changedCount, 0);
+    assert.equal(storage.read().entries["bbm.uiEditorTest.card"], undefined); assert.ok(storage.read().entries["bbm.uiEditorTest.table"]);
+    assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card").style.values.transform, undefined); assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card").style.values.width, undefined); assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card").style.values.height, undefined);
+    assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.table").style.values.transform, "translate(20px, 0px)");
+  });
+
+  await run("M67 B/D: Kind-Isolation und Element-Baseline nach erneutem Ändern", async () => {
+    const storage = persistentStorage(createEditorLayoutMemoryStorage); const { adapter, inspector, refs } = await createHarness(storage);
+    inspector.beginLayoutSession("bbm.main-layout"); adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 10 })); adapter.submitChangeRequest(request("bbm.uiEditorTest.card.title", "move", { x: 5 })); inspector.saveLayoutSession("bbm.main-layout");
+    assert.equal(inspector.resetLayoutElementToDefaults("bbm.main-layout", "bbm.uiEditorTest.card").ok, true);
+    assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card").style.values.transform, undefined); assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card.title").style.values.transform, "translate(5px, 0px)");
+    adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 5 })); assert.equal(inspector.getLayoutSessionStatus("bbm.main-layout").changedCount, 1);
+    assert.equal(inspector.discardLayoutSessionElement("bbm.main-layout", "bbm.uiEditorTest.card").ok, true); assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card").style.values.transform, undefined);
+    assert.equal(inspector.resetLayoutElementToDefaults("bbm.main-layout", "bbm.uiEditorTest.card.title").ok, true); assert.equal(refs.getBbmUiElementRef("bbm.uiEditorTest.card.title").style.values.transform, undefined);
+  });
+
+  await run("M67 C: Session-Isolation lässt andere offene Änderungen stehen", async () => {
+    const storage = persistentStorage(createEditorLayoutMemoryStorage); await saveTwo(storage); const { adapter, inspector } = await createHarness(storage); inspector.loadSavedLayout("bbm.main-layout"); inspector.beginLayoutSession("bbm.main-layout");
+    adapter.submitChangeRequest(request("bbm.uiEditorTest.card", "move", { x: 5 })); adapter.submitChangeRequest(request("bbm.uiEditorTest.table", "move", { x: 5 })); assert.equal(inspector.getLayoutSessionStatus("bbm.main-layout").changedCount, 2);
+    const result = inspector.resetLayoutElementToDefaults("bbm.main-layout", "bbm.uiEditorTest.card"); assert.equal(result.ok, true); assert.equal(result.status.changedCount, 1); assert.equal(result.status.changedByElementId["bbm.uiEditorTest.table"], true);
+  });
+
+  await run("M67 E: Panel-Abbrechen ruft keine API auf", async () => {
+    const oldDocument = global.document; try { global.document = { createElement: (tagName) => new TestNode(tagName) }; const { BbmUiEditorStatusPanel } = await importEsmFromFile(PANEL_PATH); const panel = new BbmUiEditorStatusPanel(); let calls = 0; panel.detailsNode = new TestNode("section"); panel.editorActive = true; panel.selectedElement = { elementId: "bbm.uiEditorTest.card", label: "Testkarte", editable: true }; panel.inspectorBridge = { inspectSelectedElement: () => ({ ok: true, allowedOps: ["move", "resize"], selectedElementCanResetToDefaults: true }), resetSelectedElementToDefaults: () => { calls += 1; return { ok: true }; } }; panel.renderReadonlyLayoutControls(panel.selectedElement); findNode(panel.detailsNode, (n) => n.tagName === "button" && n.textContent === "Element auf Standard …").click(); panel.detailsNode = new TestNode("section"); panel.renderReadonlyLayoutControls(panel.selectedElement); assert.match(collectText(panel.detailsNode), /Element auf Standard zurücksetzen\?/); assert.doesNotMatch(collectText(panel.detailsNode), /bbm\.uiEditorTest\.card/); findNode(panel.detailsNode, (n) => n.tagName === "button" && n.textContent === "Abbrechen").click(); assert.equal(calls, 0); } finally { global.document = oldDocument; }
+  });
+
+  await run("M67 F/G/I: fehlender Ref, Persistenzfehler und nicht editierbar blockieren/rollen zurück", async () => {
+    const storage = persistentStorage(createEditorLayoutMemoryStorage); await saveTwo(storage); const before = clone(storage.read()); let harness = await createHarness(storage, { missingRefIds: ["bbm.uiEditorTest.card"] }); assert.equal(harness.inspector.resetLayoutElementToDefaults("bbm.main-layout", "bbm.uiEditorTest.card").reason, "ELEMENT_REF_MISSING"); assert.deepEqual(storage.read(), before);
+    const failing = persistentStorage(createEditorLayoutMemoryStorage, { failDeletingCard: true }); await saveTwo(failing); harness = await createHarness(failing); harness.inspector.loadSavedLayout("bbm.main-layout"); const visibleBefore = harness.refs.getBbmUiElementRef("bbm.uiEditorTest.card").style.values.transform; const fail = harness.inspector.resetLayoutElementToDefaults("bbm.main-layout", "bbm.uiEditorTest.card"); assert.equal(fail.ok, false); assert.equal(harness.refs.getBbmUiElementRef("bbm.uiEditorTest.card").style.values.transform, visibleBefore); assert.ok(failing.read().entries["bbm.uiEditorTest.card"]);
+    const blocked = harness.inspector.resetLayoutElementToDefaults("bbm.main-layout", "bbm.main.content"); assert.equal(blocked.ok, false); assert.equal(blocked.reason, "ELEMENT_NOT_EDITABLE");
+  });
+
+  await run("M67 H/J: Scope-/Profil-Isolation und Panel-Guardrails", async () => {
+    const container = { "bbm-produktiv|bbm.main|anderer.scope": { version: 1, targetAppId: "bbm-produktiv", moduleId: "bbm.main", scopeId: "anderer.scope", layoutProfileId: "default", entries: { foreign: { layoutProfileId: "default", targetAppId: "bbm-produktiv", moduleId: "bbm.main", scopeId: "anderer.scope", elementId: "foreign", operation: "move", layoutValue: { x: 99 }, createdAt: "a", updatedAt: "b" } } } };
+    const storage = scopedContainerStorage(container); await saveTwo(storage); container["bbm-produktiv|bbm.main|bbm.main-layout"].entries.previewCard = { layoutProfileId: "preview", targetAppId: "bbm-produktiv", moduleId: "bbm.main", scopeId: "bbm.main-layout", elementId: "previewCard", operation: "move", layoutValue: { x: 1 }, createdAt: "a", updatedAt: "b" };
+    const { inspector } = await createHarness(storage); assert.equal(inspector.resetLayoutElementToDefaults("bbm.main-layout", "bbm.uiEditorTest.card").ok, true); assert.ok(container["bbm-produktiv|bbm.main|anderer.scope"].entries.foreign); assert.ok(container["bbm-produktiv|bbm.main|bbm.main-layout"].entries.previewCard); assert.ok(container["bbm-produktiv|bbm.main|bbm.main-layout"].entries["bbm.uiEditorTest.table"]);
+    const panelSource = fs.readFileSync(PANEL_PATH, "utf8"); const bridgeSource = fs.readFileSync(BRIDGE_PATH, "utf8");
+    for (const forbidden of ["localStorage", "style.setProperty", "style.removeProperty", "getBoundingClientRect", "layoutDefaults:", "baselineByElementId"]) assert.equal(panelSource.includes(forbidden), false, forbidden);
+    for (const line of panelSource.split(/\n/)) assert.doesNotMatch(line, /selectedElementCanResetToDefaults.*bbm\.uiEditorTest\.(card|table)|bbm\.uiEditorTest\.(card|table).*selectedElementCanResetToDefaults/);
+    assert.doesNotMatch(bridgeSource, /__getHostAdapter|restoreLayoutState|layoutStore/);
+  });
+}
+
+if (require.main === module) {
+  const run = async (name, fn) => { try { await fn(); console.log(`ok - ${name}`); } catch (error) { console.error(`not ok - ${name}`); console.error(error); process.exitCode = 1; } };
+  runM67ResetElementToDefaultsTests(run).then(() => { if (!process.exitCode) console.log("m67ResetElementToDefaults.test.cjs passed"); });
+}
+module.exports = { runM67ResetElementToDefaultsTests };

--- a/scripts/tests/m67ResetElementToDefaults.test.cjs
+++ b/scripts/tests/m67ResetElementToDefaults.test.cjs
@@ -83,6 +83,22 @@ async function runM67ResetElementToDefaultsTests(run) {
     const result = inspector.resetLayoutElementToDefaults("bbm.main-layout", "bbm.uiEditorTest.card"); assert.equal(result.ok, true); assert.equal(result.status.changedCount, 1); assert.equal(result.status.changedByElementId["bbm.uiEditorTest.table"], true);
   });
 
+  await run("M67 Status: echter Bridge-Pfad aktiviert Button über strukturierte Elementfelder", async () => {
+    const { createBbmEditorRuntimeInspectorBridge } = await importEsmFromFile(BRIDGE_PATH);
+    const storage = persistentStorage(createEditorLayoutMemoryStorage);
+    await saveTwo(storage);
+    const harness = await createHarness(storage);
+    const bridge = createBbmEditorRuntimeInspectorBridge({
+      registryElements: registry.map((entry) => ({ ...entry, label: entry.name, elementId: entry.id })),
+      selectedElement: { elementId: "bbm.uiEditorTest.card", label: "Testkarte", editable: true },
+      hostAdapterFactory: () => harness.adapter,
+    });
+    const status = bridge.inspectSelectedElement();
+    assert.equal(status.ok, true);
+    assert.equal(status.selectedElementHasSavedLayout, true);
+    assert.equal(status.selectedElementCanResetToDefaults, true);
+  });
+
   await run("M67 E: Panel-Abbrechen ruft keine API auf", async () => {
     const oldDocument = global.document; try { global.document = { createElement: (tagName) => new TestNode(tagName) }; const { BbmUiEditorStatusPanel } = await importEsmFromFile(PANEL_PATH); const panel = new BbmUiEditorStatusPanel(); let calls = 0; panel.detailsNode = new TestNode("section"); panel.editorActive = true; panel.selectedElement = { elementId: "bbm.uiEditorTest.card", label: "Testkarte", editable: true }; panel.inspectorBridge = { inspectSelectedElement: () => ({ ok: true, allowedOps: ["move", "resize"], selectedElementCanResetToDefaults: true }), resetSelectedElementToDefaults: () => { calls += 1; return { ok: true }; } }; panel.renderReadonlyLayoutControls(panel.selectedElement); findNode(panel.detailsNode, (n) => n.tagName === "button" && n.textContent === "Element auf Standard …").click(); panel.detailsNode = new TestNode("section"); panel.renderReadonlyLayoutControls(panel.selectedElement); assert.match(collectText(panel.detailsNode), /Element auf Standard zurücksetzen\?/); assert.doesNotMatch(collectText(panel.detailsNode), /bbm\.uiEditorTest\.card/); findNode(panel.detailsNode, (n) => n.tagName === "button" && n.textContent === "Abbrechen").click(); assert.equal(calls, 0); } finally { global.document = oldDocument; }
   });

--- a/src/renderer/editorRuntime/inspector/editorLayoutControls.js
+++ b/src/renderer/editorRuntime/inspector/editorLayoutControls.js
@@ -89,6 +89,9 @@ export function createEditorLayoutControlPanel({ scope, registry, hostAdapter, e
 
   const safeLayoutOps = toSafeLayoutOps(detailsResult.details);
   const currentLayoutEntry = findLayoutEntry(layoutState, elementId);
+  const persistenceStatus = typeof hostAdapter?.getPersistenceStatus === "function"
+    ? hostAdapter.getPersistenceStatus({ elementId: normalizeString(elementId) })
+    : {};
 
   return {
     ok: true,
@@ -123,6 +126,7 @@ export function createEditorLayoutControlPanel({ scope, registry, hostAdapter, e
         ? "Gespeicherter Layoutzustand ist verfuegbar."
         : "Standardzustand ist aktiv.",
       reason: null,
+      ...persistenceStatus,
     },
     layoutState,
     errors: [],

--- a/src/renderer/editorRuntime/inspector/editorScopeInspector.js
+++ b/src/renderer/editorRuntime/inspector/editorScopeInspector.js
@@ -334,6 +334,16 @@ export function createEditorScopeInspector({
   }
 
 
+  function resetSessionBaselineElement(scopeId, context, elementId) {
+    const normalizedScopeId = normalizeId(context.scope.scopeId);
+    const normalizedElementId = normalizeId(elementId);
+    const session = layoutSessions.get(normalizedScopeId);
+    if (!session || !normalizedElementId) return buildLayoutSessionStatus(normalizedScopeId, context);
+    const currentLayoutState = typeof context.hostAdapter.getCurrentLayoutState === "function" ? context.hostAdapter.getCurrentLayoutState() : [];
+    session.baselineByElementId.set(normalizedElementId, cloneLayoutEntry(findLayoutEntry(currentLayoutState, normalizedElementId)));
+    return buildLayoutSessionStatus(normalizedScopeId, context);
+  }
+
   function resetSessionBaseline(scopeId, context) {
     const normalizedScopeId = normalizeId(context.scope.scopeId);
     const layoutState = typeof context.hostAdapter.getCurrentLayoutState === "function" ? context.hostAdapter.getCurrentLayoutState() : [];
@@ -372,6 +382,23 @@ export function createEditorScopeInspector({
     const result = context.hostAdapter.resetLayoutToDefaults();
     if (!result?.ok) return { ...result, status: buildLayoutSessionStatus(scopeId, context) };
     return { ...result, status: resetSessionBaseline(scopeId, context) };
+  }
+
+  function resetLayoutElementToDefaults(scopeId, elementId) {
+    const context = prepareScopeContext(scopeId);
+    if (!context.ok) {
+      return { ok: false, blocked: true, reason: context.inspection.errors?.[0]?.code || "SCOPE_UNAVAILABLE", status: buildLayoutSessionStatus(scopeId, context) };
+    }
+    const normalizedElementId = normalizeId(elementId);
+    const registryElement = context.registry.find((entry) => normalizeId(entry?.id || entry?.elementId) === normalizedElementId) || null;
+    if (!registryElement) return { ok: false, blocked: true, reason: "ELEMENT_ID_UNKNOWN", status: buildLayoutSessionStatus(scopeId, context) };
+    if (!registryElement.editable) return { ok: false, blocked: true, reason: "ELEMENT_NOT_EDITABLE", status: buildLayoutSessionStatus(scopeId, context) };
+    if (typeof context.hostAdapter.resetLayoutElementToDefaults !== "function") {
+      return { ok: false, blocked: true, reason: "HOST_RESET_LAYOUT_ELEMENT_DEFAULTS_MISSING", status: buildLayoutSessionStatus(scopeId, context) };
+    }
+    const result = context.hostAdapter.resetLayoutElementToDefaults({ elementId: normalizedElementId });
+    if (!result?.ok) return { ...result, status: buildLayoutSessionStatus(scopeId, context) };
+    return { ...result, status: resetSessionBaselineElement(scopeId, context, normalizedElementId) };
   }
 
   function loadSavedLayout(scopeId) {
@@ -436,6 +463,7 @@ export function createEditorScopeInspector({
     saveLayoutSession,
     loadSavedLayout,
     resetLayoutToDefaults,
+    resetLayoutElementToDefaults,
     discardLayoutSessionElement,
     discardLayoutSession,
     endLayoutSession,

--- a/src/renderer/editorRuntime/inspector/editorScopeInspector.js
+++ b/src/renderer/editorRuntime/inspector/editorScopeInspector.js
@@ -384,6 +384,18 @@ export function createEditorScopeInspector({
     return { ...result, status: resetSessionBaseline(scopeId, context) };
   }
 
+  function reapplyCurrentLayoutState(scopeId) {
+    const context = prepareScopeContext(scopeId);
+    if (!context.ok) {
+      return { ok: false, blocked: true, reason: context.inspection.errors?.[0]?.code || "SCOPE_UNAVAILABLE", status: buildLayoutSessionStatus(scopeId, context) };
+    }
+    if (typeof context.hostAdapter.reapplyCurrentLayoutState !== "function") {
+      return { ok: false, blocked: true, reason: "HOST_REAPPLY_CURRENT_LAYOUT_STATE_MISSING", status: buildLayoutSessionStatus(scopeId, context) };
+    }
+    const result = context.hostAdapter.reapplyCurrentLayoutState();
+    return { ...result, status: buildLayoutSessionStatus(scopeId, context) };
+  }
+
   function resetLayoutElementToDefaults(scopeId, elementId) {
     const context = prepareScopeContext(scopeId);
     if (!context.ok) {
@@ -464,6 +476,7 @@ export function createEditorScopeInspector({
     loadSavedLayout,
     resetLayoutToDefaults,
     resetLayoutElementToDefaults,
+    reapplyCurrentLayoutState,
     discardLayoutSessionElement,
     discardLayoutSession,
     endLayoutSession,

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -353,6 +353,7 @@ export class BbmUiEditorStatusPanel {
     this.bindTestSurfaceElementRef("bbm.uiEditorTest.card.input", inputShell);
     this.bindTestSurfaceElementRef("bbm.uiEditorTest.card.select", selectShell);
     this.bindTestSurfaceElementRef("bbm.uiEditorTest.table", table);
+    this.inspectorBridge?.reapplyCurrentLayoutState?.();
   }
 
   renderStatus() {
@@ -704,7 +705,8 @@ export class BbmUiEditorStatusPanel {
     this.resetElementDefaultsDialogOpen = false;
     this.selectionMessage = result?.ok ? `„${label}“ wurde auf Standard zurückgesetzt.` : "Das Element konnte nicht auf Standard zurückgesetzt werden.";
     if (!result?.ok) this.layoutPersistenceStatus = "Layout konnte nicht auf Standard zurückgesetzt werden.";
-    this.renderAll();
+    this.renderStatus();
+    this.renderDetails();
     this.syncActiveSelectionRuntime();
   }
 

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -666,12 +666,12 @@ export class BbmUiEditorStatusPanel {
   openResetElementDefaultsDialog() {
     if (!this.selectedElement) return;
     this.resetElementDefaultsDialogOpen = true;
-    this.renderAll();
+    this.renderDetails();
   }
 
   closeResetElementDefaultsDialog() {
     this.resetElementDefaultsDialogOpen = false;
-    this.renderAll();
+    this.renderDetails();
   }
 
   renderResetElementDefaultsDialog() {

--- a/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
+++ b/src/renderer/ui-editor/BbmUiEditorStatusPanel.js
@@ -63,6 +63,7 @@ export class BbmUiEditorStatusPanel {
     this.layoutSessionStatus = { ok: true, active: false, changedElementIds: [], changedCount: 0, changedByElementId: {} };
     this.layoutPersistenceStatus = "Noch nicht gespeichert";
     this.resetDefaultsDialogOpen = false;
+    this.resetElementDefaultsDialogOpen = false;
     this.savedLayoutLoadedForSession = false;
     this.inspectorBridge = createBbmEditorRuntimeInspectorBridge({
       getRegistryElements: () => this.elements,
@@ -551,6 +552,7 @@ export class BbmUiEditorStatusPanel {
     const elementId = String(element.elementId || element.id || "").trim();
     if (elementId !== this.lastRenderedLayoutControlElementId) {
       this.activeLayoutControlMode = "move";
+      this.resetElementDefaultsDialogOpen = false;
       this.lastRenderedLayoutControlElementId = elementId;
     }
 
@@ -588,6 +590,18 @@ export class BbmUiEditorStatusPanel {
 
     consoleNode.append(modes, pad);
     section.appendChild(consoleNode);
+
+    const elementReset = createNode("div", "bbm-ui-editor-element-reset");
+    const elementResetButton = createNode("button", "bbm-ui-editor-panel__secondary bbm-ui-editor-panel__secondary--danger");
+    elementResetButton.type = "button";
+    elementResetButton.textContent = "Element auf Standard …";
+    elementResetButton.disabled = !Boolean(this.editorActive && element?.editable && result?.selectedElementCanResetToDefaults);
+    elementResetButton.addEventListener("click", () => this.openResetElementDefaultsDialog());
+    const elementResetHint = createNode("p", "bbm-ui-editor-panel__empty");
+    elementResetHint.textContent = "↶ verwirft Sitzungsänderungen. Element-Standard löscht die gespeicherte Anpassung.";
+    elementReset.append(elementResetButton, elementResetHint);
+    section.appendChild(elementReset);
+    if (this.resetElementDefaultsDialogOpen) section.appendChild(this.renderResetElementDefaultsDialog());
     if (this.selectionMessage) {
       const selected = createNode("p", "bbm-ui-editor-panel__notice");
       selected.textContent = this.selectionMessage;
@@ -648,6 +662,52 @@ export class BbmUiEditorStatusPanel {
     this.renderAll();
   }
 
+  openResetElementDefaultsDialog() {
+    if (!this.selectedElement) return;
+    this.resetElementDefaultsDialogOpen = true;
+    this.renderAll();
+  }
+
+  closeResetElementDefaultsDialog() {
+    this.resetElementDefaultsDialogOpen = false;
+    this.renderAll();
+  }
+
+  renderResetElementDefaultsDialog() {
+    const dialog = createNode("div", "bbm-ui-editor-reset-defaults-dialog");
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("aria-modal", "true");
+    const title = createNode("h3");
+    title.textContent = "Element auf Standard zurücksetzen?";
+    const label = asText(this.selectedElement?.label || this.selectedElement?.name, "ausgewähltes Element");
+    const text = createNode("p", "bbm-ui-editor-panel__notice");
+    text.textContent = `Die gespeicherten Layoutanpassungen für „${label}“ werden gelöscht. Das Element wird auf seine ursprüngliche Position und Darstellung zurückgesetzt.`;
+    const actions = createNode("div", "bbm-ui-editor-panel__actions");
+    const cancel = createNode("button", "bbm-ui-editor-panel__secondary");
+    cancel.type = "button";
+    cancel.textContent = "Abbrechen";
+    cancel.addEventListener("click", () => this.closeResetElementDefaultsDialog());
+    const confirm = createNode("button", "bbm-ui-editor-panel__secondary bbm-ui-editor-panel__secondary--danger");
+    confirm.type = "button";
+    confirm.textContent = "Element zurücksetzen";
+    confirm.setAttribute("data-destructive", "true");
+    confirm.addEventListener("click", () => this.confirmResetSelectedElementToDefaults());
+    actions.append(cancel, confirm);
+    dialog.append(title, text, actions);
+    return dialog;
+  }
+
+  confirmResetSelectedElementToDefaults() {
+    const label = asText(this.selectedElement?.label || this.selectedElement?.name, "Das Element");
+    const result = this.inspectorBridge?.resetSelectedElementToDefaults?.();
+    this.layoutSessionStatus = result?.status || this.layoutSessionStatus;
+    this.resetElementDefaultsDialogOpen = false;
+    this.selectionMessage = result?.ok ? `„${label}“ wurde auf Standard zurückgesetzt.` : "Das Element konnte nicht auf Standard zurückgesetzt werden.";
+    if (!result?.ok) this.layoutPersistenceStatus = "Layout konnte nicht auf Standard zurückgesetzt werden.";
+    this.renderAll();
+    this.syncActiveSelectionRuntime();
+  }
+
   openResetDefaultsDialog() {
     this.resetDefaultsDialogOpen = true;
     this.renderAll();
@@ -685,6 +745,7 @@ export class BbmUiEditorStatusPanel {
     const result = this.inspectorBridge?.resetLayoutToDefaults?.();
     this.layoutSessionStatus = result?.status || this.layoutSessionStatus;
     this.resetDefaultsDialogOpen = false;
+    this.resetElementDefaultsDialogOpen = false;
     this.layoutPersistenceStatus = result?.ok ? "Standardlayout aktiv" : "Layout konnte nicht auf Standard zurückgesetzt werden.";
     this.selectionMessage = result?.ok ? "Standardlayout aktiv." : "Layout konnte nicht auf Standard zurückgesetzt werden.";
     this.renderAll();

--- a/src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js
+++ b/src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js
@@ -237,6 +237,11 @@ export function createBbmEditorRuntimeInspectorBridge(options = {}) {
         controlPanel: panel ? { ...panel, controls: toM63cControls(panel.controls) } : null,
         controls: toM63cControls(panel?.controls),
         allowedOps: Array.isArray(panel?.selectedElement?.effectiveOps) ? [...panel.selectedElement.effectiveOps] : [],
+        selectedElementHasSavedLayout: Boolean(panel?.status?.selectedElementHasSavedLayout),
+        selectedElementDeviatesFromDefaults: Boolean(panel?.status?.selectedElementDeviatesFromDefaults),
+        selectedElementCanResetToDefaults: Boolean(panel?.status?.selectedElementCanResetToDefaults),
+        persistenceAvailable: Boolean(panel?.status?.persistenceAvailable),
+        persistencePersistent: Boolean(panel?.status?.persistencePersistent),
         registry: snapshot.transformed.registry,
         errors: panel?.errors || [],
         warnings: panel?.warnings || [],
@@ -308,6 +313,13 @@ export function createBbmEditorRuntimeInspectorBridge(options = {}) {
     return callLayoutSessionMethod("resetLayoutToDefaults");
   }
 
+  function resetSelectedElementToDefaults() {
+    const status = getStatus();
+    if (!status.ok || status.kind !== "ready") return { ok: false, blocked: true, reason: status.reason || "NO_SELECTED_ELEMENT" };
+    const snapshot = getSnapshot();
+    return callLayoutSessionMethod("resetLayoutElementToDefaults", snapshot.selectedElementId);
+  }
+
   function discardSelectedElementChanges(elementId) {
     return callLayoutSessionMethod("discardLayoutSessionElement", normalizeId(elementId));
   }
@@ -320,7 +332,7 @@ export function createBbmEditorRuntimeInspectorBridge(options = {}) {
     return callLayoutSessionMethod("endLayoutSession");
   }
 
-  return { inspectSelectedElement, getSelectedElementControlPanel, applySelectedElementLayoutAction, beginLayoutSession, getLayoutSessionStatus, saveLayoutSession, loadSavedLayout, resetLayoutToDefaults, discardSelectedElementChanges, discardAllSessionChanges, endLayoutSession, getStatus };
+  return { inspectSelectedElement, getSelectedElementControlPanel, applySelectedElementLayoutAction, beginLayoutSession, getLayoutSessionStatus, saveLayoutSession, loadSavedLayout, resetLayoutToDefaults, resetSelectedElementToDefaults, discardSelectedElementChanges, discardAllSessionChanges, endLayoutSession, getStatus };
 }
 
 export const BBM_EDITOR_RUNTIME_INSPECTOR_BRIDGE_ROLE_BY_ID = ROLE_BY_ELEMENT_ID;

--- a/src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js
+++ b/src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js
@@ -313,6 +313,10 @@ export function createBbmEditorRuntimeInspectorBridge(options = {}) {
     return callLayoutSessionMethod("resetLayoutToDefaults");
   }
 
+  function reapplyCurrentLayoutState() {
+    return callLayoutSessionMethod("reapplyCurrentLayoutState");
+  }
+
   function resetSelectedElementToDefaults() {
     const status = getStatus();
     if (!status.ok || status.kind !== "ready") return { ok: false, blocked: true, reason: status.reason || "NO_SELECTED_ELEMENT" };
@@ -332,7 +336,7 @@ export function createBbmEditorRuntimeInspectorBridge(options = {}) {
     return callLayoutSessionMethod("endLayoutSession");
   }
 
-  return { inspectSelectedElement, getSelectedElementControlPanel, applySelectedElementLayoutAction, beginLayoutSession, getLayoutSessionStatus, saveLayoutSession, loadSavedLayout, resetLayoutToDefaults, resetSelectedElementToDefaults, discardSelectedElementChanges, discardAllSessionChanges, endLayoutSession, getStatus };
+  return { inspectSelectedElement, getSelectedElementControlPanel, applySelectedElementLayoutAction, beginLayoutSession, getLayoutSessionStatus, saveLayoutSession, loadSavedLayout, resetLayoutToDefaults, resetSelectedElementToDefaults, reapplyCurrentLayoutState, discardSelectedElementChanges, discardAllSessionChanges, endLayoutSession, getStatus };
 }
 
 export const BBM_EDITOR_RUNTIME_INSPECTOR_BRIDGE_ROLE_BY_ID = ROLE_BY_ELEMENT_ID;

--- a/src/renderer/ui-editor/bbmMainUiHostAdapter.js
+++ b/src/renderer/ui-editor/bbmMainUiHostAdapter.js
@@ -166,6 +166,20 @@ function buildDefaultEntries(registry, stateElementIds = new Set()) {
     .filter((entry) => entry.elementId);
 }
 
+function readInlineStyleValue(target, propertyName) {
+  if (target?.style?.values && Object.prototype.hasOwnProperty.call(target.style.values, propertyName)) return target.style.values[propertyName];
+  if (typeof target?.style?.getPropertyValue === "function") {
+    const value = target.style.getPropertyValue(propertyName);
+    return value === "" ? undefined : value;
+  }
+  return undefined;
+}
+
+function applyInlineStyleValue(target, propertyName, value) {
+  if (value === undefined) target.style.removeProperty(propertyName);
+  else target.style.setProperty(propertyName, value);
+}
+
 function applyLayoutValueToRegisteredTarget(elementId, layoutValue, { resetMissingSize = false } = {}) {
   const target = getBbmUiElementRef(elementId);
   if (!target) {
@@ -241,23 +255,61 @@ export function createBbmMainUiHostAdapter({ registry = [], layoutStorage = shar
     }
   }
 
-  function currentDeviatesFromDefaults() {
-    const currentEntries = layoutStore.list();
-    const currentById = new Map(currentEntries.map((entry) => [normalizeId(entry.elementId), entry.layoutValue || {}]));
-    const stateIds = getStateElementIds(currentEntries);
-    const defaultEntries = buildDefaultEntries(runtimeRegistry, stateIds);
-    return defaultEntries.some((entry) => currentById.has(normalizeId(entry.elementId)) && !sameComparableLayoutValue(currentById.get(normalizeId(entry.elementId)) || {}, entry.layoutValue || {}));
+  function getCurrentEntry(elementId) {
+    const normalizedElementId = normalizeId(elementId);
+    return layoutStore.list().find((entry) => normalizeId(entry.elementId) === normalizedElementId) || null;
   }
 
-  function getPersistenceStatus() {
+  function getSavedEntry(elementId) {
+    const normalizedElementId = normalizeId(elementId);
+    return persistentLayoutStore.list().find((entry) => normalizeId(entry.elementId) === normalizedElementId && isDefaultLayoutProfile(entry)) || null;
+  }
+
+  function elementDeviatesFromDefaults(elementId) {
+    const currentEntry = getCurrentEntry(elementId);
+    if (!currentEntry) return false;
+    const registryElement = getRegistryElement(runtimeRegistry, elementId);
+    if (!registryElement) return false;
+    return !sameComparableLayoutValue(currentEntry.layoutValue || {}, buildDefaultLayoutValue(registryElement));
+  }
+
+  function currentDeviatesFromDefaults() {
+    return runtimeRegistry.some((entry) => elementDeviatesFromDefaults(entry.id));
+  }
+
+  function getSelectedLayoutStatus(elementId) {
+    const normalizedElementId = normalizeId(elementId);
+    const registryElement = getRegistryElement(runtimeRegistry, normalizedElementId);
+    const persistenceAvailable = Boolean(layoutStorage?.available);
+    const persistencePersistent = Boolean(layoutStorage?.persistent);
+    const selectedElementHasSavedLayout = Boolean(registryElement && getSavedEntry(normalizedElementId));
+    const selectedElementDeviatesFromDefaults = Boolean(registryElement && elementDeviatesFromDefaults(normalizedElementId));
+    return {
+      elementId: normalizedElementId,
+      selectedElementRegistered: Boolean(registryElement),
+      selectedElementEditable: Boolean(registryElement?.editable),
+      selectedElementHasSavedLayout,
+      selectedElementDeviatesFromDefaults,
+      selectedElementCanResetToDefaults: Boolean(
+        registryElement?.editable &&
+        persistenceAvailable &&
+        persistencePersistent &&
+        (selectedElementHasSavedLayout || selectedElementDeviatesFromDefaults)
+      ),
+    };
+  }
+
+  function getPersistenceStatus({ elementId = null } = {}) {
     const savedLayoutFound = hasSavedLayout();
     const deviatesFromDefaults = currentDeviatesFromDefaults();
+    const selectedLayoutStatus = elementId ? getSelectedLayoutStatus(elementId) : {};
     return {
       persistenceAvailable: Boolean(layoutStorage?.available),
       persistencePersistent: Boolean(layoutStorage?.persistent),
       savedLayoutFound,
       deviatesFromDefaults,
       standardLayoutActive: !savedLayoutFound && !deviatesFromDefaults,
+      ...selectedLayoutStatus,
     };
   }
 
@@ -370,6 +422,63 @@ export function createBbmMainUiHostAdapter({ registry = [], layoutStorage = shar
       }
 
       return { ok: true, blocked: false, reason: null, validation, layoutEntry, applyResult };
+    },
+
+    resetLayoutElementToDefaults({ elementId = null } = {}) {
+      const normalizedElementId = normalizeId(elementId);
+      const registryElement = getRegistryElement(runtimeRegistry, normalizedElementId);
+      const persistence = getPersistenceStatus({ elementId: normalizedElementId });
+      if (!registryElement) return { ...persistence, ok: false, blocked: true, reason: "ELEMENT_ID_UNKNOWN", layoutState: layoutStore.list(), savedLayoutState: persistentLayoutStore.list() };
+      if (!registryElement.editable) return { ...persistence, ok: false, blocked: true, reason: "ELEMENT_NOT_EDITABLE", layoutState: layoutStore.list(), savedLayoutState: persistentLayoutStore.list() };
+      if (!persistence.persistenceAvailable || !persistence.persistencePersistent) return { ...persistence, ok: false, blocked: true, reason: "LAYOUT_STORAGE_NOT_PERSISTENT", layoutState: layoutStore.list(), savedLayoutState: persistentLayoutStore.list() };
+      if (!persistence.selectedElementHasSavedLayout && !persistence.selectedElementDeviatesFromDefaults) return { ...persistence, ok: false, blocked: true, reason: "ELEMENT_LAYOUT_ALREADY_DEFAULT", layoutState: layoutStore.list(), savedLayoutState: persistentLayoutStore.list() };
+      const target = getBbmUiElementRef(normalizedElementId);
+      if (!target) return { ...persistence, ok: false, blocked: true, reason: "ELEMENT_REF_MISSING", elementId: normalizedElementId, layoutState: layoutStore.list(), savedLayoutState: persistentLayoutStore.list() };
+
+      const previousPersistentEntries = cloneLayoutEntries(persistentLayoutStore.list());
+      const previousSessionEntries = cloneLayoutEntries(layoutStore.list());
+      const previousVisibleState = {
+        transform: readInlineStyleValue(target, "transform"),
+        width: readInlineStyleValue(target, "width"),
+        height: readInlineStyleValue(target, "height"),
+        hidden: Boolean(target.hidden),
+      };
+      const ids = runtimeRegistry.map((entry) => normalizeId(entry.id)).filter(Boolean);
+      function restoreElementStyle() {
+        applyInlineStyleValue(target, "transform", previousVisibleState.transform);
+        applyInlineStyleValue(target, "width", previousVisibleState.width);
+        applyInlineStyleValue(target, "height", previousVisibleState.height);
+        target.hidden = previousVisibleState.hidden;
+      }
+      function rollback(reason, extra = {}) {
+        try { layoutStore.replace(previousSessionEntries.filter((entry) => normalizeId(entry.elementId) === normalizedElementId), [normalizedElementId]); } catch (_error) {}
+        try { persistentLayoutStore.replace(previousPersistentEntries, ids); } catch (_error) {}
+        try { restoreElementStyle(); } catch (_error) {}
+        return { ...getPersistenceStatus({ elementId: normalizedElementId }), ok: false, blocked: true, reason, ...extra, layoutState: layoutStore.list(), savedLayoutState: persistentLayoutStore.list() };
+      }
+
+      try {
+        const defaultEntry = {
+          layoutProfileId: "default",
+          targetAppId: SCOPE.targetAppId,
+          moduleId: SCOPE.moduleId,
+          scopeId: SCOPE.scopeId,
+          elementId: normalizedElementId,
+          operation: "layout.elementDefaults",
+          layoutValue: buildDefaultLayoutValue(registryElement),
+          createdAt: "",
+          updatedAt: "",
+        };
+        const applyResult = applyLayoutValueToRegisteredTarget(normalizedElementId, defaultEntry.layoutValue, { resetMissingSize: true });
+        if (!applyResult.ok) return rollback(applyResult.reason || "LAYOUT_ELEMENT_DEFAULT_APPLY_FAILED");
+        layoutStore.replace([], [normalizedElementId]);
+        persistentLayoutStore.reset(normalizedElementId);
+        const verify = persistentLayoutStore.list();
+        if (verify.some((entry) => normalizeId(entry.elementId) === normalizedElementId && isDefaultLayoutProfile(entry))) return rollback("LAYOUT_STORAGE_ELEMENT_VERIFY_FAILED");
+        return { ...getPersistenceStatus({ elementId: normalizedElementId }), ok: true, blocked: false, reason: null, elementId: normalizedElementId, layoutState: layoutStore.list(), savedLayoutState: verify };
+      } catch (error) {
+        return rollback(error?.code || "LAYOUT_ELEMENT_RESET_DEFAULTS_FAILED");
+      }
     },
 
     resetLayoutState({ elementId = null } = {}) {

--- a/src/renderer/ui-editor/bbmMainUiHostAdapter.js
+++ b/src/renderer/ui-editor/bbmMainUiHostAdapter.js
@@ -352,8 +352,8 @@ export function createBbmMainUiHostAdapter({ registry = [], layoutStorage = shar
       return persistentLayoutStore.list();
     },
 
-    getPersistenceStatus() {
-      return getPersistenceStatus();
+    getPersistenceStatus(options = {}) {
+      return getPersistenceStatus(options);
     },
 
     loadSavedLayout() {

--- a/src/renderer/ui-editor/bbmMainUiHostAdapter.js
+++ b/src/renderer/ui-editor/bbmMainUiHostAdapter.js
@@ -262,7 +262,11 @@ export function createBbmMainUiHostAdapter({ registry = [], layoutStorage = shar
 
   function getSavedEntry(elementId) {
     const normalizedElementId = normalizeId(elementId);
-    return persistentLayoutStore.list().find((entry) => normalizeId(entry.elementId) === normalizedElementId && isDefaultLayoutProfile(entry)) || null;
+    try {
+      return persistentLayoutStore.list().find((entry) => normalizeId(entry.elementId) === normalizedElementId && isDefaultLayoutProfile(entry)) || null;
+    } catch (_error) {
+      return null;
+    }
   }
 
   function elementDeviatesFromDefaults(elementId) {

--- a/src/renderer/ui-editor/bbmMainUiHostAdapter.js
+++ b/src/renderer/ui-editor/bbmMainUiHostAdapter.js
@@ -424,6 +424,15 @@ export function createBbmMainUiHostAdapter({ registry = [], layoutStorage = shar
       return { ok: true, blocked: false, reason: null, validation, layoutEntry, applyResult };
     },
 
+    reapplyCurrentLayoutState() {
+      const layoutState = layoutStore.list();
+      const applyResult = applyEntries(layoutState, { resetMissingSize: false });
+      if (!applyResult.ok) {
+        return { ...getPersistenceStatus(), ok: false, blocked: true, reason: applyResult.reason || "LAYOUT_REAPPLY_FAILED", elementId: applyResult.elementId, layoutState };
+      }
+      return { ...getPersistenceStatus(), ok: true, blocked: false, reason: null, layoutState };
+    },
+
     resetLayoutElementToDefaults({ elementId = null } = {}) {
       const normalizedElementId = normalizeId(elementId);
       const registryElement = getRegistryElement(runtimeRegistry, normalizedElementId);


### PR DESCRIPTION
### Motivation
- Add a safe, single-element reset that deletes the persisted layout entry for the currently selected editable element and restores its visible inline state to the CSS/registry default without affecting other elements. 
- Keep the four reset paths strictly separated: session undo for selected element (↶), discard all session changes, per-element persistent reset (this PR), and full-scope default reset. 
- Provide a neutral public runtime API and structured status fields so the panel never performs direct DOM/storage manipulation or maintains its own default truth.

### Description
- Introduces a host-adapter operation to reset a single element: `resetLayoutElementToDefaults({ elementId })` and implements rollback/safety (changes in `src/renderer/ui-editor/bbmMainUiHostAdapter.js`).
- Extends the inspector facade with `resetLayoutElementToDefaults(scopeId, elementId)` and a session-baseline update for the single element (changes in `src/renderer/editorRuntime/inspector/editorScopeInspector.js`).
- Extends the runtime bridge to surface structured status fields (`selectedElementHasSavedLayout`, `selectedElementDeviatesFromDefaults`, `selectedElementCanResetToDefaults`) and adds `resetSelectedElementToDefaults()` so the panel can call the single-element reset (changes in `src/renderer/ui-editor/bbmEditorRuntimeInspectorBridge.js`).
- Adds a panel button `Element auf Standard …` with a confirmation dialog (no technical ID shown) that calls the bridge API and updates session baseline only for the element, and augments layout control panel status to include persistence info (changes in `src/renderer/ui-editor/BbmUiEditorStatusPanel.js` and `src/renderer/editorRuntime/inspector/editorLayoutControls.js`).
- Adds unit/regression tests and wiring: `scripts/tests/m67ResetElementToDefaults.test.cjs` and integrates the test into `scripts/test.cjs`, and updates `STATUS.md` and `docs/UI_INSPEKTOR_AUFGABENHEFT.md`.

### Testing
- Ran the UI-Editor contract checks and unit/regression suites: `node scripts/ui-editor-contract-check.cjs` and `node scripts/ui-editor-contract-check.cjs --self-test` both passed. 
- Ran the editor tests `node scripts/tests/m64UiEditorTestSurface.test.cjs`, `node scripts/tests/m65LayoutPersistenceRoundtrip.test.cjs`, `node scripts/tests/m66ResetLayoutToDefaults.test.cjs`, and the new `node scripts/tests/m67ResetElementToDefaults.test.cjs`, all of which passed in this environment. 
- Attempted full test run via `timeout 180s node scripts/test.cjs` which produced OK outputs for included editor tests but did not complete within the Cloud time window. 
- `npm test` could not be executed in this Cloud environment because Electron system libraries are missing (`libatk-1.0.so.0`), so a local Windows/Electron acceptance run remains necessary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d383e09988322b4b10954749b5e9a)