### PR TITLE
Modul „Pläne“ — M1 Modulgerüst ergänzen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -3356,3 +3356,19 @@ Wichtig:
   - `npm test` in dieser Umgebung wegen fehlender Electron-Systembibliothek `libatk-1.0.so.0` nicht ausführbar
 - Nächster offener Schritt:
   - Vollständigen `npm test` lokal/CI mit vorhandenen Electron-Systembibliotheken erneut ausführen.
+
+## Modul Pläne – M1 Modulgerüst im bestehenden Projektkontext
+- Status: umgesetzt im Branch `codex/plaene-m1-modulgeruest`.
+- Beschreibung:
+  - Neues Projektmodul `plaene` als kleines Modulgerüst parallel zu vorhandenen Projektmodulen ergänzt.
+  - Das Modul nutzt den bestehenden generischen Projektmodul-Pfad und erzeugt keinen eigenen Projekt-State.
+  - Ohne aktives Projekt zeigt die Ansicht den Hinweis: „Kein Projekt ausgewählt. Öffnen Sie zuerst ein Projekt, um dessen Pläne zu verwalten.“
+  - Mit aktivem Projekt zeigt die Ansicht nur den übergebenen Projektkontext: Projektname, Projekt-ID, bestehenden Projektordner über die vorhandene Storage-Preview sowie lesend gezählte Gebäude und Geschosse aus vorhandenen Projektwerten.
+  - Spätere Meilensteine wie Planordner-Auswahl, PDF-Suche/-Analyse, OCR, KI, WebP, Planversionierung, Planwächter, Mobil-Synchronisation und Restarbeiten-Anbindung wurden nicht begonnen.
+- Prüfung:
+  - `node scripts/tests/plaeneModule.test.cjs` OK
+- Nächster offener Schritt:
+  - M2 erst nach Abnahme von M1 beginnen: externen Planordner projektbezogen anbinden.
+- Risiken/Hindernisse:
+  - Praktische Computer-Use-/Electron-UI-Abnahme ist in dieser Umgebung nicht verfügbar und muss lokal/auf Zielsystem nachgeholt werden.
+  - Im aktuellen Checkout ist kein Git-Remote `origin` eingerichtet; Veröffentlichung/PR hängt vom verfügbaren PR-Werkzeug ab.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -24,6 +24,7 @@ const { runBbmUiEditorInstalledArtifactsTests } = require("./tests/bbmUiEditorIn
 const { runBbmUiEditorRuntimeLauncherTests } = require("./tests/bbmUiEditorRuntimeLauncher.test.cjs");
 const { runProjektverwaltungModuleTests } = require("./tests/projektverwaltungModule.test.cjs");
 const { runRestarbeitenModuleTests } = require("./tests/restarbeitenModule.test.cjs");
+const { runPlaeneModuleTests } = require("./tests/plaeneModule.test.cjs");
 const { runRestarbeitenDataModelTests } = require("./tests/restarbeitenDataModel.test.cjs");
 const { runRestarbeitenRulesTests } = require("./tests/restarbeitenRules.test.cjs");
 const { runUiEditorContractTests } = require("./tests/uiEditorContract.test.cjs");
@@ -168,6 +169,7 @@ async function main() {
   await runBbmUiEditorRuntimeLauncherTests(run);
   await runProjektverwaltungModuleTests(run);
   await runRestarbeitenModuleTests(run);
+  await runPlaeneModuleTests(run);
   await runRestarbeitenDataModelTests(run);
   await runRestarbeitenRulesTests(run);
   await runUiEditorContractTests(run);

--- a/scripts/tests/plaeneModule.test.cjs
+++ b/scripts/tests/plaeneModule.test.cjs
@@ -1,0 +1,284 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+function createFakeDocument() {
+  const createNode = (tag, doc) => {
+    const node = {
+      tagName: String(tag || "").toUpperCase(),
+      ownerDocument: doc,
+      children: [],
+      parentElement: null,
+      style: {},
+      dataset: {},
+      attributes: {},
+      className: "",
+      textContent: "",
+      append(...nodes) {
+        for (const child of nodes) this.appendChild(child);
+      },
+      appendChild(child) {
+        if (!child || typeof child !== "object") return child;
+        if (child.nodeType === 11) {
+          for (const fragmentChild of [...child.children]) this.appendChild(fragmentChild);
+          child.children = [];
+          return child;
+        }
+        child.parentElement = this;
+        this.children.push(child);
+        return child;
+      },
+      replaceChildren(...nodes) {
+        this.children = [];
+        this.textContent = "";
+        this.append(...nodes);
+      },
+      setAttribute(name, value) {
+        const key = String(name);
+        const text = String(value);
+        this.attributes[key] = text;
+        if (key.startsWith("data-")) {
+          const dataKey = key.slice(5).replace(/-([a-z])/g, (_match, char) => char.toUpperCase());
+          this.dataset[dataKey] = text;
+        }
+      },
+      getAttribute(name) {
+        const key = String(name);
+        return Object.prototype.hasOwnProperty.call(this.attributes, key) ? this.attributes[key] : null;
+      },
+    };
+    return node;
+  };
+  const doc = {
+    createElement(tag) {
+      return createNode(tag, doc);
+    },
+    createDocumentFragment() {
+      const fragment = createNode("#fragment", doc);
+      fragment.nodeType = 11;
+      return fragment;
+    },
+    body: null,
+    head: null,
+  };
+  doc.body = createNode("body", doc);
+  doc.head = createNode("head", doc);
+  return doc;
+}
+
+function collectText(node) {
+  if (typeof node === "string") return node;
+  const ownText = String(node?.textContent || "");
+  const children = Array.isArray(node?.children) ? node.children : [];
+  return [ownText, ...children.map((child) => collectText(child))].join(" ");
+}
+
+function findNodes(node, predicate, acc = []) {
+  if (!node || typeof node !== "object") return acc;
+  if (predicate(node)) acc.push(node);
+  for (const child of Array.isArray(node?.children) ? node.children : []) {
+    findNodes(child, predicate, acc);
+  }
+  return acc;
+}
+
+function findByUiId(node, uiId) {
+  return findNodes(node, (entry) => entry.getAttribute?.("data-ui-inspector-id") === uiId)[0] || null;
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function withFakeDom(fn, bbmDb = {}) {
+  const previousDocument = globalThis.document;
+  const previousWindow = globalThis.window;
+  globalThis.document = createFakeDocument();
+  globalThis.window = { bbmDb, dispatchEvent() {} };
+  try {
+    return await fn(globalThis.document);
+  } finally {
+    globalThis.document = previousDocument;
+    globalThis.window = previousWindow;
+  }
+}
+
+async function runPlaeneModuleTests(run) {
+  const [plaeneModule, screenResolver, navigationModule, catalogModule, screenModule] = await Promise.all([
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/plaene/index.js")),
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/app/modules/moduleEntryScreenResolver.js")),
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/app/modules/moduleNavigation.js")),
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/app/modules/moduleCatalog.js")),
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/plaene/screens/PlaeneScreen.js")),
+  ]);
+
+  await run("Pläne: Modulentry bleibt im Projektmodul-System erreichbar", () => {
+    const entry = plaeneModule.getPlaeneModuleEntry();
+    assert.equal(entry.moduleId, "plaene");
+    assert.equal(entry.moduleLabel, "Pläne");
+    assert.equal(entry.workScreenId, "plaeneWork");
+    assert.equal(entry.navigation.project[0].key, "plaene");
+    assert.equal(entry.navigation.project[0].label, "Pläne");
+    assert.equal(entry.navigation.project[0].section, "plaene");
+    assert.equal(entry.shell.hideSidebar, true);
+    assert.equal(typeof screenResolver.resolveModuleWorkScreenFromEntry(entry), "function");
+  });
+
+  await run("Pläne: aktive Projektmodulnavigation enthält genau einen Pläne-Eintrag", () => {
+    const entries = navigationModule.getActiveProjectModuleNavigation();
+    const plaeneEntries = entries.filter((entry) => entry.moduleId === "plaene");
+    assert.equal(plaeneEntries.length, 1);
+    assert.equal(catalogModule.getActiveModuleIds().includes("plaene"), true);
+  });
+
+  await run("Pläne: ohne aktives Projekt zeigt die definierte Hinweisansicht", async () => withFakeDom(async () => {
+    const screen = new screenModule.default({ projectId: null, project: null });
+    const root = screen.render();
+    await flush();
+    const text = collectText(root);
+    assert.equal(text.includes("Kein Projekt ausgewählt."), true);
+    assert.equal(text.includes("Öffnen Sie zuerst ein Projekt, um dessen Pläne zu verwalten."), true);
+    assert.equal(text.includes("Modul Pläne"), false);
+    assert.equal(Boolean(findByUiId(root, "plaene.m1.no-project-notice")), true);
+  }));
+
+  await run("Pläne: aktives Projekt zeigt ausschließlich übergebene Projektwerte", async () => withFakeDom(async () => {
+    const screen = new screenModule.default({
+      projectId: "projekt-a",
+      project: {
+        id: "projekt-a",
+        name: "Projekt A",
+        buildings: ["Haus A", "Haus B"],
+        floors: ["EG", "OG"],
+      },
+    });
+    const root = screen.render();
+    await flush();
+    const text = collectText(root);
+    assert.equal(text.includes("Modul Pläne"), true);
+    assert.equal(text.includes("Aktives Projekt: Projekt A"), true);
+    assert.equal(text.includes("projekt-a"), true);
+    assert.equal(text.includes("Anzahl vorhandener Gebäude 2"), true);
+    assert.equal(text.includes("Anzahl vorhandener Geschosse 2"), true);
+    assert.equal(text.includes("Die Planordner-Anbindung folgt in Meilenstein M2."), true);
+    assert.equal(text.includes("Projekt B"), false);
+  }));
+
+  await run("Pläne: Projektwechsel nutzt neue Screen-Props statt alten lokalen Projekt-State", async () => withFakeDom(async () => {
+    const screenA = new screenModule.default({
+      projectId: "projekt-a",
+      project: { id: "projekt-a", name: "Projekt A", buildings: ["Haus A"], floors: ["EG"] },
+    });
+    const rootA = screenA.render();
+    await flush();
+
+    const screenB = new screenModule.default({
+      projectId: "projekt-b",
+      project: { id: "projekt-b", name: "Projekt B", buildings: ["Haus C", "Haus D"], floors: ["UG", "EG", "OG"] },
+    });
+    const rootB = screenB.render();
+    await flush();
+
+    const textA = collectText(rootA);
+    const textB = collectText(rootB);
+    assert.equal(textA.includes("Projekt A"), true);
+    assert.equal(textB.includes("Projekt B"), true);
+    assert.equal(textB.includes("Projekt A"), false);
+    assert.equal(textB.includes("projekt-a"), false);
+    assert.equal(textB.includes("projekt-b"), true);
+    assert.equal(textB.includes("Anzahl vorhandener Gebäude 2"), true);
+    assert.equal(textB.includes("Anzahl vorhandener Geschosse 3"), true);
+  }));
+
+  await run("Pläne: Projektordner wird nur lesend über vorhandene Storage-Preview bezogen", async () => {
+    const calls = [];
+    await withFakeDom(async () => {
+      const screen = new screenModule.default({
+        projectId: "projekt-a",
+        project: { id: "projekt-a", name: "Projekt A" },
+      });
+      const root = screen.render();
+      await flush();
+      const text = collectText(root);
+      assert.equal(calls.length, 1);
+      assert.deepEqual(calls[0], { id: "projekt-a", name: "Projekt A" });
+      assert.equal(text.includes("Projektordner 100 - Projekt A"), true);
+    }, {
+      async projectsStoragePreview(project) {
+        calls.push(project);
+        return { ok: true, projectFolder: "100 - Projekt A" };
+      },
+    });
+  });
+
+  await run("Pläne: keine projektlose Speicherung oder Plandaten-IPC im M1-Screen", async () => {
+    const calls = [];
+    await withFakeDom(async () => {
+      const screen = new screenModule.default({ projectId: null, project: null });
+      screen.render();
+      await flush();
+      assert.equal(calls.length, 0);
+    }, {
+      async projectsStoragePreview(project) {
+        calls.push(project);
+        return { ok: true, projectFolder: "soll-nicht-passieren" };
+      },
+      async plansCreate() {
+        throw new Error("plansCreate darf in M1 nicht existieren/benutzt werden");
+      },
+    });
+  });
+
+  await run("Pläne: UI-Editor-Pflichtattribute und Parent-Struktur sind im neuen DOM vorhanden", async () => withFakeDom(async () => {
+    const screen = new screenModule.default({
+      projectId: "projekt-a",
+      project: { id: "projekt-a", name: "Projekt A", buildings: ["Haus A"], floors: ["EG"] },
+    });
+    const root = screen.render();
+    await flush();
+    const expected = new Map([
+      ["plaene.m1.root", ""],
+      ["plaene.m1.header", "plaene.m1.root"],
+      ["plaene.m1.title", "plaene.m1.header"],
+      ["plaene.m1.active-project", "plaene.m1.header"],
+      ["plaene.m1.project-summary", "plaene.m1.root"],
+      ["plaene.m1.project-id", "plaene.m1.project-summary"],
+      ["plaene.m1.project-folder", "plaene.m1.project-summary"],
+      ["plaene.m1.building-count", "plaene.m1.project-summary"],
+      ["plaene.m1.floor-count", "plaene.m1.project-summary"],
+      ["plaene.m1.next-step-note", "plaene.m1.root"],
+    ]);
+    for (const [id, parentId] of expected) {
+      const node = findByUiId(root, id);
+      assert.ok(node, `${id} fehlt`);
+      assert.equal(node.getAttribute("data-ui-editor-id"), id);
+      assert.equal(node.getAttribute("data-ui-editor-parent"), parentId);
+      assert.equal(node.getAttribute("data-ui-editor-editable"), "true");
+      assert.equal(node.getAttribute("data-ui-editor-ops"), "inspect,select");
+      assert.ok(["frame", "field", "single"].includes(node.getAttribute("data-ui-editor-kind")));
+      assert.ok(node.getAttribute("data-ui-editor-label"));
+      if (parentId) assert.ok(findByUiId(root, parentId), `${id} Parent fehlt`);
+    }
+  }));
+}
+
+if (require.main === module) {
+  const results = [];
+  const run = async (name, fn) => {
+    try {
+      await fn();
+      results.push({ name, ok: true });
+      console.log(`ok - ${name}`);
+    } catch (error) {
+      results.push({ name, ok: false });
+      console.error(`not ok - ${name}`);
+      console.error(error?.stack || error?.message || error);
+    }
+  };
+  runPlaeneModuleTests(run).then(() => {
+    if (results.some((result) => !result.ok)) process.exit(1);
+  });
+}
+
+module.exports = { runPlaeneModuleTests };

--- a/src/renderer/app/modules/moduleCatalog.js
+++ b/src/renderer/app/modules/moduleCatalog.js
@@ -6,6 +6,10 @@ import {
   getRestarbeitenModuleEntry,
   RESTARBEITEN_MODULE_ID,
 } from "../../modules/restarbeiten/index.js";
+import {
+  getPlaeneModuleEntry,
+  PLAENE_MODULE_ID,
+} from "../../modules/plaene/index.js";
 
 const AVAILABLE_MODULE_ENTRIES = Object.freeze([
   Object.freeze({
@@ -16,11 +20,16 @@ const AVAILABLE_MODULE_ENTRIES = Object.freeze([
     moduleId: RESTARBEITEN_MODULE_ID,
     entry: getRestarbeitenModuleEntry(),
   }),
+  Object.freeze({
+    moduleId: PLAENE_MODULE_ID,
+    entry: getPlaeneModuleEntry(),
+  }),
 ]);
 
 const DEFAULT_ACTIVE_MODULE_IDS = Object.freeze([
   PROTOKOLL_MODULE_ID,
   RESTARBEITEN_MODULE_ID,
+  PLAENE_MODULE_ID,
 ]);
 
 const PRODUCTIVE_DEFAULT_RELEASE_STATE = Object.freeze({
@@ -225,4 +234,4 @@ export function getActiveModuleIdsForReleaseState(releaseState) {
   return RELEASE_STATE_MODULE_ACCESS.getModuleIds(releaseState);
 }
 
-export { PROTOKOLL_MODULE_ID };
+export { PROTOKOLL_MODULE_ID, RESTARBEITEN_MODULE_ID, PLAENE_MODULE_ID };

--- a/src/renderer/modules/plaene/index.js
+++ b/src/renderer/modules/plaene/index.js
@@ -1,0 +1,43 @@
+import PlaeneScreen from "./screens/PlaeneScreen.js";
+import { PLAENE_WORK_SCREEN_ID } from "./screens/index.js";
+
+export const PLAENE_MODULE_ID = "plaene";
+export const PLAENE_MODULE_LABEL = "Pläne";
+export const PLAENE_NAV_ENTRY_KEY = "plaene";
+
+function buildPlaeneModuleScreens() {
+  return Object.freeze({
+    [PLAENE_WORK_SCREEN_ID]: PlaeneScreen,
+  });
+}
+
+function buildPlaeneModuleNavigation() {
+  return Object.freeze({
+    project: Object.freeze([
+      Object.freeze({
+        key: PLAENE_NAV_ENTRY_KEY,
+        label: PLAENE_MODULE_LABEL,
+        moduleId: PLAENE_MODULE_ID,
+        workScreenId: PLAENE_WORK_SCREEN_ID,
+        section: "plaene",
+        description: "Pläne im aktuellen Projektkontext vorbereiten.",
+      }),
+    ]),
+  });
+}
+
+export function getPlaeneModuleEntry() {
+  return Object.freeze({
+    moduleId: PLAENE_MODULE_ID,
+    moduleLabel: PLAENE_MODULE_LABEL,
+    workScreenId: PLAENE_WORK_SCREEN_ID,
+    screens: buildPlaeneModuleScreens(),
+    navigation: buildPlaeneModuleNavigation(),
+    shell: Object.freeze({
+      hideSidebar: true,
+    }),
+  });
+}
+
+export { PlaeneScreen, PLAENE_WORK_SCREEN_ID };
+export * from "./screens/index.js";

--- a/src/renderer/modules/plaene/screens/PlaeneScreen.js
+++ b/src/renderer/modules/plaene/screens/PlaeneScreen.js
@@ -1,0 +1,235 @@
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+function firstProjectText(project, keys = []) {
+  for (const key of keys) {
+    const value = normalizeText(project?.[key]);
+    if (value) return value;
+  }
+  return "";
+}
+
+function getProjectName(project) {
+  return firstProjectText(project, ["name", "short", "project_name", "projectName", "title"]);
+}
+
+function collectDistinctTextValues(values = []) {
+  const out = [];
+  for (const value of values) {
+    const normalized = normalizeText(value);
+    if (normalized && !out.includes(normalized)) out.push(normalized);
+  }
+  return out;
+}
+
+function readProjectArray(project, keys = []) {
+  for (const key of keys) {
+    const value = project?.[key];
+    if (Array.isArray(value)) return value;
+  }
+  return [];
+}
+
+function resolveBuildings(project) {
+  const direct = readProjectArray(project, ["buildings", "gebaeude", "gebäude"]);
+  if (direct.length) {
+    return collectDistinctTextValues(direct.map((entry) => typeof entry === "object" ? entry.name || entry.label || entry.title || entry.id : entry));
+  }
+  return collectDistinctTextValues([
+    project?.building,
+    project?.gebaeude,
+    project?.gebäude,
+    project?.location_level_1,
+  ]);
+}
+
+function resolveFloors(project) {
+  const direct = readProjectArray(project, ["floors", "geschosse", "geschosseList"]);
+  if (direct.length) {
+    return collectDistinctTextValues(direct.map((entry) => typeof entry === "object" ? entry.name || entry.label || entry.title || entry.id : entry));
+  }
+  return collectDistinctTextValues([
+    project?.floor,
+    project?.geschoss,
+    project?.location_level_2,
+  ]);
+}
+
+function getProjectId(projectId, project) {
+  return normalizeText(projectId) || normalizeText(project?.id);
+}
+
+function setUiEditorAttributes(el, { id, kind, label, parent = "", editable = "true", ops = "inspect,select" }) {
+  el.setAttribute("data-ui-inspector-id", id);
+  el.setAttribute("data-ui-editor-id", id);
+  el.setAttribute("data-ui-editor-kind", kind);
+  el.setAttribute("data-ui-editor-label", label);
+  el.setAttribute("data-ui-editor-parent", parent);
+  el.setAttribute("data-ui-editor-editable", editable);
+  el.setAttribute("data-ui-editor-ops", ops);
+  return el;
+}
+
+function createText(tag, text, options) {
+  const el = document.createElement(tag);
+  el.textContent = text;
+  setUiEditorAttributes(el, options);
+  return el;
+}
+
+function createMetric(label, value, uiId) {
+  const row = document.createElement("div");
+  row.className = "bbm-plaene-metric";
+  setUiEditorAttributes(row, {
+    id: uiId,
+    kind: "field",
+    label,
+    parent: "plaene.m1.project-summary",
+  });
+
+  const labelEl = document.createElement("span");
+  labelEl.className = "bbm-plaene-metric__label";
+  labelEl.textContent = label;
+
+  const valueEl = document.createElement("strong");
+  valueEl.className = "bbm-plaene-metric__value";
+  valueEl.textContent = normalizeText(value) || "-";
+
+  row.append(labelEl, valueEl);
+  return row;
+}
+
+export default class PlaeneScreen {
+  constructor({ router, projectId, project, moduleId } = {}) {
+    this.router = router || null;
+    this.projectId = getProjectId(projectId, project);
+    this.project = project || null;
+    this.moduleId = moduleId || "plaene";
+    this.root = null;
+    this.projectFolder = "";
+    this.storageError = "";
+  }
+
+  render() {
+    this.root = document.createElement("section");
+    this.root.className = "bbm-plaene-screen";
+    this.root.setAttribute("data-bbm-plaene-screen", "m1");
+    setUiEditorAttributes(this.root, {
+      id: "plaene.m1.root",
+      kind: "frame",
+      label: "Pläne Modulbereich",
+      parent: "",
+    });
+    this._renderShell();
+    this.loadProjectFolder();
+    return this.root;
+  }
+
+  async loadProjectFolder() {
+    if (!this.projectId || !this.project || typeof window === "undefined") return;
+    const api = window.bbmDb || {};
+    if (typeof api.projectsStoragePreview !== "function") return;
+    try {
+      const result = await api.projectsStoragePreview(this.project);
+      if (result?.ok) {
+        this.projectFolder = normalizeText(result.projectFolder || result.paths?.projectFolder);
+        this.storageError = "";
+      } else {
+        this.storageError = normalizeText(result?.error);
+      }
+    } catch (error) {
+      this.storageError = normalizeText(error?.message);
+    }
+    this._renderShell();
+  }
+
+  _renderShell() {
+    if (!this.root) return;
+    this.root.replaceChildren();
+    if (!this.projectId) {
+      this.root.append(this._renderNoProjectNotice());
+      return;
+    }
+    this.root.append(this._renderProjectView());
+  }
+
+  _renderNoProjectNotice() {
+    const notice = document.createElement("div");
+    notice.className = "bbm-plaene-notice";
+    setUiEditorAttributes(notice, {
+      id: "plaene.m1.no-project-notice",
+      kind: "frame",
+      label: "Kein Projekt Hinweis",
+      parent: "plaene.m1.root",
+    });
+    const line1 = document.createElement("p");
+    line1.textContent = "Kein Projekt ausgewählt.";
+    const line2 = document.createElement("p");
+    line2.textContent = "Öffnen Sie zuerst ein Projekt, um dessen Pläne zu verwalten.";
+    notice.append(line1, line2);
+    return notice;
+  }
+
+  _renderProjectView() {
+    const fragment = document.createDocumentFragment();
+    const projectName = getProjectName(this.project) || "-";
+    const buildings = resolveBuildings(this.project);
+    const floors = resolveFloors(this.project);
+
+    const header = document.createElement("header");
+    header.className = "bbm-plaene-header";
+    setUiEditorAttributes(header, {
+      id: "plaene.m1.header",
+      kind: "frame",
+      label: "Pläne Kopfbereich",
+      parent: "plaene.m1.root",
+    });
+    header.append(
+      createText("h1", "Modul Pläne", {
+        id: "plaene.m1.title",
+        kind: "single",
+        label: "Modul Pläne Titel",
+        parent: "plaene.m1.header",
+      }),
+      createText("p", `Aktives Projekt: ${projectName}`, {
+        id: "plaene.m1.active-project",
+        kind: "single",
+        label: "Aktives Projekt",
+        parent: "plaene.m1.header",
+      })
+    );
+
+    const summary = document.createElement("div");
+    summary.className = "bbm-plaene-summary";
+    setUiEditorAttributes(summary, {
+      id: "plaene.m1.project-summary",
+      kind: "frame",
+      label: "Projektkontext Zusammenfassung",
+      parent: "plaene.m1.root",
+    });
+    summary.append(
+      createMetric("Projekt-ID", this.projectId, "plaene.m1.project-id"),
+      createMetric("Projektordner", this.projectFolder || (this.storageError ? `Nicht verfügbar: ${this.storageError}` : "-"), "plaene.m1.project-folder"),
+      createMetric("Anzahl vorhandener Gebäude", String(buildings.length), "plaene.m1.building-count"),
+      createMetric("Anzahl vorhandener Geschosse", String(floors.length), "plaene.m1.floor-count")
+    );
+
+    const note = createText("p", "Die Planordner-Anbindung folgt in Meilenstein M2.", {
+      id: "plaene.m1.next-step-note",
+      kind: "single",
+      label: "Hinweis Planordner M2",
+      parent: "plaene.m1.root",
+    });
+    note.className = "bbm-plaene-next-step";
+
+    fragment.append(header, summary, note);
+    return fragment;
+  }
+}
+
+export {
+  getProjectName,
+  resolveBuildings,
+  resolveFloors,
+};

--- a/src/renderer/modules/plaene/screens/index.js
+++ b/src/renderer/modules/plaene/screens/index.js
@@ -1,0 +1,3 @@
+export { default as PlaeneScreen } from "./PlaeneScreen.js";
+
+export const PLAENE_WORK_SCREEN_ID = "plaeneWork";


### PR DESCRIPTION
### Motivation
- Bereitstellung eines minimalen, sicher eingebetteten M1‑Modulgerüsts „Pläne“, das ausschließlich im bestehenden Projektkontext arbeitet und keine Protokoll‑Interna verändert.
- Ermöglichen eines klaren Integrationspunkts für spätere Meilensteine (M2+), ohne neue globale Zustände, DB‑Migrationsschritte oder zusätzliche Abhängigkeiten einzuführen.

### Description
- Neues Modul `plaene` hinzugefügt unter `src/renderer/modules/plaene/` mit Modul‑Entry, Navigationseintrag und neutralem M1‑Screen (`PlaeneScreen`) für die Anzeige des Projektkontexts.
- Modulkatalog `src/renderer/app/modules/moduleCatalog.js` erweitert, so dass `plaene` von der bestehenden generischen Projekt‑Modul‑Infrastruktur geöffnet werden kann; keine Änderungen an `protokoll`‑Sonderpfaden.
- UI‑Editor‑Metadaten (Pflichtattribute) in der M1‑DOM‑Struktur gesetzt (z. B. `plaene.m1.root`, `plaene.m1.header`, `plaene.m1.project-summary` etc.) ohne fachliche Aktionen zu registrieren.
- Fokussierter Test `scripts/tests/plaeneModule.test.cjs` hinzugefügt und in den Testlauf (`scripts/test.cjs`) eingebunden; `STATUS.md` um den M1‑Eintrag ergänzt.
- Keine Umsetzung von M2+ Funktionen (keine Ordnerwahl, keine PDF/ OCR/ KI/ WebP/ Planversionierung, keine Restarbeiten‑Anbindung, keine neuen Abhängigkeiten). Commit auf Branch `codex/plaene-m1-modulgeruest` (Commit `834caa4`).

### Testing
- `node scripts/tests/plaeneModule.test.cjs` — bestanden (prüft Modulentry, Projekt‑/ohne‑Projekt‑Ansicht, Projektwechsel, Storage‑Preview‑Aufruf, UI‑Editor‑Attribute).
- `node scripts/ui-editor-contract-check.cjs` und `node scripts/ui-editor-contract-check.cjs --self-test` — bestanden (UI‑Editor‑Guardrail für die neuen data‑ui‑Attribute).
- `node scripts/test.cjs` — lief bis einschließlich den neuen Pläne‑Tests durch, schlug danach fehl wegen bestehender Environment/Native‑Modulprobleme (`better-sqlite3` Node‑Modulversionskonflikt), welches außerhalb dieses M1‑Pakets liegt.
- `npm run lint` — zeigte vorhandene Lint/Parse‑Fehler im Repo außerhalb der vorgenommenen Änderungen (nicht durch dieses Paket verursacht).
- `npm test` / Electron‑Start in dieser Umgebung nicht möglich wegen fehlender Systembibliothek `libatk-1.0.so.0` (Computer‑Use / praktische UI‑Abnahme konnte nicht ausgeführt werden).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a624af918848322b60c68a332e01fc8)