### PR TITLE
Add 'plaene' module scaffold (M1) with screen, navigation and tests

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -3356,3 +3356,32 @@ Wichtig:
   - `npm test` in dieser Umgebung wegen fehlender Electron-Systembibliothek `libatk-1.0.so.0` nicht ausführbar
 - Nächster offener Schritt:
   - Vollständigen `npm test` lokal/CI mit vorhandenen Electron-Systembibliotheken erneut ausführen.
+
+## Modul Pläne – M1 Modulgerüst im bestehenden Projektkontext
+- Status: umgesetzt im Branch `codex/plaene-m1-modulgeruest`.
+- Beschreibung:
+  - Neues Projektmodul `plaene` als kleines Modulgerüst parallel zu vorhandenen Projektmodulen ergänzt.
+  - Das Modul nutzt den bestehenden generischen Projektmodul-Pfad und erzeugt keinen eigenen Projekt-State.
+  - Ohne aktives Projekt zeigt die Ansicht den Hinweis: „Kein Projekt ausgewählt. Öffnen Sie zuerst ein Projekt, um dessen Pläne zu verwalten.“
+  - Mit aktivem Projekt zeigt die Ansicht nur den übergebenen Projektkontext: Projektname, Projekt-ID, bestehenden Projektordner über die vorhandene Storage-Preview sowie lesend gezählte Gebäude und Geschosse aus vorhandenen Projektwerten.
+  - Spätere Meilensteine wie Planordner-Auswahl, PDF-Suche/-Analyse, OCR, KI, WebP, Planversionierung, Planwächter, Mobil-Synchronisation und Restarbeiten-Anbindung wurden nicht begonnen.
+- Prüfung:
+  - `node scripts/tests/plaeneModule.test.cjs` OK
+- Nächster offener Schritt:
+  - M2 erst nach Abnahme von M1 beginnen: externen Planordner projektbezogen anbinden.
+- Risiken/Hindernisse:
+  - Praktische Computer-Use-/Electron-UI-Abnahme ist in dieser Umgebung nicht verfügbar und muss lokal/auf Zielsystem nachgeholt werden.
+  - Im aktuellen Checkout ist kein Git-Remote `origin` eingerichtet; Veröffentlichung/PR hängt vom verfügbaren PR-Werkzeug ab.
+
+## Modul Pläne – M1 Korrektur Zurück-Button
+- Status: umgesetzt im Branch `codex/plaene-m1-zurueck-button`.
+- Beschreibung:
+  - Die Planseite erhält oben links im Kopfbereich einen sichtbaren Button „Zurück“.
+  - Mit aktivem Projekt nutzt der Button den vorhandenen Router-Weg `showProjectWorkspace(projectId, { project })` zurück in die Projekt-/Modulauswahl.
+  - Ohne aktives Projekt nutzt der Button den vorhandenen Router-Weg `showProjects()` zurück zur Projektliste.
+  - Die Button-UI ist mit den vorhandenen UI-Editor-Metadaten klassifiziert; die fachliche Navigation bleibt keine Editor-Aktion.
+  - Keine Browser-History-Logik, keine zweite Navigation und keine späteren Pläne-Meilensteine wurden ergänzt.
+- Prüfung:
+  - `node scripts/tests/plaeneModule.test.cjs` OK
+- Nächster offener Schritt:
+  - Praktische Windows-/Electron-Prüfung des Zurück-Ablaufs nachholen, da Computer Use in dieser Umgebung nicht verfügbar ist.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -24,6 +24,7 @@ const { runBbmUiEditorInstalledArtifactsTests } = require("./tests/bbmUiEditorIn
 const { runBbmUiEditorRuntimeLauncherTests } = require("./tests/bbmUiEditorRuntimeLauncher.test.cjs");
 const { runProjektverwaltungModuleTests } = require("./tests/projektverwaltungModule.test.cjs");
 const { runRestarbeitenModuleTests } = require("./tests/restarbeitenModule.test.cjs");
+const { runPlaeneModuleTests } = require("./tests/plaeneModule.test.cjs");
 const { runRestarbeitenDataModelTests } = require("./tests/restarbeitenDataModel.test.cjs");
 const { runRestarbeitenRulesTests } = require("./tests/restarbeitenRules.test.cjs");
 const { runUiEditorContractTests } = require("./tests/uiEditorContract.test.cjs");
@@ -168,6 +169,7 @@ async function main() {
   await runBbmUiEditorRuntimeLauncherTests(run);
   await runProjektverwaltungModuleTests(run);
   await runRestarbeitenModuleTests(run);
+  await runPlaeneModuleTests(run);
   await runRestarbeitenDataModelTests(run);
   await runRestarbeitenRulesTests(run);
   await runUiEditorContractTests(run);

--- a/scripts/tests/plaeneModule.test.cjs
+++ b/scripts/tests/plaeneModule.test.cjs
@@ -1,0 +1,353 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+function createFakeDocument() {
+  const createNode = (tag, doc) => {
+    const node = {
+      tagName: String(tag || "").toUpperCase(),
+      ownerDocument: doc,
+      children: [],
+      parentElement: null,
+      style: {},
+      dataset: {},
+      attributes: {},
+      className: "",
+      textContent: "",
+      append(...nodes) {
+        for (const child of nodes) this.appendChild(child);
+      },
+      appendChild(child) {
+        if (!child || typeof child !== "object") return child;
+        if (child.nodeType === 11) {
+          for (const fragmentChild of [...child.children]) this.appendChild(fragmentChild);
+          child.children = [];
+          return child;
+        }
+        child.parentElement = this;
+        this.children.push(child);
+        return child;
+      },
+      replaceChildren(...nodes) {
+        this.children = [];
+        this.textContent = "";
+        this.append(...nodes);
+      },
+      setAttribute(name, value) {
+        const key = String(name);
+        const text = String(value);
+        this.attributes[key] = text;
+        if (key.startsWith("data-")) {
+          const dataKey = key.slice(5).replace(/-([a-z])/g, (_match, char) => char.toUpperCase());
+          this.dataset[dataKey] = text;
+        }
+      },
+      getAttribute(name) {
+        const key = String(name);
+        return Object.prototype.hasOwnProperty.call(this.attributes, key) ? this.attributes[key] : null;
+      },
+    };
+    return node;
+  };
+  const doc = {
+    createElement(tag) {
+      return createNode(tag, doc);
+    },
+    createDocumentFragment() {
+      const fragment = createNode("#fragment", doc);
+      fragment.nodeType = 11;
+      return fragment;
+    },
+    body: null,
+    head: null,
+  };
+  doc.body = createNode("body", doc);
+  doc.head = createNode("head", doc);
+  return doc;
+}
+
+function collectText(node) {
+  if (typeof node === "string") return node;
+  const ownText = String(node?.textContent || "");
+  const children = Array.isArray(node?.children) ? node.children : [];
+  return [ownText, ...children.map((child) => collectText(child))].join(" ");
+}
+
+function findNodes(node, predicate, acc = []) {
+  if (!node || typeof node !== "object") return acc;
+  if (predicate(node)) acc.push(node);
+  for (const child of Array.isArray(node?.children) ? node.children : []) {
+    findNodes(child, predicate, acc);
+  }
+  return acc;
+}
+
+function findByUiId(node, uiId) {
+  return findNodes(node, (entry) => entry.getAttribute?.("data-ui-inspector-id") === uiId)[0] || null;
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function withFakeDom(fn, bbmDb = {}) {
+  const previousDocument = globalThis.document;
+  const previousWindow = globalThis.window;
+  globalThis.document = createFakeDocument();
+  globalThis.window = { bbmDb, dispatchEvent() {} };
+  try {
+    return await fn(globalThis.document);
+  } finally {
+    globalThis.document = previousDocument;
+    globalThis.window = previousWindow;
+  }
+}
+
+async function runPlaeneModuleTests(run) {
+  const [plaeneModule, screenResolver, navigationModule, catalogModule, screenModule] = await Promise.all([
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/plaene/index.js")),
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/app/modules/moduleEntryScreenResolver.js")),
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/app/modules/moduleNavigation.js")),
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/app/modules/moduleCatalog.js")),
+    importEsmFromFile(path.join(__dirname, "../../src/renderer/modules/plaene/screens/PlaeneScreen.js")),
+  ]);
+
+  await run("Pläne: Modulentry bleibt im Projektmodul-System erreichbar", () => {
+    const entry = plaeneModule.getPlaeneModuleEntry();
+    assert.equal(entry.moduleId, "plaene");
+    assert.equal(entry.moduleLabel, "Pläne");
+    assert.equal(entry.workScreenId, "plaeneWork");
+    assert.equal(entry.navigation.project[0].key, "plaene");
+    assert.equal(entry.navigation.project[0].label, "Pläne");
+    assert.equal(entry.navigation.project[0].section, "plaene");
+    assert.equal(entry.shell.hideSidebar, true);
+    assert.equal(typeof screenResolver.resolveModuleWorkScreenFromEntry(entry), "function");
+  });
+
+  await run("Pläne: aktive Projektmodulnavigation enthält genau einen Pläne-Eintrag", () => {
+    const entries = navigationModule.getActiveProjectModuleNavigation();
+    const plaeneEntries = entries.filter((entry) => entry.moduleId === "plaene");
+    assert.equal(plaeneEntries.length, 1);
+    assert.equal(catalogModule.getActiveModuleIds().includes("plaene"), true);
+  });
+
+  await run("Pläne: ohne aktives Projekt zeigt die definierte Hinweisansicht", async () => withFakeDom(async () => {
+    const screen = new screenModule.default({ projectId: null, project: null });
+    const root = screen.render();
+    await flush();
+    const text = collectText(root);
+    assert.equal(text.includes("Kein Projekt ausgewählt."), true);
+    assert.equal(text.includes("Öffnen Sie zuerst ein Projekt, um dessen Pläne zu verwalten."), true);
+    assert.equal(text.includes("Modul Pläne"), true);
+    assert.equal(Boolean(findByUiId(root, "plaene.m1.back-button")), true);
+    assert.equal(Boolean(findByUiId(root, "plaene.m1.no-project-notice")), true);
+  }));
+
+  await run("Pläne: aktives Projekt zeigt ausschließlich übergebene Projektwerte", async () => withFakeDom(async () => {
+    const screen = new screenModule.default({
+      projectId: "projekt-a",
+      project: {
+        id: "projekt-a",
+        name: "Projekt A",
+        buildings: ["Haus A", "Haus B"],
+        floors: ["EG", "OG"],
+      },
+    });
+    const root = screen.render();
+    await flush();
+    const text = collectText(root);
+    assert.equal(text.includes("Modul Pläne"), true);
+    assert.equal(text.includes("Aktives Projekt: Projekt A"), true);
+    assert.equal(text.includes("projekt-a"), true);
+    assert.equal(text.includes("Anzahl vorhandener Gebäude 2"), true);
+    assert.equal(text.includes("Anzahl vorhandener Geschosse 2"), true);
+    assert.equal(text.includes("Die Planordner-Anbindung folgt in Meilenstein M2."), true);
+    assert.equal(text.includes("Projekt B"), false);
+  }));
+
+  await run("Pläne: Projektwechsel nutzt neue Screen-Props statt alten lokalen Projekt-State", async () => withFakeDom(async () => {
+    const screenA = new screenModule.default({
+      projectId: "projekt-a",
+      project: { id: "projekt-a", name: "Projekt A", buildings: ["Haus A"], floors: ["EG"] },
+    });
+    const rootA = screenA.render();
+    await flush();
+
+    const screenB = new screenModule.default({
+      projectId: "projekt-b",
+      project: { id: "projekt-b", name: "Projekt B", buildings: ["Haus C", "Haus D"], floors: ["UG", "EG", "OG"] },
+    });
+    const rootB = screenB.render();
+    await flush();
+
+    const textA = collectText(rootA);
+    const textB = collectText(rootB);
+    assert.equal(textA.includes("Projekt A"), true);
+    assert.equal(textB.includes("Projekt B"), true);
+    assert.equal(textB.includes("Projekt A"), false);
+    assert.equal(textB.includes("projekt-a"), false);
+    assert.equal(textB.includes("projekt-b"), true);
+    assert.equal(textB.includes("Anzahl vorhandener Gebäude 2"), true);
+    assert.equal(textB.includes("Anzahl vorhandener Geschosse 3"), true);
+  }));
+
+  await run("Pläne: Projektordner wird nur lesend über vorhandene Storage-Preview bezogen", async () => {
+    const calls = [];
+    await withFakeDom(async () => {
+      const screen = new screenModule.default({
+        projectId: "projekt-a",
+        project: { id: "projekt-a", name: "Projekt A" },
+      });
+      const root = screen.render();
+      await flush();
+      const text = collectText(root);
+      assert.equal(calls.length, 1);
+      assert.deepEqual(calls[0], { id: "projekt-a", name: "Projekt A" });
+      assert.equal(text.includes("Projektordner 100 - Projekt A"), true);
+    }, {
+      async projectsStoragePreview(project) {
+        calls.push(project);
+        return { ok: true, projectFolder: "100 - Projekt A" };
+      },
+    });
+  });
+
+  await run("Pläne: keine projektlose Speicherung oder Plandaten-IPC im M1-Screen", async () => {
+    const calls = [];
+    await withFakeDom(async () => {
+      const screen = new screenModule.default({ projectId: null, project: null });
+      screen.render();
+      await flush();
+      assert.equal(calls.length, 0);
+    }, {
+      async projectsStoragePreview(project) {
+        calls.push(project);
+        return { ok: true, projectFolder: "soll-nicht-passieren" };
+      },
+      async plansCreate() {
+        throw new Error("plansCreate darf in M1 nicht existieren/benutzt werden");
+      },
+    });
+  });
+
+
+  await run("Pläne: Zurück-Button ruft mit aktivem Projekt den vorhandenen Workspace-Weg genau einmal auf", async () => withFakeDom(async () => {
+    const calls = [];
+    const project = { id: "projekt-a", name: "Projekt A", buildings: ["Haus A"], floors: ["EG"] };
+    const screen = new screenModule.default({
+      router: {
+        currentProjectId: "projekt-a",
+        async showProjectWorkspace(projectId, options) {
+          calls.push({ type: "workspace", projectId, options, currentProjectId: this.currentProjectId });
+          return true;
+        },
+        async showProjects() {
+          calls.push({ type: "projects" });
+          return true;
+        },
+      },
+      projectId: "projekt-a",
+      project,
+    });
+    const root = screen.render();
+    await flush();
+    const backButton = findByUiId(root, "plaene.m1.back-button");
+    assert.ok(backButton);
+    assert.equal(backButton.textContent, "Zurück");
+    assert.equal(backButton.getAttribute("data-ui-editor-kind"), "single");
+    assert.equal(backButton.getAttribute("data-ui-editor-parent"), "plaene.m1.header");
+    await backButton.onclick();
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].type, "workspace");
+    assert.equal(calls[0].projectId, "projekt-a");
+    assert.equal(calls[0].options.project, project);
+    assert.equal(calls[0].currentProjectId, "projekt-a");
+    assert.equal(screen.projectId, "projekt-a");
+  }));
+
+  await run("Pläne: Zurück-Button ohne Projekt nutzt die vorhandene Projektlisten-Navigation", async () => withFakeDom(async () => {
+    const calls = [];
+    const screen = new screenModule.default({
+      router: {
+        currentProjectId: null,
+        async showProjectWorkspace(projectId, options) {
+          calls.push({ type: "workspace", projectId, options });
+          return true;
+        },
+        async showProjects() {
+          calls.push({ type: "projects" });
+          return true;
+        },
+      },
+      projectId: null,
+      project: null,
+    });
+    const root = screen.render();
+    await flush();
+    const backButton = findByUiId(root, "plaene.m1.back-button");
+    assert.ok(backButton);
+    await backButton.onclick();
+    assert.deepEqual(calls, [{ type: "projects" }]);
+    assert.equal(screen.projectId, "");
+  }));
+
+  await run("Pläne: Zurück-Navigation nutzt keine Browser-History", () => {
+    const source = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/plaene/screens/PlaeneScreen.js"), "utf8");
+    assert.equal(source.includes("window.history.back"), false);
+    assert.equal(source.includes("history.back"), false);
+  });
+  await run("Pläne: UI-Editor-Pflichtattribute und Parent-Struktur sind im neuen DOM vorhanden", async () => withFakeDom(async () => {
+    const screen = new screenModule.default({
+      projectId: "projekt-a",
+      project: { id: "projekt-a", name: "Projekt A", buildings: ["Haus A"], floors: ["EG"] },
+    });
+    const root = screen.render();
+    await flush();
+    const expected = new Map([
+      ["plaene.m1.root", ""],
+      ["plaene.m1.header", "plaene.m1.root"],
+      ["plaene.m1.back-button", "plaene.m1.header"],
+      ["plaene.m1.title", "plaene.m1.header"],
+      ["plaene.m1.active-project", "plaene.m1.header"],
+      ["plaene.m1.project-summary", "plaene.m1.root"],
+      ["plaene.m1.project-id", "plaene.m1.project-summary"],
+      ["plaene.m1.project-folder", "plaene.m1.project-summary"],
+      ["plaene.m1.building-count", "plaene.m1.project-summary"],
+      ["plaene.m1.floor-count", "plaene.m1.project-summary"],
+      ["plaene.m1.next-step-note", "plaene.m1.root"],
+    ]);
+    for (const [id, parentId] of expected) {
+      const node = findByUiId(root, id);
+      assert.ok(node, `${id} fehlt`);
+      assert.equal(node.getAttribute("data-ui-editor-id"), id);
+      assert.equal(node.getAttribute("data-ui-editor-parent"), parentId);
+      assert.equal(node.getAttribute("data-ui-editor-editable"), "true");
+      assert.equal(node.getAttribute("data-ui-editor-ops"), "inspect,select");
+      assert.ok(["frame", "field", "single"].includes(node.getAttribute("data-ui-editor-kind")));
+      assert.ok(node.getAttribute("data-ui-editor-label"));
+      if (parentId) assert.ok(findByUiId(root, parentId), `${id} Parent fehlt`);
+    }
+  }));
+}
+
+if (require.main === module) {
+  const results = [];
+  const run = async (name, fn) => {
+    try {
+      await fn();
+      results.push({ name, ok: true });
+      console.log(`ok - ${name}`);
+    } catch (error) {
+      results.push({ name, ok: false });
+      console.error(`not ok - ${name}`);
+      console.error(error?.stack || error?.message || error);
+    }
+  };
+  runPlaeneModuleTests(run).then(() => {
+    if (results.some((result) => !result.ok)) process.exit(1);
+  });
+}
+
+module.exports = { runPlaeneModuleTests };

--- a/src/renderer/app/modules/moduleCatalog.js
+++ b/src/renderer/app/modules/moduleCatalog.js
@@ -6,6 +6,10 @@ import {
   getRestarbeitenModuleEntry,
   RESTARBEITEN_MODULE_ID,
 } from "../../modules/restarbeiten/index.js";
+import {
+  getPlaeneModuleEntry,
+  PLAENE_MODULE_ID,
+} from "../../modules/plaene/index.js";
 
 const AVAILABLE_MODULE_ENTRIES = Object.freeze([
   Object.freeze({
@@ -16,11 +20,16 @@ const AVAILABLE_MODULE_ENTRIES = Object.freeze([
     moduleId: RESTARBEITEN_MODULE_ID,
     entry: getRestarbeitenModuleEntry(),
   }),
+  Object.freeze({
+    moduleId: PLAENE_MODULE_ID,
+    entry: getPlaeneModuleEntry(),
+  }),
 ]);
 
 const DEFAULT_ACTIVE_MODULE_IDS = Object.freeze([
   PROTOKOLL_MODULE_ID,
   RESTARBEITEN_MODULE_ID,
+  PLAENE_MODULE_ID,
 ]);
 
 const PRODUCTIVE_DEFAULT_RELEASE_STATE = Object.freeze({
@@ -225,4 +234,4 @@ export function getActiveModuleIdsForReleaseState(releaseState) {
   return RELEASE_STATE_MODULE_ACCESS.getModuleIds(releaseState);
 }
 
-export { PROTOKOLL_MODULE_ID };
+export { PROTOKOLL_MODULE_ID, RESTARBEITEN_MODULE_ID, PLAENE_MODULE_ID };

--- a/src/renderer/modules/plaene/index.js
+++ b/src/renderer/modules/plaene/index.js
@@ -1,0 +1,43 @@
+import PlaeneScreen from "./screens/PlaeneScreen.js";
+import { PLAENE_WORK_SCREEN_ID } from "./screens/index.js";
+
+export const PLAENE_MODULE_ID = "plaene";
+export const PLAENE_MODULE_LABEL = "Pläne";
+export const PLAENE_NAV_ENTRY_KEY = "plaene";
+
+function buildPlaeneModuleScreens() {
+  return Object.freeze({
+    [PLAENE_WORK_SCREEN_ID]: PlaeneScreen,
+  });
+}
+
+function buildPlaeneModuleNavigation() {
+  return Object.freeze({
+    project: Object.freeze([
+      Object.freeze({
+        key: PLAENE_NAV_ENTRY_KEY,
+        label: PLAENE_MODULE_LABEL,
+        moduleId: PLAENE_MODULE_ID,
+        workScreenId: PLAENE_WORK_SCREEN_ID,
+        section: "plaene",
+        description: "Pläne im aktuellen Projektkontext vorbereiten.",
+      }),
+    ]),
+  });
+}
+
+export function getPlaeneModuleEntry() {
+  return Object.freeze({
+    moduleId: PLAENE_MODULE_ID,
+    moduleLabel: PLAENE_MODULE_LABEL,
+    workScreenId: PLAENE_WORK_SCREEN_ID,
+    screens: buildPlaeneModuleScreens(),
+    navigation: buildPlaeneModuleNavigation(),
+    shell: Object.freeze({
+      hideSidebar: true,
+    }),
+  });
+}
+
+export { PlaeneScreen, PLAENE_WORK_SCREEN_ID };
+export * from "./screens/index.js";

--- a/src/renderer/modules/plaene/screens/PlaeneScreen.js
+++ b/src/renderer/modules/plaene/screens/PlaeneScreen.js
@@ -1,0 +1,284 @@
+import { applyPopupButtonStyle } from "../../../ui/popupButtonStyles.js";
+
+function normalizeText(value) {
+  return String(value ?? "").trim();
+}
+
+function firstProjectText(project, keys = []) {
+  for (const key of keys) {
+    const value = normalizeText(project?.[key]);
+    if (value) return value;
+  }
+  return "";
+}
+
+function getProjectName(project) {
+  return firstProjectText(project, ["name", "short", "project_name", "projectName", "title"]);
+}
+
+function collectDistinctTextValues(values = []) {
+  const out = [];
+  for (const value of values) {
+    const normalized = normalizeText(value);
+    if (normalized && !out.includes(normalized)) out.push(normalized);
+  }
+  return out;
+}
+
+function readProjectArray(project, keys = []) {
+  for (const key of keys) {
+    const value = project?.[key];
+    if (Array.isArray(value)) return value;
+  }
+  return [];
+}
+
+function resolveBuildings(project) {
+  const direct = readProjectArray(project, ["buildings", "gebaeude", "gebäude"]);
+  if (direct.length) {
+    return collectDistinctTextValues(direct.map((entry) => typeof entry === "object" ? entry.name || entry.label || entry.title || entry.id : entry));
+  }
+  return collectDistinctTextValues([
+    project?.building,
+    project?.gebaeude,
+    project?.gebäude,
+    project?.location_level_1,
+  ]);
+}
+
+function resolveFloors(project) {
+  const direct = readProjectArray(project, ["floors", "geschosse", "geschosseList"]);
+  if (direct.length) {
+    return collectDistinctTextValues(direct.map((entry) => typeof entry === "object" ? entry.name || entry.label || entry.title || entry.id : entry));
+  }
+  return collectDistinctTextValues([
+    project?.floor,
+    project?.geschoss,
+    project?.location_level_2,
+  ]);
+}
+
+function getProjectId(projectId, project) {
+  return normalizeText(projectId) || normalizeText(project?.id);
+}
+
+function setUiEditorAttributes(el, { id, kind, label, parent = "", editable = "true", ops = "inspect,select" }) {
+  el.setAttribute("data-ui-inspector-id", id);
+  el.setAttribute("data-ui-editor-id", id);
+  el.setAttribute("data-ui-editor-kind", kind);
+  el.setAttribute("data-ui-editor-label", label);
+  el.setAttribute("data-ui-editor-parent", parent);
+  el.setAttribute("data-ui-editor-editable", editable);
+  el.setAttribute("data-ui-editor-ops", ops);
+  return el;
+}
+
+function createText(tag, text, options) {
+  const el = document.createElement(tag);
+  el.textContent = text;
+  setUiEditorAttributes(el, options);
+  return el;
+}
+
+function createBackButton(onClick) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.textContent = "Zurück";
+  button.className = "bbm-plaene-back-button";
+  applyPopupButtonStyle(button, { variant: "secondary" });
+  setUiEditorAttributes(button, {
+    id: "plaene.m1.back-button",
+    kind: "single",
+    label: "Zurück Button",
+    parent: "plaene.m1.header",
+  });
+  button.onclick = onClick;
+  return button;
+}
+
+function createMetric(label, value, uiId) {
+  const row = document.createElement("div");
+  row.className = "bbm-plaene-metric";
+  setUiEditorAttributes(row, {
+    id: uiId,
+    kind: "field",
+    label,
+    parent: "plaene.m1.project-summary",
+  });
+
+  const labelEl = document.createElement("span");
+  labelEl.className = "bbm-plaene-metric__label";
+  labelEl.textContent = label;
+
+  const valueEl = document.createElement("strong");
+  valueEl.className = "bbm-plaene-metric__value";
+  valueEl.textContent = normalizeText(value) || "-";
+
+  row.append(labelEl, valueEl);
+  return row;
+}
+
+export default class PlaeneScreen {
+  constructor({ router, projectId, project, moduleId } = {}) {
+    this.router = router || null;
+    this.projectId = getProjectId(projectId, project);
+    this.project = project || null;
+    this.moduleId = moduleId || "plaene";
+    this.root = null;
+    this.projectFolder = "";
+    this.storageError = "";
+  }
+
+  render() {
+    this.root = document.createElement("section");
+    this.root.className = "bbm-plaene-screen";
+    this.root.setAttribute("data-bbm-plaene-screen", "m1");
+    setUiEditorAttributes(this.root, {
+      id: "plaene.m1.root",
+      kind: "frame",
+      label: "Pläne Modulbereich",
+      parent: "",
+    });
+    this._renderShell();
+    this.loadProjectFolder();
+    return this.root;
+  }
+
+  async loadProjectFolder() {
+    if (!this.projectId || !this.project || typeof window === "undefined") return;
+    const api = window.bbmDb || {};
+    if (typeof api.projectsStoragePreview !== "function") return;
+    try {
+      const result = await api.projectsStoragePreview(this.project);
+      if (result?.ok) {
+        this.projectFolder = normalizeText(result.projectFolder || result.paths?.projectFolder);
+        this.storageError = "";
+      } else {
+        this.storageError = normalizeText(result?.error);
+      }
+    } catch (error) {
+      this.storageError = normalizeText(error?.message);
+    }
+    this._renderShell();
+  }
+
+  _renderShell() {
+    if (!this.root) return;
+    this.root.replaceChildren();
+    this.root.append(this._renderHeader());
+    if (!this.projectId) {
+      this.root.append(this._renderNoProjectNotice());
+      return;
+    }
+    this.root.append(this._renderProjectView());
+  }
+
+  async navigateBack() {
+    if (this.projectId && typeof this.router?.showProjectWorkspace === "function") {
+      await this.router.showProjectWorkspace(this.projectId, { project: this.project || null });
+      return true;
+    }
+    if (typeof this.router?.showProjects === "function") {
+      await this.router.showProjects();
+      return true;
+    }
+    return false;
+  }
+
+  _renderHeader() {
+    const header = document.createElement("header");
+    header.className = "bbm-plaene-header";
+    header.style.display = "flex";
+    header.style.alignItems = "flex-start";
+    header.style.gap = "12px";
+    header.style.marginBottom = "14px";
+    setUiEditorAttributes(header, {
+      id: "plaene.m1.header",
+      kind: "frame",
+      label: "Pläne Kopfbereich",
+      parent: "plaene.m1.root",
+    });
+
+    const titleGroup = document.createElement("div");
+    titleGroup.style.display = "grid";
+    titleGroup.style.gap = "4px";
+    titleGroup.append(
+      createText("h1", "Modul Pläne", {
+        id: "plaene.m1.title",
+        kind: "single",
+        label: "Modul Pläne Titel",
+        parent: "plaene.m1.header",
+      })
+    );
+
+    if (this.projectId) {
+      const projectName = getProjectName(this.project) || "-";
+      titleGroup.append(
+        createText("p", `Aktives Projekt: ${projectName}`, {
+          id: "plaene.m1.active-project",
+          kind: "single",
+          label: "Aktives Projekt",
+          parent: "plaene.m1.header",
+        })
+      );
+    }
+
+    header.append(createBackButton(() => this.navigateBack()), titleGroup);
+    return header;
+  }
+
+  _renderNoProjectNotice() {
+    const notice = document.createElement("div");
+    notice.className = "bbm-plaene-notice";
+    setUiEditorAttributes(notice, {
+      id: "plaene.m1.no-project-notice",
+      kind: "frame",
+      label: "Kein Projekt Hinweis",
+      parent: "plaene.m1.root",
+    });
+    const line1 = document.createElement("p");
+    line1.textContent = "Kein Projekt ausgewählt.";
+    const line2 = document.createElement("p");
+    line2.textContent = "Öffnen Sie zuerst ein Projekt, um dessen Pläne zu verwalten.";
+    notice.append(line1, line2);
+    return notice;
+  }
+
+  _renderProjectView() {
+    const fragment = document.createDocumentFragment();
+    const buildings = resolveBuildings(this.project);
+    const floors = resolveFloors(this.project);
+
+    const summary = document.createElement("div");
+    summary.className = "bbm-plaene-summary";
+    setUiEditorAttributes(summary, {
+      id: "plaene.m1.project-summary",
+      kind: "frame",
+      label: "Projektkontext Zusammenfassung",
+      parent: "plaene.m1.root",
+    });
+    summary.append(
+      createMetric("Projekt-ID", this.projectId, "plaene.m1.project-id"),
+      createMetric("Projektordner", this.projectFolder || (this.storageError ? `Nicht verfügbar: ${this.storageError}` : "-"), "plaene.m1.project-folder"),
+      createMetric("Anzahl vorhandener Gebäude", String(buildings.length), "plaene.m1.building-count"),
+      createMetric("Anzahl vorhandener Geschosse", String(floors.length), "plaene.m1.floor-count")
+    );
+
+    const note = createText("p", "Die Planordner-Anbindung folgt in Meilenstein M2.", {
+      id: "plaene.m1.next-step-note",
+      kind: "single",
+      label: "Hinweis Planordner M2",
+      parent: "plaene.m1.root",
+    });
+    note.className = "bbm-plaene-next-step";
+
+    fragment.append(summary, note);
+    return fragment;
+  }
+}
+
+export {
+  getProjectName,
+  resolveBuildings,
+  resolveFloors,
+};

--- a/src/renderer/modules/plaene/screens/index.js
+++ b/src/renderer/modules/plaene/screens/index.js
@@ -1,0 +1,3 @@
+export { default as PlaeneScreen } from "./PlaeneScreen.js";
+
+export const PLAENE_WORK_SCREEN_ID = "plaeneWork";


### PR DESCRIPTION
### Motivation
- Introduce a minimal "Pläne" module (M1) as a scaffold inside the existing project module system to provide a place for future plan-management features and to allow early UI/integration validation.
- Provide a simple project-context view and a reliable "Zurück" navigation behavior for the new module without adding persistent plan storage or complex IPC in M1.

### Description
- Add a new module at `src/renderer/modules/plaene` with `index.js`, `screens/PlaeneScreen.js`, and `screens/index.js` implementing a read-only M1 screen that shows project name, project id, storage-preview folder, counts for buildings/floors, and a top-left "Zurück" button that navigates using the existing router API.
- Integrate the module into the application catalog by updating `src/renderer/app/modules/moduleCatalog.js` to expose `PLAENE_MODULE_ID`, include the module in `AVAILABLE_MODULE_ENTRIES` and `DEFAULT_ACTIVE_MODULE_IDS`, and export the new constant.
- Add a comprehensive test suite `scripts/tests/plaeneModule.test.cjs` implementing a fake DOM and exercising module entry, navigation, UI-editor attributes, project-folder preview usage and the back-button behavior.
- Wire the new test into the test runner by importing and invoking `runPlaeneModuleTests` from `scripts/test.cjs`, and update `STATUS.md` with M1 and back-button rollout notes.

### Testing
- Ran the new module unit/integration tests via `node scripts/tests/plaeneModule.test.cjs`, which completed successfully (`OK`).
- The test runner was updated to call `runPlaeneModuleTests` and the plaene tests are executed when running the combined script test harness in this environment; the plaene tests passed in that context.
- Full `npm test` / Electron-based test runs are not executable in this environment due to missing system library `libatk-1.0.so.0`, so a local/CI run with Electron system libs is still recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a624af918848322b60c68a332e01fc8)