### PR TITLE
Korrektur PR #209: Pläne — „Zurück“-Button begrenzen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,4 +1,20 @@
-# STATUS.md â€” BBM-Produktiv
+# STATUS.md — BBM-Produktiv
+
+### Korrektur PR #209 – Pläne-Zurück-Button
+- Ergebnis:
+  - PR #209 wurde auf die kleine Zurück-Ergänzung im Pläne-Screen begrenzt.
+  - Der Button führt mit aktivem Projekt zur Projekt-/Modulauswahl und ohne aktives Projekt zur Projektliste, ohne den Projektkontext zu verändern.
+- Geaenderte Dateien:
+  - `src/renderer/modules/plaene/screens/PlaeneScreen.js`
+  - `scripts/tests/plaeneModule.test.cjs`
+  - `STATUS.md`
+- Pruefung:
+  - `node scripts/tests/plaeneModule.test.cjs`
+  - `node scripts/ui-editor-contract-check.cjs src/renderer/modules/plaene/screens/PlaeneScreen.js`
+- Risiken / offen:
+  - Keine automatisierte GitHub-PR-Aktualisierung aus der Sandbox möglich, falls der Remote-Zugriff blockiert bleibt.
+- Naechster Schritt:
+  - PR #209 konfliktfrei gegen `main` prüfen.
 
 ### M62 – BBM Selection Legacy Cleanup
 - Ergebnis:

--- a/scripts/tests/plaeneModule.test.cjs
+++ b/scripts/tests/plaeneModule.test.cjs
@@ -33,6 +33,12 @@ function createFakeDocument() {
         this.textContent = "";
         this.append(...nodes);
       },
+      addEventListener(name, handler) {
+        this[`on${String(name)}`] = handler;
+      },
+      click() {
+        if (typeof this.onclick === "function") this.onclick({ type: "click", target: this });
+      },
       setAttribute(name, value) {
         const key = String(name);
         const text = String(value);
@@ -141,6 +147,53 @@ async function runPlaeneModuleTests(run) {
     assert.equal(text.includes("Öffnen Sie zuerst ein Projekt, um dessen Pläne zu verwalten."), true);
     assert.equal(text.includes("Modul Pläne"), false);
     assert.equal(Boolean(findByUiId(root, "plaene.m1.no-project-notice")), true);
+  }));
+
+  await run("Pläne: Zurück ohne aktives Projekt öffnet Projektliste", async () => withFakeDom(async () => {
+    const calls = [];
+    const screen = new screenModule.default({
+      projectId: null,
+      project: null,
+      router: {
+        async showProjects() {
+          calls.push(["showProjects"]);
+        },
+      },
+    });
+    const root = screen.render();
+    await flush();
+    const buttons = findNodes(root, (node) => node.tagName === "BUTTON" && node.textContent === "Zurück");
+    assert.equal(buttons.length, 1);
+    buttons[0].click();
+    await flush();
+    assert.deepEqual(calls, [["showProjects"]]);
+  }));
+
+  await run("Pläne: Zurück mit aktivem Projekt öffnet Projekt-/Modulauswahl ohne Projektkontextänderung", async () => withFakeDom(async () => {
+    const calls = [];
+    const project = { id: "projekt-a", name: "Projekt A" };
+    const screen = new screenModule.default({
+      projectId: "projekt-a",
+      project,
+      router: {
+        async showProjectWorkspace(projectId, options) {
+          calls.push(["showProjectWorkspace", projectId, options]);
+        },
+        async showProjects() {
+          calls.push(["showProjects"]);
+        },
+      },
+    });
+    const root = screen.render();
+    await flush();
+    const buttons = findNodes(root, (node) => node.tagName === "BUTTON" && node.textContent === "Zurück");
+    assert.equal(buttons.length, 1);
+    buttons[0].click();
+    await flush();
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][0], "showProjectWorkspace");
+    assert.equal(calls[0][1], "projekt-a");
+    assert.deepEqual(calls[0][2], { project });
   }));
 
   await run("Pläne: aktives Projekt zeigt ausschließlich übergebene Projektwerte", async () => withFakeDom(async () => {

--- a/scripts/tests/plaeneModule.test.cjs
+++ b/scripts/tests/plaeneModule.test.cjs
@@ -164,6 +164,13 @@ async function runPlaeneModuleTests(run) {
     await flush();
     const buttons = findNodes(root, (node) => node.tagName === "BUTTON" && node.textContent === "Zurück");
     assert.equal(buttons.length, 1);
+    const backButtons = findNodes(root, (node) => node.getAttribute?.("data-ui-inspector-id") === "plaene.m1.back-button");
+    assert.equal(backButtons.length, 1);
+    assert.equal(backButtons[0].getAttribute("data-ui-editor-kind"), "button");
+    assert.equal(backButtons[0].getAttribute("data-ui-editor-label"), "Zurück");
+    assert.equal(backButtons[0].getAttribute("data-ui-editor-parent"), "plaene.m1.root");
+    assert.equal(backButtons[0].getAttribute("data-ui-editor-editable"), "true");
+    assert.equal(backButtons[0].getAttribute("data-ui-editor-ops"), "layout");
     buttons[0].click();
     await flush();
     assert.deepEqual(calls, [["showProjects"]]);
@@ -188,6 +195,13 @@ async function runPlaeneModuleTests(run) {
     await flush();
     const buttons = findNodes(root, (node) => node.tagName === "BUTTON" && node.textContent === "Zurück");
     assert.equal(buttons.length, 1);
+    const backButtons = findNodes(root, (node) => node.getAttribute?.("data-ui-inspector-id") === "plaene.m1.back-button");
+    assert.equal(backButtons.length, 1);
+    assert.equal(backButtons[0].getAttribute("data-ui-editor-kind"), "button");
+    assert.equal(backButtons[0].getAttribute("data-ui-editor-label"), "Zurück");
+    assert.equal(backButtons[0].getAttribute("data-ui-editor-parent"), "plaene.m1.header");
+    assert.equal(backButtons[0].getAttribute("data-ui-editor-editable"), "true");
+    assert.equal(backButtons[0].getAttribute("data-ui-editor-ops"), "layout");
     buttons[0].click();
     await flush();
     assert.equal(calls.length, 1);
@@ -293,6 +307,7 @@ async function runPlaeneModuleTests(run) {
     const expected = new Map([
       ["plaene.m1.root", ""],
       ["plaene.m1.header", "plaene.m1.root"],
+      ["plaene.m1.back-button", "plaene.m1.header"],
       ["plaene.m1.title", "plaene.m1.header"],
       ["plaene.m1.active-project", "plaene.m1.header"],
       ["plaene.m1.project-summary", "plaene.m1.root"],
@@ -308,8 +323,12 @@ async function runPlaeneModuleTests(run) {
       assert.equal(node.getAttribute("data-ui-editor-id"), id);
       assert.equal(node.getAttribute("data-ui-editor-parent"), parentId);
       assert.equal(node.getAttribute("data-ui-editor-editable"), "true");
-      assert.equal(node.getAttribute("data-ui-editor-ops"), "inspect,select");
-      assert.ok(["frame", "field", "single"].includes(node.getAttribute("data-ui-editor-kind")));
+      if (id === "plaene.m1.back-button") {
+        assert.equal(node.getAttribute("data-ui-editor-ops"), "layout");
+      } else {
+        assert.equal(node.getAttribute("data-ui-editor-ops"), "inspect,select");
+      }
+      assert.ok(["frame", "field", "single", "button"].includes(node.getAttribute("data-ui-editor-kind")));
       assert.ok(node.getAttribute("data-ui-editor-label"));
       if (parentId) assert.ok(findByUiId(root, parentId), `${id} Parent fehlt`);
     }

--- a/src/renderer/modules/plaene/screens/PlaeneScreen.js
+++ b/src/renderer/modules/plaene/screens/PlaeneScreen.js
@@ -126,6 +126,30 @@ export default class PlaeneScreen {
     return this.root;
   }
 
+
+  async goBack() {
+    if (this.projectId && typeof this.router?.showProjectWorkspace === "function") {
+      await this.router.showProjectWorkspace(this.projectId, { project: this.project });
+      return true;
+    }
+    if (typeof this.router?.showProjects === "function") {
+      await this.router.showProjects();
+      return true;
+    }
+    return false;
+  }
+
+  _renderBackButton() {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "bbm-plaene-back-button";
+    button.textContent = "Zurück";
+    button.addEventListener("click", () => {
+      void this.goBack();
+    });
+    return button;
+  }
+
   async loadProjectFolder() {
     if (!this.projectId || !this.project || typeof window === "undefined") return;
     const api = window.bbmDb || {};
@@ -148,7 +172,7 @@ export default class PlaeneScreen {
     if (!this.root) return;
     this.root.replaceChildren();
     if (!this.projectId) {
-      this.root.append(this._renderNoProjectNotice());
+      this.root.append(this._renderBackButton(), this._renderNoProjectNotice());
       return;
     }
     this.root.append(this._renderProjectView());
@@ -186,6 +210,7 @@ export default class PlaeneScreen {
       parent: "plaene.m1.root",
     });
     header.append(
+      this._renderBackButton(),
       createText("h1", "Modul Pläne", {
         id: "plaene.m1.title",
         kind: "single",

--- a/src/renderer/modules/plaene/screens/PlaeneScreen.js
+++ b/src/renderer/modules/plaene/screens/PlaeneScreen.js
@@ -139,11 +139,19 @@ export default class PlaeneScreen {
     return false;
   }
 
-  _renderBackButton() {
+  _renderBackButton(parentId) {
     const button = document.createElement("button");
     button.type = "button";
     button.className = "bbm-plaene-back-button";
     button.textContent = "Zurück";
+    setUiEditorAttributes(button, {
+      id: "plaene.m1.back-button",
+      kind: "button",
+      label: "Zurück",
+      parent: parentId,
+      editable: "true",
+      ops: "layout",
+    });
     button.addEventListener("click", () => {
       void this.goBack();
     });
@@ -172,7 +180,7 @@ export default class PlaeneScreen {
     if (!this.root) return;
     this.root.replaceChildren();
     if (!this.projectId) {
-      this.root.append(this._renderBackButton(), this._renderNoProjectNotice());
+      this.root.append(this._renderBackButton("plaene.m1.root"), this._renderNoProjectNotice());
       return;
     }
     this.root.append(this._renderProjectView());
@@ -210,7 +218,7 @@ export default class PlaeneScreen {
       parent: "plaene.m1.root",
     });
     header.append(
-      this._renderBackButton(),
+      this._renderBackButton("plaene.m1.header"),
       createText("h1", "Modul Pläne", {
         id: "plaene.m1.title",
         kind: "single",


### PR DESCRIPTION
### Motivation
- PR #209 war auf einem veralteten Stand und sollte gegenüber `main` nur die kleine Ergänzung eines sichtbaren „Zurück“-Buttons im Pläne-Screen behalten. 
- Ziel war, das bereits durch PR #208 übernommene Modulgerüst nicht erneut zu verändern und Navigation fachgerecht über den vorhandenen `Router` zu lösen. 

### Description
- In `src/renderer/modules/plaene/screens/PlaeneScreen.js` wurde eine `goBack()`-Methode und eine `_renderBackButton()`-Funktion hinzugefügt, und der Button wird oben im Header und in der projektlosen Ansicht gerendert. 
- Die `goBack()`-Logik nutzt bei vorhandenem Projekt `this.router.showProjectWorkspace(this.projectId, { project: this.project })` und sonst `this.router.showProjects()`, ohne `window.history.back()` aufzurufen oder den Projektkontext zu verändern. 
- Tests wurden in `scripts/tests/plaeneModule.test.cjs` ergänzt, um beide Zurück-Fälle (mit und ohne aktives Projekt) per Fake-DOM und Router-Mocks abzudecken, und `STATUS.md` erhielt einen kurzen Eintrag zur Korrektur. 

### Testing
- Automatisierte Modultests wurden ausgeführt mit `node scripts/tests/plaeneModule.test.cjs` und alle enthaltenen Prüffälle wurden erfolgreich ausgeführt. 
- Der UI-Vertragscheck wurde ausgeführt mit `node scripts/ui-editor-contract-check.cjs src/renderer/modules/plaene/screens/PlaeneScreen.js` und meldete keine Fehler. 
- Die Änderungen sind lokal committed on branch `work` (commit `cf2b0f5`), jedoch konnte die bestehende GitHub-PR #209 in dieser Umgebung nicht direkt aktualisiert, da Remote-Zugriff beim `git fetch`/`push` wegen Netzwerk-/Proxy-Fehler (`CONNECT tunnel failed, response 403`) blockiert war.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6255c121a88322b863975b6ee8a17a)