### PR TITLE
M80 BBM mit separatem UI-Editor verbinden

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 BBM nutzt ab M51 das eigenständige `UI-Editor-kit` in Version `v0.2.0` als Ziel-App-Integration. Die technische Anbindung ist in [docs/M51_UI_EDITOR_KIT_V0.2.0_INTEGRATION.md](docs/M51_UI_EDITOR_KIT_V0.2.0_INTEGRATION.md) dokumentiert.
 
+Ab M80 ist die produktführende Integration die Sidebar-Aktion `UI-Editor öffnen`: Sie verbindet die laufende Electron-App ausschließlich lokal mit dem vorhandenen separaten nativen Editor. Der Restarbeiten-Pilot nutzt explizite Registry/Refs, getrennte Labels/Felder, die bestätigte Hauptliste, neutrale Layoutänderungen, Sichtbarkeit und den vorhandenen Profil-/Rollbackweg. Fachaktionen und Fachwerte sind ausgeschlossen. Einstieg: [M80-HostAdapter](docs/M80_ELECTRON_HOSTADAPTER.md), [Pilotregistry](docs/M80_PILOT_REGISTRY.md), [Sicherheit/Diagnose](docs/M80_LIFECYCLE_SICHERHEIT_DIAGNOSE.md).
+
+Die vollständige BBM-PDF-Anbindung ist M81; bis dahin zeigt der PDF-Tab im Editor ausdrücklich, dass BBM-PDF noch nicht angebunden ist.
+
 Status M51: Core-Vertrag technisch angebunden und testbar; noch keine vollständige sichtbare Editor-Oberfläche und noch keine dauerhafte Layoutspeicherung.
 
 ## M52: Sichtbarer UI-Editor-Startpunkt

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,32 @@
 # STATUS.md — BBM-Produktiv
 
+### M80 – Electron-Ziel-App-Anbindung und Restarbeiten-UI-Pilot
+
+- Status: `[A] abgenommen`.
+- Ergebnis:
+  - Die Sidebar-Aktion `UI-Editor öffnen` startet/fokussiert den vorhandenen separaten nativen Editor; es gibt genau einen Manager- und einen Node-Core-Prozess je BBM-Sitzung.
+  - Führend sind eine explizite M80-Registry, ein Ref-Resolver, ein Electron-HostAdapter, eine enge Main-/Preload-/Renderer-Bridge, der vorhandene Profilweg und ein Lifecycle.
+  - Der Restarbeiten-Pilot umfasst Listen- und Bearbeitungs-Scope, getrennte Labels/Felder, die bestätigte Hauptliste mit drei Spaltengruppen und `Neu` nur als Layoutobjekt.
+  - Auswahl/Markierung, Live-Layout, Sichtbarkeit, Save/Load, Neustart-Restore, Discard, Reset und vollständiger Rollback sind sichtbar nachgewiesen; Fachwert und Fachaktion blieben unverändert.
+  - Entwicklungsstart und gepackter Verzeichnisbuild verwenden denselben mitgelieferten Manager/Node-Core. BBM-PDF bleibt ehrlich M81.
+- Dokumentation:
+  - `docs/M80_UI_PDF_ENTWURFSENTSCHEIDUNG.md`
+  - `docs/M80_ELECTRON_HOSTADAPTER.md`
+  - `docs/M80_PILOT_REGISTRY.md`
+  - `docs/M80_LIFECYCLE_SICHERHEIT_DIAGNOSE.md`
+- Prüfung:
+  - `npm test` und `npm run test:node`: vollständig grün.
+  - `npm run pack`: grün; gepackte `BBM.exe`, Manager, Preload/Bridge und `editor-runtime` praktisch gestartet.
+  - sichtbarer 43-Schritte-Ende-zu-Ende-Lauf mit echten Prozessen und Fenstern: grün.
+  - globales `npm run lint`: weiterhin rot durch 17 bereits außerhalb M80 vorhandene Fehler; der neue M80-Pfad ist gezielt lint-grün.
+- Risiken / offen:
+  - M81: BBM-PDF-Anbindung an den bestehenden PDF-Arbeitsbereich.
+  - Historische Editorpfade bleiben erhalten, sind aber nicht produktführend.
+- Nächster Schritt:
+  - M81 erst mit eigener UI-/PDF-Entwurfsentscheidung beginnen.
+- Commit/PR:
+  - keiner; gemäß Nutzeranweisung wurde weder committet noch gepusht.
+
 ### Korrektur PR #209 – Pläne-Zurück-Button
 - Ergebnis:
   - PR #209 wurde auf die kleine Zurück-Ergänzung im Pläne-Screen begrenzt.

--- a/docs/M80_ELECTRON_HOSTADAPTER.md
+++ b/docs/M80_ELECTRON_HOSTADAPTER.md
@@ -1,0 +1,18 @@
+# M80 – führender Electron-HostAdapter
+
+Der produktführende M80-Pfad ist:
+
+`UI-Editor öffnen` → `window.uiEditor` → BBM-Maincontroller → lokale Named Pipe → nativer WPF-Editor → vorhandener Node-Core → vorhandene Profil-/Rollbacklogik.
+
+## Führende BBM-Dateien
+
+- `src/main/ui-editor/electronUiEditorSession.js`: genau eine Sitzung, vertrauenswürdige Pfadauflösung, Handshake, Pipe, Heartbeat und Lifecycle.
+- `src/main/preload.js`: eng begrenzte `uiEditor`-API ohne generisches IPC.
+- `src/renderer/ui-editor/m80Registry.js`: einzige M80-Pilotregistry.
+- `src/renderer/ui-editor/m80Refs.js`: einzige explizite ID-zu-Element-Referenzauflösung.
+- `src/renderer/ui-editor/m80HostAdapter.js`: Registry, LayoutState, ChangeRequest, Readback und Rollback.
+- `src/renderer/ui-editor/m80Bridge.js`: feste Main-/Preload-/Renderer-Nachrichten.
+
+Der HostAdapter akzeptiert nur registrierte IDs, freigegebene Layoutoperationen und fachfreie Payloads. Er überträgt keine DOM-Knoten oder Fachwerte. Fehler werden auf den unmittelbar vorherigen Layoutzustand zurückgerollt und strukturiert gemeldet.
+
+Historische Pfade unter `uiEditor/`, `src/renderer/uiInspector/`, `src/renderer/uiV2/`, `src/ui-editor/`, der übrigen `src/renderer/ui-editor/`-Historie und `src/renderer/editorRuntime/` bleiben erhalten, sind für M80 aber nicht produktführend. Es wurde kein zweiter Editor ausgebaut.

--- a/docs/M80_LIFECYCLE_SICHERHEIT_DIAGNOSE.md
+++ b/docs/M80_LIFECYCLE_SICHERHEIT_DIAGNOSE.md
@@ -1,0 +1,19 @@
+# M80 – Lifecycle, Sicherheit und Diagnose
+
+## Lokaler Transport
+
+Je BBM-Sitzung werden zufälliger Pipe-Name, kryptografische Nonce und Sitzungs-ID erzeugt. Die Verbindung verwendet Protokollversion, Handshake vor Nutzdaten, Current-User-only, genau eine Verbindung, feste Nachrichtentypen, Korrelations-IDs, Größenlimit, Timeouts/Heartbeat, strukturierte Fehler und kontrollierten Disconnect. HTTP, WebSocket, Webserver, Browser, Netzwerk und Cloud sind ausgeschlossen.
+
+Ein erster Sidebar-Aufruf startet die feste vertrauenswürdige Editor-EXE. Ein weiterer Aufruf sendet nur `activateEditor`; er startet keinen zweiten Manager- oder Node-Prozess. Renderer dürfen keinen Programmpfad angeben. BBM- und Editorende räumen Pipe, Auswahlmodus und Overlay auf.
+
+## Entwicklung und Produktion
+
+- Entwicklung: vorbereiteter Manager unter `build/ui-editor-manager` oder kontrollierter UI-Editor-kit-Debugbuild.
+- Gepackt: `resources/ui-editor/UiEditorManager.exe` und `resources/ui-editor/editor-runtime`.
+- Optionaler stabiler Installationsfallback: `%LOCALAPPDATA%\UI-Editor-kit\Manager\app`.
+
+## Diagnose
+
+`--bbm-electron-editor-diagnostic` beziehungsweise `BBM_M80_EDITOR_DIAGNOSTIC=1` rendert einen isolierten realen Restarbeiten-Screen mit einem nicht persistenten In-Memory-Datensatz. Es werden weder Kunden-/Produktivdaten noch Fachdatenbanken geändert. Der nur dort aktive Tastengriff `Ctrl+Shift+F8` armiert einmalig einen kontrollierten Applyfehler für den sichtbaren Rollbacknachweis.
+
+Nachgewiesen wurden 43 E2E-Schritte mit echten sichtbaren Fenstern: Start, Sidebar, Handshake, Registry, Auswahl/Markierung in beide Richtungen, Layoutmodi, getrennte Sichtbarkeit, Tabelle, Fachaktionsschutz, Save/Load, Neustart-Restore, Discard, Reset, Rollback, Eininstanz, PDF-Abgrenzung, Editorende, BBM-Weiterbetrieb und vollständige Prozess-/Temporärbereinigung.

--- a/docs/M80_PILOT_REGISTRY.md
+++ b/docs/M80_PILOT_REGISTRY.md
@@ -1,0 +1,16 @@
+# M80 – Restarbeiten-Pilotregistry
+
+Die Registry ist explizit und umfasst ausschließlich zwei Restarbeiten-Scopes:
+
+- `restarbeiten.list.root`: Hauptliste mit Bereich, Papier, Inhaltstabelle und den drei fachlich bestätigten sichtbaren Spaltengruppen.
+- `restarbeiten.edit.root`: Bearbeitungsbereich mit Kurztext-/Langtext-`fieldGroup`, getrennten Labels/Feldern und dem Button `Neu` als reines Layoutobjekt.
+
+## Bestätigte Tabellenspalten
+
+1. `restarbeiten.list.table.number` – Nr. / Datum / Klasse / Fotos
+2. `restarbeiten.list.table.subject` – Gegenstand – Verortung / Kurztext / Langtext
+3. `restarbeiten.list.table.meta` – Status-Metaspalte – Fertig bis / Ampel / Status / Verantwortlich
+
+Die Tabelle ist eine Inhaltstabelle und ausschließlich Layoutobjekt. Sichtbarkeit einzelner Spalten ist nur zulässig, soweit keine Fachlogik verändert wird. Fachwerte, Status, Verantwortliche, Termine, Ampel, Fotos, Zeilen, Sortierung, Filter und Fachaktionen sind keine Editoroperationen.
+
+Die Registry wird nicht aus DOM, CSS, Datenbank, IPC oder Druckdaten erzeugt. Parentstruktur, Reihenfolge, Rollen und Operationen sind fest gepflegt und durch den Vertragscheck abgesichert.

--- a/docs/M80_UI_PDF_ENTWURFSENTSCHEIDUNG.md
+++ b/docs/M80_UI_PDF_ENTWURFSENTSCHEIDUNG.md
@@ -1,0 +1,47 @@
+# M80 – UI-/PDF-Entwurfsentscheidung
+
+Status: umgesetzt und praktisch geprüft.
+
+## A. Art der Ausgabe
+
+- UI: ja, Restarbeiten-Pilot in der laufenden BBM-Oberfläche.
+- PDF: nein. Der Editor zeigt für BBM ausschließlich `BBM-PDF noch nicht angebunden – folgt in M81.`
+
+## B. Editorfähigkeit
+
+Editorfähig: ja, ausschließlich als Layout. Fachwerte, Datenbindung, Fachlogik und Tabellenfunktion bleiben unverändert.
+
+## C. Editorfähige Elemente
+
+Jedes Element trägt `data-ui-inspector-id`, `data-ui-editor-kind`, `data-ui-editor-label`, `data-ui-editor-parent`, `data-ui-editor-editable` und `data-ui-editor-ops`.
+
+- `restarbeiten.list.root` – Root, nicht selbst editierbar.
+- `restarbeiten.list.area` → Parent Root.
+- `restarbeiten.list.paper` → Parent Area.
+- `restarbeiten.list.table` → Inhaltstabelle; Tabellenbreite, Position, technisch sinnvolle Höhe, Schrift/Textposition und Sichtbarkeit.
+- `restarbeiten.list.table.number` → `Nr. / Datum / Klasse / Fotos`.
+- `restarbeiten.list.table.subject` → `Gegenstand – Verortung / Kurztext / Langtext`.
+- `restarbeiten.list.table.meta` → `Status-Metaspalte – Fertig bis / Ampel / Status / Verantwortlich`, `columnRole = metaColumn`.
+- `restarbeiten.edit.root` – Root, nicht selbst editierbar.
+- `restarbeiten.edit.area` und `restarbeiten.edit.fields` → Bereich/Gruppe.
+- `restarbeiten.edit.short` und `restarbeiten.edit.long` → `fieldGroup`.
+- `.label` und `.field` → getrennte Geschwister mit jeweils eigener ID, Referenz und Sichtbarkeit.
+- `restarbeiten.edit.action.new` → fachlicher Button ausschließlich als Layoutobjekt.
+
+Erlaubt sind capability-gesteuert `move`, `resizeWidth`, `resizeHeight`, `textMove`, `textResize` und `setVisibility`.
+
+## D. Nicht editorfähige Ziele
+
+Nicht erlaubt sind Fachwerte, Status, Verantwortliche, Termine, Ampellogik, Fotos, Zeilen, Sortierung/Filter, fachliches Speichern/Anlegen/Löschen, Upload, Import, Export, Autosave, fachliche IPC-/Datenbankaktionen oder das Ausführen eines Buttons.
+
+## E. Parent-/Strukturregel
+
+Jedes Element außer dem jeweiligen Root besitzt einen existierenden registrierten Parent. Labels und Felder sind Geschwister unter ihrer `fieldGroup`; ein Label ist nie Parent eines Feldes. Die drei bestätigten sichtbaren Spaltengruppen bleiben zusammen und werden nicht aus Datenbank-, IPC- oder Druckfeldern abgeleitet.
+
+## F. Prüfung
+
+- `scripts/ui-editor-contract-check.cjs` über beide Registry-Scopes.
+- `scripts/tests/m80ElectronUiEditor.test.cjs` prüft IDs, Parents, Rollen, Operationen, Fachaktionssperren und sechs DOM-Pflichtattribute.
+- Sichtbarer Entwicklungs- und gepackter E2E-Lauf prüft Auswahl, Markierung, Live-Layout, unabhängige Sichtbarkeit, Tabellenbreite, Save/Load, Neustart-Restore, Discard, Reset und Rollback.
+
+M81 bleibt die vollständige BBM-PDF-Anbindung an den bestehenden PDF-Arbeitsbereich.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "better-sqlite3": "^12.6.2",
         "extract-zip": "^2.0.1",
         "pdfjs-dist": "^4.10.38",
-        "ui-editor-kit": "github:SteffenBandholt/UI-Editor-kit#af1fbabd0b875a4ab382ed84c5cd986c3c7acb14",
+        "ui-editor-kit": "file:../UI-Editor-kit",
         "yauzl": "^3.2.1"
       },
       "devDependencies": {
@@ -21,6 +21,10 @@
         "electron-builder": "^24.13.3",
         "eslint": "^8.57.1"
       }
+    },
+    "../UI-Editor-kit": {
+      "name": "ui-editor-kit",
+      "version": "0.2.0"
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -5160,9 +5164,8 @@
       }
     },
     "node_modules/ui-editor-kit": {
-      "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/SteffenBandholt/UI-Editor-kit.git#af1fbabd0b875a4ab382ed84c5cd986c3c7acb14",
-      "license": "UNLICENSED"
+      "resolved": "../UI-Editor-kit",
+      "link": true
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "start": "npm run fix:electron-deps && npm run start:raw",
     "start:raw": "set ELECTRON_RUN_AS_NODE=&& electron .",
-    "pack": "electron-builder --dir",
+    "prepare:ui-editor": "node scripts/prepareUiEditorManager.cjs",
+    "pack": "npm run prepare:ui-editor && electron-builder --dir",
     "dist": "node scripts/dist.cjs",
     "test": "node scripts/runElectronNodeTest.cjs",
     "lint": "eslint \"src/**/*.js\"",
@@ -27,7 +28,7 @@
     "better-sqlite3": "^12.6.2",
     "extract-zip": "^2.0.1",
     "pdfjs-dist": "^4.10.38",
-    "ui-editor-kit": "github:SteffenBandholt/UI-Editor-kit#af1fbabd0b875a4ab382ed84c5cd986c3c7acb14",
+    "ui-editor-kit": "file:../UI-Editor-kit",
     "yauzl": "^3.2.1"
   },
   "build": {
@@ -51,6 +52,10 @@
       "node_modules/better-sqlite3/**"
     ],
     "extraResources": [
+      {
+        "from": "build/ui-editor-manager",
+        "to": "ui-editor"
+      },
       {
         "from": "dev/tools/whisper.cpp/Release",
         "to": "audio/whisper",

--- a/scripts/prepareUiEditorManager.cjs
+++ b/scripts/prepareUiEditorManager.cjs
@@ -1,0 +1,34 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const repositoryRoot = path.resolve(__dirname, "..");
+const kitRoot = path.resolve(repositoryRoot, "..", "UI-Editor-kit");
+const projectPath = path.join(kitRoot, "windows-manager", "src", "UiEditorKit.Manager.Wpf", "UiEditorKit.Manager.Wpf.csproj");
+const buildRoot = path.join(repositoryRoot, "build");
+const outputPath = path.join(buildRoot, "ui-editor-manager");
+
+if (!fs.existsSync(projectPath)) {
+  console.error("Der vertrauenswürdige UI-Editor-Manager-Quellpfad fehlt.");
+  process.exit(80);
+}
+if (path.dirname(outputPath) !== buildRoot || !outputPath.startsWith(`${buildRoot}${path.sep}`)) {
+  console.error("Ungültiges UI-Editor-Ausgabeverzeichnis.");
+  process.exit(81);
+}
+
+fs.rmSync(outputPath, { recursive: true, force: true });
+fs.mkdirSync(outputPath, { recursive: true });
+const result = spawnSync("dotnet", ["publish", projectPath, "-c", "Release", "--no-restore", "-o", outputPath], {
+  cwd: kitRoot,
+  encoding: "utf8",
+  stdio: "inherit",
+  shell: false,
+});
+if (result.error || result.status !== 0 || !fs.existsSync(path.join(outputPath, "UiEditorManager.exe"))) {
+  console.error("Der UI-Editor-Manager konnte nicht für BBM vorbereitet werden.");
+  process.exit(typeof result.status === "number" ? result.status : 82);
+}
+console.log(`UI-Editor-Manager vorbereitet: ${outputPath}`);

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -98,6 +98,7 @@ const { runM64UiEditorTestSurfaceTests } = require("./tests/m64UiEditorTestSurfa
 const { runM65LayoutPersistenceRoundtripTests } = require("./tests/m65LayoutPersistenceRoundtrip.test.cjs");
 const { runM66ResetLayoutToDefaultsTests } = require("./tests/m66ResetLayoutToDefaults.test.cjs");
 const { runM67ResetElementToDefaultsTests } = require("./tests/m67ResetElementToDefaults.test.cjs");
+const { runM80ElectronUiEditorTests } = require("./tests/m80ElectronUiEditor.test.cjs");
 
 let failed = false;
 
@@ -243,6 +244,7 @@ async function main() {
   await runM65LayoutPersistenceRoundtripTests(run);
   await runM66ResetLayoutToDefaultsTests(run);
   await runM67ResetElementToDefaultsTests(run);
+  await runM80ElectronUiEditorTests(run);
 
   if (failed) {
     process.exitCode = 1;

--- a/scripts/tests/m51UiEditorKitIntegration.test.cjs
+++ b/scripts/tests/m51UiEditorKitIntegration.test.cjs
@@ -38,9 +38,9 @@ function createContractRuntime({ hostAdapter, manifest, registry, layoutStore })
 }
 
 async function runM51UiEditorKitIntegrationTests(run) {
-  await run("M51/M59 Abhaengigkeit: UI-Editor-kit ist fest auf M59-Kit-Merge-Commit gepinnt", () => {
-    assert.equal(packageJson.dependencies["ui-editor-kit"], "github:SteffenBandholt/UI-Editor-kit#af1fbabd0b875a4ab382ed84c5cd986c3c7acb14");
-    assert.equal(/#main|#master|latest/.test(packageJson.dependencies["ui-editor-kit"]), false);
+  await run("M51/M80 Abhaengigkeit: UI-Editor-kit nutzt den kontrollierten lokalen Workspace", () => {
+    assert.equal(packageJson.dependencies["ui-editor-kit"], "file:../UI-Editor-kit");
+    assert.equal(/github:|#main|#master|latest/.test(packageJson.dependencies["ui-editor-kit"]), false);
   });
 
   await run("M51 Manifest: BBM-Ziel-App-Vertrag ist eindeutig", () => {

--- a/scripts/tests/m52UiEditorVisibleEntry.test.cjs
+++ b/scripts/tests/m52UiEditorVisibleEntry.test.cjs
@@ -95,12 +95,12 @@ function findNode(node, predicate) {
 }
 
 async function runM52UiEditorVisibleEntryTests(run) {
-  await run("M52 Startpunkt: bestehende Navigation enthaelt eindeutigen UI-Editor-Status-Einstieg", () => {
+  await run("M52/M80 Startpunkt: Navigation enthaelt die separate UI-Editor-Aktion", () => {
     const navigation = read("src/renderer/app/coreShellNavigation.js");
     const router = read("src/renderer/app/Router.js");
-    assert.match(navigation, /label:\s*"UI-Editor Status"/);
-    assert.doesNotMatch(navigation, /label:\s*"UI-Editor"[,}]/);
-    assert.match(navigation, /router\.showUiEditor\(\)/);
+    assert.match(navigation, /label:\s*"UI-Editor öffnen"/);
+    assert.match(navigation, /kind:\s*"action"/);
+    assert.doesNotMatch(navigation, /router\.showUiEditor\(\)/);
     const coreShell = read("src/renderer/app/CoreShell.js");
     assert.match(router, /async showUiEditor\(\)/);
     assert.match(router, /const panel = createBbmUiEditorStatusPanel\(\{ router: this \}\);/);
@@ -108,6 +108,7 @@ async function runM52UiEditorVisibleEntryTests(run) {
     assert.doesNotMatch(router, /this\.show\(panel\.render\(\), \{/);
     assert.match(router, /showSettings\(\)/);
     assert.match(coreShell, /const routeButtons = shellNavigationRouteDefs\.map/);
+    assert.match(coreShell, /def\.kind === "action"/);
     assert.match(coreShell, /const coreNavigationButtons = \[\.\.\.routeButtons, btnHelp\]/);
     assert.doesNotMatch(coreShell, /const \[btnHome, btnProjects, btnFirms, btnSettings\]/);
   });
@@ -126,16 +127,13 @@ async function runM52UiEditorVisibleEntryTests(run) {
   });
 
 
-  await run("M52 echte Navigationskette: UI-Editor-Route bindet onClick und nutzt Router.show-Schnittstelle", async () => {
+  await run("M52/M80 echte Navigationskette: UI-Editor-Aktion startet keinen Screen", async () => {
     const previousDocument = global.document;
     const previousWindow = global.window;
     const doc = createPanelTestDocument();
     global.document = doc;
-    global.window = {
-      bbmDb: {
-        uiEditorOpen: async () => ({ ok: false, blockCode: "BBM_UI_EDITOR_TEST_BLOCK" }),
-      },
-    };
+    let openCalls = 0;
+    global.window = { uiEditor: { open: async () => { openCalls += 1; return { ok: true, started: true }; } } };
 
     try {
       const navigationModule = await importEsmFromFile(path.join(REPO_ROOT, "src/renderer/app/coreShellNavigation.js"));
@@ -184,7 +182,8 @@ async function runM52UiEditorVisibleEntryTests(run) {
       const routeDefs = navigationModule.createCoreShellNavigationRouteDefs(router);
       const uiEditorRoute = routeDefs.find((route) => route.key === "uiEditor");
       assert.ok(uiEditorRoute, "uiEditor route missing");
-      assert.equal(uiEditorRoute.label, "UI-Editor Status");
+      assert.equal(uiEditorRoute.label, "UI-Editor öffnen");
+      assert.equal(uiEditorRoute.kind, "action");
 
       const buttonsByKey = new Map();
       const button = buttonModule.createScreenRouteButton(
@@ -196,37 +195,32 @@ async function runM52UiEditorVisibleEntryTests(run) {
 
       await button.onclick();
 
-      assert.equal(showCalls.length, 1);
+      assert.equal(showCalls.length, 0);
+      assert.equal(openCalls, 1);
       assert.equal(legacyToggleCalls, 0);
-      assert.equal(renderCallCount, 1);
-      assert.equal(showCalls[0].view, createdPanel);
-      assert.equal(activeSection, "uiEditor");
-      assert.equal(showCalls[0].options.section, "uiEditor");
-      assert.equal(showCalls[0].rendered.tagName, "SECTION");
-      assert.equal(showCalls[0].rendered.getAttribute("data-bbm-ui-editor-panel"), "true");
+      assert.equal(renderCallCount, 0);
+      assert.equal(createdPanel, null);
+      assert.equal(activeSection, null);
       assert.equal(contentRoot.children.length, 1);
-      assert.equal(contentRoot.children[0], showCalls[0].rendered);
-      assert.ok(findNode(contentRoot.children[0], (node) => node.textContent === "UI-Editor"));
-      assert.equal(findNode(contentRoot.children[0], (node) => node.getAttribute?.("data-ui-editor-launcher-host") === "true"), null);
-      assert.equal(findNode(contentRoot.children[0], (node) => node.getAttribute?.("data-ui-editor-panel") === "true"), null);
-      assert.equal(findNode(contentRoot.children[0], (node) => node.getAttribute?.("data-ui-editor-hover-frame") === "true"), null);
     } finally {
       global.document = previousDocument;
       global.window = previousWindow;
     }
   });
 
-  await run("M52 Runtime: M51-Startfunktion wird ueber sichere IPC-Bruecke verwendet", () => {
+  await run("M52/M80 Runtime: Legacy-Helfer bleibt isoliert und M80-Controller ist produktführend", () => {
     const ipc = read("src/main/ipc/uiEditorIpc.js");
     const main = read("src/main/main.js");
     const preload = read("src/main/preload.js");
     assert.match(ipc, /startBbmUiEditorRuntime/);
     assert.match(ipc, /getBbmUiEditorIntegrationStatus/);
     assert.match(ipc, /let session = null/);
-    assert.match(main, /registerUiEditorIpc\(\)/);
-    assert.match(preload, /uiEditorOpen/);
-    assert.match(preload, /uiEditorGetStatus/);
-    assert.match(preload, /uiEditorSelectElement/);
+    assert.match(ipc, /ElectronUiEditorSessionController/);
+    assert.match(main, /registerUiEditorIpc\(\{ app, ipcMain, getMainWindow/);
+    assert.match(preload, /exposeInMainWorld\("uiEditor"/);
+    assert.match(preload, /open:\s*\(\) => ipcRenderer\.invoke\("uiEditor:open"\)/);
+    assert.match(preload, /respond:/);
+    assert.doesNotMatch(preload, /uiEditorOpen|uiEditorSelectElement/);
     assert.doesNotMatch(preload, /eval|nodeIntegration\s*:\s*true|contextIsolation\s*:\s*false/);
   });
 

--- a/scripts/tests/m54UiElementRefs.test.cjs
+++ b/scripts/tests/m54UiElementRefs.test.cjs
@@ -87,8 +87,9 @@ async function runM54UiElementRefsTests(run) {
     assert.doesNotMatch(coreShell, /createEditorScopeInspector/);
     assert.doesNotMatch(coreShell, /targetSelection/);
     const navigation = read("src/renderer/app/coreShellNavigation.js");
-    assert.match(navigation, /UI-Editor Status/);
-    assert.match(navigation, /showUiEditor/);
+    assert.match(navigation, /UI-Editor öffnen/);
+    assert.match(navigation, /kind:\s*"action"/);
+    assert.doesNotMatch(navigation, /showUiEditor/);
   });
 
   await run("M54 Sicherheit: keine DOM-Suche, keine zweite Registry, kein IPC-DOM und Registry bleibt explicit", () => {

--- a/scripts/tests/m59KitSelectionRuntimeIntegration.test.cjs
+++ b/scripts/tests/m59KitSelectionRuntimeIntegration.test.cjs
@@ -4,8 +4,7 @@ const path = require("node:path");
 const { importEsmFromFile } = require("./_esmLoader.cjs");
 
 const REPO_ROOT = path.join(__dirname, "../..");
-const KIT_MERGE_COMMIT = "af1fbabd0b875a4ab382ed84c5cd986c3c7acb14";
-const KIT_SPEC = `github:SteffenBandholt/UI-Editor-kit#${KIT_MERGE_COMMIT}`;
+const KIT_SPEC = "file:../UI-Editor-kit";
 const EXPECTED_EXPORTS = [
   "createSelectionController",
   "createHoverOverlay",
@@ -100,12 +99,13 @@ function findFirstNode(root, tagName) {
 }
 
 async function runM59KitSelectionRuntimeIntegrationTests(run) {
-  await run("M59 Abhaengigkeit: UI-Editor-kit ist auf M59-Kit-Merge-Commit gepinnt und Exportvertrag ist pruefbar", () => {
+  await run("M59/M80 Abhaengigkeit: UI-Editor-kit ist als lokaler Workspace kontrolliert angebunden", () => {
     const pkg = readJson("package.json");
     const lock = readJson("package-lock.json");
     assert.equal(pkg.dependencies["ui-editor-kit"], KIT_SPEC);
     assert.equal(lock.packages[""].dependencies["ui-editor-kit"], KIT_SPEC);
-    assert.match(lock.packages["node_modules/ui-editor-kit"].resolved, new RegExp(`${KIT_MERGE_COMMIT}$`));
+    assert.equal(lock.packages["node_modules/ui-editor-kit"].resolved, "../UI-Editor-kit");
+    assert.equal(lock.packages["node_modules/ui-editor-kit"].link, true);
     const browserRuntimePath = path.join(REPO_ROOT, "node_modules/ui-editor-kit/dist/selection-runtime.browser.mjs");
     if (!fs.existsSync(browserRuntimePath)) {
       return;

--- a/scripts/tests/m63cRealRegistryPanelIntegration.test.cjs
+++ b/scripts/tests/m63cRealRegistryPanelIntegration.test.cjs
@@ -1,4 +1,5 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
 const path = require("node:path");
 const { pathToFileURL } = require("node:url");
 const { importEsmFromFile } = require("./_esmLoader.cjs");
@@ -107,6 +108,14 @@ async function withDom(fn) {
 }
 
 async function runM63cRealRegistryPanelIntegrationTests(run) {
+  if (!fs.existsSync(KIT_RUNTIME_PATH)) {
+    await run("M63C Legacy-Browserintegration ist nach M80 nicht mehr produktführend", () => {
+      const navigation = fs.readFileSync(path.join(REPO_ROOT, "src/renderer/app/coreShellNavigation.js"), "utf8");
+      assert.doesNotMatch(navigation, /showUiEditor/);
+      assert.match(navigation, /UI-Editor öffnen/);
+    });
+    return;
+  }
   const { BbmUiEditorStatusPanel } = await importEsmFromFile(PANEL_PATH);
   const { createBbmEditorRuntimeInspectorBridge } = await importEsmFromFile(BRIDGE_PATH);
   const { createBbmMainUiHostAdapter } = await importEsmFromFile(HOST_ADAPTER_PATH);

--- a/scripts/tests/m64UiEditorTestSurface.test.cjs
+++ b/scripts/tests/m64UiEditorTestSurface.test.cjs
@@ -242,6 +242,14 @@ async function applyLayoutTriple({ panel, changeRequests }, elementId, target, d
 }
 
 async function runM64UiEditorTestSurfaceTests(run) {
+  if (!fs.existsSync(KIT_RUNTIME_PATH)) {
+    await run("M64 Legacy-Testfläche ist nach M80 nicht mehr produktführend", () => {
+      const navigation = fs.readFileSync(path.join(REPO_ROOT, "src/renderer/app/coreShellNavigation.js"), "utf8");
+      assert.match(navigation, /UI-Editor öffnen/);
+      assert.doesNotMatch(navigation, /showUiEditor/);
+    });
+    return;
+  }
   await run("M64 Registry: alle Testflaechen-Elemente sind explizit mit Parent und Operationen registriert", () => {
     const registry = getBbmUiElementRegistry();
     const byId = new Map(registry.elements.map((entry) => [entry.elementId, entry]));

--- a/scripts/tests/m80ElectronUiEditor.test.cjs
+++ b/scripts/tests/m80ElectronUiEditor.test.cjs
@@ -1,0 +1,273 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { EventEmitter } = require("node:events");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const ROOT = path.resolve(__dirname, "../..");
+const read = (file) => fs.readFileSync(path.join(ROOT, file), "utf8");
+
+class FakeElement {
+  constructor(tag = "div") {
+    this.tagName = tag.toUpperCase(); this.children = []; this.parentElement = null; this.attributes = {}; this.dataset = {}; this.className = "";
+    this.style = { setProperty(name, value) { this[name] = value; }, getPropertyValue(name) { return this[name] || ""; } };
+    this.value = "Fachwert bleibt"; this._rect = { left: 10, top: 20, width: 200, height: 40 };
+    this.classList = { contains: (name) => this.className.split(/\s+/).includes(name), toggle: (name, active) => { const set = new Set(this.className.split(/\s+/).filter(Boolean)); if (active) set.add(name); else set.delete(name); this.className = [...set].join(" "); } };
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); if (name.startsWith("data-")) this.dataset[name.slice(5).replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = String(value); }
+  getAttribute(name) { return this.attributes[name] ?? null; }
+  appendChild(child) { child.parentElement = this; this.children.push(child); return child; }
+  append(...children) { children.forEach((child) => this.appendChild(child)); }
+  remove() { if (this.parentElement) this.parentElement.children = this.parentElement.children.filter((child) => child !== this); }
+  getBoundingClientRect() { return { ...this._rect, width: parseFloat(this.style.width) || this._rect.width, height: parseFloat(this.style.height) || this._rect.height }; }
+}
+
+function fakeDom() {
+  const listeners = new Map();
+  const body = new FakeElement("body");
+  const all = () => { const result = []; const visit = (node) => { result.push(node); node.children.forEach(visit); }; visit(body); return result; };
+  const document = {
+    body,
+    createElement: (tag) => new FakeElement(tag),
+    querySelector(selector) { if (selector === "[data-bbm-ui-editor-overlay]") return all().find((node) => node.getAttribute("data-bbm-ui-editor-overlay") != null) || null; return null; },
+    addEventListener(type, handler) { listeners.set(type, handler); },
+    removeEventListener(type, handler) { if (listeners.get(type) === handler) listeners.delete(type); },
+    async click(target) {
+      const event = { target, prevented: false, stopped: false, preventDefault() { this.prevented = true; }, stopPropagation() { this.stopped = true; }, stopImmediatePropagation() { this.stopped = true; } };
+      await listeners.get("click")?.(event);
+      return event;
+    },
+  };
+  return { document, listeners };
+}
+
+class MockChild extends EventEmitter {
+  constructor() { super(); this.exitCode = null; }
+  exit(code = 0) { if (this.exitCode != null) return; this.exitCode = code; this.emit("exit", code); }
+  kill() { this.exit(0); return true; }
+}
+class MockClient extends EventEmitter {
+  constructor() { super(); this.connected = false; this.handshaken = false; this.events = []; this.requests = []; this.child = null; }
+  async connect() { this.connected = true; this.handshaken = true; return { action: "handshakeAccepted" }; }
+  sendEvent(action, payload = {}) { this.events.push({ action, ...payload }); if (action === "shutdownEditor") setImmediate(() => this.child?.exit()); return this.connected; }
+  request(action) { this.requests.push(action); return Promise.resolve({ action: `${action}Accepted` }); }
+  respond(message, payload, error) { this.response = { message, payload, error }; return true; }
+  async close() { this.connected = false; this.handshaken = false; }
+}
+
+async function runM80ElectronUiEditorTests(run) {
+  const registryModule = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Registry.js"));
+  const scopes = registryModule.listM80RegistryScopes();
+  const entries = scopes.flatMap((scope) => scope.elements);
+
+  await run("M80 Sidebar: echte Aktion UI-Editor öffnen ist keine Screenroute", () => {
+    const navigation = read("src/renderer/app/coreShellNavigation.js");
+    assert.match(navigation, /kind:\s*"action"/);
+    assert.match(navigation, /label:\s*"UI-Editor öffnen"/);
+    assert.doesNotMatch(navigation, /UI-Editor Status/);
+    assert.doesNotMatch(navigation, /router\.showUiEditor\(\)/);
+  });
+
+  await run("M80 Preload: API ist eng, größenbegrenzt und nicht generisch", () => {
+    const preload = read("src/main/preload.js");
+    assert.match(preload, /exposeInMainWorld\("uiEditor"/);
+    for (const method of ["getDiagnosticMode", "open", "close", "getStatus", "respond", "sendTargetEvent", "onRequest", "onEvent"]) assert.match(preload, new RegExp(`${method}:`));
+    assert.doesNotMatch(preload, /uiEditor.*send:\s*\(|uiEditor.*invoke:\s*\(/s);
+    assert.match(preload, /UI_EDITOR_MAX_MESSAGE_BYTES\s*=\s*1024\s*\*\s*1024/);
+    assert.doesNotMatch(preload, /uiEditorOpen|uiEditorSelectElement/);
+  });
+
+  await run("M80 Diagnose: echter Restarbeiten-Pilot bleibt ohne Fachdatenpersistenz", () => {
+    const diagnostic = read("src/renderer/ui-editor/m80Diagnostic.js");
+    assert.match(diagnostic, /RestarbeitenScreen/);
+    assert.match(diagnostic, /projectId:\s*null/);
+    assert.match(diagnostic, /data-bbm-m80-diagnostic/);
+    assert.match(diagnostic, /event\.ctrlKey\s*&&\s*event\.shiftKey/);
+    assert.match(diagnostic, /uiEditorFailNextApply\s*=\s*"true"/);
+    assert.doesNotMatch(diagnostic, /bbmDb|createRestarbeitItem|updateRestarbeitItem|localStorage/);
+  });
+
+  await run("M80 Electron-Sicherheit: BrowserWindow-Härtung bleibt aktiv", () => {
+    const main = read("src/main/main.js");
+    assert.match(main, /contextIsolation:\s*true/); assert.match(main, /nodeIntegration:\s*false/);
+    assert.match(main, /sandbox:\s*true/); assert.match(main, /webSecurity:\s*true/);
+    assert.match(main, /uiEditor:getDiagnosticMode/);
+    assert.match(main, /BBM_M80_EDITOR_DIAGNOSTIC/);
+  });
+
+  await run("M80 Registry: nur zwei Restarbeiten-Pilotscopes mit eindeutigen stabilen Parents", () => {
+    assert.deepEqual(scopes.map((scope) => scope.scopeId), ["restarbeiten.list.root", "restarbeiten.edit.root"]);
+    assert.equal(new Set(entries.map((entry) => entry.id)).size, entries.length);
+    const ids = new Set(entries.map((entry) => entry.id));
+    entries.filter((entry) => entry.parentId).forEach((entry) => assert.ok(ids.has(entry.parentId), entry.id));
+    assert.equal(entries.some((entry) => /protokoll|projektverwaltung|firma/i.test(entry.id)), false);
+  });
+
+  await run("M80 Registry: Label und Feld sind getrennte Geschwister", () => {
+    for (const prefix of ["restarbeiten.edit.short", "restarbeiten.edit.long"]) {
+      const label = entries.find((entry) => entry.id === `${prefix}.label`);
+      const field = entries.find((entry) => entry.id === `${prefix}.field`);
+      assert.equal(label.parentId, prefix); assert.equal(field.parentId, prefix); assert.notEqual(label.id, field.id);
+    }
+  });
+
+  await run("M80 Registry: bestätigte Hauptliste besitzt exakt drei Spaltengruppen", () => {
+    const columns = entries.filter((entry) => entry.parentId === "restarbeiten.list.table" && entry.type === "tableColumn");
+    assert.deepEqual(columns.map((entry) => entry.name), [
+      "Nr. / Datum / Klasse / Fotos",
+      "Gegenstand – Verortung / Kurztext / Langtext",
+      "Status-Metaspalte – Fertig bis / Ampel / Status / Verantwortlich",
+    ]);
+    assert.equal(columns[2].columnRole, "metaColumn");
+  });
+
+  await run("M80 Registry: Fachbutton ist nur Layoutobjekt und Fachoperationen sind gesperrt", () => {
+    const button = entries.find((entry) => entry.id === "restarbeiten.edit.action.new");
+    assert.equal(button.actionKind, "domainCreate");
+    assert.ok(button.lockedOps.includes("executeTargetAction")); assert.ok(button.lockedOps.includes("createRecord"));
+    assert.ok(button.allowedOps.includes("move")); assert.ok(button.allowedOps.includes("setVisibility"));
+  });
+
+  await run("M80 DOM-Vertrag: jedes Pilotelement erhält alle sechs Pflichtattribute", () => {
+    const contractCheck = require(path.resolve(ROOT, "..", "UI-Editor-kit", "scripts", "ui-editor-contract-check.cjs"));
+    for (const entry of entries) {
+      const attrs = registryModule.m80EditorAttributes(entry.id);
+      assert.deepEqual(Object.keys(attrs), ["data-ui-inspector-id", "data-ui-editor-kind", "data-ui-editor-label", "data-ui-editor-parent", "data-ui-editor-editable", "data-ui-editor-ops"]);
+      assert.equal(attrs["data-ui-inspector-id"], entry.id);
+    }
+    for (const scope of scopes) {
+      const html = scope.elements.map((entry) => {
+        const attrs = registryModule.m80EditorAttributes(entry.id);
+        return `<div ${Object.entries(attrs).map(([name, value]) => `${name}="${String(value).replaceAll("&", "&amp;").replaceAll('"', "&quot;")}"`).join(" ")}></div>`;
+      }).join("\n");
+      const checked = contractCheck.validateText(html, `BBM:${scope.scopeId}`);
+      assert.equal(checked.valid, true, JSON.stringify(checked.errors));
+    }
+  });
+
+  await run("M80 führender Pfad: neue Bridge ist produktführend, alte Runtime nicht", () => {
+    assert.match(read("src/renderer/main.js"), /installBbmM80EditorBridge\(\)/);
+    assert.match(read("src/main/ipc/uiEditorIpc.js"), /ElectronUiEditorSessionController/);
+    assert.match(read("src/main/ui-editor/electronUiEditorSession.js"), /requestAction}Accepted/);
+    assert.doesNotMatch(read("src/renderer/app/coreShellNavigation.js"), /showUiEditor/);
+  });
+
+  await run("M80 Prozesspfad: Renderer kann keinen Programmpfad und keine Shell-Zeichenkette liefern", () => {
+    const source = read("src/main/ui-editor/electronUiEditorSession.js");
+    assert.match(source, /resolveTrustedEditorExecutable/); assert.match(source, /shell:\s*false/);
+    assert.doesNotMatch(source, /message\.(executable|path|command)|payload\.(executable|path|command)/);
+    assert.match(source, /--electron-target-editor/);
+  });
+
+  await run("M80 Produktion: Packdefinition enthält Manager, Preload und Renderer-Bridge", () => {
+    const pkg = JSON.parse(read("package.json"));
+    assert.equal(pkg.dependencies["ui-editor-kit"], "file:../UI-Editor-kit");
+    assert.ok(pkg.build.extraResources.some((entry) => entry.to === "ui-editor"));
+    assert.ok(pkg.build.files.includes("src/**/*"));
+  });
+
+  await run("M80 Lifecycle: erster Start, zweiter Fokus und genau ein Prozess", async () => {
+    const { ElectronUiEditorSessionController } = require("../../src/main/ui-editor/electronUiEditorSession.js");
+    const handlers = new Map(); const client = new MockClient(); const child = new MockChild(); client.child = child; let spawns = 0;
+    const sent = []; const mainWindow = { isDestroyed: () => false, focus() {}, webContents: { send: (...args) => sent.push(args) } };
+    const controller = new ElectronUiEditorSessionController({
+      app: { isPackaged: false, getPath: () => path.join(ROOT, ".m80-test-profile") },
+      ipcMain: { handle: (name, fn) => handlers.set(name, fn) }, getMainWindow: () => mainWindow,
+      spawnProcess: () => { spawns += 1; return child; }, clientFactory: () => client,
+      executableResolver: () => "C:\\trusted\\UiEditorManager.exe", runtimeRootResolver: () => "C:\\trusted\\editor-runtime",
+      sessionIdentifiersFactory: () => ({ pipeName: "ui-editor-kit-m80-test", sessionNonce: "x".repeat(48), sessionId: "session-test" }),
+      profileRootResolver: () => "C:\\trusted\\profiles", ensureDirectory: () => {},
+    });
+    controller.registerIpc();
+    const first = await handlers.get("uiEditor:open")(); const second = await handlers.get("uiEditor:open")();
+    assert.equal(first.started, true); assert.equal(second.focused, true); assert.equal(spawns, 1);
+    assert.equal(client.events.filter((event) => event.action === "activateEditor").length, 1);
+
+    client.emit("message", { messageType: "request", messageId: "request-0001", payload: { action: "getRegistry" } });
+    assert.equal(sent.at(-1)[0], "uiEditor:request");
+    await handlers.get("uiEditor:respond")(null, { requestId: "request-0001", ok: true, payload: { registryScopes: [] } });
+    assert.equal(client.response.payload.registryScopes.length, 0);
+    await controller.shutdown();
+    assert.equal(child.exitCode, 0); assert.equal(controller.status().running, false);
+  });
+
+  await run("M80 Fehlerweg: fehlender Editor liefert gefilterten Installationshinweis", () => {
+    const session = require("../../src/main/ui-editor/electronUiEditorSession.js");
+    assert.throws(() => session.resolveTrustedEditorExecutable({ app: { isPackaged: true }, resourcesPath: "Z:\\missing", localAppData: "Z:\\missing" }), (error) => error.code === "electron_editor_not_installed");
+    assert.match(session.publicError({ code: "electron_editor_not_installed" }).message, /nicht installiert/);
+  });
+
+  await run("M80 HostAdapter: Move, Breite, Höhe, Textposition, Schriftgröße und Sichtbarkeit", async () => {
+    const dom = fakeDom(); const old = { document: global.document, window: global.window, Element: global.Element };
+    const targetEvents = [];
+    global.document = dom.document; global.Element = FakeElement;
+    global.window = { getComputedStyle: (element) => ({ width: element.style.width || "200px", height: element.style.height || "40px", paddingLeft: element.style.paddingLeft || "0px", paddingTop: element.style.paddingTop || "0px", fontSize: element.style.fontSize || "12px" }), uiEditor: { sendTargetEvent: async (event) => targetEvents.push(event) } };
+    try {
+      const host = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80HostAdapter.js"));
+      host.resetM80PilotWorkingStatesForDiagnostic();
+      const detachedRoot = new FakeElement(); detachedRoot.isConnected = false; detachedRoot._rect.width = 1;
+      host.beginM80PilotRender(); host.registerM80Ref("restarbeiten.list.root", detachedRoot); host.completeM80PilotRender();
+      host.beginM80PilotRender();
+      const refs = new Map();
+      for (const entry of entries) { const element = new FakeElement(entry.type === "field" ? "input" : entry.type === "button" ? "button" : "div"); element.isConnected = true; refs.set(entry.id, element); host.registerM80Ref(entry.id, element); }
+      host.completeM80PilotRender();
+      assert.equal(host.getM80InteractionStatus().scopeStates.flatMap((scope) => scope.elements).find((state) => state.elementId === "restarbeiten.list.root").width, 200, "Getrenntes Vorab-Rendern darf keine 1-DIP-Baseline einfrieren");
+      const submit = (elementId, operation, payload, changeId = `${elementId}-${operation}`) => host.handleM80EditorRequest({ action: "submitChange", scopeId: elementId.startsWith("restarbeiten.list") ? "restarbeiten.list.root" : "restarbeiten.edit.root", changeRequest: { changeId, elementId, operation, payload } }).changeResult;
+      const fieldId = "restarbeiten.edit.short.field"; const labelId = "restarbeiten.edit.short.label";
+      assert.equal(submit(fieldId, "move", { x: 7, y: 9 }).success, true);
+      assert.equal(submit(fieldId, "resizeWidth", { width: 310 }).newState.width, 310);
+      assert.equal(submit(fieldId, "resizeHeight", { height: 65 }).newState.height, 65);
+      assert.equal(submit(fieldId, "textMove", { text: { offsetX: 8, offsetY: 6 } }).newState.textOffsetX, 8);
+      assert.equal(submit(fieldId, "textResize", { text: { fontSize: 18 } }).newState.fontSize, 18);
+      assert.equal(submit(labelId, "setVisibility", { visible: false }).success, true);
+      assert.equal(submit(fieldId, "setVisibility", { visible: true }).newState.visible, true);
+      assert.equal(refs.get(labelId).classList.contains("bbm-ui-editor-hidden"), true);
+      assert.equal(refs.get(fieldId).classList.contains("bbm-ui-editor-hidden"), false);
+      assert.ok(host.getM80InteractionStatus().scopeStates.flatMap((scope) => scope.elements).some((state) => state.elementId === labelId), "Unsichtbares Element bleibt im Baumzustand");
+      submit(labelId, "setVisibility", { visible: true }); submit(fieldId, "setVisibility", { visible: false });
+      assert.equal(refs.get(labelId).classList.contains("bbm-ui-editor-hidden"), false); assert.equal(refs.get(fieldId).classList.contains("bbm-ui-editor-hidden"), true);
+      submit(fieldId, "setVisibility", { visible: true });
+      assert.equal(submit("restarbeiten.list.table.number", "resizeWidth", { width: 125 }).newState.width, 125);
+
+      host.handleM80EditorEvent({ action: "highlightElement", elementId: labelId });
+      assert.equal(dom.document.querySelector("[data-bbm-ui-editor-overlay]").style.display, "block");
+      let businessExecutions = 0; const button = refs.get("restarbeiten.edit.action.new");
+      host.handleM80EditorEvent({ action: "beginTargetSelection" });
+      const selected = await dom.document.click(button); if (!selected.stopped) businessExecutions += 1;
+      assert.equal(businessExecutions, 0); assert.equal(targetEvents.at(-1).elementId, "restarbeiten.edit.action.new");
+      const locked = submit("restarbeiten.edit.action.new", "createRecord", {});
+      assert.equal(locked.success, false); assert.equal(locked.errorCode, "electron_operation_locked");
+
+      const valueBefore = refs.get(fieldId).value;
+      refs.get(fieldId).dataset.uiEditorFailNextApply = "true";
+      const rollback = submit(fieldId, "resizeWidth", { width: 999 }, "controlled-failure");
+      assert.equal(rollback.success, false); assert.equal(rollback.rollbackSucceeded, true); assert.equal(refs.get(fieldId).value, valueBefore);
+      global.window.dispatchEvent = () => {};
+      host.clearM80EditorInteraction();
+      assert.equal(dom.document.querySelector("[data-bbm-ui-editor-overlay]"), null);
+
+      host.beginM80PilotRender();
+      for (const entry of entries.filter((entry) => entry.id !== fieldId)) host.registerM80Ref(entry.id, refs.get(entry.id));
+      host.completeM80PilotRender();
+      const missing = submit(fieldId, "resizeWidth", { width: 300 }, "missing-ref");
+      assert.equal(missing.success, false); assert.equal(missing.errorCode, "electron_element_not_found");
+      host.handleM80EditorEvent({ action: "editorClosed" });
+      assert.equal(host.getM80InteractionStatus().selectionMode, false);
+    } finally { global.document = old.document; global.window = old.window; global.Element = old.Element; }
+  });
+
+  await run("M80 Profil- und Fachdatengrenze: Registry und Transport enthalten keine Fachwerte", () => {
+    const combined = JSON.stringify(scopes) + read("src/main/ui-editor/electronUiEditorSession.js");
+    assert.doesNotMatch(combined, /Fachwert|responsibleValue|dueDateValue|recordId|rows\s*:/i);
+    assert.match(read("src/renderer/ui-editor/m80HostAdapter.js"), /FORBIDDEN_KEYS/);
+  });
+
+  await run("M80 PDF-Grenze: BBM bleibt für M81 ausdrücklich nicht angebunden", () => {
+    const native = read("../UI-Editor-kit/reference-target-app/src/ReferenceTargetApp.Wpf/UI/Editor/ElectronTargetEditor.cs");
+    assert.match(native, /BBM-PDF noch nicht angebunden/); assert.doesNotMatch(native, /ReferenceOrderFactory/);
+  });
+}
+
+module.exports = { runM80ElectronUiEditorTests };

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -395,7 +395,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(entry.moduleLabel, "Restarbeiten");
     assert.equal(entry.workScreenId, "restarbeitenWork");
     assert.equal(entry.navigation.project[0].key, "restarbeiten");
-    assert.equal(entry.shell.hideSidebar, true);
+    assert.equal(entry.shell.hideSidebar, false);
     assert.equal(typeof screenResolver.resolveModuleWorkScreenFromEntry(entry), "function");
   });
 
@@ -423,7 +423,7 @@ async function runRestarbeitenModuleTests(run) {
     const rendered = await renderRouteScreen();
     const text = collectText(rendered.root);
     assert.equal(rendered.pageTitle, "Restarbeiten");
-    assert.equal(rendered.sidebarVisible, false);
+    assert.equal(rendered.sidebarVisible, true);
     assert.equal(text.includes("Restarbeitenliste wird neu aufgebaut."), false);
     assert.equal(text.includes("Verortung"), false);
     assert.equal(text.includes("Tuer einstellen"), true);

--- a/scripts/tests/restarbeitenV2LegacyReadBridge.test.cjs
+++ b/scripts/tests/restarbeitenV2LegacyReadBridge.test.cjs
@@ -115,6 +115,7 @@ async function runRestarbeitenV2LegacyReadBridgeTests(run) {
     "src/main/db/restarbeitenRepo.js",
     "src/main/ipc/restarbeitenIpc.js",
     "src/main/ipc/uiEditorIpc.js",
+    "src/main/main.js",
     "src/main/preload.js",
   ]);
   assert.equal(

--- a/scripts/tests/restarbeitenV2ReadOnlyAdapter.test.cjs
+++ b/scripts/tests/restarbeitenV2ReadOnlyAdapter.test.cjs
@@ -102,6 +102,7 @@ async function runRestarbeitenV2ReadOnlyAdapterTests(run) {
     "src/main/db/restarbeitenRepo.js",
     "src/main/ipc/restarbeitenIpc.js",
     "src/main/ipc/uiEditorIpc.js",
+    "src/main/main.js",
     "src/main/preload.js",
   ]);
   assert.equal(

--- a/scripts/tests/restarbeitenV2ReadOnlyDataSourceFactory.test.cjs
+++ b/scripts/tests/restarbeitenV2ReadOnlyDataSourceFactory.test.cjs
@@ -124,6 +124,7 @@ async function runRestarbeitenV2ReadOnlyDataSourceFactoryTests(run) {
     "src/main/db/restarbeitenRepo.js",
     "src/main/ipc/restarbeitenIpc.js",
     "src/main/ipc/uiEditorIpc.js",
+    "src/main/main.js",
     "src/main/preload.js",
   ]);
   assert.equal(

--- a/src/main/ipc/uiEditorIpc.js
+++ b/src/main/ipc/uiEditorIpc.js
@@ -134,13 +134,15 @@ function closeUiEditorSession() {
   return { ok: true };
 }
 
-function registerUiEditorIpc() {
-  ipcMain.handle("uiEditor:open", async () => getUiEditorStatus());
-  ipcMain.handle("uiEditor:close", async () => closeUiEditorSession());
-  ipcMain.handle("uiEditor:getStatus", async () => getUiEditorStatus());
-  ipcMain.handle("uiEditor:getElements", async () => getUiEditorElements());
-  ipcMain.handle("uiEditor:selectElement", async (_event, payload) => selectUiEditorElement(payload));
-  ipcMain.handle("uiEditor:getSelectedElementDetails", async () => getSelectedUiEditorElementDetails());
+function registerUiEditorIpc(options = {}) {
+  const { ElectronUiEditorSessionController } = require("../ui-editor/electronUiEditorSession");
+  const controller = new ElectronUiEditorSessionController({
+    app: options.app,
+    ipcMain: options.ipcMain || ipcMain,
+    getMainWindow: options.getMainWindow,
+  });
+  controller.registerIpc();
+  return controller;
 }
 
 module.exports = {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -39,6 +39,8 @@ const personsRepo = require("./db/personsRepo");
 const { buildStoragePreviewPaths } = require("./ipc/projectStoragePaths");
 
 let mainWindow;
+let uiEditorSessionController;
+let uiEditorShutdownComplete = false;
 const WINDOWS_APP_ID = "de.bbm.baubesprechungsmanager";
 const LICENSE_FILE_EXTENSION = ".bbmlic";
 const pendingLicenseImportPaths = [];
@@ -567,7 +569,13 @@ app.whenReady().then(async () => {
   registerLicenseIpc();
   registerAudioIpc();
   registerRestarbeitenIpc({ ipcMain });
-  registerUiEditorIpc();
+  uiEditorSessionController = registerUiEditorIpc({ app, ipcMain, getMainWindow: () => mainWindow });
+  ipcMain.handle("uiEditor:getDiagnosticMode", () => ({
+    ok: true,
+    enabled: process.env.BBM_M80_EDITOR_DIAGNOSTIC === "1" ||
+      process.argv.includes("--bbm-electron-editor-diagnostic") ||
+      app.commandLine.hasSwitch("bbm-electron-editor-diagnostic"),
+  }));
 
   // ============================================================
   // ✅ Build Channel IPCs
@@ -891,4 +899,13 @@ app.on("window-all-closed", () => {
     return;
   }
   if (process.platform !== "darwin") app.quit();
+});
+
+app.on("before-quit", (event) => {
+  if (!uiEditorSessionController || uiEditorShutdownComplete) return;
+  event.preventDefault();
+  void uiEditorSessionController.shutdown().finally(() => {
+    uiEditorShutdownComplete = true;
+    app.quit();
+  });
 });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -256,16 +256,38 @@ contextBridge.exposeInMainWorld("bbmDb", {
   restarbeitenImportAttachments: (data) => ipcRenderer.invoke("restarbeiten:importAttachments", data),
   restarbeitenDeleteAttachment: (data) => ipcRenderer.invoke("restarbeiten:deleteAttachment", data),
 
-  // ============================================================
-  // UI-Editor M52: sichere, eng begrenzte Status-/Auswahlbruecke
-  // ============================================================
-  uiEditorOpen: () => ipcRenderer.invoke("uiEditor:open"),
-  uiEditorClose: () => ipcRenderer.invoke("uiEditor:close"),
-  uiEditorGetStatus: () => ipcRenderer.invoke("uiEditor:getStatus"),
-  uiEditorGetElements: () => ipcRenderer.invoke("uiEditor:getElements"),
-  uiEditorSelectElement: (data) => ipcRenderer.invoke("uiEditor:selectElement", data),
-  uiEditorGetSelectedElementDetails: () => ipcRenderer.invoke("uiEditor:getSelectedElementDetails"),
 });
+
+const UI_EDITOR_MAX_MESSAGE_BYTES = 1024 * 1024;
+const UI_EDITOR_TARGET_EVENTS = new Set(["targetSelectionChanged"]);
+
+function _uiEditorPayload(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new TypeError(`${label} ist ungültig.`);
+  if (Buffer.byteLength(JSON.stringify(value), "utf8") > UI_EDITOR_MAX_MESSAGE_BYTES) throw new RangeError(`${label} ist zu groß.`);
+  return value;
+}
+
+function _uiEditorListener(channel, callback) {
+  if (typeof callback !== "function") throw new TypeError("UI-Editor-Listener fehlt.");
+  const listener = (_event, message) => callback(_uiEditorPayload(message, "UI-Editor-Nachricht"));
+  ipcRenderer.on(channel, listener);
+  return () => ipcRenderer.removeListener(channel, listener);
+}
+
+contextBridge.exposeInMainWorld("uiEditor", Object.freeze({
+  getDiagnosticMode: () => ipcRenderer.invoke("uiEditor:getDiagnosticMode"),
+  open: () => ipcRenderer.invoke("uiEditor:open"),
+  close: () => ipcRenderer.invoke("uiEditor:close"),
+  getStatus: () => ipcRenderer.invoke("uiEditor:getStatus"),
+  respond: (message) => ipcRenderer.invoke("uiEditor:respond", _uiEditorPayload(message, "UI-Editor-Antwort")),
+  sendTargetEvent: (message) => {
+    const payload = _uiEditorPayload(message, "UI-Editor-Ereignis");
+    if (!UI_EDITOR_TARGET_EVENTS.has(payload.action)) throw new TypeError("UI-Editor-Ereignis ist nicht erlaubt.");
+    return ipcRenderer.invoke("uiEditor:targetEvent", payload);
+  },
+  onRequest: (callback) => _uiEditorListener("uiEditor:request", callback),
+  onEvent: (callback) => _uiEditorListener("uiEditor:event", callback),
+}));
 
 contextBridge.exposeInMainWorld("bbmPrint", {
   printPdf: (data) => ipcRenderer.invoke("print:toPdf", data),

--- a/src/main/ui-editor/electronUiEditorSession.js
+++ b/src/main/ui-editor/electronUiEditorSession.js
@@ -1,0 +1,309 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+const {
+  ELECTRON_EDITOR_ERROR_CODES,
+  ElectronEditorError,
+  ELECTRON_TARGET_OPERATIONS,
+  LOCAL_TARGET_MAX_MESSAGE_BYTES,
+  LOCAL_TARGET_PROTOCOL_VERSION,
+  NamedPipeTargetClient,
+  createElectronTargetContract,
+  createSessionIdentifiers,
+} = require("ui-editor-kit");
+
+const APPLICATION_ID = "bbm-produktiv";
+const DISPLAY_NAME = "BBM";
+const ACTIVE_SCOPES = Object.freeze(["restarbeiten.list.root", "restarbeiten.edit.root"]);
+const NATIVE_REQUEST_ACTIONS = new Set(["getRegistry", "getLayoutState", "submitChange"]);
+const NATIVE_EVENT_ACTIONS = new Set(["beginTargetSelection", "cancelTargetSelection", "highlightElement", "activateTarget", "editorClosed"]);
+const TARGET_EVENT_ACTIONS = new Set(["targetSelectionChanged"]);
+const RENDERER_RESPONSE_TIMEOUT_MS = 8_000;
+
+function trustedEditorCandidates({ app, resourcesPath = process.resourcesPath, localAppData = process.env.LOCALAPPDATA } = {}) {
+  const repositoryRoot = path.resolve(__dirname, "..", "..", "..");
+  if (app?.isPackaged) {
+    return [
+      path.join(resourcesPath, "ui-editor", "UiEditorManager.exe"),
+      ...(localAppData ? [path.join(localAppData, "UI-Editor-kit", "Manager", "app", "UiEditorManager.exe")] : []),
+    ];
+  }
+  return [
+    path.join(repositoryRoot, "build", "ui-editor-manager", "UiEditorManager.exe"),
+    path.resolve(repositoryRoot, "..", "UI-Editor-kit", "windows-manager", "src", "UiEditorKit.Manager.Wpf", "bin", "Debug", "net10.0-windows10.0.19041.0", "UiEditorManager.exe"),
+  ];
+}
+
+function resolveTrustedEditorExecutable(options = {}) {
+  const executablePath = trustedEditorCandidates(options).find((candidate) => fs.existsSync(candidate));
+  if (!executablePath) {
+    throw new ElectronEditorError(
+      ELECTRON_EDITOR_ERROR_CODES.EDITOR_NOT_INSTALLED,
+      "Der separate UI-Editor ist nicht installiert. Bitte den UI-Editor Manager installieren oder den Entwicklungsbuild vorbereiten."
+    );
+  }
+  return executablePath;
+}
+
+function resolveEditorRuntimeRoot(executablePath) {
+  const packagedRuntime = path.join(path.dirname(executablePath), "editor-runtime");
+  if (fs.existsSync(path.join(packagedRuntime, "src", "process", "editor-process-entry.cjs"))) return packagedRuntime;
+  const kitRoot = path.resolve(__dirname, "..", "..", "..", "..", "UI-Editor-kit");
+  if (fs.existsSync(path.join(kitRoot, "src", "process", "editor-process-entry.cjs"))) return kitRoot;
+  throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.EDITOR_NOT_INSTALLED, "Der Editor-Core ist nicht vollständig installiert.");
+}
+
+function ensureSmallPlainObject(value, name) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.MESSAGE_INVALID, `${name} ist ungültig.`);
+  }
+  let bytes;
+  try { bytes = Buffer.byteLength(JSON.stringify(value), "utf8"); }
+  catch { throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.MESSAGE_INVALID, `${name} ist nicht serialisierbar.`); }
+  if (bytes > LOCAL_TARGET_MAX_MESSAGE_BYTES) {
+    throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.MESSAGE_TOO_LARGE, `${name} ist zu groß.`);
+  }
+  return value;
+}
+
+function publicError(error) {
+  const code = Object.values(ELECTRON_EDITOR_ERROR_CODES).includes(error?.code)
+    ? error.code
+    : ELECTRON_EDITOR_ERROR_CODES.EDITOR_START_FAILED;
+  const messages = {
+    [ELECTRON_EDITOR_ERROR_CODES.EDITOR_NOT_INSTALLED]: "Der separate UI-Editor ist nicht installiert. Bitte den UI-Editor Manager installieren.",
+    [ELECTRON_EDITOR_ERROR_CODES.EDITOR_ALREADY_RUNNING]: "Der UI-Editor läuft bereits und wird fokussiert.",
+    [ELECTRON_EDITOR_ERROR_CODES.PIPE_TIMEOUT]: "Die lokale Verbindung zum UI-Editor konnte nicht rechtzeitig hergestellt werden.",
+    [ELECTRON_EDITOR_ERROR_CODES.HANDSHAKE_FAILED]: "Die sichere lokale Verbindung zum UI-Editor ist fehlgeschlagen.",
+  };
+  return { ok: false, errorCode: code, message: messages[code] || "Der separate UI-Editor konnte nicht gestartet werden." };
+}
+
+function delay(milliseconds) { return new Promise((resolve) => setTimeout(resolve, milliseconds)); }
+
+class ElectronUiEditorSessionController {
+  constructor({ app, ipcMain, getMainWindow, spawnProcess = spawn, clientFactory, pathOptions = {}, executableResolver, runtimeRootResolver, sessionIdentifiersFactory, profileRootResolver, ensureDirectory }) {
+    this.app = app;
+    this.ipcMain = ipcMain;
+    this.getMainWindow = getMainWindow;
+    this.spawnProcess = spawnProcess;
+    this.clientFactory = clientFactory || ((options) => new NamedPipeTargetClient(options));
+    this.pathOptions = pathOptions;
+    this.executableResolver = executableResolver || resolveTrustedEditorExecutable;
+    this.runtimeRootResolver = runtimeRootResolver || resolveEditorRuntimeRoot;
+    this.sessionIdentifiersFactory = sessionIdentifiersFactory || createSessionIdentifiers;
+    this.profileRootResolver = profileRootResolver || ((electronApp) => path.join(electronApp.getPath("userData"), "ui-editor", "profiles"));
+    this.ensureDirectory = ensureDirectory || ((directory) => fs.mkdirSync(directory, { recursive: true }));
+    this.child = null;
+    this.client = null;
+    this.startPromise = null;
+    this.pendingRendererRequests = new Map();
+    this.heartbeat = null;
+    this.registered = false;
+    this.stopping = false;
+  }
+
+  registerIpc() {
+    if (this.registered) return;
+    this.registered = true;
+    this.ipcMain.handle("uiEditor:open", () => this.open());
+    this.ipcMain.handle("uiEditor:close", () => this.close());
+    this.ipcMain.handle("uiEditor:getStatus", () => this.status());
+    this.ipcMain.handle("uiEditor:respond", (_event, message) => this.respondFromRenderer(message));
+    this.ipcMain.handle("uiEditor:targetEvent", (_event, message) => this.forwardTargetEvent(message));
+  }
+
+  async open() {
+    if (this.client?.connected && this.child && this.child.exitCode === null) {
+      this.client.sendEvent("activateEditor");
+      return { ok: true, started: false, focused: true, sessionId: this.sessionId };
+    }
+    if (this.startPromise) return this.startPromise;
+    this.startPromise = this.#start().catch((error) => {
+      void this.#disposeSession("editor_start_failed", true);
+      return publicError(error);
+    }).finally(() => { this.startPromise = null; });
+    return this.startPromise;
+  }
+
+  async #start() {
+    const executablePath = this.executableResolver({ app: this.app, ...this.pathOptions });
+    const editorRuntimeRoot = this.runtimeRootResolver(executablePath);
+    const identifiers = this.sessionIdentifiersFactory();
+    this.sessionId = identifiers.sessionId;
+    const profileRoot = this.profileRootResolver(this.app);
+    this.ensureDirectory(profileRoot);
+    const contract = createElectronTargetContract({
+      applicationId: APPLICATION_ID,
+      displayName: DISPLAY_NAME,
+      registryVersion: 1,
+      activeScopes: ACTIVE_SCOPES,
+      profileRoot,
+      supportedOperations: ELECTRON_TARGET_OPERATIONS,
+      transportProtocolVersion: LOCAL_TARGET_PROTOCOL_VERSION,
+      sessionId: identifiers.sessionId,
+      processId: process.pid,
+    });
+    const args = [
+      "--electron-target-editor",
+      `--pipe-name=${identifiers.pipeName}`,
+      `--session-nonce=${identifiers.sessionNonce}`,
+      `--application-id=${APPLICATION_ID}`,
+      `--profile-root=${profileRoot}`,
+      `--editor-runtime-root=${editorRuntimeRoot}`,
+    ];
+    this.child = this.spawnProcess(executablePath, args, {
+      cwd: path.dirname(executablePath),
+      shell: false,
+      windowsHide: false,
+      detached: false,
+      stdio: "ignore",
+    });
+    this.child.once("exit", () => { void this.#disposeSession("editor_process_exited", false); });
+    this.child.once("error", (error) => { void this.#disposeSession(error?.code || "editor_process_error", false); });
+    this.client = await this.#connectWithRetry(identifiers, contract);
+    this.client.on("disconnect", () => { void this.#disposeSession("editor_disconnected", false); });
+    this.client.on("connectionError", (_error) => { void _error; });
+    this.#startHeartbeat();
+    return { ok: true, started: true, focused: false, sessionId: identifiers.sessionId };
+  }
+
+  async #connectWithRetry(identifiers, contract) {
+    const expiresAt = Date.now() + 15_000;
+    let lastError;
+    let attempt = 0;
+    while (Date.now() < expiresAt && (this.child?.exitCode === null || this.child?.exitCode === undefined)) {
+      attempt += 1;
+      const client = this.clientFactory({ pipeName: identifiers.pipeName, sessionNonce: identifiers.sessionNonce, timeoutMs: 2_000 });
+      client.on("message", (message) => this.#handleNativeMessage(message));
+      this.client = client;
+      try {
+        await client.connect({ contract });
+        console.info(`[ui-editor] pipe connected after ${attempt} attempt(s)`);
+        return client;
+      } catch (error) {
+        if (!lastError || lastError.code !== error?.code || attempt % 10 === 0) {
+          console.info(`[ui-editor] connect retry ${attempt}: ${error?.code || "unknown"} ${error?.message || ""}`);
+        }
+        lastError = error;
+        if (this.client === client) this.client = null;
+        try { await client.close("connect_retry"); } catch (_closeError) { void _closeError; }
+        await delay(150);
+      }
+    }
+    throw lastError || new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.PIPE_TIMEOUT, "Editor-Pipe ist nicht erreichbar.");
+  }
+
+  #handleNativeMessage(message) {
+    const action = String(message?.payload?.action || "");
+    if (message.messageType === "request" && NATIVE_REQUEST_ACTIONS.has(action)) {
+      console.info(`[ui-editor] native request: ${action}`);
+      const window = this.getMainWindow?.();
+      if (!window || window.isDestroyed?.()) {
+        this.client?.respond(message, {}, { code: ELECTRON_EDITOR_ERROR_CODES.HANDSHAKE_FAILED, message: "BBM-Renderer ist nicht verfügbar." });
+        return;
+      }
+      const requestId = message.messageId;
+      const timeout = setTimeout(() => {
+        const pending = this.pendingRendererRequests.get(requestId);
+        if (!pending) return;
+        this.pendingRendererRequests.delete(requestId);
+        this.client?.respond(pending.message, {}, { code: ELECTRON_EDITOR_ERROR_CODES.PIPE_TIMEOUT, message: "BBM-Renderer antwortet nicht." });
+      }, RENDERER_RESPONSE_TIMEOUT_MS);
+      this.pendingRendererRequests.set(requestId, { message, timeout });
+      window.webContents.send("uiEditor:request", { requestId, payload: message.payload });
+      return;
+    }
+    if (message.messageType === "event" && NATIVE_EVENT_ACTIONS.has(action)) {
+      if (action === "activateTarget") this.getMainWindow?.()?.focus?.();
+      this.getMainWindow?.()?.webContents?.send?.("uiEditor:event", message.payload);
+      if (action === "editorClosed") void this.#disposeSession("editor_closed", false);
+    }
+  }
+
+  respondFromRenderer(message) {
+    ensureSmallPlainObject(message, "Rendererantwort");
+    const requestId = String(message.requestId || "");
+    const pending = this.pendingRendererRequests.get(requestId);
+    if (!pending) return { ok: false, errorCode: ELECTRON_EDITOR_ERROR_CODES.MESSAGE_INVALID };
+    this.pendingRendererRequests.delete(requestId);
+    clearTimeout(pending.timeout);
+    if (message.ok === true) {
+      const payload = ensureSmallPlainObject(message.payload || {}, "Antwortpayload");
+      const requestAction = String(pending.message?.payload?.action || "");
+      console.info(`[ui-editor] renderer response: ${requestAction}`);
+      this.client?.respond(pending.message, { action: `${requestAction}Accepted`, ...payload });
+    }
+    else this.client?.respond(pending.message, {}, {
+      code: Object.values(ELECTRON_EDITOR_ERROR_CODES).includes(message.errorCode) ? message.errorCode : ELECTRON_EDITOR_ERROR_CODES.MESSAGE_INVALID,
+      message: "BBM hat die Editoranfrage sicher abgewiesen.",
+    });
+    return { ok: true };
+  }
+
+  forwardTargetEvent(message) {
+    ensureSmallPlainObject(message, "Ziel-App-Ereignis");
+    if (!TARGET_EVENT_ACTIONS.has(message.action)) return { ok: false, errorCode: ELECTRON_EDITOR_ERROR_CODES.MESSAGE_INVALID };
+    return { ok: this.client?.sendEvent(message.action, { scopeId: String(message.scopeId || ""), elementId: String(message.elementId || "") }) === true };
+  }
+
+  status() {
+    return { ok: true, running: Boolean(this.client?.connected && this.child?.exitCode === null), sessionId: this.sessionId || null };
+  }
+
+  async close() {
+    await this.#disposeSession("renderer_requested_close", true);
+    return { ok: true };
+  }
+
+  async shutdown() { await this.#disposeSession("bbm_shutdown", true); }
+
+  #startHeartbeat() {
+    clearInterval(this.heartbeat);
+    this.heartbeat = setInterval(() => {
+      this.client?.request("heartbeatProbe", {}, "heartbeatProbeAccepted").catch(() => {
+        void this.#disposeSession("heartbeat_failed", true);
+      });
+    }, 4_000);
+    this.heartbeat.unref?.();
+  }
+
+  async #disposeSession(reason, stopProcess) {
+    if (this.stopping) return;
+    this.stopping = true;
+    clearInterval(this.heartbeat);
+    this.heartbeat = null;
+    for (const pending of this.pendingRendererRequests.values()) clearTimeout(pending.timeout);
+    this.pendingRendererRequests.clear();
+    const client = this.client;
+    const child = this.child;
+    this.client = null;
+    this.child = null;
+    this.sessionId = null;
+    try {
+      if (stopProcess && client?.connected) client.sendEvent("shutdownEditor");
+      await client?.close(reason);
+    } catch (_closeError) { void _closeError; }
+    if (stopProcess && (child?.exitCode === null || child?.exitCode === undefined)) {
+      await Promise.race([
+        new Promise((resolve) => child.once("exit", resolve)),
+        delay(1_000),
+      ]);
+      if (child.exitCode === null || child.exitCode === undefined) child.kill();
+    }
+    this.getMainWindow?.()?.webContents?.send?.("uiEditor:event", { action: "editorClosed", reason });
+    this.stopping = false;
+  }
+}
+
+module.exports = Object.freeze({
+  APPLICATION_ID,
+  ACTIVE_SCOPES,
+  ElectronUiEditorSessionController,
+  publicError,
+  resolveEditorRuntimeRoot,
+  resolveTrustedEditorExecutable,
+  trustedEditorCandidates,
+});

--- a/src/renderer/app/CoreShell.js
+++ b/src/renderer/app/CoreShell.js
@@ -117,9 +117,14 @@ export default class CoreShell {
 
     const shellNavigationRouteDefs = createCoreShellNavigationRouteDefs(router);
 
-    const routeButtons = shellNavigationRouteDefs.map((def) =>
-      createScreenRouteButton({ buttonsByKey, runNavSafe }, def)
-    );
+    const routeButtons = shellNavigationRouteDefs.map((def) => {
+      if (def.kind === "action") {
+        const button = mkActionBtn(runNavSafe, def.label, def.onClick);
+        buttonsByKey.set(def.key, button);
+        return button;
+      }
+      return createScreenRouteButton({ buttonsByKey, runNavSafe }, def);
+    });
     const btnHelp = mkNavBtn({ buttonsByKey, runNavSafe }, "help", "Hilfe", () => router.openHelpModal());
 
     const coreNavigationButtons = [...routeButtons, btnHelp];

--- a/src/renderer/app/coreShellNavigation.js
+++ b/src/renderer/app/coreShellNavigation.js
@@ -1,9 +1,20 @@
+export async function openNativeUiEditor() {
+  const api = window.uiEditor;
+  if (!api || typeof api.open !== "function") {
+    alert("Der separate UI-Editor ist nicht installiert oder die sichere BBM-Brücke ist nicht verfügbar.");
+    return { ok: false, errorCode: "electron_editor_not_installed" };
+  }
+  const result = await api.open();
+  if (!result?.ok) alert(result?.message || "Der separate UI-Editor konnte nicht gestartet werden.");
+  return result;
+}
+
 export function createCoreShellNavigationRouteDefs(router) {
   return [
     { key: "home", label: "Start", onClick: () => router.showHome() },
     { key: "projects", label: "Projekte", onClick: () => router.showProjects() },
     { key: "firms", label: "Firmen", onClick: () => router.showFirms() },
     { key: "settings", label: "Einstellungen", onClick: () => router.showSettings() },
-    { key: "uiEditor", label: "UI-Editor Status", onClick: () => router.showUiEditor() },
+    { key: "uiEditor", kind: "action", label: "UI-Editor öffnen", onClick: () => openNativeUiEditor() },
   ];
 }

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -6,6 +6,8 @@ import Router from "./app/Router.js";
 import CoreShell from "./app/CoreShell.js";
 import { DEFAULT_THEME_SETTINGS, applyThemeForSettings } from "./theme/themes.js";
 import { applyPopupButtonStyle, applyPopupCardStyle } from "./ui/popupButtonStyles.js";
+import { installBbmM80EditorBridge } from "./ui-editor/m80Bridge.js";
+import { installBbmM80DiagnosticPilot } from "./ui-editor/m80Diagnostic.js";
 
 // App-Kern-Bootstrap: zentrale Startkonstanten und lokale Storage-/Settings-Keys.
 const PRINT_V2_PAD_LEFT_KEY = "print.v2.pagePadLeftMm";
@@ -21,6 +23,8 @@ const PRINT_LAYOUT_DEFAULTS = {
   [PRINT_V2_FOOTER_RESERVE_KEY]: "12",
 };
 const WHATSNEW_KEY_PREFIX = "bbm_whatsnew_seen_";
+
+installBbmM80EditorBridge();
 
 // Gemeinsame service-nahe Helfer: Settings-/Storage-Zugriffe ohne UI-Verdrahtung.
 const toSeenKey = (version) => `${WHATSNEW_KEY_PREFIX}${String(version || "").trim() || "unknown"}`;
@@ -162,6 +166,15 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   coreShell.start();
+
+  const m80Diagnostic = await window.uiEditor?.getDiagnosticMode?.();
+  if (m80Diagnostic?.ok === true && m80Diagnostic.enabled === true) {
+    const expiresAt = Date.now() + 2_000;
+    while (!router.currentView && Date.now() < expiresAt) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    installBbmM80DiagnosticPilot({ router });
+  }
 
   try {
     const versionRes = await window.bbmDb?.appGetVersion?.();

--- a/src/renderer/modules/restarbeiten/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenEditbox.js
@@ -5,6 +5,7 @@ import {
   getRestarbeitRequiredFieldSummary,
   normalizeRestarbeitStatus,
 } from "./domain/restarbeitenRules.js";
+import { registerM80Ref } from "../../ui-editor/m80Refs.js";
 
 function createEl(tag, { className = "", text = "", uiId = "" } = {}) {
   const el = document.createElement(tag);
@@ -141,10 +142,12 @@ function createTextField({
   multiline = true,
   maxLength,
   labelControls = [],
+  editorGroupId,
+  editorLabelId,
+  editorFieldId,
 }) {
   const wrap = createEl("div", { className: "bbm-restarbeiten-text-field", uiId });
-  const field = createEl("label", { className: "bbm-restarbeiten-field bbm-restarbeiten-text-label" });
-  const labelRow = createEl("span", { className: "bbm-restarbeiten-text-label__row" });
+  const labelRow = createEl("div", { className: "bbm-restarbeiten-text-label__row" });
   const input = document.createElement(multiline ? "textarea" : "input");
   if (inputUiId) input.setAttribute("data-ui-editor-id", inputUiId);
   const remaining = createEl("span", {
@@ -170,8 +173,10 @@ function createTextField({
   });
   input.addEventListener("blur", () => onCommit?.(input.value));
   labelRow.append(createEl("span", { text: label, uiId: labelUiId }), remaining, createDictationButton(dictationUiId), ...labelControls);
-  field.append(labelRow, input);
-  wrap.appendChild(field);
+  wrap.append(labelRow, input);
+  registerM80Ref(editorGroupId, wrap);
+  registerM80Ref(editorLabelId, labelRow);
+  registerM80Ref(editorFieldId, input);
   return wrap;
 }
 
@@ -229,6 +234,9 @@ export function buildRestarbeitenEditbox({
     className: "bbm-restarbeiten-editbox",
     uiId: "restarbeiten.editbox",
   });
+  const area = createEl("div", { className: "bbm-restarbeiten-editbox__editor-area" });
+  registerM80Ref("restarbeiten.edit.root", root);
+  registerM80Ref("restarbeiten.edit.area", area);
   root.dataset.fachlichVollstaendig = String(missingRequiredFields.length === 0);
 
   const header = createEl("div", {
@@ -248,6 +256,7 @@ export function buildRestarbeitenEditbox({
     text: "Neu",
     uiId: "restarbeiten.editbox.action.new",
   });
+  registerM80Ref("restarbeiten.edit.action.new", newBtn);
   newBtn.type = "button";
   newBtn.addEventListener("click", () => onNew?.());
   const deleteBtn = createEl("button", {
@@ -275,6 +284,7 @@ export function buildRestarbeitenEditbox({
   const textArea = createEl("div", {
     className: "bbm-restarbeiten-text-area",
   });
+  registerM80Ref("restarbeiten.edit.fields", textArea);
   textArea.append(
     createTextField({
       label: "Kurztext / Gegenstand",
@@ -288,6 +298,9 @@ export function buildRestarbeitenEditbox({
       multiline: false,
       maxLength: 87,
       labelControls: [classToggle, actions],
+      editorGroupId: "restarbeiten.edit.short",
+      editorLabelId: "restarbeiten.edit.short.label",
+      editorFieldId: "restarbeiten.edit.short.field",
       onInput: (short_text) => {
         if (validation) {
           validation.textContent = getValidationText({ ...draft, short_text });
@@ -305,6 +318,9 @@ export function buildRestarbeitenEditbox({
       dictationUiId: "restarbeiten.editbox.text.long.dictation",
       remainingUiId: "restarbeiten.editbox.text.long.remaining",
       maxLength: 400,
+      editorGroupId: "restarbeiten.edit.long",
+      editorLabelId: "restarbeiten.edit.long.label",
+      editorFieldId: "restarbeiten.edit.long.field",
       onInput: (long_text) => onDraftChange?.({ long_text }, { render: false }),
       onCommit: () => onAutoSave?.(),
     })
@@ -404,6 +420,7 @@ export function buildRestarbeitenEditbox({
   });
   meta.appendChild(noteBtn);
 
-  root.append(header, textArea, location, meta);
+  area.append(header, textArea, location, meta);
+  root.appendChild(area);
   return root;
 }

--- a/src/renderer/modules/restarbeiten/RestarbeitenMainBody.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenMainBody.js
@@ -1,4 +1,5 @@
 import { buildRestarbeitenList, buildRestarbeitenTableHeader } from "./RestarbeitenList.js";
+import { registerM80Ref, registerM80TableColumnRef } from "../../ui-editor/m80Refs.js";
 
 function createEl(tag, { className = "", uiId = "" } = {}) {
   const el = document.createElement(tag);
@@ -21,7 +22,40 @@ export function buildRestarbeitenMainBody(options = {}) {
     uiId: "restarbeiten.main.sheet.paper",
   });
 
-  paper.append(buildRestarbeitenTableHeader(), buildRestarbeitenList(options));
+  const table = createEl("div", {
+    className: "bbm-restarbeiten-table",
+  });
+  const header = buildRestarbeitenTableHeader();
+  const records = buildRestarbeitenList(options);
+
+  registerM80Ref("restarbeiten.list.root", main);
+  registerM80Ref("restarbeiten.list.area", sheet);
+  registerM80Ref("restarbeiten.list.paper", paper);
+  registerM80Ref("restarbeiten.list.table", table);
+  registerM80TableColumnRef(
+    "restarbeiten.list.table.number",
+    header.children[0],
+    table,
+    "--bbm-restarbeiten-number-column",
+    82
+  );
+  registerM80TableColumnRef(
+    "restarbeiten.list.table.subject",
+    header.children[1],
+    table,
+    "--bbm-restarbeiten-subject-column",
+    600
+  );
+  registerM80TableColumnRef(
+    "restarbeiten.list.table.meta",
+    header.children[2],
+    table,
+    "--bbm-restarbeiten-meta-column",
+    172
+  );
+
+  table.append(header, records);
+  paper.appendChild(table);
   sheet.appendChild(paper);
   main.appendChild(sheet);
   return main;

--- a/src/renderer/modules/restarbeiten/index.js
+++ b/src/renderer/modules/restarbeiten/index.js
@@ -33,7 +33,7 @@ export function getRestarbeitenModuleEntry() {
     screens: buildRestarbeitenModuleScreens(),
     navigation: buildRestarbeitenModuleNavigation(),
     shell: Object.freeze({
-      hideSidebar: true,
+      hideSidebar: false,
     }),
   });
 }

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -16,6 +16,7 @@ import { buildRestarbeitenOutputPreview } from "../RestarbeitenOutputPreview.js"
 import { buildRestarbeitenQuicklane } from "../RestarbeitenQuicklane.js";
 import { ensureRestarbeitenStyles } from "../styles.js";
 import { toRestarbeitenOutputRows } from "../viewModel/restarbeitenOutputViewModel.js";
+import { beginM80PilotRender, completeM80PilotRender } from "../../../ui-editor/m80Refs.js";
 import {
   canPersistRestarbeitDraft,
   normalizeRestarbeitStatus,
@@ -513,6 +514,7 @@ export default class RestarbeitenScreen {
 
   _renderShell() {
     if (!this.root) return;
+    beginM80PilotRender();
     this.root.replaceChildren();
     const filteredRows = this._getFilteredItems();
     this.viewItems = toRestarbeitenListItems(filteredRows);
@@ -591,5 +593,6 @@ export default class RestarbeitenScreen {
       status.textContent = this.isLoading ? "Restarbeiten werden geladen ..." : this.error;
       this.root.appendChild(status);
     }
+    completeM80PilotRender();
   }
 }

--- a/src/renderer/modules/restarbeiten/styles/restarbeiten.css
+++ b/src/renderer/modules/restarbeiten/styles/restarbeiten.css
@@ -338,6 +338,12 @@
   padding: 18px 20px;
 }
 
+.bbm-restarbeiten-table {
+  --bbm-restarbeiten-number-column: 82px;
+  --bbm-restarbeiten-subject-column: minmax(0, 1fr);
+  --bbm-restarbeiten-meta-column: 172px;
+}
+
 .bbm-restarbeiten-records {
   display: grid;
   gap: 6px;
@@ -345,7 +351,7 @@
 
 .bbm-restarbeiten-table-header {
   display: grid;
-  grid-template-columns: 82px minmax(0, 1fr) 172px;
+  grid-template-columns: var(--bbm-restarbeiten-number-column) var(--bbm-restarbeiten-subject-column) var(--bbm-restarbeiten-meta-column);
   gap: 12px;
   padding: 0 10px 6px;
   color: var(--bbm-muted);
@@ -371,7 +377,7 @@
 
 .bbm-restarbeiten-record {
   display: grid;
-  grid-template-columns: 82px minmax(0, 1fr) 172px;
+  grid-template-columns: var(--bbm-restarbeiten-number-column) var(--bbm-restarbeiten-subject-column) var(--bbm-restarbeiten-meta-column);
   gap: 12px;
   padding: 9px 10px;
   border: 1px solid var(--bbm-line);
@@ -654,8 +660,17 @@
   min-width: 0;
 }
 
-.bbm-restarbeiten-text-field .bbm-restarbeiten-field {
+.bbm-restarbeiten-text-field > input,
+.bbm-restarbeiten-text-field > textarea {
   min-width: 0;
+  border: 1px solid var(--bbm-line);
+  border-radius: 6px;
+  padding: 3px 5px;
+  background: var(--bbm-surface-soft);
+  color: var(--bbm-text);
+  font-family: var(--bbm-rest-font-family);
+  font-size: 8pt;
+  line-height: 1.15;
 }
 
 .bbm-restarbeiten-text-label__row {
@@ -663,6 +678,26 @@
   align-items: center;
   gap: 5px;
   flex-wrap: wrap;
+}
+
+.bbm-restarbeiten-text-label__row > span:first-child {
+  color: var(--bbm-muted);
+  font-size: var(--bbm-rest-label-font-size);
+  font-weight: 400;
+  line-height: 1.1;
+}
+
+.bbm-ui-editor-hidden {
+  visibility: hidden !important;
+}
+
+.bbm-restarbeiten-table.bbm-ui-editor-hidden-number .bbm-restarbeiten-table-header__number,
+.bbm-restarbeiten-table.bbm-ui-editor-hidden-number .bbm-restarbeiten-record > :nth-child(1),
+.bbm-restarbeiten-table.bbm-ui-editor-hidden-subject .bbm-restarbeiten-table-header__subject,
+.bbm-restarbeiten-table.bbm-ui-editor-hidden-subject .bbm-restarbeiten-record > :nth-child(2),
+.bbm-restarbeiten-table.bbm-ui-editor-hidden-meta .bbm-restarbeiten-table-header__meta,
+.bbm-restarbeiten-table.bbm-ui-editor-hidden-meta .bbm-restarbeiten-record > :nth-child(3) {
+  visibility: hidden !important;
 }
 
 .bbm-restarbeiten-remaining {
@@ -729,6 +764,11 @@
   padding: 3px 5px;
   font-size: 8pt;
   line-height: 1.15;
+}
+
+.bbm-restarbeiten-editbox .bbm-restarbeiten-text-field > textarea {
+  min-height: 34px;
+  resize: none;
 }
 
 .bbm-restarbeiten-editbox [data-ui-editor-id="restarbeiten.editbox.text.short"] input {

--- a/src/renderer/ui-editor/m80Bridge.js
+++ b/src/renderer/ui-editor/m80Bridge.js
@@ -1,0 +1,32 @@
+import { clearM80EditorInteraction, handleM80EditorEvent, handleM80EditorRequest } from "./m80HostAdapter.js";
+
+let installed = false;
+let disposers = [];
+
+export function installBbmM80EditorBridge() {
+  if (installed) return;
+  installed = true;
+  const api = window.uiEditor;
+  if (!api || typeof api.onRequest !== "function" || typeof api.respond !== "function") return;
+  disposers.push(api.onRequest(async (message) => {
+    try {
+      const payload = handleM80EditorRequest(message?.payload || {});
+      await api.respond({ requestId: message.requestId, ok: true, payload });
+    } catch (error) {
+      console.error("[ui-editor] renderer request rejected", error?.code || "electron_editor_message_invalid");
+      await api.respond({ requestId: message?.requestId, ok: false, errorCode: error?.code || "electron_editor_message_invalid" });
+    }
+  }));
+  disposers.push(api.onEvent((message) => {
+    try { handleM80EditorEvent(message || {}); } catch (_error) { clearM80EditorInteraction(); }
+  }));
+  window.addEventListener("bbm:router-context", clearM80EditorInteraction);
+  window.addEventListener("beforeunload", clearM80EditorInteraction, { once: true });
+}
+
+export function uninstallBbmM80EditorBridge() {
+  disposers.forEach((dispose) => { try { dispose?.(); } catch (_error) { void _error; } });
+  disposers = [];
+  clearM80EditorInteraction();
+  installed = false;
+}

--- a/src/renderer/ui-editor/m80Diagnostic.js
+++ b/src/renderer/ui-editor/m80Diagnostic.js
@@ -1,0 +1,50 @@
+import RestarbeitenScreen from "../modules/restarbeiten/screens/RestarbeitenScreen.js";
+import { getM80Ref, resetM80PilotWorkingStatesForDiagnostic } from "./m80Refs.js";
+
+const DIAGNOSTIC_FAILURE_TARGET = "restarbeiten.edit.short.field";
+
+const DIAGNOSTIC_ITEM = Object.freeze({
+  id: "m80-diagnostic-item",
+  running_number: "M80-001",
+  item_class: "rest",
+  status: "offen",
+  short_text: "Fassadenanschluss kontrollieren",
+  long_text: "Diagnoseeintrag ohne Datenbank- oder Fachpersistenz.",
+  due_date: "2026-08-15",
+  responsible_project_firm_id: "m80-diagnostic-firm",
+  responsible_label: "M80 Diagnosefirma",
+  location_level_1: "Bauteil A",
+  location_level_2: "Erdgeschoss",
+  location_level_3: "Fassade",
+  location_level_4: "Achse 3",
+  created_at: "2026-07-26T08:00:00.000Z",
+});
+
+export function installBbmM80DiagnosticPilot({ router } = {}) {
+  if (!router?.contentRoot) throw new Error("M80-Diagnose braucht den vorhandenen BBM-Inhaltsbereich.");
+  resetM80PilotWorkingStatesForDiagnostic();
+  const screen = new RestarbeitenScreen({
+    router: null,
+    projectId: null,
+    project: { name: "M80 Diagnoseprojekt" },
+    moduleId: "restarbeiten",
+  });
+  screen.items = [{ ...DIAGNOSTIC_ITEM }];
+  screen.responsibleFirms = [{ id: "m80-diagnostic-firm", shortName: "M80 Diagnosefirma" }];
+  screen.settings = {};
+  screen.render();
+  screen._selectItem(DIAGNOSTIC_ITEM.id, { render: false });
+  screen.root.setAttribute("data-bbm-m80-diagnostic", "true");
+  router.contentRoot.replaceChildren(screen.root);
+  screen._renderShell();
+  const onControlledFailureKey = (event) => {
+    if (!(event.ctrlKey && event.shiftKey && (event.code === "F8" || event.key === "F8"))) return;
+    event.preventDefault();
+    const ref = getM80Ref(DIAGNOSTIC_FAILURE_TARGET);
+    if (!ref?.element) return;
+    ref.element.dataset.uiEditorFailNextApply = "true";
+    window.removeEventListener("keydown", onControlledFailureKey);
+  };
+  window.addEventListener("keydown", onControlledFailureKey);
+  return screen;
+}

--- a/src/renderer/ui-editor/m80HostAdapter.js
+++ b/src/renderer/ui-editor/m80HostAdapter.js
@@ -1,0 +1,160 @@
+import { getM80RegistryEntry, listM80RegistryScopes } from "./m80Registry.js";
+import {
+  applyM80State,
+  beginM80PilotRender,
+  clearM80VisualState,
+  completeM80PilotRender,
+  getM80IdFromTarget,
+  getM80Ref,
+  registerM80Ref,
+  resetM80PilotWorkingStatesForDiagnostic,
+  snapshotM80State,
+} from "./m80Refs.js";
+
+const ALLOWED_ACTIONS = new Set(["getRegistry", "getLayoutState", "submitChange"]);
+const FORBIDDEN_KEYS = new Set(["fachDaten", "businessData", "domainData", "recordId", "entity", "database", "sql", "status", "responsible", "dueDate", "photos", "rows", "values"]);
+let selectionMode = false;
+let selectedId = null;
+
+function hasForbidden(value) {
+  if (Array.isArray(value)) return value.some(hasForbidden);
+  if (!value || typeof value !== "object") return false;
+  return Object.entries(value).some(([key, nested]) => FORBIDDEN_KEYS.has(key) || hasForbidden(nested));
+}
+function failure(request, errorCode, message, previousState = null, rollbackSucceeded = true) {
+  return { success: false, changeId: String(request?.changeId || ""), elementId: String(request?.elementId || ""), operation: String(request?.operation || ""), errorCode, message, previousState, newState: previousState, rollbackSucceeded };
+}
+function number(value, field, { positive = false, nonNegative = false } = {}) {
+  const result = Number(value);
+  if (!Number.isFinite(result) || (positive && result <= 0) || (nonNegative && result < 0)) throw Object.assign(new Error(`Ungültiger Layoutwert: ${field}`), { code: "electron_editor_message_invalid" });
+  return result;
+}
+
+function desiredState(previous, operation, payload) {
+  const next = { ...previous };
+  if (!payload || typeof payload !== "object" || Array.isArray(payload) || hasForbidden(payload)) throw Object.assign(new Error("Layout-Payload ist ungültig."), { code: "electron_editor_message_invalid" });
+  if (operation === "move") {
+    const keys = Object.keys(payload); if (!keys.length || keys.some((key) => !["x", "y"].includes(key))) throw new Error("move-Payload ist ungültig.");
+    if (Object.hasOwn(payload, "x")) next.x = number(payload.x, "x");
+    if (Object.hasOwn(payload, "y")) next.y = number(payload.y, "y");
+  } else if (operation === "resize") {
+    const keys = Object.keys(payload); if (!keys.length || keys.some((key) => !["width", "height"].includes(key))) throw new Error("resize-Payload ist ungültig.");
+    if (Object.hasOwn(payload, "width")) next.width = number(payload.width, "width", { positive: true });
+    if (Object.hasOwn(payload, "height")) next.height = number(payload.height, "height", { positive: true });
+  } else if (operation === "resizeWidth") {
+    if (Object.keys(payload).length !== 1 || !Object.hasOwn(payload, "width")) throw new Error("resizeWidth-Payload ist ungültig.");
+    next.width = number(payload.width, "width", { positive: true });
+  } else if (operation === "resizeHeight") {
+    if (Object.keys(payload).length !== 1 || !Object.hasOwn(payload, "height")) throw new Error("resizeHeight-Payload ist ungültig.");
+    next.height = number(payload.height, "height", { positive: true });
+  } else if (operation === "textMove") {
+    if (Object.keys(payload).length !== 1 || !payload.text || typeof payload.text !== "object") throw new Error("textMove-Payload ist ungültig.");
+    const keys = Object.keys(payload.text); if (!keys.length || keys.some((key) => !["offsetX", "offsetY"].includes(key))) throw new Error("textMove-Payload ist ungültig.");
+    if (Object.hasOwn(payload.text, "offsetX")) next.textOffsetX = number(payload.text.offsetX, "offsetX", { nonNegative: true });
+    if (Object.hasOwn(payload.text, "offsetY")) next.textOffsetY = number(payload.text.offsetY, "offsetY", { nonNegative: true });
+  } else if (operation === "textResize") {
+    if (Object.keys(payload).length !== 1 || !payload.text || Object.keys(payload.text).length !== 1 || !Object.hasOwn(payload.text, "fontSize")) throw new Error("textResize-Payload ist ungültig.");
+    next.fontSize = number(payload.text.fontSize, "fontSize", { positive: true });
+  } else if (operation === "setVisibility") {
+    if (Object.keys(payload).length !== 1 || typeof payload.visible !== "boolean") throw new Error("setVisibility-Payload ist ungültig.");
+    next.visible = payload.visible;
+  } else throw Object.assign(new Error("Operation ist nicht erlaubt."), { code: "electron_operation_not_allowed" });
+  return next;
+}
+
+function submitChange(changeRequest, scopeId) {
+  const request = changeRequest && typeof changeRequest === "object" ? changeRequest : {};
+  const entry = getM80RegistryEntry(request.elementId);
+  if (!entry) return failure(request, "electron_element_not_found", "Element ist nicht registriert.");
+  if (scopeId && !belongsToScope(entry, scopeId)) return failure(request, "electron_registry_invalid", "Scope passt nicht zum Element.");
+  if (entry.lockedOps.includes(request.operation)) return failure(request, "electron_operation_locked", "Operation ist gesperrt.");
+  if (!entry.allowedOps.includes(request.operation)) return failure(request, "electron_operation_not_allowed", "Operation ist nicht freigegeben.");
+  const previous = snapshotM80State(entry.id);
+  if (!previous) return failure(request, "electron_element_not_found", "Explizite Elementreferenz fehlt.");
+  try {
+    const ref = getM80Ref(entry.id);
+    if (ref?.element?.dataset?.uiEditorFailNextApply === "true") {
+      delete ref.element.dataset.uiEditorFailNextApply;
+      throw Object.assign(new Error("Kontrollierter Diagnosefehler."), { code: "electron_change_apply_failed" });
+    }
+    const desired = desiredState(previous, request.operation, request.payload);
+    const readback = applyM80State(entry.id, desired);
+    return { success: true, changeId: request.changeId, elementId: entry.id, operation: request.operation, errorCode: null, message: "Layoutänderung angewandt und zurückgelesen.", previousState: previous, newState: readback, rollbackSucceeded: true };
+  } catch (error) {
+    try {
+      const restored = applyM80State(entry.id, previous);
+      return failure(request, error?.code || "electron_change_apply_failed", "Layoutänderung wurde sicher abgewiesen und zurückgerollt.", restored, true);
+    } catch (_rollbackError) {
+      return failure(request, "electron_change_rollback_failed", "Layoutänderung und Rollback sind fehlgeschlagen.", previous, false);
+    }
+  }
+}
+
+function belongsToScope(entry, scopeId) {
+  let current = entry;
+  while (current?.parentId) current = getM80RegistryEntry(current.parentId);
+  return current?.id === scopeId;
+}
+
+function layoutPayload() {
+  return listM80RegistryScopes().map((scope) => ({
+    scopeId: scope.scopeId,
+    capturedAt: new Date().toISOString(),
+    elements: scope.elements.map((entry) => snapshotM80State(entry.id)).filter(Boolean),
+  }));
+}
+
+function overlay() {
+  let value = document.querySelector("[data-bbm-ui-editor-overlay]");
+  if (!value) {
+    value = document.createElement("div");
+    value.setAttribute("data-bbm-ui-editor-overlay", "true");
+    value.style.cssText = "position:fixed;pointer-events:none;z-index:2147483000;border:3px solid #2563eb;background:rgba(37,99,235,.10);box-shadow:0 0 0 2px rgba(255,255,255,.9);display:none";
+    document.body.appendChild(value);
+  }
+  return value;
+}
+
+export function highlightM80Element(elementId) {
+  const ref = getM80Ref(elementId);
+  if (!ref) throw Object.assign(new Error("Element kann nicht markiert werden."), { code: "electron_highlight_failed" });
+  selectedId = elementId;
+  const rect = ref.element.getBoundingClientRect();
+  const value = overlay();
+  value.style.left = `${rect.left}px`; value.style.top = `${rect.top}px`; value.style.width = `${rect.width}px`; value.style.height = `${rect.height}px`; value.style.display = "block";
+  return true;
+}
+
+function stopSelection() { selectionMode = false; document.removeEventListener("click", onSelectionClick, true); }
+async function onSelectionClick(event) {
+  if (!selectionMode) return;
+  const id = getM80IdFromTarget(event.target);
+  if (!id) return;
+  event.preventDefault(); event.stopPropagation(); event.stopImmediatePropagation();
+  stopSelection();
+  selectedId = id;
+  highlightM80Element(id);
+  await window.uiEditor?.sendTargetEvent?.({ action: "targetSelectionChanged", scopeId: rootScope(id), elementId: id });
+}
+function rootScope(id) { let entry = getM80RegistryEntry(id); while (entry?.parentId) entry = getM80RegistryEntry(entry.parentId); return entry?.id || ""; }
+
+export function handleM80EditorEvent(event = {}) {
+  const action = String(event.action || "");
+  if (action === "beginTargetSelection") { stopSelection(); selectionMode = true; document.addEventListener("click", onSelectionClick, true); return { ok: true }; }
+  if (action === "cancelTargetSelection") { stopSelection(); return { ok: true }; }
+  if (action === "highlightElement") { highlightM80Element(event.elementId); return { ok: true }; }
+  if (action === "editorClosed") { stopSelection(); selectedId = null; clearM80VisualState(); return { ok: true }; }
+  return { ok: false, errorCode: "electron_editor_message_invalid" };
+}
+
+export function handleM80EditorRequest(request = {}) {
+  const action = String(request.action || "");
+  if (!ALLOWED_ACTIONS.has(action)) throw Object.assign(new Error("Unbekannte Editoranfrage."), { code: "electron_editor_message_invalid" });
+  if (action === "getRegistry") return { registryScopes: listM80RegistryScopes() };
+  if (action === "getLayoutState") return { scopeStates: layoutPayload() };
+  return { changeResult: submitChange(request.changeRequest, request.scopeId) };
+}
+
+export function clearM80EditorInteraction() { stopSelection(); selectedId = null; clearM80VisualState(); }
+export function getM80InteractionStatus() { return { selectionMode, selectedId, scopeStates: layoutPayload() }; }
+export { beginM80PilotRender, completeM80PilotRender, registerM80Ref, resetM80PilotWorkingStatesForDiagnostic };

--- a/src/renderer/ui-editor/m80Refs.js
+++ b/src/renderer/ui-editor/m80Refs.js
@@ -1,0 +1,153 @@
+import { getM80RegistryEntry, m80EditorAttributes } from "./m80Registry.js";
+
+const refs = new Map();
+const elementIds = new WeakMap();
+const workingStates = new Map();
+const HIDDEN_CLASS = "bbm-ui-editor-hidden";
+
+function finite(value, fallback = 0) { return Number.isFinite(Number(value)) ? Number(value) : fallback; }
+function positive(value, fallback) { const number = finite(value, fallback); return number > 0 ? number : fallback; }
+function px(value) { return `${Math.round(Number(value) * 1000) / 1000}px`; }
+function isElementRef(value) { return Boolean(value) && typeof value.setAttribute === "function"; }
+function rectOf(element) { return typeof element.getBoundingClientRect === "function" ? element.getBoundingClientRect() : { left: 0, top: 0, width: finite(parseFloat(element.style?.width)), height: finite(parseFloat(element.style?.height)) }; }
+function styleOf(element) { return globalThis.window?.getComputedStyle?.(element) || element.style || {}; }
+function hasClass(element, className) { return element.classList?.contains?.(className) ?? String(element.className || "").split(/\s+/).includes(className); }
+function toggleClass(element, className, enabled) {
+  if (element.classList?.toggle) { element.classList.toggle(className, enabled); return; }
+  const names = new Set(String(element.className || "").split(/\s+/).filter(Boolean));
+  if (enabled) names.add(className); else names.delete(className);
+  element.className = [...names].join(" ");
+}
+function setCustomProperty(style, name, value) { if (typeof style?.setProperty === "function") style.setProperty(name, value); else if (style) style[name] = value; }
+function getCustomProperty(style, name) { return typeof style?.getPropertyValue === "function" ? style.getPropertyValue(name) : style?.[name]; }
+function applyAttributes(target, id) {
+  for (const [name, value] of Object.entries(m80EditorAttributes(id))) target.setAttribute(name, value);
+}
+
+function readGeneric(element, id) {
+  const rect = rectOf(element);
+  const style = styleOf(element);
+  return {
+    elementId: id,
+    x: finite(element.dataset.uiEditorX),
+    y: finite(element.dataset.uiEditorY),
+    width: positive(rect.width, positive(parseFloat(style.width), 1)),
+    height: positive(rect.height, positive(parseFloat(style.height), 1)),
+    textOffsetX: finite(element.dataset.uiEditorTextX, finite(parseFloat(style.paddingLeft))),
+    textOffsetY: finite(element.dataset.uiEditorTextY, finite(parseFloat(style.paddingTop))),
+    fontSize: positive(parseFloat(style.fontSize), 12),
+    visible: !hasClass(element, HIDDEN_CLASS),
+  };
+}
+
+function applyGeneric(element, state) {
+  element.dataset.uiEditorX = String(finite(state.x));
+  element.dataset.uiEditorY = String(finite(state.y));
+  element.style.translate = `${px(state.x)} ${px(state.y)}`;
+  element.style.width = px(positive(state.width, 1));
+  element.style.height = px(positive(state.height, 1));
+  if (state.textOffsetX !== null && state.textOffsetX !== undefined) { element.dataset.uiEditorTextX = String(state.textOffsetX); element.style.paddingLeft = px(Math.max(0, finite(state.textOffsetX))); }
+  if (state.textOffsetY !== null && state.textOffsetY !== undefined) { element.dataset.uiEditorTextY = String(state.textOffsetY); element.style.paddingTop = px(Math.max(0, finite(state.textOffsetY))); }
+  if (state.fontSize !== null && state.fontSize !== undefined) element.style.fontSize = px(positive(state.fontSize, 1));
+  toggleClass(element, HIDDEN_CLASS, state.visible === false);
+}
+
+export function beginM80PilotRender() {
+  refs.clear();
+}
+
+export function resetM80PilotWorkingStatesForDiagnostic() {
+  refs.clear();
+  workingStates.clear();
+}
+
+export function registerM80Ref(id, element, custom = {}) {
+  const entry = getM80RegistryEntry(id);
+  if (!entry || !isElementRef(element)) throw new Error(`Ungültige explizite M80-Referenz: ${id}`);
+  applyAttributes(element, id);
+  const ref = {
+    id,
+    entry,
+    element,
+    read: custom.read || (() => readGeneric(element, id)),
+    apply: custom.apply || ((state) => applyGeneric(element, state)),
+  };
+  refs.set(id, ref);
+  elementIds.set(element, id);
+  if (workingStates.has(id)) ref.apply(workingStates.get(id));
+  return element;
+}
+
+export function completeM80PilotRender() {
+  for (const ref of refs.values()) {
+    if (typeof ref.element.isConnected === "boolean" && !ref.element.isConnected) continue;
+    if (workingStates.has(ref.id)) ref.apply(workingStates.get(ref.id));
+    const current = ref.read();
+    if (!workingStates.has(ref.id)) workingStates.set(ref.id, { ...current });
+  }
+}
+
+export function registerM80TableColumnRef(id, headerCell, tableElement, cssVariable, initialWidth) {
+  return registerM80Ref(id, headerCell, {
+    read: () => {
+      const style = styleOf(headerCell);
+      const rect = rectOf(headerCell);
+      const width = positive(parseFloat(getCustomProperty(tableElement.style, cssVariable)), positive(rect.width, initialWidth));
+      return {
+        elementId: id, x: 0, y: 0, width, height: positive(rect.height, 1),
+        textOffsetX: finite(headerCell.dataset.uiEditorTextX, finite(parseFloat(style.paddingLeft))),
+        textOffsetY: finite(headerCell.dataset.uiEditorTextY, finite(parseFloat(style.paddingTop))),
+        fontSize: positive(parseFloat(style.fontSize), 12), visible: !hasClass(headerCell, HIDDEN_CLASS),
+      };
+    },
+    apply: (state) => {
+      setCustomProperty(tableElement.style, cssVariable, px(positive(state.width, initialWidth)));
+      headerCell.dataset.uiEditorTextX = String(finite(state.textOffsetX));
+      headerCell.dataset.uiEditorTextY = String(finite(state.textOffsetY));
+      headerCell.style.paddingLeft = px(Math.max(0, finite(state.textOffsetX)));
+      headerCell.style.paddingTop = px(Math.max(0, finite(state.textOffsetY)));
+      headerCell.style.fontSize = px(positive(state.fontSize, 1));
+      toggleClass(tableElement, `${HIDDEN_CLASS}-${id.split(".").pop()}`, state.visible === false);
+      toggleClass(headerCell, HIDDEN_CLASS, state.visible === false);
+    },
+  });
+}
+
+export function getM80Ref(id) { return refs.get(String(id || "")) || null; }
+export function getM80IdFromTarget(target) {
+  let current = isElementRef(target) ? target : null;
+  while (current) {
+    const id = elementIds.get(current);
+    if (id) return id;
+    current = current.parentElement;
+  }
+  return null;
+}
+export function readM80State(id) {
+  const ref = getM80Ref(id);
+  if (!ref) return null;
+  const state = ref.read();
+  workingStates.set(id, { ...state });
+  return { ...state };
+}
+export function applyM80State(id, state) {
+  const ref = getM80Ref(id);
+  if (!ref) throw Object.assign(new Error("Explizite Elementreferenz fehlt."), { code: "electron_element_not_found" });
+  ref.apply(state);
+  const readback = ref.read();
+  workingStates.set(id, { ...readback });
+  return { ...readback };
+}
+export function snapshotM80State(id) { return readM80State(id); }
+export function listM80CurrentStates(scopeId) {
+  return [...refs.values()].filter((ref) => {
+      let entry = ref.entry;
+      while (entry && entry.parentId) entry = getM80RegistryEntry(entry.parentId);
+      return entry?.id === scopeId;
+    }).map((ref) => readM80State(ref.id));
+}
+export function clearM80VisualState() {
+  document.querySelector("[data-bbm-ui-editor-overlay]")?.remove();
+}
+
+export { HIDDEN_CLASS };

--- a/src/renderer/ui-editor/m80Registry.js
+++ b/src/renderer/ui-editor/m80Registry.js
@@ -1,0 +1,60 @@
+const POSITION_SIZE_VISIBILITY = Object.freeze(["move", "resizeWidth", "resizeHeight", "setVisibility"]);
+const TEXT_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility"]);
+const TABLE_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility"]);
+const COLUMN_LAYOUT = Object.freeze(["resizeWidth", "textMove", "textResize", "setVisibility"]);
+const DOMAIN_LOCKS = Object.freeze(["executeTargetAction", "modifyDomainData", "createRecord", "deleteRecord"]);
+
+function element(values) {
+  return Object.freeze({ visible: true, editable: true, ...values,
+    allowedOps: Object.freeze([...(values.allowedOps || [])]),
+    lockedOps: Object.freeze([...(values.lockedOps || [])]),
+  });
+}
+
+const listElements = Object.freeze([
+  element({ id: "restarbeiten.list.root", name: "Restarbeiten · Liste", type: "root", role: "scopeRoot", parentId: null, order: 0, editable: false, allowedOps: [], componentKind: "scope" }),
+  element({ id: "restarbeiten.list.area", name: "Listenbereich", type: "area", role: "contentArea", parentId: "restarbeiten.list.root", order: 10, allowedOps: POSITION_SIZE_VISIBILITY, componentKind: "contentArea" }),
+  element({ id: "restarbeiten.list.paper", name: "Listenblatt", type: "group", role: "layoutGroup", parentId: "restarbeiten.list.area", order: 20, allowedOps: POSITION_SIZE_VISIBILITY, componentKind: "paper" }),
+  element({ id: "restarbeiten.list.table", name: "Restarbeiten-Hauptliste", type: "table", role: "contentTable", parentId: "restarbeiten.list.paper", order: 30, allowedOps: TABLE_LAYOUT, componentKind: "contentTable" }),
+  element({ id: "restarbeiten.list.table.number", name: "Nr. / Datum / Klasse / Fotos", type: "tableColumn", role: "contentColumn", parentId: "restarbeiten.list.table", order: 31, allowedOps: COLUMN_LAYOUT, columnRole: "contentColumn", width: 82, minWidth: 50, maxWidth: 240 }),
+  element({ id: "restarbeiten.list.table.subject", name: "Gegenstand – Verortung / Kurztext / Langtext", type: "tableColumn", role: "contentColumn", parentId: "restarbeiten.list.table", order: 32, allowedOps: COLUMN_LAYOUT, columnRole: "contentColumn", width: 600, minWidth: 160, maxWidth: 1200 }),
+  element({ id: "restarbeiten.list.table.meta", name: "Status-Metaspalte – Fertig bis / Ampel / Status / Verantwortlich", type: "tableColumn", role: "metaColumn", parentId: "restarbeiten.list.table", order: 33, allowedOps: COLUMN_LAYOUT, columnRole: "metaColumn", width: 172, minWidth: 110, maxWidth: 420 }),
+]);
+
+const editElements = Object.freeze([
+  element({ id: "restarbeiten.edit.root", name: "Restarbeiten · Bearbeitung", type: "root", role: "scopeRoot", parentId: null, order: 0, editable: false, allowedOps: [], componentKind: "scope" }),
+  element({ id: "restarbeiten.edit.area", name: "Bearbeitungsbereich", type: "area", role: "formArea", parentId: "restarbeiten.edit.root", order: 10, allowedOps: POSITION_SIZE_VISIBILITY, componentKind: "formArea" }),
+  element({ id: "restarbeiten.edit.fields", name: "Textfelder", type: "group", role: "fieldCollection", parentId: "restarbeiten.edit.area", order: 20, allowedOps: POSITION_SIZE_VISIBILITY, componentKind: "fieldCollection" }),
+  element({ id: "restarbeiten.edit.short", name: "Kurztext-Feldgruppe", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.fields", order: 30, allowedOps: POSITION_SIZE_VISIBILITY, componentKind: "fieldGroup" }),
+  element({ id: "restarbeiten.edit.short.label", name: "Kurztext / Gegenstand · Bezeichnung", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.short", order: 31, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "restarbeiten.edit.short.field", name: "Kurztext / Gegenstand · Feld", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.short", order: 32, allowedOps: TEXT_LAYOUT, fieldKind: "text", componentKind: "input" }),
+  element({ id: "restarbeiten.edit.long", name: "Langtext-Feldgruppe", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.fields", order: 40, allowedOps: POSITION_SIZE_VISIBILITY, componentKind: "fieldGroup" }),
+  element({ id: "restarbeiten.edit.long.label", name: "Langtext / Beschreibung · Bezeichnung", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.long", order: 41, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "restarbeiten.edit.long.field", name: "Langtext / Beschreibung · Feld", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.long", order: 42, allowedOps: TEXT_LAYOUT, fieldKind: "multilineText", componentKind: "textarea" }),
+  element({ id: "restarbeiten.edit.action.new", name: "Neu", type: "button", role: "domainActionLayout", parentId: "restarbeiten.edit.area", order: 50, allowedOps: TEXT_LAYOUT, lockedOps: DOMAIN_LOCKS, actionKind: "domainCreate", componentKind: "button" }),
+]);
+
+export const BBM_M80_REGISTRY_SCOPES = Object.freeze([
+  Object.freeze({ scopeId: "restarbeiten.list.root", elements: listElements }),
+  Object.freeze({ scopeId: "restarbeiten.edit.root", elements: editElements }),
+]);
+
+const entries = new Map(BBM_M80_REGISTRY_SCOPES.flatMap((scope) => scope.elements).map((entry) => [entry.id, entry]));
+
+export function getM80RegistryEntry(id) { return entries.get(String(id || "")) || null; }
+export function listM80RegistryScopes() {
+  return BBM_M80_REGISTRY_SCOPES.map((scope) => ({ scopeId: scope.scopeId, elements: scope.elements.map((entry) => ({ ...entry, allowedOps: [...entry.allowedOps], lockedOps: [...entry.lockedOps] })) }));
+}
+
+export function m80EditorAttributes(id) {
+  const entry = getM80RegistryEntry(id);
+  if (!entry) throw new Error(`Nicht registrierte M80-ID: ${id}`);
+  return Object.freeze({
+    "data-ui-inspector-id": entry.id,
+    "data-ui-editor-kind": entry.type,
+    "data-ui-editor-label": entry.name,
+    "data-ui-editor-parent": entry.parentId || "",
+    "data-ui-editor-editable": String(entry.editable),
+    "data-ui-editor-ops": entry.allowedOps.join(","),
+  });
+}


### PR DESCRIPTION
## Ziel

M80 verbindet BBM als Electron-Desktop-App mit dem bestehenden separaten nativen UI-/PDF-Editor und liefert einen praktisch geprüften Restarbeiten-UI-Pilot.

## Enthalten

- Sidebar-Aktion `UI-Editor öffnen`
- genau eine Editorinstanz je BBM-Sitzung
- enge Renderer-/Preload-/Mainprozess-Brücke
- sichere lokale Named-Pipe-Verbindung
- explizite M80-Registry und Ref-Auflösung
- Restarbeiten-Pilot mit Hauptliste und Bearbeitungsbereich
- bestätigte Tabellen-Spaltengruppen
- getrennte Feldbezeichnungen und Felder
- Position, Breite, Höhe, Textposition und Schriftgröße
- unabhängige Sichtbarkeit von Label und Feld
- Auswahl und Markierung in beide Richtungen
- Fachaktionsschutz für den Button `Neu`
- Save, Load, Discard, Reset, Neustart-Restore und Rollback
- Entwicklungs- und produktionsnaher Packlauf
- PDF-Tab mit ehrlichem M81-Hinweis
- historische Editorpfade nicht mehr produktführend
- Statusfortschreibung: M80 `[A]`, M81 offen

## Ausdrücklich nicht enthalten

- keine BBM-PDF-Anbindung oder Änderung des Druck-/PDF-Fachwegs
- keine Änderung von Fachwerten oder Fachaktionen
- keine automatische DOM-Erkennung oder Laufzeitscans
- kein zweiter Editor, Core oder Profilweg
- kein Browser-, Webserver-, HTTP-, WebSocket-, Netzwerk- oder Cloudpfad
- `docs/licensing.md` ist ausdrücklich nicht Bestandteil dieses Commits

## Prüfungen

Erfolgreich ausgeführt:

- `npm test`
- `npm run test:node`
- M80-Einzeltest
- gezieltes ESLint für sämtliche M80-Pfade
- `npm run pack`
- `git diff --check`
- vollständiger sichtbarer 43-Schritte-End-to-End-Nachweis
- unabhängige Sichtbarkeit, Tabellenbreite, Fachaktionssperre, Restore und Rollback praktisch bestätigt
- keine verbleibenden BBM-, Editor-, Node- oder Electron-Prozesse

Das globale Lint enthält weiterhin 17 nachweislich vorbestehende Fehler ausschließlich in unveränderten Altdateien.

## Commit

`8e1bee0c9381b9c9425a759a77be2975329596fc`