### PR TITLE
M80.1 Restarbeiten vollständig registrieren und Registry aktualisieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ BBM nutzt ab M51 das eigenständige `UI-Editor-kit` in Version `v0.2.0` als Ziel
 
 Ab M80 ist die produktführende Integration die Sidebar-Aktion `UI-Editor öffnen`: Sie verbindet die laufende Electron-App ausschließlich lokal mit dem vorhandenen separaten nativen Editor. Der Restarbeiten-Pilot nutzt explizite Registry/Refs, getrennte Labels/Felder, die bestätigte Hauptliste, neutrale Layoutänderungen, Sichtbarkeit und den vorhandenen Profil-/Rollbackweg. Fachaktionen und Fachwerte sind ausgeschlossen. Einstieg: [M80-HostAdapter](docs/M80_ELECTRON_HOSTADAPTER.md), [Pilotregistry](docs/M80_PILOT_REGISTRY.md), [Sicherheit/Diagnose](docs/M80_LIFECYCLE_SICHERHEIT_DIAGNOSE.md).
 
+M80.1 ergänzt Registryversion und deterministischen Fingerprint, vollständige Scope-Inventare, Refresh vor jedem Öffnen/Fokussieren und bei Laufzeitereignissen sowie sicheren Profilabgleich. Nur die drei vollständig registrierten Restarbeiten-Scopes sind aktiv; alle weiteren noch nicht sicher inventarisierten BBM-Bereiche bleiben ausdrücklich gesperrt. Details: [M80.1-Bestands-App-Registrierung](docs/M80_1_BESTANDSAPP_REGISTRIERUNG.md).
+
 Die vollständige BBM-PDF-Anbindung ist M81; bis dahin zeigt der PDF-Tab im Editor ausdrücklich, dass BBM-PDF noch nicht angebunden ist.
 
 Status M51: Core-Vertrag technisch angebunden und testbar; noch keine vollständige sichtbare Editor-Oberfläche und noch keine dauerhafte Layoutspeicherung.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,28 @@
 # STATUS.md — BBM-Produktiv
 
+### M80.1 – Bestands-App-Registrierung, Registry-Refresh und vollständige Restarbeiten-Anbindung
+
+- Status: `[A] abgenommen`.
+- Ergebnis:
+  - Registryversion `2` und deterministischer SHA-256-Fingerprint werden vor jedem Öffnen/Fokussieren gemeinsam geprüft.
+  - Fünf Registry-Laufzeitereignisse lösen denselben sicheren Refresh aus; Fehler, Dirty-Zustand und notwendige Migration überschreiben den gültigen Stand nicht.
+  - Der vorhandene Profilweg behält kompatible stabile IDs, startet neue IDs mit Baseline, ignoriert/archiviert entfernte IDs und entfernt entfallene Capabilities.
+  - Vollständig und aktiv sind `restarbeiten.layout.root`, `restarbeiten.list.root` und `restarbeiten.edit.root` mit lückenlosen erwarteten Inventaren und auflösbaren Refs.
+  - Die Hauptliste besitzt ausschließlich die drei bestätigten Spaltengruppen. Die sichtbare Editbox ist elementweise einschließlich aller Labels, Felder, Auswahl-/Datumsfelder, Hinweise und Fachbuttons als Layoutobjekte registriert.
+  - Alle übrigen nicht sicher inventarisierten BBM- und Restarbeiten-Bereiche sind ausdrücklich gesperrt; keine BBM-Gesamtvollständigkeit wird behauptet.
+- Dokumentation:
+  - `docs/M80_1_BESTANDSAPP_REGISTRIERUNG.md`
+- Prüfung bisher:
+  - `npm test`, `npm run test:node` und die M80.1-Einzeltests grün.
+  - gezieltes ESLint der neuen und produktführend geänderten M80.1-Dateien grün; globaler Altbestand unverändert bei 17 Fehlern und 371 Warnungen.
+  - produktionsnahes `npm run pack` grün.
+  - sichtbarer gepackter Lauf: alle 49 Editbox-Elemente und alle sieben Listenknoten auswählbar, genau drei Tabellenspalten, unabhängige Label-/Feld- und Sichtbarkeitsänderung, Fachaktionssperre, Save/Load/Restore/Reset/Discard/Rollback, kontrollierter Registry-Reload, Dirty-Konflikt und genau eine Editorinstanz grün.
+- Risiken / offen:
+  - alle nicht vollständig inventarisierten BBM-Scopes bleiben ausdrücklich gesperrt.
+  - M81 BBM-PDF und M82 App-Starterpaket bleiben offen; keine Arbeit daran wurde begonnen.
+- Commit/PR:
+  - keiner; gemäß Nutzeranweisung weder Commit noch Push noch PR.
+
 ### M80 – Electron-Ziel-App-Anbindung und Restarbeiten-UI-Pilot
 
 - Status: `[A] abgenommen`.

--- a/docs/M80_1_BESTANDSAPP_REGISTRIERUNG.md
+++ b/docs/M80_1_BESTANDSAPP_REGISTRIERUNG.md
@@ -1,0 +1,73 @@
+# M80.1 – BBM-Bestands-App-Registrierung
+
+## Führender Registrierungsweg
+
+BBM liefert bei jedem Klick auf `UI-Editor öffnen` einen frisch aus den expliziten Renderer-Refs erzeugten Registrierungsstand. Der Main-Prozess ergänzt den Ziel-App-Vertrag, berechnet den deterministischen Fingerprint, validiert Version, Registry, Refs, Scope-Status und Inventar und öffnet oder fokussiert erst danach den vorhandenen nativen Editor.
+
+Es gibt weiterhin nur eine führende BBM-Registry unter `src/renderer/ui-editor/m80Registry.js`, einen Ref-Resolver, einen Electron-HostAdapter, den vorhandenen Editor/Node-Core und den vorhandenen atomaren Profilweg. Es existiert keine automatische DOM-Erkennung und keine zweite Schattenregistry als Wahrheit.
+
+## Registryvertrag
+
+- `registryVersion`: `2`
+- `registryStatus`: `incomplete`, weil nicht alle produktiven BBM-Bereiche sicher inventarisiert sind
+- Fingerprint: deterministisches SHA-256 über die sortierte Layout-/Vertragsstruktur
+- `activeScopes`: nur vollständige, aktuell auflösbare Scopes
+- Laufzeitereignisse: `registryChanged`, `registryStatusChanged`, `scopeAdded`, `scopeChanged`, `scopeRemoved`
+
+Fachwerte, aktuelle Eingaben, Kunden-/Projektdaten, dynamische Tabellenzeilen, Fotos, Status-, Verantwortlichen- und Terminwerte gehen weder in Registry noch Fingerprint ein.
+
+## Vollständige Scopes
+
+### `restarbeiten.layout.root`
+
+Nicht editierbarer Scope-Root mit dem eigenen editierbaren Container `restarbeiten.layout.split` sowie Hauptlisten- und Editboxbereich. `resizeHeight` am Split-Container ändert eine gemeinsame Trennposition; Mindesthöhen von 180 px für die Liste und 160 px für die Editbox verhindern widersprüchliche Einzelhöhen. Beide Bereiche können zusätzlich layoutbezogen in Breite und Sichtbarkeit bearbeitet werden.
+
+### `restarbeiten.list.root`
+
+Enthält Listenbereich, Listenblatt, Inhaltstabelle und genau die drei vom Nutzer bestätigten sichtbaren Spaltengruppen:
+
+1. Nr. / Datum / Klasse / Fotos
+2. Gegenstand – Verortung / Kurztext / Langtext
+3. Status-Metaspalte – Fertig bis / Ampel / Status / Verantwortlich
+
+Die Tabelle und ihre Spalten sind ausschließlich Layoutobjekte. Fachwerte, Fotos, Zeilen, Sortierung, Filter, Status, Verantwortliche, Termine und Ampellogik bleiben gesperrt.
+
+### `restarbeiten.edit.root`
+
+Das Inventar enthält Root, Bearbeitungsbereich, Kopf und aktuellen Datensatzhinweis; Kurztextgruppe mit Bezeichnung, Restzeichen, Diktat, Klassenbezeichnung/-auswahl, Klassenbuttons, Neu/Löschen und Feld; Langtextgruppe mit Bezeichnung, Restzeichen, Diktat und Feld; vier Verortungsgruppen mit jeweils getrenntem Label und Feld; Status, Fertig bis und Verantwortlich mit jeweils getrenntem Label und Feld; Ampel, Pflichtfeldhinweis und Notizbutton.
+
+Jedes sichtbare Element besitzt stabile ID, Parent, Scope, Typ, Rolle, semantischen Schlüssel, Ref, Baseline, Capabilities, `lockedOps`, Sichtbarkeit und Registrierungsstatus. Labels und Felder sind Geschwister. Alle Fachbuttons sind nur Layoutobjekte und sperren insbesondere Ausführung und Fachdatenänderung.
+
+## Ausdrücklich gesperrte Scopes
+
+Die folgenden vorhandenen Bereiche sind nicht sicher vollständig inventarisiert und werden daher nicht als editorfähig behauptet:
+
+- `bbm.shell`, `bbm.home`, `bbm.projects`, `bbm.project-workspace`
+- `bbm.firms`, `bbm.project-firms`, `bbm.protokoll`
+- `bbm.settings`, `bbm.help`, `bbm.dialogs`
+- `restarbeiten.filterbar`, `restarbeiten.quicklane`, `restarbeiten.notes`
+- `restarbeiten.output-preview` – zusätzlich wegen der M81-PDF-Grenze gesperrt
+
+## Refresh und Profilverhalten
+
+Jeder Öffnungs- und Fokusweg validiert zuerst den aktuellen Stand. Bei kompatibler Änderung wird die laufende Editorinstanz kontrolliert beendet und genau eine neue Instanz mit der neuen Registry gestartet. Fehler ersetzen die vorherige gültige Registry nicht. Dirty-Konflikte und Parent-/Bedeutungsänderungen blockieren den Wechsel.
+
+Stabile IDs behalten kompatible Layoutwerte. Neue IDs verwenden die Ziel-App-Baseline. Entfernte IDs werden nicht mehr angewendet und kontrolliert ignoriert/archiviert. Entfallene Capabilities entfernen nicht mehr erlaubte Profilwerte. Der vorhandene Profilpfad bleibt alleinige Persistenzautorität.
+
+Dirty-Zustände vergleichen ausschließlich registrierte und damit persistierbare Capabilities. Nicht freigegebene Laufzeitmaße dürfen nach Restore oder Refresh keinen falschen Profilkonflikt erzeugen. Explizit gesetzte DOM-Außenmaße werden als `border-box` ohne nachträgliches `flex-shrink` angewandt, damit gespeicherte Layoutbreiten über BBM-Neustarts stabil bleiben.
+
+## Historische Bestände
+
+Verglichen wurden `uiEditor/`, `src/renderer/uiInspector/`, `src/renderer/uiV2/`, `src/ui-editor/`, `src/renderer/ui-editor/`, `src/renderer/editorRuntime/` und frühere Restarbeiten-/Editbox-Registries. Wiederverwendet wurden bestätigte stabile Bedeutungen und der frühere Restarbeiten-Elementbestand; Parents, Refs und sichtbare Elemente wurden gegen die heutige tatsächliche UI geprüft. Veraltete Scanner, Overlays, Selector-Fallbacks, Memory-Registries und eingebettete Editoroberflächen bleiben historisch und nicht produktführend.
+
+## Grenzen
+
+- Keine Fachlogik oder Fachdatenänderung.
+- Keine automatische UI-Erkennung.
+- Kein Browser-, Webserver-, Netzwerk- oder Cloudpfad.
+- Kein zweiter Editor, Core oder Profilweg.
+- M81 PDF und M82 App-Starterpaket bleiben offen.
+
+## Praktische Abnahme
+
+Die Abnahme lief mit `dist/win-unpacked/BBM.exe` und dem mitgepackten vorhandenen nativen Editor. Geprüft wurden die drei aktiven Scopes, alle 49 sichtbaren Editbox-Elemente, alle sieben Knoten der Hauptliste mit exakt drei Spaltengruppen, Hauptsplit und Pane-Größen, unabhängige Label-/Feldbearbeitung, Sichtbarkeit, Fachaktionssperre, Save/Load/Restore/Reset/Discard und Rollback. Ein kontrollierter Registrywechsel ersetzte die laufende Instanz erst nach erfolgreichem Refresh; ein zweiter Wechsel wurde mit ungespeicherter Änderung sichtbar blockiert und nach Discard sauber geladen. Zu jedem Zeitpunkt existierte genau eine Editorinstanz.

--- a/docs/M80_ELECTRON_HOSTADAPTER.md
+++ b/docs/M80_ELECTRON_HOSTADAPTER.md
@@ -15,4 +15,6 @@ Der produktführende M80-Pfad ist:
 
 Der HostAdapter akzeptiert nur registrierte IDs, freigegebene Layoutoperationen und fachfreie Payloads. Er überträgt keine DOM-Knoten oder Fachwerte. Fehler werden auf den unmittelbar vorherigen Layoutzustand zurückgerollt und strukturiert gemeldet.
 
+Ab M80.1 erzeugt jeder Öffnungsweg den aktuellen Registrierungsdescriptor neu. Der Main-Prozess berechnet den Fingerprint, validiert vollständige Inventare und Refs und vergleicht den Stand vor Öffnen oder Fokus. Dieselbe Prüfung läuft nach `registryChanged`, `registryStatusChanged`, `scopeAdded`, `scopeChanged` und `scopeRemoved`. Ungültige Daten ersetzen keinen gültigen Stand; Dirty- und Migrationskonflikte blockieren den Wechsel. Bei einer kompatiblen Änderung wird genau eine neue Editorinstanz mit der aktualisierten Registry gestartet.
+
 Historische Pfade unter `uiEditor/`, `src/renderer/uiInspector/`, `src/renderer/uiV2/`, `src/ui-editor/`, der übrigen `src/renderer/ui-editor/`-Historie und `src/renderer/editorRuntime/` bleiben erhalten, sind für M80 aber nicht produktführend. Es wurde kein zweiter Editor ausgebaut.

--- a/docs/M80_LIFECYCLE_SICHERHEIT_DIAGNOSE.md
+++ b/docs/M80_LIFECYCLE_SICHERHEIT_DIAGNOSE.md
@@ -14,6 +14,8 @@ Ein erster Sidebar-Aufruf startet die feste vertrauenswürdige Editor-EXE. Ein w
 
 ## Diagnose
 
-`--bbm-electron-editor-diagnostic` beziehungsweise `BBM_M80_EDITOR_DIAGNOSTIC=1` rendert einen isolierten realen Restarbeiten-Screen mit einem nicht persistenten In-Memory-Datensatz. Es werden weder Kunden-/Produktivdaten noch Fachdatenbanken geändert. Der nur dort aktive Tastengriff `Ctrl+Shift+F8` armiert einmalig einen kontrollierten Applyfehler für den sichtbaren Rollbacknachweis.
+`--bbm-electron-editor-diagnostic` beziehungsweise `BBM_M80_EDITOR_DIAGNOSTIC=1` rendert einen isolierten realen Restarbeiten-Screen mit einem nicht persistenten In-Memory-Datensatz. Es werden weder Kunden-/Produktivdaten noch Fachdatenbanken geändert. Der nur dort aktive Tastengriff `Ctrl+Shift+F8` armiert einmalig einen kontrollierten Applyfehler für den sichtbaren Rollbacknachweis. `Ctrl+Shift+F9` erhöht ausschließlich im Diagnosemodus eine kontrollierte Registryrevision und eine neutrale Baseline-Grenze; der nächste normale Sidebar-Klick belegt damit Reload und Dirty-Konfliktschutz ohne neue ID oder geänderte Fachbedeutung.
 
 Nachgewiesen wurden 43 E2E-Schritte mit echten sichtbaren Fenstern: Start, Sidebar, Handshake, Registry, Auswahl/Markierung in beide Richtungen, Layoutmodi, getrennte Sichtbarkeit, Tabelle, Fachaktionsschutz, Save/Load, Neustart-Restore, Discard, Reset, Rollback, Eininstanz, PDF-Abgrenzung, Editorende, BBM-Weiterbetrieb und vollständige Prozess-/Temporärbereinigung.
+
+Die M80.1-Erweiterungsabnahme belegt zusätzlich alle 49 sichtbaren Editbox-Elemente, die sieben Knoten der Hauptliste mit exakt drei bestätigten Spaltengruppen, einen kompatiblen Registry-Reload auf genau eine neue Instanz, den sichtbaren `registry_profile_conflict` bei ungespeicherter Änderung und den anschließenden erfolgreichen Reload nach Discard. Der BBM-Neustart stellt das gespeicherte Layout ohne falschen Dirty-Zustand wieder her.

--- a/docs/M80_PILOT_REGISTRY.md
+++ b/docs/M80_PILOT_REGISTRY.md
@@ -1,9 +1,10 @@
 # M80 – Restarbeiten-Pilotregistry
 
-Die Registry ist explizit und umfasst ausschließlich zwei Restarbeiten-Scopes:
+Die Registry ist explizit. M80.1 erweitert den Pilot auf drei vollständige Restarbeiten-Scopes und führt alle übrigen nicht sicher inventarisierten BBM-Bereiche ausdrücklich als gesperrt:
 
+- `restarbeiten.layout.root`: gemeinsames Hauptlayout mit konsistenter Trennposition und Mindesthöhen für Hauptliste und Editbox.
 - `restarbeiten.list.root`: Hauptliste mit Bereich, Papier, Inhaltstabelle und den drei fachlich bestätigten sichtbaren Spaltengruppen.
-- `restarbeiten.edit.root`: Bearbeitungsbereich mit Kurztext-/Langtext-`fieldGroup`, getrennten Labels/Feldern und dem Button `Neu` als reines Layoutobjekt.
+- `restarbeiten.edit.root`: vollständiger sichtbarer Bearbeitungsbereich mit Kopf, Kurz-/Langtext, Klasse, Verortung, Status, Termin, Ampel, Verantwortlich, Hinweisen und allen Buttons als reine Layoutobjekte.
 
 ## Bestätigte Tabellenspalten
 
@@ -14,3 +15,5 @@ Die Registry ist explizit und umfasst ausschließlich zwei Restarbeiten-Scopes:
 Die Tabelle ist eine Inhaltstabelle und ausschließlich Layoutobjekt. Sichtbarkeit einzelner Spalten ist nur zulässig, soweit keine Fachlogik verändert wird. Fachwerte, Status, Verantwortliche, Termine, Ampel, Fotos, Zeilen, Sortierung, Filter und Fachaktionen sind keine Editoroperationen.
 
 Die Registry wird nicht aus DOM, CSS, Datenbank, IPC oder Druckdaten erzeugt. Parentstruktur, Reihenfolge, Rollen und Operationen sind fest gepflegt und durch den Vertragscheck abgesichert.
+
+Registryversion `2`, Fingerprint, Scope-Inventare, Refresh und die vollständige Liste gesperrter Scopes sind in `M80_1_BESTANDSAPP_REGISTRIERUNG.md` dokumentiert.

--- a/scripts/test.cjs
+++ b/scripts/test.cjs
@@ -99,6 +99,7 @@ const { runM65LayoutPersistenceRoundtripTests } = require("./tests/m65LayoutPers
 const { runM66ResetLayoutToDefaultsTests } = require("./tests/m66ResetLayoutToDefaults.test.cjs");
 const { runM67ResetElementToDefaultsTests } = require("./tests/m67ResetElementToDefaults.test.cjs");
 const { runM80ElectronUiEditorTests } = require("./tests/m80ElectronUiEditor.test.cjs");
+const { runM801RegistrationRefreshTests } = require("./tests/m80-1RegistrationRefresh.test.cjs");
 
 let failed = false;
 
@@ -245,6 +246,7 @@ async function main() {
   await runM66ResetLayoutToDefaultsTests(run);
   await runM67ResetElementToDefaultsTests(run);
   await runM80ElectronUiEditorTests(run);
+  await runM801RegistrationRefreshTests(run);
 
   if (failed) {
     process.exitCode = 1;

--- a/scripts/tests/m52UiEditorVisibleEntry.test.cjs
+++ b/scripts/tests/m52UiEditorVisibleEntry.test.cjs
@@ -218,7 +218,7 @@ async function runM52UiEditorVisibleEntryTests(run) {
     assert.match(ipc, /ElectronUiEditorSessionController/);
     assert.match(main, /registerUiEditorIpc\(\{ app, ipcMain, getMainWindow/);
     assert.match(preload, /exposeInMainWorld\("uiEditor"/);
-    assert.match(preload, /open:\s*\(\) => ipcRenderer\.invoke\("uiEditor:open"\)/);
+    assert.match(preload, /open:\s*\(registration\) => ipcRenderer\.invoke\("uiEditor:open",/);
     assert.match(preload, /respond:/);
     assert.doesNotMatch(preload, /uiEditorOpen|uiEditorSelectElement/);
     assert.doesNotMatch(preload, /eval|nodeIntegration\s*:\s*true|contextIsolation\s*:\s*false/);

--- a/scripts/tests/m80-1RegistrationRefresh.test.cjs
+++ b/scripts/tests/m80-1RegistrationRefresh.test.cjs
@@ -1,0 +1,239 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { EventEmitter } = require("node:events");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+const {
+  createElectronTargetContract,
+  createRegistryFingerprint,
+  validateRegistrationSnapshot,
+  LOCAL_TARGET_PROTOCOL_VERSION,
+} = require("ui-editor-kit");
+
+const ROOT = path.resolve(__dirname, "../..");
+let runtimeRegistration;
+
+class MockChild extends EventEmitter {
+  constructor() { super(); this.exitCode = null; }
+  kill() { if (this.exitCode === null) { this.exitCode = 0; this.emit("exit", 0); } return true; }
+}
+
+class MockClient extends EventEmitter {
+  constructor(child, dirty = false) { super(); this.child = child; this.connected = false; this.dirty = dirty; this.events = []; }
+  async connect() { this.connected = true; }
+  async request(action) { return { action: `${action}Accepted`, isDirty: this.dirty, dirtyElementIds: this.dirty ? ["restarbeiten.edit.short.field"] : [] }; }
+  sendEvent(action, payload = {}) { this.events.push({ action, ...payload }); if (action === "shutdownEditor") setImmediate(() => this.child.kill()); return true; }
+  async close() { this.connected = false; }
+  respond() { return true; }
+}
+
+function createFakeDocument() {
+  const createNode = (tag, doc) => {
+    const style = {
+      setProperty(name, value) { this[name] = value; },
+      getPropertyValue(name) { return this[name] || ""; },
+    };
+    const node = {
+      tagName: String(tag || "").toUpperCase(), ownerDocument: doc, children: [], parentElement: null,
+      style, dataset: {}, attributes: {}, className: "", textContent: "", disabled: false, value: "", type: "", hidden: false, isConnected: true,
+      append(...nodes) { for (const child of nodes) this.appendChild(child); },
+      appendChild(child) { if (child && typeof child === "object") child.parentElement = this; this.children.push(child); return child; },
+      replaceChildren(...nodes) { this.children = []; this.append(...nodes); },
+      remove() { if (this.parentElement) this.parentElement.children = this.parentElement.children.filter((child) => child !== this); },
+      setAttribute(name, value) { this.attributes[name] = String(value); if (name.startsWith("data-")) this.dataset[name.slice(5).replace(/-([a-z])/g, (_m, c) => c.toUpperCase())] = String(value); },
+      getAttribute(name) { return this.attributes[name] ?? null; },
+      addEventListener(type, handler) { this.listeners ||= {}; this.listeners[type] ||= []; this.listeners[type].push(handler); },
+      removeEventListener() {},
+      getBoundingClientRect() { return { left: 0, top: 0, width: Number.parseFloat(style.width) || 900, height: Number.parseFloat(style.height) || (this.className.includes("workspace__list") ? 420 : this.className.includes("workspace__edit") ? 250 : 670) }; },
+      querySelector(selector) { const match = selector.match(/^\[([^=\]]+)(?:="([^"]*)")?\]$/); return match ? find(this, (entry) => entry.getAttribute?.(match[1]) !== null && (match[2] === null || entry.getAttribute(match[1]) === match[2])) : null; },
+    };
+    node.classList = {
+      contains: (name) => node.className.split(/\s+/).includes(name),
+      toggle: (name, enabled) => { const values = new Set(node.className.split(/\s+/).filter(Boolean)); if (enabled) values.add(name); else values.delete(name); node.className = [...values].join(" "); },
+    };
+    return node;
+  };
+  const doc = { createElement: (tag) => createNode(tag, doc), createElementNS: (_ns, tag) => createNode(tag, doc), addEventListener() {}, removeEventListener() {} };
+  doc.body = createNode("body", doc); doc.head = createNode("head", doc); doc.querySelector = (selector) => doc.body.querySelector(selector);
+  return doc;
+}
+
+function find(root, predicate) {
+  if (!root) return null;
+  if (predicate(root)) return root;
+  for (const child of root.children || []) { const match = find(child, predicate); if (match) return match; }
+  return null;
+}
+
+async function runM801RegistrationRefreshTests(run) {
+  await run("M80.1 BBM: führende Registry, vollständige Restarbeiten-Refs und gesperrte Restscopes", async () => {
+    const previous = { document: global.document, window: global.window, Element: global.Element };
+    const document = createFakeDocument();
+    global.document = document;
+    global.Element = Object;
+    global.window = {
+      getComputedStyle: (element) => ({ width: element.style.width || "900px", height: element.style.height || "24px", paddingLeft: element.style.paddingLeft || "0px", paddingTop: element.style.paddingTop || "0px", fontSize: element.style.fontSize || "12px" }),
+      dispatchEvent() {}, addEventListener() {}, uiEditor: { sendTargetEvent: async () => ({ ok: true }) },
+    };
+    try {
+      const harness = await importEsmFromFile(path.join(ROOT, "scripts/tests/m80-1RuntimeHarness.mjs"));
+      const rendered = harness.renderRestarbeitenRegistration();
+      document.body.appendChild(rendered.root);
+      const registration = rendered.registration;
+      runtimeRegistration = structuredClone(registration);
+      assert.equal(registration.registryVersion, 2);
+      assert.equal(registration.registryStatus, "incomplete");
+      assert.deepEqual(registration.activeScopes, ["restarbeiten.layout.root", "restarbeiten.list.root", "restarbeiten.edit.root"]);
+      const complete = registration.registryScopes.filter((scope) => scope.status === "complete");
+      const blocked = registration.registryScopes.filter((scope) => scope.status === "blocked");
+      assert.equal(complete.length, 3);
+      assert.ok(blocked.some((scope) => scope.scopeId === "bbm.protokoll"));
+      assert.ok(blocked.some((scope) => scope.scopeId === "restarbeiten.filterbar"));
+      for (const scope of complete) {
+        assert.equal(scope.expectedElementIds.length, scope.elements.length, scope.scopeId);
+        assert.ok(scope.elements.every((entry) => entry.referenceResolved && rendered.getRef(entry.id)), scope.scopeId);
+      }
+
+      const edit = complete.find((scope) => scope.scopeId === "restarbeiten.edit.root");
+      const ids = new Set(edit.elements.map((entry) => entry.id));
+      for (const id of [
+        "restarbeiten.edit.header.current", "restarbeiten.edit.short.label", "restarbeiten.edit.short.field",
+        "restarbeiten.edit.short.remaining", "restarbeiten.edit.short.dictation", "restarbeiten.edit.class.label",
+        "restarbeiten.edit.class.control", "restarbeiten.edit.class.rest", "restarbeiten.edit.class.defect",
+        "restarbeiten.edit.action.new", "restarbeiten.edit.action.delete", "restarbeiten.edit.long.label",
+        "restarbeiten.edit.long.field", "restarbeiten.edit.location.1.label", "restarbeiten.edit.location.1.field",
+        "restarbeiten.edit.location.4.label", "restarbeiten.edit.location.4.field", "restarbeiten.edit.meta.status.label",
+        "restarbeiten.edit.meta.status.field", "restarbeiten.edit.meta.due.label", "restarbeiten.edit.meta.due.field",
+        "restarbeiten.edit.meta.ampel", "restarbeiten.edit.meta.responsible.label", "restarbeiten.edit.meta.responsible.field",
+        "restarbeiten.edit.validation", "restarbeiten.edit.action.note",
+      ]) assert.ok(ids.has(id), id);
+      for (const button of edit.elements.filter((entry) => entry.type === "button")) {
+        assert.ok(button.lockedOps.includes("executeTargetAction"), button.id);
+        assert.ok(button.lockedOps.includes("modifyDomainData"), button.id);
+      }
+      const columns = complete.find((scope) => scope.scopeId === "restarbeiten.list.root").elements.filter((entry) => entry.type === "tableColumn");
+      assert.deepEqual(columns.map((entry) => entry.name), [
+        "Nr. / Datum / Klasse / Fotos",
+        "Gegenstand – Verortung / Kurztext / Langtext",
+        "Status-Metaspalte – Fertig bis / Ampel / Status / Verantwortlich",
+      ]);
+
+      const fingerprint = createRegistryFingerprint(registration.registryScopes);
+      const contract = createElectronTargetContract({
+        applicationId: registration.applicationId, displayName: registration.displayName, appVersion: "1.5.0",
+        registryVersion: registration.registryVersion, registryFingerprint: fingerprint, registryStatus: registration.registryStatus,
+        activeScopes: registration.activeScopes, profileRoot: "C:\\m80-1-profile", supportedOperations: registration.supportedOperations,
+        transportProtocolVersion: LOCAL_TARGET_PROTOCOL_VERSION, sessionId: "m80-1-session", processId: process.pid,
+      });
+      const validation = validateRegistrationSnapshot({ contract, registryScopes: registration.registryScopes });
+      assert.equal(validation.ok, true, JSON.stringify(validation.errors));
+
+      const currentFingerprint = createRegistryFingerprint(registration.registryScopes);
+      rendered.setDiagnosticRegistryRevision(1);
+      const changedRegistration = rendered.registrationDescriptor();
+      assert.equal(changedRegistration.registryVersion, registration.registryVersion + 1);
+      assert.notEqual(createRegistryFingerprint(changedRegistration.registryScopes), currentFingerprint);
+      rendered.setDiagnosticRegistryRevision(0);
+
+      const split = rendered.request({ action: "submitChange", scopeId: "restarbeiten.layout.root", changeRequest: { changeId: "split", elementId: "restarbeiten.layout.split", operation: "resizeHeight", payload: { height: 300 } } }).changeResult;
+      assert.equal(split.success, true);
+      assert.equal(rendered.getRef("restarbeiten.layout.split").element.style["--bbm-restarbeiten-list-height"], "300px");
+      const minimum = rendered.request({ action: "submitChange", scopeId: "restarbeiten.layout.root", changeRequest: { changeId: "split-min", elementId: "restarbeiten.layout.split", operation: "resizeHeight", payload: { height: 1 } } }).changeResult;
+      assert.equal(minimum.newState.height >= 180, true);
+
+      const shortInput = rendered.getRef("restarbeiten.edit.short.field").element;
+      const fachwert = shortInput.value;
+      const defectButton = rendered.getRef("restarbeiten.edit.class.defect").element;
+      const resizeDefect = rendered.request({ action: "submitChange", scopeId: "restarbeiten.edit.root", changeRequest: { changeId: "resize-defect", elementId: "restarbeiten.edit.class.defect", operation: "resizeWidth", payload: { width: 44 } } }).changeResult;
+      assert.equal(resizeDefect.success, true);
+      assert.equal(defectButton.style.boxSizing, "border-box", "gemessene Außenbreiten werden ohne content-box-Drift angewandt");
+      assert.equal(defectButton.style.flexShrink, "0", "explizite Editorbreiten werden nicht durch Flexbox nachträglich verkleinert");
+      assert.equal(resizeDefect.newState.width, 44);
+      const hideLabel = rendered.request({ action: "submitChange", scopeId: "restarbeiten.edit.root", changeRequest: { changeId: "hide-label", elementId: "restarbeiten.edit.short.label", operation: "setVisibility", payload: { visible: false } } }).changeResult;
+      assert.equal(hideLabel.success, true);
+      assert.equal(rendered.getRef("restarbeiten.edit.short.label").element.classList.contains("bbm-ui-editor-hidden"), true);
+      assert.equal(shortInput.classList.contains("bbm-ui-editor-hidden"), false);
+      assert.equal(shortInput.value, fachwert, "Fachwert bleibt unverändert");
+    } finally {
+      global.document = previous.document; global.window = previous.window; global.Element = previous.Element;
+    }
+  });
+
+  await run("M80.1 BBM: Refresh-Bridge, Runtimeereignisse und Schutzpfade sind verdrahtet", () => {
+    const session = fs.readFileSync(path.join(ROOT, "src/main/ui-editor/electronUiEditorSession.js"), "utf8");
+    const preload = fs.readFileSync(path.join(ROOT, "src/main/preload.js"), "utf8");
+    const navigation = fs.readFileSync(path.join(ROOT, "src/renderer/app/coreShellNavigation.js"), "utf8");
+    for (const action of ["registryChanged", "registryStatusChanged", "scopeAdded", "scopeChanged", "scopeRemoved"]) {
+      assert.match(session, new RegExp(action));
+      assert.match(preload, new RegExp(action));
+    }
+    assert.match(session, /prepareRegistryRefresh/);
+    assert.match(session, /compareRegistrySnapshots/);
+    assert.match(session, /validateRegistrationSnapshot/);
+    assert.match(navigation, /UI-Registry wird geprüft/);
+    assert.doesNotMatch(session + preload + navigation, /WebSocket|https?:\/\//i);
+  });
+
+  await run("M80.1 BBM: jeder Öffnungsweg refresht, Änderung lädt neu und Dirty-Konflikt schützt", async () => {
+    assert.ok(runtimeRegistration);
+    const { ElectronUiEditorSessionController } = require("../../src/main/ui-editor/electronUiEditorSession.js");
+    const children = [];
+    const clients = [];
+    const controller = new ElectronUiEditorSessionController({
+      app: { isPackaged: false, getPath: () => "C:\\m80-1-user", getVersion: () => "1.5.0" },
+      ipcMain: { handle() {} }, getMainWindow: () => ({ isDestroyed: () => false, webContents: { send() {} } }),
+      spawnProcess: () => { const child = children.at(-1); return child; },
+      clientFactory: () => { const client = new MockClient(children.at(-1)); clients.push(client); return client; },
+      executableResolver: () => "C:\\trusted\\UiEditorManager.exe",
+      runtimeRootResolver: () => "C:\\trusted\\editor-runtime",
+      sessionIdentifiersFactory: () => ({ pipeName: `ui-editor-kit-m80-${children.length}`, sessionNonce: "x".repeat(48), sessionId: `session-${children.length}` }),
+      profileRootResolver: () => "C:\\trusted\\profiles", ensureDirectory: () => {},
+    });
+    const start = async (registration) => { children.push(new MockChild()); return controller.open(registration); };
+    const first = await start(runtimeRegistration);
+    assert.equal(first.started, true);
+    const second = await controller.open(runtimeRegistration);
+    assert.equal(second.focused, true);
+    assert.ok(clients[0].events.some((event) => event.action === "activateEditor"));
+
+    const changed = structuredClone(runtimeRegistration);
+    const scope = changed.registryScopes.find((entry) => entry.scopeId === "restarbeiten.edit.root");
+    const source = scope.elements.find((entry) => entry.id === "restarbeiten.edit.validation");
+    scope.elements.push({ ...source, id: "restarbeiten.edit.runtimeHint", name: "Runtime-Hinweis", semanticKey: "restarbeiten.edit.runtimeHint", refKey: "restarbeiten.edit.runtimeHint", order: 103 });
+    scope.expectedElementIds.push("restarbeiten.edit.runtimeHint");
+    children.push(new MockChild());
+    const refreshed = await controller.open(changed);
+    assert.equal(refreshed.ok, true);
+    assert.equal(refreshed.registryRefreshStatus, "changed");
+    assert.deepEqual(refreshed.addedElementIds, ["restarbeiten.edit.runtimeHint"]);
+    assert.equal(children[0].exitCode, 0, "alte Instanz beendet");
+    assert.equal(children[1].exitCode, null, "genau eine neue Instanz aktiv");
+
+    clients.at(-1).dirty = true;
+    const changedAgain = structuredClone(changed);
+    changedAgain.registryVersion += 1;
+    const conflict = await controller.open(changedAgain);
+    assert.equal(conflict.ok, false);
+    assert.equal(conflict.errorCode, "registry_profile_conflict");
+    assert.equal(children[1].exitCode, null, "gültiger laufender Stand bleibt erhalten");
+    await controller.shutdown();
+  });
+}
+
+module.exports = { runM801RegistrationRefreshTests };
+
+if (require.main === module) {
+  let failed = false;
+  const run = async (name, test) => {
+    try { await test(); console.log(`ok - ${name}`); }
+    catch (error) { failed = true; console.error(`not ok - ${name}`); console.error(error?.stack || error); }
+  };
+  runM801RegistrationRefreshTests(run).then(() => {
+    if (failed) process.exitCode = 1;
+  }).catch((error) => {
+    process.exitCode = 1;
+    console.error(error?.stack || error);
+  });
+}

--- a/scripts/tests/m80-1RuntimeHarness.mjs
+++ b/scripts/tests/m80-1RuntimeHarness.mjs
@@ -1,0 +1,22 @@
+import RestarbeitenScreen from "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js";
+import {
+  createM80RegistrationDescriptor,
+  handleM80EditorRequest,
+  resetM80PilotWorkingStatesForDiagnostic,
+  setM80DiagnosticRegistryRevision,
+} from "../../src/renderer/ui-editor/m80HostAdapter.js";
+import { getM80Ref } from "../../src/renderer/ui-editor/m80Refs.js";
+
+export function renderRestarbeitenRegistration() {
+  resetM80PilotWorkingStatesForDiagnostic();
+  const screen = new RestarbeitenScreen({ projectId: "m80-1-project", project: { id: "m80-1-project" } });
+  const root = screen.render();
+  return {
+    root,
+    registration: createM80RegistrationDescriptor(),
+    getRef: (id) => getM80Ref(id),
+    request: (payload) => handleM80EditorRequest(payload),
+    setDiagnosticRegistryRevision: (value) => setM80DiagnosticRegistryRevision(value),
+    registrationDescriptor: () => createM80RegistrationDescriptor(),
+  };
+}

--- a/scripts/tests/m80ElectronUiEditor.test.cjs
+++ b/scripts/tests/m80ElectronUiEditor.test.cjs
@@ -61,6 +61,18 @@ async function runM80ElectronUiEditorTests(run) {
   const registryModule = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Registry.js"));
   const scopes = registryModule.listM80RegistryScopes();
   const entries = scopes.flatMap((scope) => scope.elements);
+  const registrationScopes = scopes.map((scope) => scope.status === "complete" ? {
+    ...scope,
+    elements: scope.elements.map((entry) => ({ ...entry, referenceResolved: true })),
+  } : scope);
+  const registration = {
+    applicationId: "bbm-produktiv", displayName: "BBM", framework: "electron",
+    registryVersion: registryModule.BBM_M80_REGISTRY_VERSION, registryStatus: "incomplete",
+    activeScopes: [...registryModule.BBM_M80_ACTIVE_SCOPES],
+    supportedOperations: ["move", "resize", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility"],
+    uiCapability: "layout", pdfCapability: "unavailable", labelFieldSeparation: true, visibilityCapability: true,
+    registryScopes: registrationScopes,
+  };
 
   await run("M80 Sidebar: echte Aktion UI-Editor öffnen ist keine Screenroute", () => {
     const navigation = read("src/renderer/app/coreShellNavigation.js");
@@ -97,8 +109,9 @@ async function runM80ElectronUiEditorTests(run) {
     assert.match(main, /BBM_M80_EDITOR_DIAGNOSTIC/);
   });
 
-  await run("M80 Registry: nur zwei Restarbeiten-Pilotscopes mit eindeutigen stabilen Parents", () => {
-    assert.deepEqual(scopes.map((scope) => scope.scopeId), ["restarbeiten.list.root", "restarbeiten.edit.root"]);
+  await run("M80 Registry: drei aktive Restarbeiten-Scopes und explizit gesperrte Restbereiche", () => {
+    assert.deepEqual(scopes.filter((scope) => scope.status === "complete").map((scope) => scope.scopeId), ["restarbeiten.layout.root", "restarbeiten.list.root", "restarbeiten.edit.root"]);
+    assert.ok(scopes.some((scope) => scope.scopeId === "bbm.protokoll" && scope.status === "blocked"));
     assert.equal(new Set(entries.map((entry) => entry.id)).size, entries.length);
     const ids = new Set(entries.map((entry) => entry.id));
     entries.filter((entry) => entry.parentId).forEach((entry) => assert.ok(ids.has(entry.parentId), entry.id));
@@ -173,7 +186,7 @@ async function runM80ElectronUiEditorTests(run) {
     const handlers = new Map(); const client = new MockClient(); const child = new MockChild(); client.child = child; let spawns = 0;
     const sent = []; const mainWindow = { isDestroyed: () => false, focus() {}, webContents: { send: (...args) => sent.push(args) } };
     const controller = new ElectronUiEditorSessionController({
-      app: { isPackaged: false, getPath: () => path.join(ROOT, ".m80-test-profile") },
+      app: { isPackaged: false, getPath: () => path.join(ROOT, ".m80-test-profile"), getVersion: () => "1.5.0" },
       ipcMain: { handle: (name, fn) => handlers.set(name, fn) }, getMainWindow: () => mainWindow,
       spawnProcess: () => { spawns += 1; return child; }, clientFactory: () => client,
       executableResolver: () => "C:\\trusted\\UiEditorManager.exe", runtimeRootResolver: () => "C:\\trusted\\editor-runtime",
@@ -181,14 +194,15 @@ async function runM80ElectronUiEditorTests(run) {
       profileRootResolver: () => "C:\\trusted\\profiles", ensureDirectory: () => {},
     });
     controller.registerIpc();
-    const first = await handlers.get("uiEditor:open")(); const second = await handlers.get("uiEditor:open")();
+    const first = await handlers.get("uiEditor:open")(null, registration); const second = await handlers.get("uiEditor:open")(null, registration);
     assert.equal(first.started, true); assert.equal(second.focused, true); assert.equal(spawns, 1);
     assert.equal(client.events.filter((event) => event.action === "activateEditor").length, 1);
 
     client.emit("message", { messageType: "request", messageId: "request-0001", payload: { action: "getRegistry" } });
     assert.equal(sent.at(-1)[0], "uiEditor:request");
-    await handlers.get("uiEditor:respond")(null, { requestId: "request-0001", ok: true, payload: { registryScopes: [] } });
-    assert.equal(client.response.payload.registryScopes.length, 0);
+    await handlers.get("uiEditor:respond")(null, { requestId: "request-0001", ok: true, payload: { registryScopes: registrationScopes } });
+    assert.equal(client.response.payload.registryScopes.length, registrationScopes.length);
+    assert.match(client.response.payload.registryFingerprint, /^sha256:[a-f0-9]{64}$/);
     await controller.shutdown();
     assert.equal(child.exitCode, 0); assert.equal(controller.status().running, false);
   });

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1745,7 +1745,8 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(source.includes("window.scrollTo"), false);
     assert.equal(source.includes("scrollIntoView"), true);
     assert.equal(source.includes("data-bbm-restarbeiten-record-id"), true);
-    assert.equal(css.includes("grid-template-rows: 96px minmax(0, 1fr) 250px;"), true);
+    assert.equal(css.includes("grid-template-rows: 96px minmax(0, 1fr);"), true);
+    assert.equal(css.includes("grid-template-rows: var(--bbm-restarbeiten-list-height) minmax(160px, 1fr);"), true);
     assert.equal(css.includes(".bbm-restarbeiten-main {\n  min-height: 0;\n  overflow: auto;"), true);
     assert.equal(css.includes(".bbm-restarbeiten-screen {\n  min-height: calc(100vh - 92px);"), true);
     assert.equal(css.includes(".bbm-restarbeiten-record__number {\n  font-size: 8.5pt;\n  font-weight: 600;\n  line-height: 1.15;"), true);

--- a/scripts/tests/restarbeitenV2LegacyReadBridge.test.cjs
+++ b/scripts/tests/restarbeitenV2LegacyReadBridge.test.cjs
@@ -117,6 +117,7 @@ async function runRestarbeitenV2LegacyReadBridgeTests(run) {
     "src/main/ipc/uiEditorIpc.js",
     "src/main/main.js",
     "src/main/preload.js",
+    "src/main/ui-editor/electronUiEditorSession.js",
   ]);
   assert.equal(
     diffFiles.some((file) => file.startsWith("src/main/") && !allowedRestarbeitenMainFiles.has(file)),

--- a/scripts/tests/restarbeitenV2ReadOnlyAdapter.test.cjs
+++ b/scripts/tests/restarbeitenV2ReadOnlyAdapter.test.cjs
@@ -104,6 +104,7 @@ async function runRestarbeitenV2ReadOnlyAdapterTests(run) {
     "src/main/ipc/uiEditorIpc.js",
     "src/main/main.js",
     "src/main/preload.js",
+    "src/main/ui-editor/electronUiEditorSession.js",
   ]);
   assert.equal(
     diffFiles.some((file) => file.startsWith("src/main/") && !allowedRestarbeitenMainFiles.has(file)),

--- a/scripts/tests/restarbeitenV2ReadOnlyDataSourceFactory.test.cjs
+++ b/scripts/tests/restarbeitenV2ReadOnlyDataSourceFactory.test.cjs
@@ -126,6 +126,7 @@ async function runRestarbeitenV2ReadOnlyDataSourceFactoryTests(run) {
     "src/main/ipc/uiEditorIpc.js",
     "src/main/main.js",
     "src/main/preload.js",
+    "src/main/ui-editor/electronUiEditorSession.js",
   ]);
   assert.equal(
     diffFiles.some((file) => file.startsWith("src/main/") && !allowedRestarbeitenMainFiles.has(file)),

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -259,7 +259,7 @@ contextBridge.exposeInMainWorld("bbmDb", {
 });
 
 const UI_EDITOR_MAX_MESSAGE_BYTES = 1024 * 1024;
-const UI_EDITOR_TARGET_EVENTS = new Set(["targetSelectionChanged"]);
+const UI_EDITOR_TARGET_EVENTS = new Set(["targetSelectionChanged", "registryChanged", "registryStatusChanged", "scopeAdded", "scopeChanged", "scopeRemoved"]);
 
 function _uiEditorPayload(value, label) {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new TypeError(`${label} ist ungültig.`);
@@ -276,7 +276,7 @@ function _uiEditorListener(channel, callback) {
 
 contextBridge.exposeInMainWorld("uiEditor", Object.freeze({
   getDiagnosticMode: () => ipcRenderer.invoke("uiEditor:getDiagnosticMode"),
-  open: () => ipcRenderer.invoke("uiEditor:open"),
+  open: (registration) => ipcRenderer.invoke("uiEditor:open", _uiEditorPayload(registration, "UI-Editor-Registrierung")),
   close: () => ipcRenderer.invoke("uiEditor:close"),
   getStatus: () => ipcRenderer.invoke("uiEditor:getStatus"),
   respond: (message) => ipcRenderer.invoke("uiEditor:respond", _uiEditorPayload(message, "UI-Editor-Antwort")),

--- a/src/main/ui-editor/electronUiEditorSession.js
+++ b/src/main/ui-editor/electronUiEditorSession.js
@@ -5,21 +5,25 @@ const path = require("node:path");
 const { spawn } = require("node:child_process");
 const {
   ELECTRON_EDITOR_ERROR_CODES,
+  ELECTRON_TARGET_ADAPTER_VERSION,
   ElectronEditorError,
-  ELECTRON_TARGET_OPERATIONS,
   LOCAL_TARGET_MAX_MESSAGE_BYTES,
   LOCAL_TARGET_PROTOCOL_VERSION,
   NamedPipeTargetClient,
+  compareRegistrySnapshots,
   createElectronTargetContract,
+  createRegistryFingerprint,
   createSessionIdentifiers,
+  validateRegistrationSnapshot,
 } = require("ui-editor-kit");
 
 const APPLICATION_ID = "bbm-produktiv";
 const DISPLAY_NAME = "BBM";
-const ACTIVE_SCOPES = Object.freeze(["restarbeiten.list.root", "restarbeiten.edit.root"]);
+const ACTIVE_SCOPES = Object.freeze(["restarbeiten.layout.root", "restarbeiten.list.root", "restarbeiten.edit.root"]);
 const NATIVE_REQUEST_ACTIONS = new Set(["getRegistry", "getLayoutState", "submitChange"]);
 const NATIVE_EVENT_ACTIONS = new Set(["beginTargetSelection", "cancelTargetSelection", "highlightElement", "activateTarget", "editorClosed"]);
-const TARGET_EVENT_ACTIONS = new Set(["targetSelectionChanged"]);
+const REGISTRY_EVENT_ACTIONS = new Set(["registryChanged", "registryStatusChanged", "scopeAdded", "scopeChanged", "scopeRemoved"]);
+const TARGET_EVENT_ACTIONS = new Set(["targetSelectionChanged", ...REGISTRY_EVENT_ACTIONS]);
 const RENDERER_RESPONSE_TIMEOUT_MS = 8_000;
 
 function trustedEditorCandidates({ app, resourcesPath = process.resourcesPath, localAppData = process.env.LOCALAPPDATA } = {}) {
@@ -77,6 +81,11 @@ function publicError(error) {
     [ELECTRON_EDITOR_ERROR_CODES.EDITOR_ALREADY_RUNNING]: "Der UI-Editor läuft bereits und wird fokussiert.",
     [ELECTRON_EDITOR_ERROR_CODES.PIPE_TIMEOUT]: "Die lokale Verbindung zum UI-Editor konnte nicht rechtzeitig hergestellt werden.",
     [ELECTRON_EDITOR_ERROR_CODES.HANDSHAKE_FAILED]: "Die sichere lokale Verbindung zum UI-Editor ist fehlgeschlagen.",
+    [ELECTRON_EDITOR_ERROR_CODES.REGISTRY_REFRESH_FAILED]: "Die aktuelle UI-Registry konnte nicht sicher geladen werden. Der vorherige gültige Stand bleibt erhalten.",
+    [ELECTRON_EDITOR_ERROR_CODES.REGISTRY_SCOPE_BLOCKED]: "Für den aktuellen BBM-Bereich ist noch kein vollständiger, auflösbarer Editor-Scope verfügbar.",
+    [ELECTRON_EDITOR_ERROR_CODES.REGISTRY_INCOMPATIBLE]: "BBM-Registry und Editor-Adapter sind nicht kompatibel.",
+    [ELECTRON_EDITOR_ERROR_CODES.REGISTRY_PROFILE_CONFLICT]: "Die Registry wurde geändert, aber im Editor bestehen ungespeicherte Änderungen.",
+    [ELECTRON_EDITOR_ERROR_CODES.REGISTRY_PROFILE_MIGRATION_REQUIRED]: "Die Registryänderung benötigt wegen geänderter IDs oder Parents eine ausdrückliche Profilmigration.",
   };
   return { ok: false, errorCode: code, message: messages[code] || "Der separate UI-Editor konnte nicht gestartet werden." };
 }
@@ -101,6 +110,7 @@ class ElectronUiEditorSessionController {
     this.startPromise = null;
     this.pendingRendererRequests = new Map();
     this.heartbeat = null;
+    this.currentRegistration = null;
     this.registered = false;
     this.stopping = false;
   }
@@ -108,66 +118,130 @@ class ElectronUiEditorSessionController {
   registerIpc() {
     if (this.registered) return;
     this.registered = true;
-    this.ipcMain.handle("uiEditor:open", () => this.open());
+    this.ipcMain.handle("uiEditor:open", (_event, registration) => this.open(registration));
     this.ipcMain.handle("uiEditor:close", () => this.close());
     this.ipcMain.handle("uiEditor:getStatus", () => this.status());
     this.ipcMain.handle("uiEditor:respond", (_event, message) => this.respondFromRenderer(message));
     this.ipcMain.handle("uiEditor:targetEvent", (_event, message) => this.forwardTargetEvent(message));
   }
 
-  async open() {
-    if (this.client?.connected && this.child && this.child.exitCode === null) {
-      this.client.sendEvent("activateEditor");
-      return { ok: true, started: false, focused: true, sessionId: this.sessionId };
-    }
+  async open(registration, reason = "open") {
     if (this.startPromise) return this.startPromise;
-    this.startPromise = this.#start().catch((error) => {
-      void this.#disposeSession("editor_start_failed", true);
-      return publicError(error);
-    }).finally(() => { this.startPromise = null; });
+    this.startPromise = this.#openAfterRefresh(registration, reason)
+      .catch((error) => publicError(error))
+      .finally(() => { this.startPromise = null; });
     return this.startPromise;
   }
 
-  async #start() {
-    const executablePath = this.executableResolver({ app: this.app, ...this.pathOptions });
-    const editorRuntimeRoot = this.runtimeRootResolver(executablePath);
-    const identifiers = this.sessionIdentifiersFactory();
-    this.sessionId = identifiers.sessionId;
-    const profileRoot = this.profileRootResolver(this.app);
-    this.ensureDirectory(profileRoot);
+  #registrationSnapshot(registration, { sessionId, profileRoot }) {
+    ensureSmallPlainObject(registration, "Ziel-App-Registrierung");
+    if (registration.applicationId !== APPLICATION_ID || registration.displayName !== DISPLAY_NAME) {
+      throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.REGISTRY_INCOMPATIBLE, "Ziel-App-Kennung der Registrierung ist ungültig.");
+    }
+    const registryScopes = Array.isArray(registration.registryScopes) ? registration.registryScopes : [];
+    const activeScopes = Array.isArray(registration.activeScopes) ? registration.activeScopes.map(String) : [];
+    if (activeScopes.length === 0) {
+      throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.REGISTRY_SCOPE_BLOCKED, "Kein vollständiger Scope ist im aktuellen BBM-Bereich auflösbar.");
+    }
     const contract = createElectronTargetContract({
-      applicationId: APPLICATION_ID,
-      displayName: DISPLAY_NAME,
-      registryVersion: 1,
-      activeScopes: ACTIVE_SCOPES,
+      applicationId: registration.applicationId,
+      displayName: registration.displayName,
+      appVersion: this.app.getVersion?.() || "0.0.0-dev",
+      registryVersion: registration.registryVersion,
+      registryFingerprint: createRegistryFingerprint(registryScopes),
+      registryStatus: registration.registryStatus,
+      activeScopes,
       profileRoot,
-      supportedOperations: ELECTRON_TARGET_OPERATIONS,
+      supportedOperations: registration.supportedOperations,
       transportProtocolVersion: LOCAL_TARGET_PROTOCOL_VERSION,
-      sessionId: identifiers.sessionId,
+      sessionId,
       processId: process.pid,
     });
+    if (registration.framework !== contract.framework || registration.uiCapability !== contract.uiCapability ||
+        registration.pdfCapability !== contract.pdfCapability || registration.labelFieldSeparation !== true ||
+        registration.visibilityCapability !== true || contract.adapterVersion !== ELECTRON_TARGET_ADAPTER_VERSION) {
+      throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.REGISTRY_INCOMPATIBLE, "Ziel-App-Vertrag oder Adapter-Capabilities sind nicht kompatibel.");
+    }
+    const snapshot = { contract, registryScopes };
+    const validation = validateRegistrationSnapshot(snapshot);
+    if (!validation.ok) {
+      const first = validation.errors[0];
+      throw new ElectronEditorError(first?.code || ELECTRON_EDITOR_ERROR_CODES.REGISTRATION_FAILED, "BBM-Registry ist unvollständig oder ungültig.", validation.errors);
+    }
+    return snapshot;
+  }
+
+  async #openAfterRefresh(registration, reason) {
+    const running = Boolean(this.client?.connected && this.child && this.child.exitCode === null && this.currentRegistration);
+    if (!running) return this.#start(registration);
+    let candidate;
+    try {
+      candidate = this.#registrationSnapshot(registration, {
+        sessionId: this.currentRegistration.contract.sessionId,
+        profileRoot: this.currentRegistration.contract.profileRoot,
+      });
+    } catch (error) {
+      throw new ElectronEditorError(error?.code || ELECTRON_EDITOR_ERROR_CODES.REGISTRY_REFRESH_FAILED, error?.message || "Registry-Refresh fehlgeschlagen.");
+    }
+    const comparison = compareRegistrySnapshots(this.currentRegistration, candidate);
+    const guard = await this.client.request("prepareRegistryRefresh", {
+      reason,
+      registryVersion: candidate.contract.registryVersion,
+      registryFingerprint: candidate.contract.registryFingerprint,
+      comparison,
+    }, "prepareRegistryRefreshAccepted");
+    if (comparison.status !== "current" && guard?.isDirty === true) {
+      throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.REGISTRY_PROFILE_CONFLICT, "Ungespeicherte Editoränderungen verhindern den Registry-Refresh.");
+    }
+    if (comparison.migrationRequiredIds.length) {
+      throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.REGISTRY_PROFILE_MIGRATION_REQUIRED, "Geänderte Parents oder Bedeutungen benötigen eine Profilmigration.");
+    }
+    if (comparison.status === "current") {
+      if (reason === "open" || reason === "focus") this.client.sendEvent("activateEditor");
+      return { ok: true, started: false, focused: reason === "open" || reason === "focus", sessionId: this.sessionId, registryRefreshStatus: "current" };
+    }
+    await this.#disposeSession("registry_changed", true);
+    const result = await this.#start(registration);
+    return { ...result, registryRefreshStatus: "changed", addedElementIds: comparison.addedElementIds, removedElementIds: comparison.removedElementIds };
+  }
+
+  async #start(registration) {
+    const identifiers = this.sessionIdentifiersFactory();
+    const profileRoot = this.profileRootResolver(this.app);
+    this.ensureDirectory(profileRoot);
+    const registrationSnapshot = this.#registrationSnapshot(registration, { sessionId: identifiers.sessionId, profileRoot });
+    const contract = registrationSnapshot.contract;
+    const executablePath = this.executableResolver({ app: this.app, ...this.pathOptions });
+    const editorRuntimeRoot = this.runtimeRootResolver(executablePath);
     const args = [
       "--electron-target-editor",
       `--pipe-name=${identifiers.pipeName}`,
       `--session-nonce=${identifiers.sessionNonce}`,
-      `--application-id=${APPLICATION_ID}`,
+      `--application-id=${contract.applicationId}`,
       `--profile-root=${profileRoot}`,
       `--editor-runtime-root=${editorRuntimeRoot}`,
     ];
-    this.child = this.spawnProcess(executablePath, args, {
-      cwd: path.dirname(executablePath),
-      shell: false,
-      windowsHide: false,
-      detached: false,
-      stdio: "ignore",
-    });
-    this.child.once("exit", () => { void this.#disposeSession("editor_process_exited", false); });
-    this.child.once("error", (error) => { void this.#disposeSession(error?.code || "editor_process_error", false); });
-    this.client = await this.#connectWithRetry(identifiers, contract);
-    this.client.on("disconnect", () => { void this.#disposeSession("editor_disconnected", false); });
-    this.client.on("connectionError", (_error) => { void _error; });
-    this.#startHeartbeat();
-    return { ok: true, started: true, focused: false, sessionId: identifiers.sessionId };
+    try {
+      this.sessionId = identifiers.sessionId;
+      this.child = this.spawnProcess(executablePath, args, {
+        cwd: path.dirname(executablePath),
+        shell: false,
+        windowsHide: false,
+        detached: false,
+        stdio: "ignore",
+      });
+      this.child.once("exit", () => { void this.#disposeSession("editor_process_exited", false); });
+      this.child.once("error", (error) => { void this.#disposeSession(error?.code || "editor_process_error", false); });
+      this.client = await this.#connectWithRetry(identifiers, contract);
+      this.client.on("disconnect", () => { void this.#disposeSession("editor_disconnected", false); });
+      this.client.on("connectionError", (_error) => { void _error; });
+      this.currentRegistration = registrationSnapshot;
+      this.#startHeartbeat();
+      return { ok: true, started: true, focused: false, sessionId: identifiers.sessionId, registryRefreshStatus: "changed" };
+    } catch (error) {
+      await this.#disposeSession("editor_start_failed", true);
+      throw error;
+    }
   }
 
   async #connectWithRetry(identifiers, contract) {
@@ -231,8 +305,27 @@ class ElectronUiEditorSessionController {
     this.pendingRendererRequests.delete(requestId);
     clearTimeout(pending.timeout);
     if (message.ok === true) {
-      const payload = ensureSmallPlainObject(message.payload || {}, "Antwortpayload");
+      let payload = ensureSmallPlainObject(message.payload || {}, "Antwortpayload");
       const requestAction = String(pending.message?.payload?.action || "");
+      if (requestAction === "getRegistry") {
+        const registryScopes = Array.isArray(payload.registryScopes) ? payload.registryScopes : [];
+        const candidate = { contract: this.currentRegistration?.contract, registryScopes };
+        const validation = validateRegistrationSnapshot(candidate);
+        if (!this.currentRegistration || !validation.ok || validation.fingerprint !== this.currentRegistration.contract.registryFingerprint) {
+          this.client?.respond(pending.message, {}, {
+            code: validation.errors?.[0]?.code || ELECTRON_EDITOR_ERROR_CODES.REGISTRY_REFRESH_FAILED,
+            message: "Die Registry hat sich nach dem Preflight geändert oder ist ungültig.",
+          });
+          return { ok: false, errorCode: validation.errors?.[0]?.code || ELECTRON_EDITOR_ERROR_CODES.REGISTRY_REFRESH_FAILED };
+        }
+        payload = {
+          ...payload,
+          registryVersion: this.currentRegistration.contract.registryVersion,
+          registryFingerprint: this.currentRegistration.contract.registryFingerprint,
+          registryStatus: this.currentRegistration.contract.registryStatus,
+          activeScopes: [...this.currentRegistration.contract.activeScopes],
+        };
+      }
       console.info(`[ui-editor] renderer response: ${requestAction}`);
       this.client?.respond(pending.message, { action: `${requestAction}Accepted`, ...payload });
     }
@@ -243,14 +336,26 @@ class ElectronUiEditorSessionController {
     return { ok: true };
   }
 
-  forwardTargetEvent(message) {
+  async forwardTargetEvent(message) {
     ensureSmallPlainObject(message, "Ziel-App-Ereignis");
     if (!TARGET_EVENT_ACTIONS.has(message.action)) return { ok: false, errorCode: ELECTRON_EDITOR_ERROR_CODES.MESSAGE_INVALID };
+    if (REGISTRY_EVENT_ACTIONS.has(message.action)) {
+      const result = await this.open(message.registration, message.action);
+      if (result.ok) this.client?.sendEvent(message.action, { scopeId: String(message.scopeId || ""), registryRefreshStatus: result.registryRefreshStatus });
+      return result;
+    }
     return { ok: this.client?.sendEvent(message.action, { scopeId: String(message.scopeId || ""), elementId: String(message.elementId || "") }) === true };
   }
 
   status() {
-    return { ok: true, running: Boolean(this.client?.connected && this.child?.exitCode === null), sessionId: this.sessionId || null };
+    return {
+      ok: true,
+      running: Boolean(this.client?.connected && this.child?.exitCode === null),
+      sessionId: this.sessionId || null,
+      registryVersion: this.currentRegistration?.contract.registryVersion || null,
+      registryFingerprint: this.currentRegistration?.contract.registryFingerprint || null,
+      registryStatus: this.currentRegistration?.contract.registryStatus || "registrationRequired",
+    };
   }
 
   async close() {
@@ -282,6 +387,7 @@ class ElectronUiEditorSessionController {
     this.client = null;
     this.child = null;
     this.sessionId = null;
+    this.currentRegistration = null;
     try {
       if (stopProcess && client?.connected) client.sendEvent("shutdownEditor");
       await client?.close(reason);

--- a/src/renderer/app/coreShellNavigation.js
+++ b/src/renderer/app/coreShellNavigation.js
@@ -1,10 +1,34 @@
+import { createM80RegistrationDescriptor } from "../ui-editor/m80HostAdapter.js";
+
+function showRegistryRefreshStatus(message, state = "checking") {
+  const doc = globalThis.document;
+  if (!doc?.body || typeof doc.createElement !== "function") return;
+  let status = doc.querySelector?.("[data-bbm-ui-editor-registry-status]");
+  if (!status) {
+    status = doc.createElement("div");
+    status.setAttribute("data-bbm-ui-editor-registry-status", "true");
+    status.setAttribute("role", "status");
+    status.setAttribute("aria-live", "polite");
+    status.style.cssText = "position:fixed;right:18px;bottom:18px;z-index:2147482000;padding:9px 12px;border-radius:8px;background:#172033;color:#fff;box-shadow:0 8px 24px rgba(15,23,42,.24);font:600 12px/1.3 system-ui,sans-serif";
+    doc.body.appendChild(status);
+  }
+  status.dataset.state = state;
+  status.textContent = message;
+}
+
 export async function openNativeUiEditor() {
   const api = window.uiEditor;
   if (!api || typeof api.open !== "function") {
     alert("Der separate UI-Editor ist nicht installiert oder die sichere BBM-Brücke ist nicht verfügbar.");
     return { ok: false, errorCode: "electron_editor_not_installed" };
   }
-  const result = await api.open();
+  showRegistryRefreshStatus("UI-Registry wird geprüft …", "checking");
+  const result = await api.open(createM80RegistrationDescriptor());
+  if (result?.ok) {
+    showRegistryRefreshStatus(result.registryRefreshStatus === "changed" ? "UI-Registry aktualisiert." : "UI-Registry ist aktuell.", result.registryRefreshStatus || "current");
+  } else {
+    showRegistryRefreshStatus(result?.message || "UI-Registry konnte nicht freigegeben werden.", "blocked");
+  }
   if (!result?.ok) alert(result?.message || "Der separate UI-Editor konnte nicht gestartet werden.");
   return result;
 }

--- a/src/renderer/modules/restarbeiten/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenEditbox.js
@@ -25,9 +25,13 @@ function createField({
   onInput,
   onCommit,
   required = false,
+  editorGroupId,
+  editorLabelId,
+  editorFieldId,
 } = {}) {
   const wrap = createEl("label", { className: "bbm-restarbeiten-field", uiId });
-  wrap.appendChild(createEl("span", { text: label, uiId: labelUiId }));
+  const labelElement = createEl("span", { text: label, uiId: labelUiId });
+  wrap.appendChild(labelElement);
   const input = document.createElement(type === "textarea" ? "textarea" : type === "select" ? "select" : "input");
   if (type === "date") input.type = "date";
   if (required) input.required = true;
@@ -50,6 +54,9 @@ function createField({
     input.addEventListener("blur", () => onCommit?.(input.value));
   }
   wrap.appendChild(input);
+  if (editorGroupId) registerM80Ref(editorGroupId, wrap);
+  if (editorLabelId) registerM80Ref(editorLabelId, labelElement);
+  if (editorFieldId) registerM80Ref(editorFieldId, input);
   return wrap;
 }
 
@@ -154,6 +161,8 @@ function createTextField({
     className: "bbm-restarbeiten-remaining",
     uiId: remainingUiId,
   });
+  const labelElement = createEl("span", { text: label, uiId: labelUiId });
+  const dictation = createDictationButton(dictationUiId);
   const updateRemaining = () => {
     if (typeof maxLength !== "number") return;
     const left = Math.max(0, maxLength - String(input.value || "").length);
@@ -172,11 +181,13 @@ function createTextField({
     onInput?.(input.value);
   });
   input.addEventListener("blur", () => onCommit?.(input.value));
-  labelRow.append(createEl("span", { text: label, uiId: labelUiId }), remaining, createDictationButton(dictationUiId), ...labelControls);
+  labelRow.append(labelElement, remaining, dictation, ...labelControls);
   wrap.append(labelRow, input);
   registerM80Ref(editorGroupId, wrap);
-  registerM80Ref(editorLabelId, labelRow);
+  registerM80Ref(editorLabelId, labelElement);
   registerM80Ref(editorFieldId, input);
+  registerM80Ref(`${editorGroupId}.remaining`, remaining);
+  registerM80Ref(`${editorGroupId}.dictation`, dictation);
   return wrap;
 }
 
@@ -187,11 +198,12 @@ function createClassToggle({ value = "rest", uiId, labelUiId, onChange, onCommit
       : "bbm-restarbeiten-field bbm-restarbeiten-class-field",
     uiId,
   });
-  if (!inline || labelUiId) wrap.appendChild(createEl("span", { text: "Klasse", uiId: labelUiId }));
+  const labelElement = createEl("span", { text: "Klasse", uiId: labelUiId });
+  if (!inline || labelUiId) wrap.appendChild(labelElement);
   const classToggle = createEl("div", { className: "bbm-restarbeiten-class-toggle" });
   for (const option of [
-    { value: "rest", label: "Rest" },
-    { value: "mangel", label: "Mangel" },
+    { value: "rest", label: "Rest", editorId: "restarbeiten.edit.class.rest" },
+    { value: "mangel", label: "Mangel", editorId: "restarbeiten.edit.class.defect" },
   ]) {
     const btn = createEl("button", { className: "bbm-restarbeiten-word-switch", text: option.label });
     btn.type = "button";
@@ -202,8 +214,12 @@ function createClassToggle({ value = "rest", uiId, labelUiId, onChange, onCommit
       onCommit?.(option.value);
     });
     classToggle.appendChild(btn);
+    registerM80Ref(option.editorId, btn);
   }
   wrap.appendChild(classToggle);
+  registerM80Ref("restarbeiten.edit.class", wrap);
+  registerM80Ref("restarbeiten.edit.class.label", labelElement);
+  registerM80Ref("restarbeiten.edit.class.control", classToggle);
   return wrap;
 }
 
@@ -271,6 +287,10 @@ export function buildRestarbeitenEditbox({
   });
   actions.append(newBtn, deleteBtn);
   header.append(currentRecord);
+  registerM80Ref("restarbeiten.edit.header", header);
+  registerM80Ref("restarbeiten.edit.header.current", currentRecord);
+  registerM80Ref("restarbeiten.edit.short.actions", actions);
+  registerM80Ref("restarbeiten.edit.action.delete", deleteBtn);
 
   const classToggle = createClassToggle({
     value: draft.item_class || "rest",
@@ -330,6 +350,7 @@ export function buildRestarbeitenEditbox({
     className: "bbm-restarbeiten-edit-group bbm-restarbeiten-edit-group--stack",
     uiId: "restarbeiten.editbox.location",
   });
+  registerM80Ref("restarbeiten.edit.location", location);
   labels.forEach((label, index) => {
     const sourceKey = `location_level_${index + 1}`;
     location.appendChild(
@@ -338,6 +359,9 @@ export function buildRestarbeitenEditbox({
         labelUiId: `restarbeiten.editbox.location.level${index + 1}.label`,
         value: draft[sourceKey] || "",
         uiId: `restarbeiten.editbox.location.level${index + 1}`,
+        editorGroupId: `restarbeiten.edit.location.${index + 1}`,
+        editorLabelId: `restarbeiten.edit.location.${index + 1}.label`,
+        editorFieldId: `restarbeiten.edit.location.${index + 1}.field`,
         onInput: (value) => onDraftChange?.({ [sourceKey]: value }, { render: false }),
         onCommit: () => onAutoSave?.(),
       })
@@ -348,12 +372,14 @@ export function buildRestarbeitenEditbox({
     className: "bbm-restarbeiten-edit-group bbm-restarbeiten-edit-group--stack",
     uiId: "restarbeiten.editbox.meta",
   });
+  registerM80Ref("restarbeiten.edit.meta", meta);
   const ampelWrap = createEl("span", {
     className: "bbm-restarbeiten-ampel-field",
     uiId: "restarbeiten.editbox.meta.ampel",
   });
   ampelWrap.hidden = showAmpel === false;
   ampelWrap.style.display = showAmpel === false ? "none" : "";
+  registerM80Ref("restarbeiten.edit.meta.ampel", ampelWrap);
   const ampel = createEl("span", {
     className: "bbm-restarbeiten-ampel",
   });
@@ -365,6 +391,9 @@ export function buildRestarbeitenEditbox({
     value: draft.due_date || "",
     type: "date",
     uiId: "restarbeiten.editbox.meta.dueDate",
+    editorGroupId: "restarbeiten.edit.meta.due",
+    editorLabelId: "restarbeiten.edit.meta.due.label",
+    editorFieldId: "restarbeiten.edit.meta.due.field",
     onInput: (due_date) => onDraftChange?.({ due_date }),
     onCommit: () => onAutoSave?.(),
   });
@@ -378,6 +407,9 @@ export function buildRestarbeitenEditbox({
         ? RESTARBEITEN_STATUS_OPTIONS
         : [{ value: "", label: "Status ungueltig" }, ...RESTARBEITEN_STATUS_OPTIONS],
       uiId: "restarbeiten.editbox.meta.status",
+      editorGroupId: "restarbeiten.edit.meta.status",
+      editorLabelId: "restarbeiten.edit.meta.status.label",
+      editorFieldId: "restarbeiten.edit.meta.status.field",
       onInput: (status) => onDraftChange?.({ status }),
       onCommit: () => onAutoSave?.(),
     }),
@@ -390,6 +422,9 @@ export function buildRestarbeitenEditbox({
       type: "select",
       options: [{ value: "", label: "Nicht zugeordnet" }, ...responsibleOptions],
       uiId: "restarbeiten.editbox.meta.responsible",
+      editorGroupId: "restarbeiten.edit.meta.responsible",
+      editorLabelId: "restarbeiten.edit.meta.responsible.label",
+      editorFieldId: "restarbeiten.edit.meta.responsible.field",
       onInput: (responsible_project_firm_id) => {
         const selected = responsibleOptions.find((item) => String(item.value) === String(responsible_project_firm_id));
         onDraftChange?.({
@@ -405,6 +440,7 @@ export function buildRestarbeitenEditbox({
     text: validationText,
     uiId: "restarbeiten.editbox.validation.shortText",
   });
+  registerM80Ref("restarbeiten.edit.validation", validation);
   meta.appendChild(validation);
   const noteBtn = createEl("button", {
     className: "bbm-restarbeiten-button bbm-restarbeiten-note",
@@ -418,6 +454,7 @@ export function buildRestarbeitenEditbox({
   noteBtn.addEventListener("click", () => {
     if (draft.id) onNote?.();
   });
+  registerM80Ref("restarbeiten.edit.action.note", noteBtn);
   meta.appendChild(noteBtn);
 
   area.append(header, textArea, location, meta);

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -16,7 +16,7 @@ import { buildRestarbeitenOutputPreview } from "../RestarbeitenOutputPreview.js"
 import { buildRestarbeitenQuicklane } from "../RestarbeitenQuicklane.js";
 import { ensureRestarbeitenStyles } from "../styles.js";
 import { toRestarbeitenOutputRows } from "../viewModel/restarbeitenOutputViewModel.js";
-import { beginM80PilotRender, completeM80PilotRender } from "../../../ui-editor/m80Refs.js";
+import { beginM80PilotRender, completeM80PilotRender, registerM80SharedVerticalLayout } from "../../../ui-editor/m80Refs.js";
 import {
   canPersistRestarbeitDraft,
   normalizeRestarbeitStatus,
@@ -526,8 +526,7 @@ export default class RestarbeitenScreen {
       }))
       .filter((entry) => entry.value && entry.label);
 
-    this.root.append(
-      buildRestarbeitenQuicklane({
+    const quicklane = buildRestarbeitenQuicklane({
         pinned: this.quicklanePinned,
         showAmpel: this.showAmpelInList,
         showLongtext: this.showLongtextInList,
@@ -544,8 +543,8 @@ export default class RestarbeitenScreen {
         onAmpelToggle: () => this.toggleAmpelDisplay(),
         onLongtextToggle: () => this.toggleLongtextDisplay(),
         onPreview: () => this.openRestarbeitenPreview(),
-      }),
-      buildRestarbeitenFilterbar({
+      });
+    const filterbar = buildRestarbeitenFilterbar({
         settings: this.settings,
         filters: this.filters,
         filterOptions: this._buildFilterOptions(),
@@ -554,37 +553,46 @@ export default class RestarbeitenScreen {
           this._renderShell();
         },
         onClose: () => this.router?.showProjectWorkspace?.(this.projectId, { project: this.project }),
-      }),
-      this.outputPreviewOpen
-        ? buildRestarbeitenOutputPreview({
+      });
+    this.root.append(quicklane, filterbar);
+
+    if (this.outputPreviewOpen) {
+      this.root.appendChild(buildRestarbeitenOutputPreview({
             items: toRestarbeitenOutputRows(filteredRows),
             projectName: normalizeText(this.project?.name || this.project?.project_name || this.project?.title),
             onClose: () => this.closeRestarbeitenPreview(),
-          })
-        : buildRestarbeitenMainBody({
-            items: this.viewItems,
-            selectedId: this.selectedId,
-            showAmpel: this.showAmpelInList,
-            showLongtext: this.showLongtextInList,
-            onSelect: (id) => this._selectItem(id),
-            onPhotos: (id) => this.openRestarbeitPhotos(id),
-          })
-    );
-
-    if (!this.outputPreviewOpen) {
-      this.root.appendChild(
-        buildRestarbeitenEditbox({
-          settings: this.settings,
-          draft: this.draft,
-          showAmpel: this.showAmpelInList,
-          responsibleOptions,
-          onNew: () => this._newDraft(),
-          onDraftChange: (patch, options) => this._updateDraft(patch, options),
-          onDelete: () => this._deleteDraft().catch((err) => this._setStubMessage(err?.message || String(err))),
-          onNote: () => this._openNotesPopup().catch((err) => this._setStubMessage(err?.message || String(err))),
-          onAutoSave: () => this._autoSaveDraft().catch((err) => this._setStubMessage(err?.message || String(err))),
-        })
-      );
+          }));
+    } else {
+      const main = buildRestarbeitenMainBody({
+        items: this.viewItems,
+        selectedId: this.selectedId,
+        showAmpel: this.showAmpelInList,
+        showLongtext: this.showLongtextInList,
+        onSelect: (id) => this._selectItem(id),
+        onPhotos: (id) => this.openRestarbeitPhotos(id),
+      });
+      const editbox = buildRestarbeitenEditbox({
+        settings: this.settings,
+        draft: this.draft,
+        showAmpel: this.showAmpelInList,
+        responsibleOptions,
+        onNew: () => this._newDraft(),
+        onDraftChange: (patch, options) => this._updateDraft(patch, options),
+        onDelete: () => this._deleteDraft().catch((err) => this._setStubMessage(err?.message || String(err))),
+        onNote: () => this._openNotesPopup().catch((err) => this._setStubMessage(err?.message || String(err))),
+        onAutoSave: () => this._autoSaveDraft().catch((err) => this._setStubMessage(err?.message || String(err))),
+      });
+      const workspace = document.createElement("div");
+      workspace.className = "bbm-restarbeiten-workspace";
+      const listPane = document.createElement("div");
+      listPane.className = "bbm-restarbeiten-workspace__list";
+      const editPane = document.createElement("div");
+      editPane.className = "bbm-restarbeiten-workspace__edit";
+      listPane.appendChild(main);
+      editPane.appendChild(editbox);
+      workspace.append(listPane, editPane);
+      registerM80SharedVerticalLayout({ scopeRoot: this.root, root: workspace, listPane, editPane });
+      this.root.appendChild(workspace);
     }
 
     if (this.isLoading || this.error) {

--- a/src/renderer/modules/restarbeiten/styles/restarbeiten.css
+++ b/src/renderer/modules/restarbeiten/styles/restarbeiten.css
@@ -31,12 +31,33 @@
   height: calc(100vh - 92px);
   position: relative;
   display: grid;
-  grid-template-rows: 96px minmax(0, 1fr) 250px;
+  grid-template-rows: 96px minmax(0, 1fr);
   background: var(--bbm-bg);
   color: var(--bbm-text);
   font-family: var(--bbm-rest-font-family);
   line-height: var(--bbm-rest-line-height);
   overflow: hidden;
+}
+
+.bbm-restarbeiten-workspace {
+  --bbm-restarbeiten-list-height: minmax(180px, 1.6fr);
+  min-height: 0;
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: var(--bbm-restarbeiten-list-height) minmax(160px, 1fr);
+}
+
+.bbm-restarbeiten-workspace__list,
+.bbm-restarbeiten-workspace__edit {
+  min-width: 320px;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.bbm-restarbeiten-workspace__list > .bbm-restarbeiten-main,
+.bbm-restarbeiten-workspace__edit > .bbm-restarbeiten-editbox {
+  width: auto;
+  height: 100%;
 }
 
 .bbm-restarbeiten-screen[data-output-preview="true"] {
@@ -613,7 +634,7 @@
   padding: 9px 10px;
   box-sizing: border-box;
   min-height: 0;
-  max-height: 226px;
+  max-height: none;
   overflow: hidden;
   display: grid;
   grid-template-columns: minmax(260px, 1fr) 98px 98px;

--- a/src/renderer/ui-editor/m80Diagnostic.js
+++ b/src/renderer/ui-editor/m80Diagnostic.js
@@ -1,5 +1,6 @@
 import RestarbeitenScreen from "../modules/restarbeiten/screens/RestarbeitenScreen.js";
 import { getM80Ref, resetM80PilotWorkingStatesForDiagnostic } from "./m80Refs.js";
+import { advanceM80DiagnosticRegistryRevision } from "./m80HostAdapter.js";
 
 const DIAGNOSTIC_FAILURE_TARGET = "restarbeiten.edit.short.field";
 
@@ -45,6 +46,13 @@ export function installBbmM80DiagnosticPilot({ router } = {}) {
     ref.element.dataset.uiEditorFailNextApply = "true";
     window.removeEventListener("keydown", onControlledFailureKey);
   };
+  const onRegistryRevisionKey = (event) => {
+    if (!(event.ctrlKey && event.shiftKey && (event.code === "F9" || event.key === "F9"))) return;
+    event.preventDefault();
+    const revision = advanceM80DiagnosticRegistryRevision();
+    screen.root.dataset.bbmM80DiagnosticRegistryRevision = String(revision);
+  };
   window.addEventListener("keydown", onControlledFailureKey);
+  window.addEventListener("keydown", onRegistryRevisionKey);
   return screen;
 }

--- a/src/renderer/ui-editor/m80HostAdapter.js
+++ b/src/renderer/ui-editor/m80HostAdapter.js
@@ -1,10 +1,17 @@
-import { getM80RegistryEntry, listM80RegistryScopes } from "./m80Registry.js";
+import {
+  BBM_M80_ACTIVE_SCOPES,
+  BBM_M80_REGISTRY_STATUS,
+  BBM_M80_REGISTRY_VERSION,
+  getM80RegistryEntry,
+  listM80RegistryScopes,
+} from "./m80Registry.js";
 import {
   applyM80State,
   beginM80PilotRender,
   clearM80VisualState,
   completeM80PilotRender,
   getM80IdFromTarget,
+  getM80ReferenceStatus,
   getM80Ref,
   registerM80Ref,
   resetM80PilotWorkingStatesForDiagnostic,
@@ -12,9 +19,11 @@ import {
 } from "./m80Refs.js";
 
 const ALLOWED_ACTIONS = new Set(["getRegistry", "getLayoutState", "submitChange"]);
+const REGISTRY_EVENT_ACTIONS = new Set(["registryChanged", "registryStatusChanged", "scopeAdded", "scopeChanged", "scopeRemoved"]);
 const FORBIDDEN_KEYS = new Set(["fachDaten", "businessData", "domainData", "recordId", "entity", "database", "sql", "status", "responsible", "dueDate", "photos", "rows", "values"]);
 let selectionMode = false;
 let selectedId = null;
+let diagnosticRegistryRevision = 0;
 
 function hasForbidden(value) {
   if (Array.isArray(value)) return value.some(hasForbidden);
@@ -97,11 +106,69 @@ function belongsToScope(entry, scopeId) {
 }
 
 function layoutPayload() {
-  return listM80RegistryScopes().map((scope) => ({
+  return createM80RegistrationDescriptor().activeScopes.map((scopeId) => listM80RegistryScopes().find((scope) => scope.scopeId === scopeId)).filter(Boolean).map((scope) => ({
     scopeId: scope.scopeId,
     capturedAt: new Date().toISOString(),
     elements: scope.elements.map((entry) => snapshotM80State(entry.id)).filter(Boolean),
   }));
+}
+
+export function createM80RegistrationDescriptor() {
+  const registryScopes = listM80RegistryScopes().map((scope) => {
+    if (scope.status !== "complete") return scope;
+    const elements = scope.elements.map((entry) => {
+      const resolved = { ...entry, ...getM80ReferenceStatus(entry.id) };
+      if (diagnosticRegistryRevision > 0 && entry.id === "restarbeiten.edit.validation") {
+        return {
+          ...resolved,
+          baseline: {
+            ...resolved.baseline,
+            maxWidth: Number(resolved.baseline?.maxWidth || 1200) + diagnosticRegistryRevision,
+          },
+        };
+      }
+      return resolved;
+    });
+    const referenceComplete = elements.every((entry) => entry.referenceResolved === true);
+    return {
+      ...scope,
+      status: referenceComplete ? "complete" : "blocked",
+      reason: referenceComplete ? null : "registry_reference_missing",
+      elements,
+    };
+  });
+  const activeScopes = BBM_M80_ACTIVE_SCOPES.filter((scopeId) => registryScopes.some((scope) => scope.scopeId === scopeId && scope.status === "complete"));
+  return {
+    applicationId: "bbm-produktiv",
+    displayName: "BBM",
+    framework: "electron",
+    registryVersion: BBM_M80_REGISTRY_VERSION + diagnosticRegistryRevision,
+    registryStatus: BBM_M80_REGISTRY_STATUS,
+    activeScopes,
+    supportedOperations: ["move", "resize", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility"],
+    uiCapability: "layout",
+    pdfCapability: "unavailable",
+    labelFieldSeparation: true,
+    visibilityCapability: true,
+    registryScopes,
+  };
+}
+
+export function setM80DiagnosticRegistryRevision(value) {
+  const revision = Number(value);
+  if (!Number.isInteger(revision) || revision < 0) throw new Error("Ungültige Diagnose-Registryrevision.");
+  diagnosticRegistryRevision = revision;
+  return diagnosticRegistryRevision;
+}
+
+export function advanceM80DiagnosticRegistryRevision() {
+  diagnosticRegistryRevision += 1;
+  return diagnosticRegistryRevision;
+}
+
+export async function emitM80RegistryEvent(action, scopeId = "") {
+  if (!REGISTRY_EVENT_ACTIONS.has(action)) throw Object.assign(new Error("Unbekanntes Registryereignis."), { code: "electron_editor_message_invalid" });
+  return window.uiEditor?.sendTargetEvent?.({ action, scopeId: String(scopeId || ""), registration: createM80RegistrationDescriptor() });
 }
 
 function overlay() {
@@ -150,7 +217,15 @@ export function handleM80EditorEvent(event = {}) {
 export function handleM80EditorRequest(request = {}) {
   const action = String(request.action || "");
   if (!ALLOWED_ACTIONS.has(action)) throw Object.assign(new Error("Unbekannte Editoranfrage."), { code: "electron_editor_message_invalid" });
-  if (action === "getRegistry") return { registryScopes: listM80RegistryScopes() };
+  if (action === "getRegistry") {
+    const registration = createM80RegistrationDescriptor();
+    return {
+      registryVersion: registration.registryVersion,
+      registryStatus: registration.registryStatus,
+      activeScopes: registration.activeScopes,
+      registryScopes: registration.registryScopes,
+    };
+  }
   if (action === "getLayoutState") return { scopeStates: layoutPayload() };
   return { changeResult: submitChange(request.changeRequest, request.scopeId) };
 }

--- a/src/renderer/ui-editor/m80Refs.js
+++ b/src/renderer/ui-editor/m80Refs.js
@@ -7,6 +7,7 @@ const HIDDEN_CLASS = "bbm-ui-editor-hidden";
 
 function finite(value, fallback = 0) { return Number.isFinite(Number(value)) ? Number(value) : fallback; }
 function positive(value, fallback) { const number = finite(value, fallback); return number > 0 ? number : fallback; }
+function clamp(value, minimum, maximum) { return Math.min(maximum, Math.max(minimum, value)); }
 function px(value) { return `${Math.round(Number(value) * 1000) / 1000}px`; }
 function isElementRef(value) { return Boolean(value) && typeof value.setAttribute === "function"; }
 function rectOf(element) { return typeof element.getBoundingClientRect === "function" ? element.getBoundingClientRect() : { left: 0, top: 0, width: finite(parseFloat(element.style?.width)), height: finite(parseFloat(element.style?.height)) }; }
@@ -40,12 +41,20 @@ function readGeneric(element, id) {
   };
 }
 
-function applyGeneric(element, state) {
+function bounded(entry, field, value, fallback) {
+  const baseline = entry?.baseline || {};
+  const capitalized = field[0].toUpperCase() + field.slice(1);
+  return clamp(positive(value, fallback), positive(baseline[`min${capitalized}`], 1), positive(baseline[`max${capitalized}`], Number.MAX_SAFE_INTEGER));
+}
+
+function applyGeneric(element, state, entry) {
   element.dataset.uiEditorX = String(finite(state.x));
   element.dataset.uiEditorY = String(finite(state.y));
   element.style.translate = `${px(state.x)} ${px(state.y)}`;
-  element.style.width = px(positive(state.width, 1));
-  element.style.height = px(positive(state.height, 1));
+  element.style.boxSizing = "border-box";
+  element.style.flexShrink = "0";
+  element.style.width = px(bounded(entry, "width", state.width, 1));
+  element.style.height = px(bounded(entry, "height", state.height, 1));
   if (state.textOffsetX !== null && state.textOffsetX !== undefined) { element.dataset.uiEditorTextX = String(state.textOffsetX); element.style.paddingLeft = px(Math.max(0, finite(state.textOffsetX))); }
   if (state.textOffsetY !== null && state.textOffsetY !== undefined) { element.dataset.uiEditorTextY = String(state.textOffsetY); element.style.paddingTop = px(Math.max(0, finite(state.textOffsetY))); }
   if (state.fontSize !== null && state.fontSize !== undefined) element.style.fontSize = px(positive(state.fontSize, 1));
@@ -70,7 +79,7 @@ export function registerM80Ref(id, element, custom = {}) {
     entry,
     element,
     read: custom.read || (() => readGeneric(element, id)),
-    apply: custom.apply || ((state) => applyGeneric(element, state)),
+    apply: custom.apply || ((state) => applyGeneric(element, state, entry)),
   };
   refs.set(id, ref);
   elementIds.set(element, id);
@@ -88,6 +97,7 @@ export function completeM80PilotRender() {
 }
 
 export function registerM80TableColumnRef(id, headerCell, tableElement, cssVariable, initialWidth) {
+  const entry = getM80RegistryEntry(id);
   return registerM80Ref(id, headerCell, {
     read: () => {
       const style = styleOf(headerCell);
@@ -101,7 +111,7 @@ export function registerM80TableColumnRef(id, headerCell, tableElement, cssVaria
       };
     },
     apply: (state) => {
-      setCustomProperty(tableElement.style, cssVariable, px(positive(state.width, initialWidth)));
+      setCustomProperty(tableElement.style, cssVariable, px(bounded(entry, "width", state.width, initialWidth)));
       headerCell.dataset.uiEditorTextX = String(finite(state.textOffsetX));
       headerCell.dataset.uiEditorTextY = String(finite(state.textOffsetY));
       headerCell.style.paddingLeft = px(Math.max(0, finite(state.textOffsetX)));
@@ -111,6 +121,33 @@ export function registerM80TableColumnRef(id, headerCell, tableElement, cssVaria
       toggleClass(headerCell, HIDDEN_CLASS, state.visible === false);
     },
   });
+}
+
+export function registerM80SharedVerticalLayout({ scopeRoot, root, listPane, editPane, minimumListHeight = 180, minimumEditHeight = 160 } = {}) {
+  if (!isElementRef(scopeRoot) || !isElementRef(root) || !isElementRef(listPane) || !isElementRef(editPane)) throw new Error("M80-Hauptlayoutreferenzen fehlen.");
+  const splitHeight = () => positive(rectOf(listPane).height, 420);
+  const availableHeight = () => positive(rectOf(root).height, splitHeight() + positive(rectOf(editPane).height, 250));
+  const applySplit = (requestedHeight) => {
+    const available = availableHeight();
+    const maximumListHeight = Math.max(minimumListHeight, available - minimumEditHeight);
+    setCustomProperty(root.style, "--bbm-restarbeiten-list-height", px(clamp(positive(requestedHeight, splitHeight()), minimumListHeight, maximumListHeight)));
+  };
+  registerM80Ref("restarbeiten.layout.root", scopeRoot);
+  registerM80Ref("restarbeiten.layout.split", root, {
+    read: () => ({
+      elementId: "restarbeiten.layout.split", x: 0, y: 0,
+      width: positive(rectOf(root).width, 900), height: splitHeight(),
+      textOffsetX: 0, textOffsetY: 0, fontSize: 12,
+      visible: !hasClass(root, HIDDEN_CLASS),
+    }),
+    apply: (state) => {
+      applySplit(state.height);
+      toggleClass(root, HIDDEN_CLASS, state.visible === false);
+    },
+  });
+  registerM80Ref("restarbeiten.layout.list", listPane);
+  registerM80Ref("restarbeiten.layout.edit", editPane);
+  return root;
 }
 
 export function getM80Ref(id) { return refs.get(String(id || "")) || null; }
@@ -145,6 +182,10 @@ export function listM80CurrentStates(scopeId) {
       while (entry && entry.parentId) entry = getM80RegistryEntry(entry.parentId);
       return entry?.id === scopeId;
     }).map((ref) => readM80State(ref.id));
+}
+export function getM80ReferenceStatus(id) {
+  const ref = getM80Ref(id);
+  return { refKey: String(id || ""), referenceResolved: Boolean(ref && (typeof ref.element.isConnected !== "boolean" || ref.element.isConnected)) };
 }
 export function clearM80VisualState() {
   document.querySelector("[data-bbm-ui-editor-overlay]")?.remove();

--- a/src/renderer/ui-editor/m80Registry.js
+++ b/src/renderer/ui-editor/m80Registry.js
@@ -1,49 +1,160 @@
-const POSITION_SIZE_VISIBILITY = Object.freeze(["move", "resizeWidth", "resizeHeight", "setVisibility"]);
+export const BBM_M80_REGISTRY_VERSION = 2;
+export const BBM_M80_REGISTRY_STATUS = "incomplete";
+
+const CONTAINER_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "setVisibility"]);
+const PANE_LAYOUT = Object.freeze(["resizeWidth", "setVisibility"]);
 const TEXT_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility"]);
 const TABLE_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility"]);
 const COLUMN_LAYOUT = Object.freeze(["resizeWidth", "textMove", "textResize", "setVisibility"]);
+const SPLIT_LAYOUT = Object.freeze(["resizeHeight", "setVisibility"]);
 const DOMAIN_LOCKS = Object.freeze(["executeTargetAction", "modifyDomainData", "createRecord", "deleteRecord"]);
 
+function defaultBaseline(values = {}) {
+  return Object.freeze({
+    x: 0, y: 0, width: 100, height: 24, textOffsetX: 0, textOffsetY: 0,
+    fontSize: 12, visible: true, minWidth: 24, maxWidth: 2400, minHeight: 18, maxHeight: 1600,
+    ...values,
+  });
+}
+
 function element(values) {
-  return Object.freeze({ visible: true, editable: true, ...values,
-    allowedOps: Object.freeze([...(values.allowedOps || [])]),
+  const allowedOps = Object.freeze([...(values.allowedOps || [])]);
+  return Object.freeze({
+    visible: true,
+    editable: allowedOps.length > 0,
+    ...values,
+    semanticKey: values.semanticKey || values.id,
+    registrationStatus: values.registrationStatus || (allowedOps.length > 0 ? "editorEnabled" : "editorContainer"),
+    refKey: values.refKey || values.id,
+    baseline: defaultBaseline(values.baseline),
+    allowedOps,
     lockedOps: Object.freeze([...(values.lockedOps || [])]),
   });
 }
 
-const listElements = Object.freeze([
-  element({ id: "restarbeiten.list.root", name: "Restarbeiten · Liste", type: "root", role: "scopeRoot", parentId: null, order: 0, editable: false, allowedOps: [], componentKind: "scope" }),
-  element({ id: "restarbeiten.list.area", name: "Listenbereich", type: "area", role: "contentArea", parentId: "restarbeiten.list.root", order: 10, allowedOps: POSITION_SIZE_VISIBILITY, componentKind: "contentArea" }),
-  element({ id: "restarbeiten.list.paper", name: "Listenblatt", type: "group", role: "layoutGroup", parentId: "restarbeiten.list.area", order: 20, allowedOps: POSITION_SIZE_VISIBILITY, componentKind: "paper" }),
-  element({ id: "restarbeiten.list.table", name: "Restarbeiten-Hauptliste", type: "table", role: "contentTable", parentId: "restarbeiten.list.paper", order: 30, allowedOps: TABLE_LAYOUT, componentKind: "contentTable" }),
-  element({ id: "restarbeiten.list.table.number", name: "Nr. / Datum / Klasse / Fotos", type: "tableColumn", role: "contentColumn", parentId: "restarbeiten.list.table", order: 31, allowedOps: COLUMN_LAYOUT, columnRole: "contentColumn", width: 82, minWidth: 50, maxWidth: 240 }),
-  element({ id: "restarbeiten.list.table.subject", name: "Gegenstand – Verortung / Kurztext / Langtext", type: "tableColumn", role: "contentColumn", parentId: "restarbeiten.list.table", order: 32, allowedOps: COLUMN_LAYOUT, columnRole: "contentColumn", width: 600, minWidth: 160, maxWidth: 1200 }),
-  element({ id: "restarbeiten.list.table.meta", name: "Status-Metaspalte – Fertig bis / Ampel / Status / Verantwortlich", type: "tableColumn", role: "metaColumn", parentId: "restarbeiten.list.table", order: 33, allowedOps: COLUMN_LAYOUT, columnRole: "metaColumn", width: 172, minWidth: 110, maxWidth: 420 }),
-]);
+function domainButton(values) {
+  return element({ ...values, type: "button", role: "domainActionLayout", allowedOps: TEXT_LAYOUT, lockedOps: DOMAIN_LOCKS, actionKind: values.actionKind || "domain" });
+}
 
-const editElements = Object.freeze([
-  element({ id: "restarbeiten.edit.root", name: "Restarbeiten · Bearbeitung", type: "root", role: "scopeRoot", parentId: null, order: 0, editable: false, allowedOps: [], componentKind: "scope" }),
-  element({ id: "restarbeiten.edit.area", name: "Bearbeitungsbereich", type: "area", role: "formArea", parentId: "restarbeiten.edit.root", order: 10, allowedOps: POSITION_SIZE_VISIBILITY, componentKind: "formArea" }),
-  element({ id: "restarbeiten.edit.fields", name: "Textfelder", type: "group", role: "fieldCollection", parentId: "restarbeiten.edit.area", order: 20, allowedOps: POSITION_SIZE_VISIBILITY, componentKind: "fieldCollection" }),
-  element({ id: "restarbeiten.edit.short", name: "Kurztext-Feldgruppe", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.fields", order: 30, allowedOps: POSITION_SIZE_VISIBILITY, componentKind: "fieldGroup" }),
-  element({ id: "restarbeiten.edit.short.label", name: "Kurztext / Gegenstand · Bezeichnung", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.short", order: 31, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "restarbeiten.edit.short.field", name: "Kurztext / Gegenstand · Feld", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.short", order: 32, allowedOps: TEXT_LAYOUT, fieldKind: "text", componentKind: "input" }),
-  element({ id: "restarbeiten.edit.long", name: "Langtext-Feldgruppe", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.fields", order: 40, allowedOps: POSITION_SIZE_VISIBILITY, componentKind: "fieldGroup" }),
-  element({ id: "restarbeiten.edit.long.label", name: "Langtext / Beschreibung · Bezeichnung", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.long", order: 41, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "restarbeiten.edit.long.field", name: "Langtext / Beschreibung · Feld", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.long", order: 42, allowedOps: TEXT_LAYOUT, fieldKind: "multilineText", componentKind: "textarea" }),
-  element({ id: "restarbeiten.edit.action.new", name: "Neu", type: "button", role: "domainActionLayout", parentId: "restarbeiten.edit.area", order: 50, allowedOps: TEXT_LAYOUT, lockedOps: DOMAIN_LOCKS, actionKind: "domainCreate", componentKind: "button" }),
+function completeScope(scopeId, elements) {
+  return Object.freeze({
+    scopeId,
+    status: "complete",
+    inventoryStatus: "complete",
+    expectedElementIds: Object.freeze(elements.map((entry) => entry.id)),
+    elements: Object.freeze(elements),
+  });
+}
+
+function blockedScope(scopeId, name, reason = "registration_inventory_pending") {
+  return Object.freeze({
+    scopeId,
+    name,
+    status: "blocked",
+    inventoryStatus: "notInventoried",
+    expectedElementIds: Object.freeze([]),
+    elements: Object.freeze([]),
+    reason,
+  });
+}
+
+const layoutElements = [
+  element({ id: "restarbeiten.layout.root", name: "Restarbeiten · Hauptlayout", type: "root", role: "scopeRoot", parentId: null, order: 0, editable: false, allowedOps: [], componentKind: "scope", baseline: { width: 900, height: 670, minHeight: 340, maxHeight: 1600 } }),
+  element({ id: "restarbeiten.layout.split", name: "Restarbeiten · Verhältnis Hauptliste/Editbox", type: "area", role: "layout", parentId: "restarbeiten.layout.root", order: 10, allowedOps: SPLIT_LAYOUT, componentKind: "verticalSplit", baseline: { width: 900, height: 420, minHeight: 180, maxHeight: 1200 } }),
+  element({ id: "restarbeiten.layout.list", name: "Restarbeiten · Hauptlistenbereich", type: "area", role: "layout", parentId: "restarbeiten.layout.split", order: 20, allowedOps: PANE_LAYOUT, componentKind: "splitPane", baseline: { width: 900, height: 420, minWidth: 320, minHeight: 180 } }),
+  element({ id: "restarbeiten.layout.edit", name: "Restarbeiten · Editboxbereich", type: "area", role: "layout", parentId: "restarbeiten.layout.split", order: 30, allowedOps: PANE_LAYOUT, componentKind: "splitPane", baseline: { width: 900, height: 250, minWidth: 320, minHeight: 160 } }),
+];
+
+const listElements = [
+  element({ id: "restarbeiten.list.root", name: "Restarbeiten · Liste", type: "root", role: "scopeRoot", parentId: null, order: 0, editable: false, allowedOps: [], componentKind: "scope" }),
+  element({ id: "restarbeiten.list.area", name: "Listenbereich", type: "area", role: "contentArea", parentId: "restarbeiten.list.root", order: 10, allowedOps: CONTAINER_LAYOUT, componentKind: "contentArea", baseline: { width: 900, height: 420, minWidth: 320, minHeight: 180 } }),
+  element({ id: "restarbeiten.list.paper", name: "Listenblatt", type: "group", role: "layoutGroup", parentId: "restarbeiten.list.area", order: 20, allowedOps: CONTAINER_LAYOUT, componentKind: "paper", baseline: { width: 900, height: 720, minWidth: 320, minHeight: 240 } }),
+  element({ id: "restarbeiten.list.table", name: "Restarbeiten-Hauptliste", type: "table", role: "contentTable", parentId: "restarbeiten.list.paper", order: 30, allowedOps: TABLE_LAYOUT, componentKind: "contentTable", baseline: { width: 858, height: 680, minWidth: 320, minHeight: 160 } }),
+  element({ id: "restarbeiten.list.table.number", name: "Nr. / Datum / Klasse / Fotos", type: "tableColumn", role: "contentColumn", parentId: "restarbeiten.list.table", order: 31, allowedOps: COLUMN_LAYOUT, columnRole: "contentColumn", baseline: { width: 82, height: 28, minWidth: 50, maxWidth: 240 } }),
+  element({ id: "restarbeiten.list.table.subject", name: "Gegenstand – Verortung / Kurztext / Langtext", type: "tableColumn", role: "contentColumn", parentId: "restarbeiten.list.table", order: 32, allowedOps: COLUMN_LAYOUT, columnRole: "contentColumn", baseline: { width: 600, height: 28, minWidth: 160, maxWidth: 1200 } }),
+  element({ id: "restarbeiten.list.table.meta", name: "Status-Metaspalte – Fertig bis / Ampel / Status / Verantwortlich", type: "tableColumn", role: "metaColumn", parentId: "restarbeiten.list.table", order: 33, allowedOps: COLUMN_LAYOUT, columnRole: "metaColumn", baseline: { width: 172, height: 28, minWidth: 110, maxWidth: 420 } }),
+];
+
+const editElements = [
+  element({ id: "restarbeiten.edit.root", name: "Restarbeiten · Bearbeitung", type: "root", role: "scopeRoot", parentId: null, order: 0, editable: false, allowedOps: [], componentKind: "scope", baseline: { width: 900, height: 250, minWidth: 320, minHeight: 160 } }),
+  element({ id: "restarbeiten.edit.area", name: "Bearbeitungsbereich", type: "area", role: "formArea", parentId: "restarbeiten.edit.root", order: 10, allowedOps: CONTAINER_LAYOUT, componentKind: "formArea", baseline: { width: 878, height: 226, minWidth: 300, minHeight: 140 } }),
+  element({ id: "restarbeiten.edit.header", name: "Editbox-Kopf", type: "group", role: "layoutGroup", parentId: "restarbeiten.edit.area", order: 20, allowedOps: CONTAINER_LAYOUT, componentKind: "header" }),
+  element({ id: "restarbeiten.edit.header.current", name: "Aktueller Datensatz", type: "label", role: "status", parentId: "restarbeiten.edit.header", order: 21, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "restarbeiten.edit.fields", name: "Textfelder", type: "group", role: "fieldCollection", parentId: "restarbeiten.edit.area", order: 30, allowedOps: CONTAINER_LAYOUT, componentKind: "fieldCollection" }),
+  element({ id: "restarbeiten.edit.short", name: "Kurztext-Feldgruppe", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.fields", order: 40, allowedOps: CONTAINER_LAYOUT, componentKind: "fieldGroup" }),
+  element({ id: "restarbeiten.edit.short.label", name: "Kurztext / Gegenstand · Bezeichnung", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.short", order: 41, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "restarbeiten.edit.short.remaining", name: "Restzeichen Kurztext", type: "label", role: "status", parentId: "restarbeiten.edit.short", order: 42, allowedOps: TEXT_LAYOUT, componentKind: "counter" }),
+  domainButton({ id: "restarbeiten.edit.short.dictation", name: "Diktat Kurztext", parentId: "restarbeiten.edit.short", order: 43, actionKind: "domainDictation" }),
+  element({ id: "restarbeiten.edit.class", name: "Klasse", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.short", order: 44, allowedOps: CONTAINER_LAYOUT, componentKind: "choiceField" }),
+  element({ id: "restarbeiten.edit.class.label", name: "Klasse · Bezeichnung", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.class", order: 45, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "restarbeiten.edit.class.control", name: "Klasse · Auswahl", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.class", order: 46, allowedOps: TEXT_LAYOUT, fieldKind: "buttonChoice", componentKind: "choice" }),
+  domainButton({ id: "restarbeiten.edit.class.rest", name: "Klasse Rest", parentId: "restarbeiten.edit.class.control", order: 47, actionKind: "domainSelection" }),
+  domainButton({ id: "restarbeiten.edit.class.defect", name: "Klasse Mangel", parentId: "restarbeiten.edit.class.control", order: 48, actionKind: "domainSelection" }),
+  element({ id: "restarbeiten.edit.short.actions", name: "Datensatzaktionen", type: "group", role: "layoutGroup", parentId: "restarbeiten.edit.short", order: 49, allowedOps: CONTAINER_LAYOUT, componentKind: "actionGroup" }),
+  domainButton({ id: "restarbeiten.edit.action.new", name: "Neu", parentId: "restarbeiten.edit.short.actions", order: 50, actionKind: "domainCreate" }),
+  domainButton({ id: "restarbeiten.edit.action.delete", name: "Löschen", parentId: "restarbeiten.edit.short.actions", order: 51, actionKind: "domainDelete" }),
+  element({ id: "restarbeiten.edit.short.field", name: "Kurztext / Gegenstand · Feld", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.short", order: 52, allowedOps: TEXT_LAYOUT, fieldKind: "text", componentKind: "input" }),
+  element({ id: "restarbeiten.edit.long", name: "Langtext-Feldgruppe", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.fields", order: 60, allowedOps: CONTAINER_LAYOUT, componentKind: "fieldGroup" }),
+  element({ id: "restarbeiten.edit.long.label", name: "Langtext / Beschreibung · Bezeichnung", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.long", order: 61, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "restarbeiten.edit.long.remaining", name: "Restzeichen Langtext", type: "label", role: "status", parentId: "restarbeiten.edit.long", order: 62, allowedOps: TEXT_LAYOUT, componentKind: "counter" }),
+  domainButton({ id: "restarbeiten.edit.long.dictation", name: "Diktat Langtext", parentId: "restarbeiten.edit.long", order: 63, actionKind: "domainDictation" }),
+  element({ id: "restarbeiten.edit.long.field", name: "Langtext / Beschreibung · Feld", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.long", order: 64, allowedOps: TEXT_LAYOUT, fieldKind: "multilineText", componentKind: "textarea" }),
+  element({ id: "restarbeiten.edit.location", name: "Verortung", type: "group", role: "fieldCollection", parentId: "restarbeiten.edit.area", order: 70, allowedOps: CONTAINER_LAYOUT, componentKind: "locationGroup" }),
+  ...[1, 2, 3, 4].flatMap((level, index) => [
+    element({ id: `restarbeiten.edit.location.${level}`, name: `Verortung L${level}`, type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.location", order: 71 + index * 3, allowedOps: CONTAINER_LAYOUT, componentKind: "fieldGroup" }),
+    element({ id: `restarbeiten.edit.location.${level}.label`, name: `Verortung L${level} · Bezeichnung`, type: "label", role: "fieldLabel", parentId: `restarbeiten.edit.location.${level}`, order: 72 + index * 3, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+    element({ id: `restarbeiten.edit.location.${level}.field`, name: `Verortung L${level} · Feld`, type: "field", role: "dataFieldLayout", parentId: `restarbeiten.edit.location.${level}`, order: 73 + index * 3, allowedOps: TEXT_LAYOUT, fieldKind: "text", componentKind: "input" }),
+  ]),
+  element({ id: "restarbeiten.edit.meta", name: "Status und Zuordnung", type: "group", role: "fieldCollection", parentId: "restarbeiten.edit.area", order: 90, allowedOps: CONTAINER_LAYOUT, componentKind: "metaGroup" }),
+  element({ id: "restarbeiten.edit.meta.status", name: "Status", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.meta", order: 91, allowedOps: CONTAINER_LAYOUT, componentKind: "fieldGroup" }),
+  element({ id: "restarbeiten.edit.meta.status.label", name: "Status · Bezeichnung", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.meta.status", order: 92, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "restarbeiten.edit.meta.status.field", name: "Status · Auswahl", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.meta.status", order: 93, allowedOps: TEXT_LAYOUT, fieldKind: "select", componentKind: "select" }),
+  element({ id: "restarbeiten.edit.meta.due", name: "Fertig bis", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.meta", order: 94, allowedOps: CONTAINER_LAYOUT, componentKind: "fieldGroup" }),
+  element({ id: "restarbeiten.edit.meta.due.label", name: "Fertig bis · Bezeichnung", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.meta.due", order: 95, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "restarbeiten.edit.meta.due.field", name: "Fertig bis · Datum", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.meta.due", order: 96, allowedOps: TEXT_LAYOUT, fieldKind: "date", componentKind: "dateInput" }),
+  element({ id: "restarbeiten.edit.meta.ampel", name: "Ampel", type: "statusIndicator", role: "status", parentId: "restarbeiten.edit.meta", order: 97, allowedOps: TEXT_LAYOUT, componentKind: "statusIndicator" }),
+  element({ id: "restarbeiten.edit.meta.responsible", name: "Verantwortlich", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.meta", order: 98, allowedOps: CONTAINER_LAYOUT, componentKind: "fieldGroup" }),
+  element({ id: "restarbeiten.edit.meta.responsible.label", name: "Verantwortlich · Bezeichnung", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.meta.responsible", order: 99, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "restarbeiten.edit.meta.responsible.field", name: "Verantwortlich · Auswahl", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.meta.responsible", order: 100, allowedOps: TEXT_LAYOUT, fieldKind: "select", componentKind: "select" }),
+  element({ id: "restarbeiten.edit.validation", name: "Pflichtfeldhinweis", type: "label", role: "status", parentId: "restarbeiten.edit.meta", order: 101, allowedOps: TEXT_LAYOUT, componentKind: "validation" }),
+  domainButton({ id: "restarbeiten.edit.action.note", name: "Notiz", parentId: "restarbeiten.edit.meta", order: 102, actionKind: "domainNote" }),
+];
+
+export const BBM_M80_ACTIVE_SCOPES = Object.freeze([
+  "restarbeiten.layout.root",
+  "restarbeiten.list.root",
+  "restarbeiten.edit.root",
 ]);
 
 export const BBM_M80_REGISTRY_SCOPES = Object.freeze([
-  Object.freeze({ scopeId: "restarbeiten.list.root", elements: listElements }),
-  Object.freeze({ scopeId: "restarbeiten.edit.root", elements: editElements }),
+  completeScope("restarbeiten.layout.root", layoutElements),
+  completeScope("restarbeiten.list.root", listElements),
+  completeScope("restarbeiten.edit.root", editElements),
+  blockedScope("bbm.shell", "Shell und Hauptnavigation"),
+  blockedScope("bbm.home", "Start"),
+  blockedScope("bbm.projects", "Projektverwaltung"),
+  blockedScope("bbm.project-workspace", "Projektarbeitsplatz"),
+  blockedScope("bbm.firms", "Firmen und Personen"),
+  blockedScope("bbm.project-firms", "Projektfirmen und Projektpersonen"),
+  blockedScope("bbm.protokoll", "Protokoll"),
+  blockedScope("bbm.settings", "Einstellungen"),
+  blockedScope("bbm.help", "Hilfe"),
+  blockedScope("bbm.dialogs", "Produktive Dialoge"),
+  blockedScope("restarbeiten.filterbar", "Restarbeiten · Filterleiste"),
+  blockedScope("restarbeiten.quicklane", "Restarbeiten · Quicklane"),
+  blockedScope("restarbeiten.notes", "Restarbeiten · Notizdialog"),
+  blockedScope("restarbeiten.output-preview", "Restarbeiten · Ausgabevorschau", "M81_pdf_excluded"),
 ]);
 
 const entries = new Map(BBM_M80_REGISTRY_SCOPES.flatMap((scope) => scope.elements).map((entry) => [entry.id, entry]));
 
 export function getM80RegistryEntry(id) { return entries.get(String(id || "")) || null; }
 export function listM80RegistryScopes() {
-  return BBM_M80_REGISTRY_SCOPES.map((scope) => ({ scopeId: scope.scopeId, elements: scope.elements.map((entry) => ({ ...entry, allowedOps: [...entry.allowedOps], lockedOps: [...entry.lockedOps] })) }));
+  return BBM_M80_REGISTRY_SCOPES.map((scope) => ({
+    ...scope,
+    expectedElementIds: [...scope.expectedElementIds],
+    elements: scope.elements.map((entry) => ({ ...entry, baseline: { ...entry.baseline }, allowedOps: [...entry.allowedOps], lockedOps: [...entry.lockedOps] })),
+  }));
 }
 
 export function m80EditorAttributes(id) {


### PR DESCRIPTION
## Ziel

M80.1 vervollständigt die Restarbeiten-Registrierung, ergänzt das bearbeitbare Hauptlayout und bindet den verpflichtenden Registry-Refresh an jeden Editorstart und jedes Fokussieren.

## Enthalten

- Refresh vor jedem Klick auf `UI-Editor öffnen`
- Refresh auch vor dem Fokussieren einer laufenden Editorinstanz
- Registryversion, Fingerprint und Statusübertragung
- Laufzeitereignisse für Registry-Änderungen
- Dirty-Konfliktschutz und kontrollierter Reload
- Profilabgleich für stabile und neue IDs
- vollständig registrierte Scopes:
  - `restarbeiten.layout.root`
  - `restarbeiten.list.root`
  - `restarbeiten.edit.root`
- bearbeitbares Verhältnis zwischen Hauptliste und Editbox
- vollständige Editbox mit 49 registrierten Elementen
- sieben Listenknoten mit exakt drei bestätigten Spaltengruppen
- unabhängige Label-/Feldbearbeitung und Sichtbarkeit
- Fachaktionsschutz, Save, Load, Restore, Reset, Discard und Rollback
- andere BBM-Scopes bleiben ausdrücklich `incomplete` oder `blocked`

## Ausdrücklich nicht enthalten

- keine vollständige Registrierung aller BBM-Oberflächen
- keine BBM-PDF-Anbindung
- kein App-Starterpaket
- keine Änderung der Fachwerte oder Fachaktionen
- `docs/licensing.md` ist ausdrücklich nicht Bestandteil dieses Commits

## Prüfungen

- `npm test`
- `npm run test:node`
- M80.1-Einzeltest – 3/3 bestanden
- gezieltes ESLint für M80.1-Dateien fehlerfrei
- `npm run pack`
- `git diff --check`
- sichtbare Prüfung mit gepacktem BBM und nativem Editor
- Registry-Refresh, Layoutverhältnis, 49 Editbox-Elemente, Restore, Dirty-Schutz und Rollback praktisch bestätigt

Das globale Lint enthält weiterhin ausschließlich den bekannten Altbestand von 17 Fehlern und 371 Warnungen.

## Commit

`60aea62ba16811ca820f3040af4c025d787942a0`