### PR TITLE
M81 BBM-Protokoll-PDF mit nativem PDF-Editor verbinden

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ab M80 ist die produktführende Integration die Sidebar-Aktion `UI-Editor öffne
 
 M80.1 ergänzt Registryversion und deterministischen Fingerprint, vollständige Scope-Inventare, Refresh vor jedem Öffnen/Fokussieren und bei Laufzeitereignissen sowie sicheren Profilabgleich. Nur die drei vollständig registrierten Restarbeiten-Scopes sind aktiv; alle weiteren noch nicht sicher inventarisierten BBM-Bereiche bleiben ausdrücklich gesperrt. Details: [M80.1-Bestands-App-Registrierung](docs/M80_1_BESTANDSAPP_REGISTRIERUNG.md).
 
-Die vollständige BBM-PDF-Anbindung ist M81; bis dahin zeigt der PDF-Tab im Editor ausdrücklich, dass BBM-PDF noch nicht angebunden ist.
+M81 bindet die reale BBM-Protokoll-PDF über eine explizite 28-Element-Registry an den vorhandenen nativen M77-PDF-Arbeitsbereich an. BBM behält den bestehenden Paginierungs- und `printToPDF`-Fachweg; der Editor nutzt denselben PDF-Core, Profilweg, Readback und Rollback. Details: [M81-BBM-PDF-Adapter](docs/M81_BBM_PDF_ADAPTER.md).
 
 Status M51: Core-Vertrag technisch angebunden und testbar; noch keine vollständige sichtbare Editor-Oberfläche und noch keine dauerhafte Layoutspeicherung.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,27 @@
 # STATUS.md — BBM-Produktiv
 
+### M81 – BBM-PDF an den bestehenden PDF-Arbeitsbereich angebunden
+
+- Status: `[A] abgenommen`; automatisierte Pflichtprüfungen und sichtbare native Abnahme sind abgeschlossen.
+- Ergebnis:
+  - Der vorhandene native M77-PDF-Arbeitsbereich verarbeitet die explizite BBM-Registry mit 28 Elementen über denselben lokalen Electron-Vertrag und denselben Profilweg.
+  - Die reale Protokoll-PDF wird weiterhin über BBMs bestehenden Paginierungs- und `printToPDF`-Pfad erzeugt und anschließend in der vorhandenen Vorschau zurückgelesen.
+  - Titel, getrennte Labels/Werte, Teilnehmerbereich, TOP-Tabelle mit drei sichtbaren Spalten sowie Kopf-/Fuß- und Wiederholungsbereiche sind capability-gesteuert bearbeitbar.
+  - Fachwerte, Fachaktionen, Datenbank-, Datei- und Druckaktionen bleiben gesperrt; kein zweiter Core, Renderer oder Profilweg wurde eingeführt.
+  - Kompatible stabile Profile werden kontrolliert übernommen; Regeneration, Readback, Save, Neustart-Restore, Reset, Discard und Batchrollback verwenden den bestehenden Zustandsweg.
+- Praktische Prüfung:
+  - reales Protokoll, 28 Registry-Elemente und reale dreiseitige PDF,
+  - Titel-, Label/Wert-, Tabellen-, Spalten-, Kopf- und Fußauswahl,
+  - Layoutänderung, Vorschau-veraltet-Status, Regeneration, Save und Restore nach Neustart,
+  - Einzel-/Gesamt-Reset und Discard,
+  - vollständiger Rollback bei absichtlich ungültiger Spaltensumme.
+- Dokumentation:
+  - `docs/M81_BBM_PDF_ADAPTER.md`
+- Risiken / offen:
+  - M82 App-Starterpaket bleibt offen und unangetastet.
+- Commit/PR:
+  - keiner; gemäß Nutzeranweisung weder Commit noch Push noch PR noch Merge.
+
 ### M80.2 – Restarbeiten-Header und Editbox direkt editierbar
 
 - Status: `[A] abgenommen`; die sichtbare native Abnahme und der stabilisierte BBM-Pflichtprüfungsblock sind abgeschlossen.
@@ -20,7 +42,7 @@
   - Das UI-Editor-kit ist mit 88 Manager- und 51 Ziel-App-Tests, `npm test`, Pack-Dry-Run und Release-Check grün.
 - Risiken / offen:
   - Das globale Lint bleibt unverändert auf dem bekannten Repo-Bestand von 17 Fehlern/371 Warnungen rot; das gezielte ESLint aller geänderten Harness-/Skriptdateien ist grün.
-  - M81 BBM-PDF und M82 App-Starterpaket bleiben offen und unangetastet.
+  - M81 ist abgenommen; M82 App-Starterpaket bleibt offen und unangetastet.
 - Commit/PR:
   - keiner; gemäß Nutzeranweisung weder Commit noch Push noch PR noch Merge.
 

--- a/docs/M81_BBM_PDF_ADAPTER.md
+++ b/docs/M81_BBM_PDF_ADAPTER.md
@@ -1,0 +1,43 @@
+# M81 – BBM-PDF-Adapter
+
+Status: `[A] abgenommen`
+
+## Ziel und Grenze
+
+M81 bindet die reale BBM-Protokoll-PDF an den bereits vorhandenen nativen PDF-Arbeitsbereich des UI-Editor-kits an. BBM bleibt Eigentümerin von Registry, Layoutzustand, Fachkontext, Paginierung und `webContents.printToPDF`. Der Editor bleibt fachneutral.
+
+Nicht eingeführt wurden ein zweiter PDF-Core, ein zweiter Renderer, ein zweiter Profilpfad, Browser-/Server-/Netzwerkbetrieb oder eine Änderung des Fachdatenschemas.
+
+## Explizite Registry
+
+Der Scope `pdf.bbm.protocol` enthält 28 explizite Layoutobjekte mit stabilen IDs und vollständigen Parent-Beziehungen:
+
+- Dokumentroot und A4-Hochformat-Seite,
+- Kopf- und Fußbereich einschließlich Wiederholung,
+- Titel,
+- getrennte Beschriftungs- und Wertobjekte,
+- Teilnehmerbereich,
+- TOP-Tabelle mit den sichtbaren Spalten `TOP`, `Gegenstand` und `Verantwortlich/Termin`,
+- Tabellenkopf und wiederholte Tabellenbereiche.
+
+Erlaubte Operationen werden pro Element aus der Registry abgeleitet: Position, Größe, Textposition, Schriftgröße, Ausrichtung, Zeilenabstand, Sichtbarkeit, Seitenränder und kontrollierte Spaltenbreiten. Fachwerte, Fachaktionen, Datenbank-, Datei- und Druckaktionen bleiben gesperrt.
+
+## Laufweg
+
+Die laufende Electron-App stellt den optionalen PDF-Vertrag über dieselbe gehärtete lokale Pipe wie die UI-Integration bereit. Der native Editor verwendet den bestehenden M77-PDF-Core, die bestehende `PdfLayoutSession`, den atomaren Profilstore unter `pdf-layouts` und die vorhandene Vorschau.
+
+Bei Regeneration führt BBM den neutralen Layoutzustand vor dem vorhandenen Paginierungsweg zu. Der bestehende Protokoll-Renderer erzeugt die Seiten und der bestehende `printToPDF`-Pfad schreibt die kontrollierte Vorschau-PDF. Der Editor liest genau diese Datei und fachwertfreie Seiten-/Elementmetadaten zurück.
+
+Stabile kompatible Profile werden übernommen; neue Registry-Elemente beginnen mit Baseline und unbekannte Alt-IDs werden nicht angewendet. Fehlerhafte Batches werden vollständig auf den Ausgangszustand zurückgerollt. Save, Neustart-Restore, Reset und Discard verwenden den vorhandenen Profil- und Sitzungsweg.
+
+## Nachweis
+
+- Adapter-, Registry-, Sicherheits-, Readback-, Rollback-, Reset-/Restore- und Regenerationstests sind automatisiert.
+- Die vollständigen BBM- und UI-Editor-kit-Pflichtläufe sind Bestandteil der Abnahme.
+- Sichtbar geprüft wurde ein reales BBM-Protokoll mit 28 Registry-Elementen und einer real erzeugten dreiseitigen PDF.
+- Titel, Label/Wert, TOP-Tabelle, zwei Spalten, Kopf und Fuß wurden ausgewählt; Layoutänderungen, veraltete Vorschau, Regeneration, Save und Neustart-Restore wurden bestätigt.
+- Einzel-/Gesamt-Reset und Discard wurden bestätigt.
+- Eine absichtlich ungültige Spaltensumme löste einen Batchfehler und vollständigen Rollback aus.
+- Es wurde keine `ReferenceOrder`-PDF als BBM-Nachweis verwendet.
+
+M82 bleibt offen und wurde nicht begonnen.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -142,6 +142,7 @@ const TEST_GROUPS = Object.freeze([
       ["m80ElectronUiEditor.test.cjs", "runM80ElectronUiEditorTests"],
       ["m80-1RegistrationRefresh.test.cjs", "runM801RegistrationRefreshTests"],
       ["m80-2HeaderEditboxLayout.test.cjs", "runM802HeaderEditboxLayoutTests"],
+      ["m81BbmPdfAdapter.test.cjs", "runM81BbmPdfAdapterTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),
   }),

--- a/scripts/tests/m80ElectronUiEditor.test.cjs
+++ b/scripts/tests/m80ElectronUiEditor.test.cjs
@@ -290,9 +290,9 @@ async function runM80ElectronUiEditorTests(run) {
     assert.match(read("src/renderer/ui-editor/m80HostAdapter.js"), /FORBIDDEN_KEYS/);
   });
 
-  await run("M80 PDF-Grenze: BBM bleibt für M81 ausdrücklich nicht angebunden", () => {
+  await run("M80/M81 PDF-Grenze: nativer Adapter nutzt kein Referenz-Fachmodell", () => {
     const native = read("../UI-Editor-kit/reference-target-app/src/ReferenceTargetApp.Wpf/UI/Editor/ElectronTargetEditor.cs");
-    assert.match(native, /BBM-PDF noch nicht angebunden/); assert.doesNotMatch(native, /ReferenceOrderFactory/);
+    assert.match(native, /CreatePdfHostAdapterAsync/); assert.doesNotMatch(native, /ReferenceOrderFactory/);
   });
 }
 

--- a/scripts/tests/m81BbmPdfAdapter.test.cjs
+++ b/scripts/tests/m81BbmPdfAdapter.test.cjs
@@ -1,0 +1,114 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "../..");
+const read = (file) => fs.readFileSync(path.join(ROOT, file), "utf8");
+
+async function runM81BbmPdfAdapterTests(run) {
+  const { createBbmPdfAdapter, getBbmPdfRegistry, SCOPE_ID, REGISTRY_FINGERPRINT } = require("../../src/main/ui-editor/bbmPdfAdapter.cjs");
+  const registry = getBbmPdfRegistry();
+  const byId = new Map(registry.elements.map((entry) => [entry.id, entry]));
+
+  await run("M81 BBM-PDF-Registry ist explizit, vollstaendig und deterministisch", () => {
+    assert.equal(registry.scopeId, "pdf.bbm.protocol");
+    assert.equal(registry.elements.length, 28);
+    assert.equal(new Set(registry.elements.map((entry) => entry.id)).size, registry.elements.length);
+    registry.elements.filter((entry) => entry.parentId).forEach((entry) => assert.ok(byId.has(entry.parentId), entry.id));
+    for (const kind of ["document", "page", "area", "header", "footer", "group", "label", "value", "table", "tableColumn", "repeatingArea"])
+      assert.ok(registry.elements.some((entry) => entry.kind === kind), kind);
+    assert.equal(registry.registryFingerprint, REGISTRY_FINGERPRINT);
+    assert.match(REGISTRY_FINGERPRINT, /^sha256:[a-f0-9]{64}$/);
+  });
+
+  await run("M81 Labels, Werte, Tabellenkopf, Inhalt und drei echte TOP-Spalten sind getrennt", () => {
+    assert.notEqual(byId.get(`${SCOPE_ID}.header.project.label`).id, byId.get(`${SCOPE_ID}.header.project.value`).id);
+    assert.notEqual(byId.get(`${SCOPE_ID}.footer.label`).id, byId.get(`${SCOPE_ID}.footer.value`).id);
+    assert.ok(byId.has(`${SCOPE_ID}.tops.header`));
+    assert.ok(byId.has(`${SCOPE_ID}.tops.rows`));
+    assert.deepEqual(registry.elements.filter((entry) => entry.kind === "tableColumn").map((entry) => entry.name),
+      ["Spalte TOP", "Spalte Gegenstand", "Spalte Status / Fertig bis / verantw"]);
+  });
+
+  await run("M81 Registry und Vertrag enthalten keine Fachwerte oder freie Ausgabepfade", () => {
+    const serialized = JSON.stringify(registry);
+    for (const key of ["projectData", "meetingData", "rows", "records", "statusValue", "responsibleValue", "dueDate", "filePath", "outputPath"])
+      assert.equal(serialized.includes(`"${key}"`), false, key);
+    registry.elements.forEach((entry) => {
+      for (const operation of ["changeText", "changeValue", "modifyDomainData", "changeStatus", "changeDueDate", "changeResponsible"])
+        assert.ok(entry.lockedOps.includes(operation), `${entry.id}:${operation}`);
+    });
+  });
+
+  await run("M81 Adapter wendet Layout an, liest zurueck und markiert Vorschau veraltet", () => {
+    const adapter = createBbmPdfAdapter();
+    adapter.setActiveDocumentContext({ projectId: "p1", meetingId: "m1" });
+    const request = { changeId: "c1", scopeId: SCOPE_ID, elementId: `${SCOPE_ID}.header.title`, operation: "textResize", payload: { text: { fontSize: 15 } } };
+    const result = adapter.submitPdfChangeRequest(request);
+    assert.equal(result.success, true);
+    assert.equal(result.newState.fontSize, 15);
+    assert.equal(adapter.getCurrentPdfLayoutState().elements.find((entry) => entry.elementId === request.elementId).fontSize, 15);
+    assert.equal(adapter.getPreviewMetadata().stale, true);
+  });
+
+  await run("M81 Ausrichtung, Sichtbarkeit, Zeilenabstand, Rand und Spaltenbreite sind capability-gesteuert", () => {
+    const adapter = createBbmPdfAdapter();
+    const submit = (elementId, operation, payload) => adapter.submitPdfChangeRequest({ changeId: `${operation}-1`, scopeId: SCOPE_ID, elementId, operation, payload });
+    assert.equal(submit(`${SCOPE_ID}.header.title`, "setTextAlignment", { textAlignment: "center" }).newState.textAlignment, "center");
+    assert.equal(submit(`${SCOPE_ID}.header.title`, "setLineSpacing", { lineSpacing: 1.4 }).newState.lineSpacing, 1.4);
+    assert.equal(submit(`${SCOPE_ID}.closing`, "setVisibility", { visible: false }).newState.visible, false);
+    assert.equal(submit(`${SCOPE_ID}.page-template`, "setPageMargins", { marginTop: 5, marginRight: 12, marginBottom: 8, marginLeft: 12 }).newState.marginTop, 5);
+    assert.equal(submit(`${SCOPE_ID}.tops.column.text`, "resizeWidth", { width: 130 }).newState.width, 130);
+    assert.equal(submit(`${SCOPE_ID}.tops.column.text`, "setVisibility", { visible: false }).errorCode, "pdf_operation_locked");
+  });
+
+  await run("M81 Applyfehler laesst vorherigen Zustand als erfolgreichen Rollback stehen", () => {
+    const adapter = createBbmPdfAdapter();
+    const before = adapter.getCurrentPdfLayoutState();
+    adapter.failNextApply();
+    const result = adapter.submitPdfChangeRequest({ changeId: "fail", scopeId: SCOPE_ID, elementId: `${SCOPE_ID}.header.title`, operation: "textResize", payload: { text: { fontSize: 18 } } });
+    assert.equal(result.success, false);
+    assert.equal(result.rollbackSucceeded, true);
+    assert.deepEqual(adapter.getCurrentPdfLayoutState().elements, before.elements);
+  });
+
+  await run("M81 Reset, Discard und Restore nutzen denselben neutralen LayoutState", () => {
+    const adapter = createBbmPdfAdapter();
+    const baseline = adapter.getCurrentPdfLayoutState();
+    adapter.submitPdfChangeRequest({ changeId: "x", scopeId: SCOPE_ID, elementId: `${SCOPE_ID}.footer`, operation: "resizeWidth", payload: { width: 180 } });
+    const changed = adapter.getCurrentPdfLayoutState();
+    adapter.replaceCurrentPdfLayoutState(baseline);
+    assert.equal(adapter.getCurrentPdfLayoutState().elements.find((entry) => entry.elementId === `${SCOPE_ID}.footer`).width, 186);
+    adapter.replaceCurrentPdfLayoutState(changed);
+    assert.equal(adapter.getCurrentPdfLayoutState().elements.find((entry) => entry.elementId === `${SCOPE_ID}.footer`).width, 180);
+  });
+
+  await run("M81 explizite Neuerzeugung aktualisiert Seitenzahl und nur BBM-kontrollierten Pfad", async () => {
+    const adapter = createBbmPdfAdapter({ regenerate: async () => ({ pageCount: 3, controlledOutputPath: path.join(ROOT, ".m81-controlled-preview.pdf"), generatedAt: "2026-01-01T00:00:00.000Z", renderBounds: [] }) });
+    assert.equal(adapter.getPdfContract(), null);
+    const context = adapter.setActiveDocumentContext({ projectId: "projekt", meetingId: "protokoll" });
+    assert.equal(context.pdfRegistryStatus, "available");
+    const contract = adapter.getPdfContract();
+    assert.equal(contract.pdfRegistryStatus, "available");
+    assert.equal(contract.activeDocumentId.includes("projekt"), false);
+    const preview = await adapter.regeneratePdfPreview();
+    assert.equal(preview.stale, false);
+    assert.equal(preview.pageCount, 3);
+    assert.equal(preview.generation, 1);
+  });
+
+  await run("M81 nutzt echten BBM-printToPDF-Pfad und kein ReferenceOrder-Modell", () => {
+    const printIpc = read("src/main/ipc/printIpc.js");
+    const renderer = read("src/renderer/print/pdfEditorLayout.js");
+    const nativeEditor = read("../UI-Editor-kit/reference-target-app/src/ReferenceTargetApp.Wpf/UI/Editor/ElectronTargetEditor.cs");
+    assert.match(printIpc, /generatePdfForUiEditor/);
+    assert.match(printIpc, /printToPDF/);
+    assert.match(renderer, /pdf\.bbm\.protocol/);
+    assert.doesNotMatch([printIpc, renderer, nativeEditor].join("\n"), /ReferenceOrderFactory/);
+    assert.doesNotMatch([printIpc, renderer].join("\n"), /https?:|WebSocket|fetch\s*\(/i);
+  });
+}
+
+module.exports = { runM81BbmPdfAdapterTests };

--- a/scripts/tests/restarbeitenV2LegacyReadBridge.test.cjs
+++ b/scripts/tests/restarbeitenV2LegacyReadBridge.test.cjs
@@ -113,10 +113,12 @@ async function runRestarbeitenV2LegacyReadBridgeTests(run) {
   const allowedRestarbeitenMainFiles = new Set([
     "src/main/db/database.js",
     "src/main/db/restarbeitenRepo.js",
+    "src/main/ipc/printIpc.js",
     "src/main/ipc/restarbeitenIpc.js",
     "src/main/ipc/uiEditorIpc.js",
     "src/main/main.js",
     "src/main/preload.js",
+    "src/main/ui-editor/bbmPdfAdapter.cjs",
     "src/main/ui-editor/electronUiEditorSession.js",
   ]);
   assert.equal(

--- a/scripts/tests/restarbeitenV2ReadOnlyAdapter.test.cjs
+++ b/scripts/tests/restarbeitenV2ReadOnlyAdapter.test.cjs
@@ -100,10 +100,12 @@ async function runRestarbeitenV2ReadOnlyAdapterTests(run) {
   const allowedRestarbeitenMainFiles = new Set([
     "src/main/db/database.js",
     "src/main/db/restarbeitenRepo.js",
+    "src/main/ipc/printIpc.js",
     "src/main/ipc/restarbeitenIpc.js",
     "src/main/ipc/uiEditorIpc.js",
     "src/main/main.js",
     "src/main/preload.js",
+    "src/main/ui-editor/bbmPdfAdapter.cjs",
     "src/main/ui-editor/electronUiEditorSession.js",
   ]);
   assert.equal(

--- a/scripts/tests/restarbeitenV2ReadOnlyDataSourceFactory.test.cjs
+++ b/scripts/tests/restarbeitenV2ReadOnlyDataSourceFactory.test.cjs
@@ -122,10 +122,12 @@ async function runRestarbeitenV2ReadOnlyDataSourceFactoryTests(run) {
   const allowedRestarbeitenMainFiles = new Set([
     "src/main/db/database.js",
     "src/main/db/restarbeitenRepo.js",
+    "src/main/ipc/printIpc.js",
     "src/main/ipc/restarbeitenIpc.js",
     "src/main/ipc/uiEditorIpc.js",
     "src/main/main.js",
     "src/main/preload.js",
+    "src/main/ui-editor/bbmPdfAdapter.cjs",
     "src/main/ui-editor/electronUiEditorSession.js",
   ]);
   assert.equal(

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 97, "96 bisherige Suite-Einstiege plus Harness-Test");
+    assert.equal(suites.length, 98, "97 Suite-Einstiege plus Harness-Test einschliesslich M81");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/src/main/ipc/printIpc.js
+++ b/src/main/ipc/printIpc.js
@@ -384,7 +384,7 @@ function attachPrintDebugPipes(win, jobId) {
   win.webContents.on("crashed", () => console.log(`[print:${jobId}] webContents crashed`));
 }
 
-async function printToPdf(payload = {}) {
+async function _printToPdf(payload = {}, includeMetadata = false) {
   const jobId = _randId();
   const { resolvePrintMode } = await _loadPrintModesModule();
   const mode = resolvePrintMode(payload.mode, { fallback: "protocol" });
@@ -485,12 +485,19 @@ async function printToPdf(payload = {}) {
             0
           )}`
         );
+        if (msg?.ok === false) throw new Error("Print-Renderer hat die PDF-Erzeugung abgewiesen.");
         const pdfBuffer = await win.webContents.printToPDF(options);
         fs.writeFileSync(outPath, pdfBuffer);
         console.log(`[print:${jobId}] PDF written -> ${outPath}`);
         done = true;
         cleanup();
-        resolve(outPath);
+        resolve(includeMetadata ? {
+          filePath: outPath,
+          controlledOutputPath: outPath,
+          pageCount: Number(msg?.previewMetadata?.pageCount || 0),
+          generatedAt: new Date().toISOString(),
+          renderBounds: Array.isArray(msg?.previewMetadata?.renderBounds) ? msg.previewMetadata.renderBounds : [],
+        } : outPath);
       } catch (err) {
         console.log(`[print:${jobId}] printToPDF ERROR: ${err?.message || err}`);
         done = true;
@@ -515,6 +522,7 @@ async function printToPdf(payload = {}) {
         testOrientation: payload.testOrientation || null,
         debug,
         layoutCalibrationEnabled: _readLayoutCalibrationEnabled(),
+        pdfEditorPreview: payload.pdfEditorPreview === true,
       });
     });
 
@@ -526,6 +534,14 @@ async function printToPdf(payload = {}) {
       reject(err);
     });
   });
+}
+
+async function printToPdf(payload = {}) {
+  return _printToPdf(payload, false);
+}
+
+async function generatePdfForUiEditor(payload = {}) {
+  return _printToPdf({ ...payload, pdfEditorPreview: true, silent: true }, true);
 }
 
 function registerPrintIpc() {
@@ -546,6 +562,12 @@ function registerPrintIpc() {
         restarbeitenLocationLabels: p.restarbeitenLocationLabels || null,
         showAmpelInList: typeof p.showAmpelInList === "boolean" ? p.showAmpelInList : null,
       });
+      if (p.pdfEditorPreview === true && data.mode === "protocol") {
+        const { getSharedBbmPdfAdapter } = require("../ui-editor/bbmPdfAdapter.cjs");
+        const pdfAdapter = getSharedBbmPdfAdapter();
+        data.pdfEditorLayoutState = pdfAdapter.getCurrentPdfLayoutState();
+        data.pdfEditorRegistry = pdfAdapter.getPdfRegistry();
+      }
       // Version/Channel für PDF-Footer mitgeben
       data.appVersion = app.getVersion ? app.getVersion() : "";
       data.buildChannel = app.isPackaged ? "STABLE" : "DEV";
@@ -691,4 +713,4 @@ function registerPrintIpc() {
   );
 }
 
-module.exports = { registerPrintIpc };
+module.exports = { registerPrintIpc, generatePdfForUiEditor };

--- a/src/main/ipc/uiEditorIpc.js
+++ b/src/main/ipc/uiEditorIpc.js
@@ -136,10 +136,22 @@ function closeUiEditorSession() {
 
 function registerUiEditorIpc(options = {}) {
   const { ElectronUiEditorSessionController } = require("../ui-editor/electronUiEditorSession");
+  const { getSharedBbmPdfAdapter } = require("../ui-editor/bbmPdfAdapter.cjs");
+  const { generatePdfForUiEditor } = require("./printIpc");
+  const pdfAdapter = getSharedBbmPdfAdapter();
+  pdfAdapter.configureRegenerate(async ({ projectId, meetingId, activeDocumentId }) => generatePdfForUiEditor({
+    mode: "protocol",
+    projectId,
+    meetingId,
+    targetDir: "temp",
+    fileName: `BBM-UI-Editor-${activeDocumentId}.pdf`,
+    overwrite: true,
+  }));
   const controller = new ElectronUiEditorSessionController({
     app: options.app,
     ipcMain: options.ipcMain || ipcMain,
     getMainWindow: options.getMainWindow,
+    pdfAdapter,
   });
   controller.registerIpc();
   return controller;

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -279,6 +279,7 @@ contextBridge.exposeInMainWorld("uiEditor", Object.freeze({
   open: (registration) => ipcRenderer.invoke("uiEditor:open", _uiEditorPayload(registration, "UI-Editor-Registrierung")),
   close: () => ipcRenderer.invoke("uiEditor:close"),
   getStatus: () => ipcRenderer.invoke("uiEditor:getStatus"),
+  preparePdfContext: (context) => ipcRenderer.invoke("uiEditor:preparePdfContext", _uiEditorPayload(context, "PDF-Dokumentkontext")),
   respond: (message) => ipcRenderer.invoke("uiEditor:respond", _uiEditorPayload(message, "UI-Editor-Antwort")),
   sendTargetEvent: (message) => {
     const payload = _uiEditorPayload(message, "UI-Editor-Ereignis");

--- a/src/main/ui-editor/bbmPdfAdapter.cjs
+++ b/src/main/ui-editor/bbmPdfAdapter.cjs
@@ -1,0 +1,369 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const {
+  PDF_TARGET_CONTRACT_VERSION,
+  PDF_TARGET_OPERATIONS,
+  createPdfRegistryFingerprint,
+  validatePdfRegistry,
+  validatePdfTargetContract,
+} = require("ui-editor-kit");
+
+const APPLICATION_ID = "bbm-produktiv";
+const DOCUMENT_TYPE_ID = "protocol";
+const DISPLAY_NAME = "BBM-Protokoll";
+const SCOPE_ID = "pdf.bbm.protocol";
+const PDF_REGISTRY_VERSION = 1;
+const DOMAIN_LOCKS = Object.freeze([
+  "changeText", "changeValue", "modifyDomainData", "createRecord", "deleteRecord", "saveDomainData",
+  "upload", "import", "export", "autosave", "sortRecords", "filterRecords", "changeStatus",
+  "changeDueDate", "changeResponsible", "deleteImage", "executeTargetAction", "setPageBreakRule",
+]);
+
+const ALL_LAYOUT_OPERATIONS = Object.freeze([...PDF_TARGET_OPERATIONS]);
+
+function box(x, y, width, height, extra = {}) {
+  return Object.freeze({ x, y, width, height, ...extra });
+}
+
+function bounds(minX, maxX, minY, maxY, minWidth, maxWidth, minHeight, maxHeight) {
+  return Object.freeze({ minX, maxX, minY, maxY, minWidth, maxWidth, minHeight, maxHeight });
+}
+
+function element(values) {
+  const capabilities = Object.freeze([...(values.capabilities || [])]);
+  return Object.freeze({
+    id: values.id,
+    name: values.name,
+    scopeId: SCOPE_ID,
+    parentId: values.parentId ?? null,
+    kind: values.kind,
+    role: values.role,
+    pageArea: values.pageArea || "body",
+    order: values.order,
+    visible: true,
+    editable: capabilities.length > 0,
+    capabilities,
+    allowedOps: capabilities,
+    lockedOps: Object.freeze([...new Set([
+      ...ALL_LAYOUT_OPERATIONS.filter((operation) => !capabilities.includes(operation)),
+      ...DOMAIN_LOCKS,
+      ...(values.lockedOps || []),
+    ])]),
+    baseline: Object.freeze({ ...values.baseline }),
+    layoutBounds: Object.freeze({ ...values.layoutBounds }),
+    refKey: values.refKey,
+    rendererKey: values.rendererKey,
+    ...(values.columnRole ? { columnRole: values.columnRole } : {}),
+  });
+}
+
+const PAGE_BOUNDS = bounds(0, 210, 0, 297, 1, 210, 1, 297);
+const HEADER_BOUNDS = bounds(0, 210, 0, 120, 5, 210, 2, 120);
+const BODY_BOUNDS = bounds(0, 210, 70, 297, 5, 210, 2, 227);
+const FOOTER_BOUNDS = bounds(0, 210, 180, 297, 5, 210, 2, 100);
+const TEXT = Object.freeze(["move", "resizeWidth", "textResize", "setTextAlignment", "setVisibility"]);
+
+const ELEMENTS = Object.freeze([
+  element({ id: SCOPE_ID, name: "BBM-Protokoll", kind: "document", role: "layout", pageArea: "document", order: 0,
+    baseline: box(0, 0, 210, 297, { visible: true }), layoutBounds: PAGE_BOUNDS, refKey: "protocol.document", rendererKey: "printRoot" }),
+  element({ id: `${SCOPE_ID}.page-template`, name: "A4-Seite", parentId: SCOPE_ID, kind: "page", role: "layout", pageArea: "document", order: 10,
+    capabilities: ["setPageMargins"], baseline: box(0, 0, 210, 297, { marginTop: 2, marginRight: 12, marginBottom: 0, marginLeft: 12, visible: true }),
+    layoutBounds: PAGE_BOUNDS, refKey: "protocol.page", rendererKey: ".page" }),
+  element({ id: `${SCOPE_ID}.header`, name: "Seitenkopf", parentId: `${SCOPE_ID}.page-template`, kind: "header", role: "layout", pageArea: "header", order: 20,
+    capabilities: ["resizeHeight", "setVisibility"], baseline: box(12, 2, 186, 90, { visible: true }), layoutBounds: HEADER_BOUNDS,
+    refKey: "protocol.header", rendererKey: ".v2HeaderFull,.v2HeaderMini" }),
+  element({ id: `${SCOPE_ID}.header.logos`, name: "Logobereich", parentId: `${SCOPE_ID}.header`, kind: "group", role: "content", pageArea: "header", order: 30,
+    capabilities: ["move", "resizeWidth", "resizeHeight", "setVisibility"], baseline: box(12, 2, 186, 50, { visible: true }), layoutBounds: HEADER_BOUNDS,
+    refKey: "protocol.header.logos", rendererKey: ".v2GlobalHeaderBlock" }),
+  element({ id: `${SCOPE_ID}.header.project`, name: "Projektzeile", parentId: `${SCOPE_ID}.header`, kind: "group", role: "layout", pageArea: "header", order: 40,
+    capabilities: ["move", "resizeWidth"], baseline: box(12, 62, 120, 12, { visible: true }), layoutBounds: HEADER_BOUNDS,
+    refKey: "protocol.header.project", rendererKey: ".v2FullLeftWrap" }),
+  element({ id: `${SCOPE_ID}.header.project.label`, name: "Projekt · Bezeichnung", parentId: `${SCOPE_ID}.header.project`, kind: "label", role: "fieldLabel", pageArea: "header", order: 41,
+    capabilities: TEXT, baseline: box(12, 62, 28, 6, { fontSize: 16, textAlignment: "left", visible: true }), layoutBounds: HEADER_BOUNDS,
+    refKey: "protocol.header.project.label", rendererKey: ".v2Project" }),
+  element({ id: `${SCOPE_ID}.header.project.value`, name: "Projekt · Wert", parentId: `${SCOPE_ID}.header.project`, kind: "value", role: "content", pageArea: "header", order: 42,
+    capabilities: TEXT, baseline: box(40, 62, 92, 6, { fontSize: 16, textAlignment: "left", visible: true }), layoutBounds: HEADER_BOUNDS,
+    refKey: "protocol.header.project.value", rendererKey: ".v2ProjectName" }),
+  element({ id: `${SCOPE_ID}.header.title`, name: "Dokumenttitel", parentId: `${SCOPE_ID}.header`, kind: "value", role: "content", pageArea: "header", order: 50,
+    capabilities: [...TEXT, "setLineSpacing"], baseline: box(12, 74, 120, 10, { fontSize: 14, textAlignment: "left", lineSpacing: 1.1, visible: true }), layoutBounds: HEADER_BOUNDS,
+    refKey: "protocol.header.title", rendererKey: ".v2ProtocolTitle,.v2MiniProtocolTitle" }),
+  element({ id: `${SCOPE_ID}.header.meta`, name: "Kopfmetadaten", parentId: `${SCOPE_ID}.header`, kind: "group", role: "meta", pageArea: "header", order: 60,
+    capabilities: ["move", "resizeWidth", "resizeHeight"], baseline: box(145, 62, 53, 22, { visible: true }), layoutBounds: HEADER_BOUNDS,
+    refKey: "protocol.header.meta", rendererKey: ".v2HeaderRight,.v2MiniRight" }),
+  element({ id: `${SCOPE_ID}.header.meta.page-label`, name: "Seite · Bezeichnung", parentId: `${SCOPE_ID}.header.meta`, kind: "label", role: "fieldLabel", pageArea: "header", order: 61,
+    capabilities: TEXT, baseline: box(145, 62, 16, 6, { fontSize: 9, textAlignment: "right", visible: true }), layoutBounds: HEADER_BOUNDS,
+    refKey: "protocol.header.meta.page-label", rendererKey: ".v2MiniPageLabel" }),
+  element({ id: `${SCOPE_ID}.header.meta.page-value`, name: "Seite · Wert", parentId: `${SCOPE_ID}.header.meta`, kind: "value", role: "meta", pageArea: "header", order: 62,
+    capabilities: TEXT, baseline: box(161, 62, 37, 6, { fontSize: 9, textAlignment: "right", visible: true }), layoutBounds: HEADER_BOUNDS,
+    refKey: "protocol.header.meta.page-value", rendererKey: ".v2MiniPageValue" }),
+  element({ id: `${SCOPE_ID}.body`, name: "Dokumentinhalt", parentId: `${SCOPE_ID}.page-template`, kind: "area", role: "layout", pageArea: "body", order: 100,
+    baseline: box(12, 95, 186, 165, { visible: true }), layoutBounds: BODY_BOUNDS, refKey: "protocol.body", rendererKey: ".v2PageBody" }),
+  element({ id: `${SCOPE_ID}.participants`, name: "Teilnehmerbereich", parentId: `${SCOPE_ID}.body`, kind: "group", role: "content", pageArea: "body", order: 110,
+    capabilities: ["move", "resizeWidth", "setVisibility"], baseline: box(12, 95, 186, 32, { visible: true }), layoutBounds: BODY_BOUNDS,
+    refKey: "protocol.participants", rendererKey: ".v2ParticipantsBlock" }),
+  element({ id: `${SCOPE_ID}.participants.title`, name: "Teilnehmer · Überschrift", parentId: `${SCOPE_ID}.participants`, kind: "label", role: "heading", pageArea: "body", order: 111,
+    capabilities: TEXT, baseline: box(12, 95, 186, 6, { fontSize: 10, textAlignment: "left", visible: true }), layoutBounds: BODY_BOUNDS,
+    refKey: "protocol.participants.title", rendererKey: ".v2ParticipantsTitle" }),
+  element({ id: `${SCOPE_ID}.participants.rows`, name: "Teilnehmer · Wiederholung", parentId: `${SCOPE_ID}.participants`, kind: "repeatingArea", role: "content", pageArea: "body", order: 112,
+    capabilities: ["resizeWidth", "setLineSpacing"], baseline: box(12, 101, 186, 26, { lineSpacing: 1.1, visible: true }), layoutBounds: BODY_BOUNDS,
+    refKey: "protocol.participants.rows", rendererKey: ".v2ParticipantsTable tbody" }),
+  element({ id: `${SCOPE_ID}.tops`, name: "TOP-Tabelle", parentId: `${SCOPE_ID}.body`, kind: "table", role: "content", pageArea: "body", order: 200,
+    capabilities: ["move", "resizeWidth", "setVisibility"], baseline: box(12, 130, 186, 120, { visible: true }), layoutBounds: BODY_BOUNDS,
+    refKey: "protocol.tops", rendererKey: ".topsTable" }),
+  element({ id: `${SCOPE_ID}.tops.header`, name: "TOP-Tabelle · Kopf", parentId: `${SCOPE_ID}.tops`, kind: "group", role: "structure", pageArea: "body", order: 210,
+    capabilities: ["resizeHeight", "textResize", "setTextAlignment", "setVisibility"], baseline: box(12, 130, 186, 8, { fontSize: 8, textAlignment: "left", visible: true }), layoutBounds: BODY_BOUNDS,
+    refKey: "protocol.tops.header", rendererKey: ".topsTable thead" }),
+  element({ id: `${SCOPE_ID}.tops.rows`, name: "TOP-Tabelle · Wiederholung", parentId: `${SCOPE_ID}.tops`, kind: "repeatingArea", role: "content", pageArea: "body", order: 220,
+    capabilities: ["setLineSpacing"], baseline: box(12, 138, 186, 112, { lineSpacing: 1.35, visible: true }), layoutBounds: BODY_BOUNDS,
+    refKey: "protocol.tops.rows", rendererKey: ".topsTable tbody" }),
+  element({ id: `${SCOPE_ID}.tops.column.number`, name: "Spalte TOP", parentId: `${SCOPE_ID}.tops`, kind: "tableColumn", role: "structure", columnRole: "structureColumn", pageArea: "body", order: 230,
+    capabilities: ["resizeWidth"], baseline: box(12, 130, 23, 120, { visible: true }), layoutBounds: BODY_BOUNDS,
+    refKey: "protocol.tops.column.number", rendererKey: ".topsTable .colNr" }),
+  element({ id: `${SCOPE_ID}.tops.column.text`, name: "Spalte Gegenstand", parentId: `${SCOPE_ID}.tops`, kind: "tableColumn", role: "content", columnRole: "contentColumn", pageArea: "body", order: 231,
+    capabilities: ["resizeWidth"], baseline: box(35, 130, 133, 120, { visible: true }), layoutBounds: BODY_BOUNDS,
+    refKey: "protocol.tops.column.text", rendererKey: ".topsTable .colText" }),
+  element({ id: `${SCOPE_ID}.tops.column.meta`, name: "Spalte Status / Fertig bis / verantw", parentId: `${SCOPE_ID}.tops`, kind: "tableColumn", role: "meta", columnRole: "metaColumn", pageArea: "body", order: 232,
+    capabilities: ["resizeWidth"], baseline: box(168, 130, 30, 120, { visible: true }), layoutBounds: BODY_BOUNDS,
+    refKey: "protocol.tops.column.meta", rendererKey: ".topsTable .colMeta" }),
+  element({ id: `${SCOPE_ID}.tops.heading.number`, name: "Tabellenkopf TOP", parentId: `${SCOPE_ID}.tops.header`, kind: "label", role: "columnHeader", pageArea: "body", order: 240,
+    capabilities: ["textResize", "setTextAlignment", "setVisibility"], baseline: box(12, 130, 23, 8, { fontSize: 8, textAlignment: "left", visible: true }), layoutBounds: BODY_BOUNDS,
+    refKey: "protocol.tops.heading.number", rendererKey: ".topsTable thead .colNr" }),
+  element({ id: `${SCOPE_ID}.tops.heading.text`, name: "Tabellenkopf Gegenstand", parentId: `${SCOPE_ID}.tops.header`, kind: "label", role: "columnHeader", pageArea: "body", order: 241,
+    capabilities: ["textResize", "setTextAlignment", "setVisibility"], baseline: box(35, 130, 133, 8, { fontSize: 8, textAlignment: "left", visible: true }), layoutBounds: BODY_BOUNDS,
+    refKey: "protocol.tops.heading.text", rendererKey: ".topsTable thead .colText" }),
+  element({ id: `${SCOPE_ID}.tops.heading.meta`, name: "Tabellenkopf Status / Fertig bis / verantw", parentId: `${SCOPE_ID}.tops.header`, kind: "label", role: "columnHeader", pageArea: "body", order: 242,
+    capabilities: ["textResize", "setTextAlignment", "setVisibility"], baseline: box(168, 130, 30, 8, { fontSize: 8, textAlignment: "left", visible: true }), layoutBounds: BODY_BOUNDS,
+    refKey: "protocol.tops.heading.meta", rendererKey: ".topsTable thead .colMeta" }),
+  element({ id: `${SCOPE_ID}.closing`, name: "Abschlussbereich", parentId: `${SCOPE_ID}.body`, kind: "group", role: "content", pageArea: "body", order: 300,
+    capabilities: ["move", "resizeWidth", "setVisibility"], baseline: box(12, 225, 186, 35, { visible: true }), layoutBounds: BODY_BOUNDS,
+    refKey: "protocol.closing", rendererKey: ".v2TopsTail" }),
+  element({ id: `${SCOPE_ID}.footer`, name: "Aufgestellt-Bereich", parentId: `${SCOPE_ID}.page-template`, kind: "footer", role: "content", pageArea: "footer", order: 400,
+    capabilities: ["move", "resizeWidth", "resizeHeight", "setVisibility"], baseline: box(12, 260, 186, 30, { visible: true }), layoutBounds: FOOTER_BOUNDS,
+    refKey: "protocol.footer", rendererKey: ".v2ProtocolFooter" }),
+  element({ id: `${SCOPE_ID}.footer.label`, name: "Aufgestellt · Bezeichnung", parentId: `${SCOPE_ID}.footer`, kind: "label", role: "fieldLabel", pageArea: "footer", order: 401,
+    capabilities: TEXT, baseline: box(12, 260, 40, 6, { fontSize: 9, textAlignment: "left", visible: true }), layoutBounds: FOOTER_BOUNDS,
+    refKey: "protocol.footer.label", rendererKey: ".v2ProtocolFooterTitle" }),
+  element({ id: `${SCOPE_ID}.footer.value`, name: "Aufgestellt · Wert", parentId: `${SCOPE_ID}.footer`, kind: "value", role: "content", pageArea: "footer", order: 402,
+    capabilities: [...TEXT, "setLineSpacing"], baseline: box(12, 266, 186, 24, { fontSize: 8, textAlignment: "left", lineSpacing: 1.35, visible: true }), layoutBounds: FOOTER_BOUNDS,
+    refKey: "protocol.footer.value", rendererKey: ".v2ProtocolFooterLine" }),
+]);
+
+const REGISTRY_BASE = Object.freeze({
+  applicationId: APPLICATION_ID,
+  documentTypeId: DOCUMENT_TYPE_ID,
+  displayName: DISPLAY_NAME,
+  scopeId: SCOPE_ID,
+  unit: "mm",
+  pageSettings: Object.freeze({ format: "A4", orientation: "portrait", width: 210, height: 297,
+    margins: Object.freeze({ top: 2, right: 12, bottom: 0, left: 12 }) }),
+  elements: ELEMENTS,
+});
+
+const REGISTRY_FINGERPRINT = createPdfRegistryFingerprint(REGISTRY_BASE);
+const REGISTRY = Object.freeze({ ...REGISTRY_BASE, registryVersion: PDF_REGISTRY_VERSION, registryFingerprint: REGISTRY_FINGERPRINT });
+const REGISTRY_VALIDATION = validatePdfRegistry(REGISTRY);
+if (!REGISTRY_VALIDATION.ok) {
+  const error = new TypeError("BBM-PDF-Registry ist ungültig.");
+  error.validationErrors = REGISTRY_VALIDATION.errors;
+  throw error;
+}
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function stateFromRegistry() {
+  return {
+    scopeId: SCOPE_ID,
+    capturedAt: new Date().toISOString(),
+    elements: ELEMENTS.map((entry) => ({ elementId: entry.id, scopeId: SCOPE_ID, ...clone(entry.baseline) })),
+  };
+}
+
+function finite(value, field, { positive = false, nonNegative = false } = {}) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || (positive && number <= 0) || (nonNegative && number < 0)) {
+    throw Object.assign(new Error(`Ungültiger PDF-Layoutwert: ${field}`), { code: "pdf_invalid_number" });
+  }
+  return number;
+}
+
+function desiredState(previous, operation, payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) throw Object.assign(new Error("PDF-Payload fehlt."), { code: "pdf_invalid_payload" });
+  const next = { ...previous };
+  if (operation === "move") {
+    if (Object.hasOwn(payload, "x")) next.x = finite(payload.x, "x");
+    if (Object.hasOwn(payload, "y")) next.y = finite(payload.y, "y");
+  } else if (operation === "resize" || operation === "resizeWidth" || operation === "resizeHeight") {
+    if (Object.hasOwn(payload, "width")) next.width = finite(payload.width, "width", { positive: true });
+    if (Object.hasOwn(payload, "height")) next.height = finite(payload.height, "height", { positive: true });
+  } else if (operation === "textMove") {
+    if (!payload.text || typeof payload.text !== "object") throw Object.assign(new Error("Text-Payload fehlt."), { code: "pdf_invalid_payload" });
+    if (Object.hasOwn(payload.text, "offsetX")) next.textOffsetX = finite(payload.text.offsetX, "offsetX", { nonNegative: true });
+    if (Object.hasOwn(payload.text, "offsetY")) next.textOffsetY = finite(payload.text.offsetY, "offsetY", { nonNegative: true });
+  } else if (operation === "textResize") {
+    next.fontSize = finite(payload?.text?.fontSize, "fontSize", { positive: true });
+  } else if (operation === "setTextAlignment") {
+    const alignment = String(payload.textAlignment || "").trim().toLowerCase();
+    if (!new Set(["left", "center", "right"]).has(alignment)) throw Object.assign(new Error("Textausrichtung ist ungültig."), { code: "pdf_invalid_payload" });
+    next.textAlignment = alignment;
+  } else if (operation === "setLineSpacing") {
+    next.lineSpacing = finite(payload.lineSpacing, "lineSpacing", { positive: true });
+  } else if (operation === "setVisibility") {
+    if (typeof payload.visible !== "boolean") throw Object.assign(new Error("Sichtbarkeit ist ungültig."), { code: "pdf_invalid_payload" });
+    next.visible = payload.visible;
+  } else if (operation === "setPageMargins") {
+    for (const field of ["marginTop", "marginRight", "marginBottom", "marginLeft"]) {
+      if (Object.hasOwn(payload, field)) next[field] = finite(payload[field], field, { nonNegative: true });
+    }
+  } else throw Object.assign(new Error("PDF-Operation ist nicht erlaubt."), { code: "pdf_operation_not_allowed" });
+  return next;
+}
+
+function validateState(entry, state, allStates) {
+  const limit = entry.layoutBounds;
+  if (state.x < limit.minX || state.x > limit.maxX || state.y < limit.minY || state.y > limit.maxY ||
+      state.width < limit.minWidth || state.width > limit.maxWidth || state.height < limit.minHeight || state.height > limit.maxHeight ||
+      state.x + state.width > 210.000001 || state.y + state.height > 297.000001) {
+    throw Object.assign(new Error("PDF-Layout verlässt die registrierten Grenzen."), { code: "pdf_out_of_page_bounds" });
+  }
+  if (entry.kind === "tableColumn" && state.width < 5) throw Object.assign(new Error("PDF-Spalte ist kleiner als 5 mm."), { code: "pdf_invalid_column_width" });
+  if (entry.kind === "tableColumn") {
+    const widths = ["number", "text", "meta"].map((name) => allStates.get(`${SCOPE_ID}.tops.column.${name}`).width);
+    if (widths.reduce((sum, value) => sum + value, 0) > allStates.get(`${SCOPE_ID}.tops`).width + 0.000001) {
+      throw Object.assign(new Error("PDF-Spaltensumme überschreitet die Tabellenbreite."), { code: "pdf_invalid_table_width" });
+    }
+  }
+  if (entry.id.endsWith("page-template")) {
+    const horizontal = Number(state.marginLeft || 0) + Number(state.marginRight || 0);
+    const vertical = Number(state.marginTop || 0) + Number(state.marginBottom || 0);
+    if (horizontal >= 210 || vertical >= 297) throw Object.assign(new Error("PDF-Seitenränder sind ungültig."), { code: "pdf_invalid_page_margins" });
+  }
+}
+
+function safeDocumentId(projectId, meetingId) {
+  if (!projectId || !meetingId) return "";
+  return `bbm-protocol-${crypto.createHash("sha256").update(`${projectId}\0${meetingId}`, "utf8").digest("hex").slice(0, 24)}`;
+}
+
+function createBbmPdfAdapter({ regenerate } = {}) {
+  let regenerateHandler = regenerate;
+  let working = stateFromRegistry();
+  let context = null;
+  let preview = { state: "missing", stale: true, generation: 0, pageCount: 0, generatedAt: null, activeDocumentId: "", controlledOutputPath: null, renderBounds: [] };
+  let failNextApplyForDiagnostic = false;
+
+  function getPdfRegistry() { return clone(REGISTRY); }
+  function getCurrentPdfLayoutState() { return clone({ ...working, capturedAt: new Date().toISOString() }); }
+  function activeDocumentId() { return safeDocumentId(context?.projectId, context?.meetingId); }
+  function setActiveDocumentContext(value = {}) {
+    const projectId = String(value.projectId || "").trim();
+    const meetingId = String(value.meetingId || "").trim();
+    context = projectId && meetingId ? { projectId, meetingId } : null;
+    const id = activeDocumentId();
+    if (preview.activeDocumentId !== id) preview = { state: "missing", stale: true, generation: 0, pageCount: 0, generatedAt: null, activeDocumentId: id, controlledOutputPath: null, renderBounds: [] };
+    return { ok: Boolean(context), activeDocumentId: id, pdfRegistryStatus: context ? "available" : "incomplete" };
+  }
+  function getPdfContract() {
+    if (!context) return null;
+    const contract = {
+      applicationId: APPLICATION_ID,
+      documentTypeId: DOCUMENT_TYPE_ID,
+      displayName: DISPLAY_NAME,
+      contractVersion: PDF_TARGET_CONTRACT_VERSION,
+      registryVersion: PDF_REGISTRY_VERSION,
+      registryFingerprint: REGISTRY_FINGERPRINT,
+      profileScope: SCOPE_ID,
+      supportedOperations: [...PDF_TARGET_OPERATIONS],
+      pageSettingsCapability: "margins",
+      previewCapability: "nativePdf",
+      regenerateCapability: "explicit",
+      activeDocumentId: activeDocumentId(),
+      pdfRegistryStatus: "available",
+    };
+    const result = validatePdfTargetContract(contract);
+    if (!result.ok) throw Object.assign(new Error("BBM-PDF-Vertrag ist ungültig."), { code: "pdf_contract_invalid", validationErrors: result.errors });
+    return contract;
+  }
+  function submitPdfChangeRequest(request = {}) {
+    const entry = ELEMENTS.find((candidate) => candidate.id === request.elementId);
+    const failure = (code, message, previousState = null, rollbackSucceeded = true) => ({ success: false, changeId: String(request.changeId || ""), elementId: String(request.elementId || ""), operation: String(request.operation || ""), errorCode: code, message, previousState, newState: previousState, rollbackSucceeded });
+    if (!entry) return failure("pdf_unknown_element", "PDF-Element ist nicht registriert.");
+    if (request.scopeId !== SCOPE_ID) return failure("pdf_layout_incompatible", "PDF-Scope passt nicht.");
+    if (entry.lockedOps.includes(request.operation)) return failure("pdf_operation_locked", "PDF-Operation ist gesperrt.");
+    if (!entry.capabilities.includes(request.operation)) return failure("pdf_operation_not_allowed", "PDF-Operation ist nicht freigegeben.");
+    const previous = working.elements.find((state) => state.elementId === entry.id);
+    try {
+      if (failNextApplyForDiagnostic) {
+        failNextApplyForDiagnostic = false;
+        throw Object.assign(new Error("Kontrollierter PDF-Diagnosefehler."), { code: "pdf_change_apply_failed" });
+      }
+      const next = desiredState(previous, request.operation, request.payload);
+      const nextStates = new Map(working.elements.map((state) => [state.elementId, state.elementId === entry.id ? next : state]));
+      validateState(entry, next, nextStates);
+      working = { scopeId: SCOPE_ID, capturedAt: new Date().toISOString(), elements: [...nextStates.values()].map(clone) };
+      preview = { ...preview, state: preview.controlledOutputPath ? "stale" : "missing", stale: true };
+      return { success: true, changeId: request.changeId, elementId: entry.id, operation: request.operation, errorCode: null,
+        message: "PDF-Layoutänderung angewandt und zurückgelesen.", previousState: clone(previous), newState: clone(next), rollbackSucceeded: true };
+    } catch (error) {
+      const readback = working.elements.find((state) => state.elementId === entry.id);
+      return failure(error?.code || "pdf_change_apply_failed", "PDF-Layoutänderung wurde sicher abgewiesen; der vorherige Zustand blieb erhalten.", clone(readback), true);
+    }
+  }
+  async function regeneratePdfPreview() {
+    if (!context) throw Object.assign(new Error("Kein aktives BBM-Protokoll für die PDF-Vorschau."), { code: "pdf_document_unavailable" });
+    if (typeof regenerateHandler !== "function") throw Object.assign(new Error("PDF-Neuerzeugung ist nicht angebunden."), { code: "pdf_regenerate_unavailable" });
+    const result = await regenerateHandler({ ...context, activeDocumentId: activeDocumentId(), layoutState: getCurrentPdfLayoutState() });
+    preview = {
+      state: "current", stale: false, generation: preview.generation + 1,
+      pageCount: Number(result.pageCount || 0), generatedAt: result.generatedAt || new Date().toISOString(),
+      activeDocumentId: activeDocumentId(), controlledOutputPath: String(result.controlledOutputPath || ""),
+      renderBounds: Array.isArray(result.renderBounds) ? result.renderBounds.map(clone) : [],
+    };
+    return getPreviewMetadata();
+  }
+  function getPreviewMetadata() {
+    return clone(preview);
+  }
+  function replaceCurrentPdfLayoutState(state) {
+    if (!state || state.scopeId !== SCOPE_ID || !Array.isArray(state.elements)) throw Object.assign(new Error("PDF-LayoutState ist ungültig."), { code: "pdf_layout_incompatible" });
+    const requested = new Map(state.elements.map((entry) => [entry.elementId, entry]));
+    const original = working;
+    try {
+      const next = stateFromRegistry();
+      next.elements = next.elements.map((baseline) => requested.has(baseline.elementId) ? { ...baseline, ...clone(requested.get(baseline.elementId)), elementId: baseline.elementId, scopeId: SCOPE_ID } : baseline);
+      const byId = new Map(next.elements.map((entry) => [entry.elementId, entry]));
+      for (const definition of ELEMENTS) validateState(definition, byId.get(definition.id), byId);
+      working = { ...next, capturedAt: new Date().toISOString() };
+      preview = { ...preview, state: preview.controlledOutputPath ? "stale" : "missing", stale: true };
+      return getCurrentPdfLayoutState();
+    } catch (error) {
+      working = original;
+      throw error;
+    }
+  }
+  function resetForDiagnostic() { working = stateFromRegistry(); context = null; preview = { state: "missing", stale: true, generation: 0, pageCount: 0, generatedAt: null, activeDocumentId: "", controlledOutputPath: null, renderBounds: [] }; failNextApplyForDiagnostic = false; }
+  function failNextApply() { failNextApplyForDiagnostic = true; }
+  function configureRegenerate(handler) {
+    if (typeof handler !== "function") throw new TypeError("PDF-Neuerzeugungshandler fehlt.");
+    regenerateHandler = handler;
+  }
+
+  return Object.freeze({ getPdfRegistry, getCurrentPdfLayoutState, submitPdfChangeRequest, regeneratePdfPreview, getPreviewMetadata,
+    getPdfContract, setActiveDocumentContext, replaceCurrentPdfLayoutState, resetForDiagnostic, failNextApply, configureRegenerate });
+}
+
+const sharedBbmPdfAdapter = createBbmPdfAdapter();
+
+module.exports = Object.freeze({
+  APPLICATION_ID,
+  DOCUMENT_TYPE_ID,
+  DISPLAY_NAME,
+  SCOPE_ID,
+  PDF_REGISTRY_VERSION,
+  REGISTRY_FINGERPRINT,
+  createBbmPdfAdapter,
+  getSharedBbmPdfAdapter: () => sharedBbmPdfAdapter,
+  getBbmPdfRegistry: () => clone(REGISTRY),
+});

--- a/src/main/ui-editor/electronUiEditorSession.js
+++ b/src/main/ui-editor/electronUiEditorSession.js
@@ -21,6 +21,13 @@ const APPLICATION_ID = "bbm-produktiv";
 const DISPLAY_NAME = "BBM";
 const ACTIVE_SCOPES = Object.freeze(["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]);
 const NATIVE_REQUEST_ACTIONS = new Set(["getRegistry", "getLayoutState", "submitChange"]);
+const NATIVE_PDF_REQUEST_ACTIONS = new Set([
+  "getPdfRegistry",
+  "getCurrentPdfLayoutState",
+  "submitPdfChangeRequest",
+  "regeneratePdfPreview",
+  "getPreviewMetadata",
+]);
 const NATIVE_EVENT_ACTIONS = new Set(["beginTargetSelection", "cancelTargetSelection", "highlightElement", "activateTarget", "editorClosed"]);
 const REGISTRY_EVENT_ACTIONS = new Set(["registryChanged", "registryStatusChanged", "scopeAdded", "scopeChanged", "scopeRemoved"]);
 const TARGET_EVENT_ACTIONS = new Set(["targetSelectionChanged", ...REGISTRY_EVENT_ACTIONS]);
@@ -93,10 +100,11 @@ function publicError(error) {
 function delay(milliseconds) { return new Promise((resolve) => setTimeout(resolve, milliseconds)); }
 
 class ElectronUiEditorSessionController {
-  constructor({ app, ipcMain, getMainWindow, spawnProcess = spawn, clientFactory, pathOptions = {}, executableResolver, runtimeRootResolver, sessionIdentifiersFactory, profileRootResolver, ensureDirectory }) {
+  constructor({ app, ipcMain, getMainWindow, pdfAdapter = null, spawnProcess = spawn, clientFactory, pathOptions = {}, executableResolver, runtimeRootResolver, sessionIdentifiersFactory, profileRootResolver, ensureDirectory }) {
     this.app = app;
     this.ipcMain = ipcMain;
     this.getMainWindow = getMainWindow;
+    this.pdfAdapter = pdfAdapter;
     this.spawnProcess = spawnProcess;
     this.clientFactory = clientFactory || ((options) => new NamedPipeTargetClient(options));
     this.pathOptions = pathOptions;
@@ -123,6 +131,14 @@ class ElectronUiEditorSessionController {
     this.ipcMain.handle("uiEditor:getStatus", () => this.status());
     this.ipcMain.handle("uiEditor:respond", (_event, message) => this.respondFromRenderer(message));
     this.ipcMain.handle("uiEditor:targetEvent", (_event, message) => this.forwardTargetEvent(message));
+    this.ipcMain.handle("uiEditor:preparePdfContext", (_event, context) => this.preparePdfContext(context));
+  }
+
+  preparePdfContext(context = {}) {
+    if (!this.pdfAdapter) return { ok: false, pdfRegistryStatus: "unavailable", activeDocumentId: "" };
+    const result = this.pdfAdapter.setActiveDocumentContext({ projectId: context?.projectId, meetingId: context?.meetingId });
+    console.info(`[ui-editor] PDF context: ${result.pdfRegistryStatus}`);
+    return result;
   }
 
   async open(registration, reason = "open") {
@@ -143,6 +159,7 @@ class ElectronUiEditorSessionController {
     if (activeScopes.length === 0) {
       throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.REGISTRY_SCOPE_BLOCKED, "Kein vollständiger Scope ist im aktuellen BBM-Bereich auflösbar.");
     }
+    const pdfContract = this.pdfAdapter?.getPdfContract?.() || null;
     const contract = createElectronTargetContract({
       applicationId: registration.applicationId,
       displayName: registration.displayName,
@@ -156,9 +173,11 @@ class ElectronUiEditorSessionController {
       transportProtocolVersion: LOCAL_TARGET_PROTOCOL_VERSION,
       sessionId,
       processId: process.pid,
+      pdfCapability: pdfContract ? "available" : "unavailable",
+      pdfContract,
     });
     if (registration.framework !== contract.framework || registration.uiCapability !== contract.uiCapability ||
-        registration.pdfCapability !== contract.pdfCapability || registration.labelFieldSeparation !== true ||
+        registration.labelFieldSeparation !== true ||
         registration.visibilityCapability !== true || contract.adapterVersion !== ELECTRON_TARGET_ADAPTER_VERSION) {
       throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.REGISTRY_INCOMPATIBLE, "Ziel-App-Vertrag oder Adapter-Capabilities sind nicht kompatibel.");
     }
@@ -184,25 +203,28 @@ class ElectronUiEditorSessionController {
       throw new ElectronEditorError(error?.code || ELECTRON_EDITOR_ERROR_CODES.REGISTRY_REFRESH_FAILED, error?.message || "Registry-Refresh fehlgeschlagen.");
     }
     const comparison = compareRegistrySnapshots(this.currentRegistration, candidate);
+    const previousPdf = this.currentRegistration.contract.pdfContract;
+    const nextPdf = candidate.contract.pdfContract;
+    const pdfChanged = JSON.stringify(previousPdf) !== JSON.stringify(nextPdf);
     const guard = await this.client.request("prepareRegistryRefresh", {
       reason,
       registryVersion: candidate.contract.registryVersion,
       registryFingerprint: candidate.contract.registryFingerprint,
       comparison,
     }, "prepareRegistryRefreshAccepted");
-    if (comparison.status !== "current" && guard?.isDirty === true) {
+    if ((comparison.status !== "current" || pdfChanged) && guard?.isDirty === true) {
       throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.REGISTRY_PROFILE_CONFLICT, "Ungespeicherte Editoränderungen verhindern den Registry-Refresh.");
     }
     if (comparison.migrationRequiredIds.length) {
       throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.REGISTRY_PROFILE_MIGRATION_REQUIRED, "Geänderte Parents oder Bedeutungen benötigen eine Profilmigration.");
     }
-    if (comparison.status === "current") {
+    if (comparison.status === "current" && !pdfChanged) {
       if (reason === "open" || reason === "focus") this.client.sendEvent("activateEditor");
       return { ok: true, started: false, focused: reason === "open" || reason === "focus", sessionId: this.sessionId, registryRefreshStatus: "current" };
     }
     await this.#disposeSession("registry_changed", true);
     const result = await this.#start(registration);
-    return { ...result, registryRefreshStatus: "changed", addedElementIds: comparison.addedElementIds, removedElementIds: comparison.removedElementIds };
+    return { ...result, registryRefreshStatus: "changed", pdfRegistryRefreshStatus: pdfChanged ? "changed" : "current", addedElementIds: comparison.addedElementIds, removedElementIds: comparison.removedElementIds };
   }
 
   async #start(registration) {
@@ -272,6 +294,10 @@ class ElectronUiEditorSessionController {
 
   #handleNativeMessage(message) {
     const action = String(message?.payload?.action || "");
+    if (message.messageType === "request" && NATIVE_PDF_REQUEST_ACTIONS.has(action)) {
+      void this.#handleNativePdfRequest(message, action);
+      return;
+    }
     if (message.messageType === "request" && NATIVE_REQUEST_ACTIONS.has(action)) {
       console.info(`[ui-editor] native request: ${action}`);
       const window = this.getMainWindow?.();
@@ -294,6 +320,21 @@ class ElectronUiEditorSessionController {
       if (action === "activateTarget") this.getMainWindow?.()?.focus?.();
       this.getMainWindow?.()?.webContents?.send?.("uiEditor:event", message.payload);
       if (action === "editorClosed") void this.#disposeSession("editor_closed", false);
+    }
+  }
+
+  async #handleNativePdfRequest(message, action) {
+    try {
+      if (!this.pdfAdapter || !this.pdfAdapter.getPdfContract()) throw Object.assign(new Error("BBM-PDF ist nicht verfügbar."), { code: "pdf_document_unavailable" });
+      let payload;
+      if (action === "getPdfRegistry") payload = { pdfRegistry: this.pdfAdapter.getPdfRegistry() };
+      else if (action === "getCurrentPdfLayoutState") payload = { layoutState: this.pdfAdapter.getCurrentPdfLayoutState() };
+      else if (action === "submitPdfChangeRequest") payload = { changeResult: this.pdfAdapter.submitPdfChangeRequest(message.payload?.changeRequest) };
+      else if (action === "regeneratePdfPreview") payload = { previewMetadata: await this.pdfAdapter.regeneratePdfPreview() };
+      else payload = { previewMetadata: this.pdfAdapter.getPreviewMetadata() };
+      this.client?.respond(message, { action: `${action}Accepted`, ...payload });
+    } catch (error) {
+      this.client?.respond(message, {}, { code: String(error?.code || "pdf_request_failed"), message: String(error?.message || "BBM-PDF-Anfrage fehlgeschlagen.") });
     }
   }
 

--- a/src/renderer/app/coreShellNavigation.js
+++ b/src/renderer/app/coreShellNavigation.js
@@ -16,11 +16,14 @@ function showRegistryRefreshStatus(message, state = "checking") {
   status.textContent = message;
 }
 
-export async function openNativeUiEditor() {
+export async function openNativeUiEditor(context = {}) {
   const api = window.uiEditor;
   if (!api || typeof api.open !== "function") {
     alert("Der separate UI-Editor ist nicht installiert oder die sichere BBM-Brücke ist nicht verfügbar.");
     return { ok: false, errorCode: "electron_editor_not_installed" };
+  }
+  if (typeof api.preparePdfContext === "function" && context?.projectId && context?.meetingId) {
+    await api.preparePdfContext({ projectId: context?.projectId || null, meetingId: context?.meetingId || null });
   }
   showRegistryRefreshStatus("UI-Registry wird geprüft …", "checking");
   const result = await api.open(createM80RegistrationDescriptor());
@@ -39,6 +42,9 @@ export function createCoreShellNavigationRouteDefs(router) {
     { key: "projects", label: "Projekte", onClick: () => router.showProjects() },
     { key: "firms", label: "Firmen", onClick: () => router.showFirms() },
     { key: "settings", label: "Einstellungen", onClick: () => router.showSettings() },
-    { key: "uiEditor", kind: "action", label: "UI-Editor öffnen", onClick: () => openNativeUiEditor() },
+    { key: "uiEditor", kind: "action", label: "UI-Editor öffnen", onClick: () => openNativeUiEditor({
+      projectId: router.currentProjectId,
+      meetingId: router.currentMeetingId || router.lastTopsMeetingId,
+    }) },
   ];
 }

--- a/src/renderer/modules/protokoll/screens/TopsScreen.js
+++ b/src/renderer/modules/protokoll/screens/TopsScreen.js
@@ -1615,6 +1615,9 @@ export default class TopsScreen {
   }
 
   async load() {
+    if (this.projectId && this.meetingId && typeof window.uiEditor?.preparePdfContext === "function") {
+      await window.uiEditor.preparePdfContext({ projectId: this.projectId, meetingId: this.meetingId });
+    }
     const showAmpelInList = await this._loadDisplaySetting({
       key: "tops.ampelEnabled",
       fallback: true,

--- a/src/renderer/print/layout/PrintShell.js
+++ b/src/renderer/print/layout/PrintShell.js
@@ -655,21 +655,23 @@ export function renderPrint({ pages, data } = {}) {
     } else {
       pageEl.appendChild(renderV2MiniHeader({ data: runtimeData, pageNo, totalPages, modeLabel }));
     }
+    const pageBody = _el("div", "v2PageBody");
     const intro = _buildIntro(page);
-    if (intro) pageEl.appendChild(intro);
+    if (intro) pageBody.appendChild(intro);
     const preRemarks = _buildPreRemarks(page);
-    if (preRemarks) pageEl.appendChild(preRemarks);
+    if (preRemarks) pageBody.appendChild(preRemarks);
     const isTops = String(page?.table?.type || "") === "tops";
     const hasRows = (page?.table?.rows || []).length > 0;
     // Tops-Tabelle ohne Zeilen nicht rendern (sonst Tabellenkopf allein).
     const renderTable = !(isTops && !hasRows);
     if (renderTable) {
-      pageEl.appendChild(_buildTable(page, runtimeData));
+      pageBody.appendChild(_buildTable(page, runtimeData));
     }
     if (isTops && idx === tailPageIdx) {
       const tail = _buildTopsTail(page, runtimeData);
-      if (tail) pageEl.appendChild(tail);
+      if (tail) pageBody.appendChild(tail);
     }
+    pageEl.appendChild(pageBody);
     pageEl.appendChild(_el("div", "v2FooterReserveSpacer"));
     root.appendChild(pageEl);
   });

--- a/src/renderer/print/pdfEditorLayout.js
+++ b/src/renderer/print/pdfEditorLayout.js
@@ -1,0 +1,149 @@
+const ATTRIBUTE_NAMES = Object.freeze({
+  id: "data-ui-inspector-id",
+  kind: "data-ui-editor-kind",
+  label: "data-ui-editor-label",
+  parent: "data-ui-editor-parent",
+  editable: "data-ui-editor-editable",
+  operations: "data-ui-editor-ops",
+});
+
+function stateMap(data) {
+  return new Map((data?.pdfEditorLayoutState?.elements || []).map((entry) => [entry.elementId, entry]));
+}
+
+function registryEntries(data) {
+  return Array.isArray(data?.pdfEditorRegistry?.elements) ? data.pdfEditorRegistry.elements : [];
+}
+
+function state(data, suffix) {
+  return stateMap(data).get(`pdf.bbm.protocol${suffix}`) || null;
+}
+
+function clone(value) {
+  return value === null || value === undefined ? value : structuredClone(value);
+}
+
+export function prepareBbmPdfEditorLayout(data) {
+  if (!data?.pdfEditorLayoutState || !data?.pdfEditorRegistry) return data;
+  const page = state(data, ".page-template");
+  if (page) {
+    data.v2Layout = {
+      ...(data.v2Layout || {}),
+      pagePadTopMm: Number(page.marginTop),
+      pagePadRightMm: Number(page.marginRight),
+      pagePadBottomMm: Number(page.marginBottom),
+      pagePadLeftMm: Number(page.marginLeft),
+    };
+  }
+  const header = state(data, ".header");
+  if (header) data.v2Layout = { ...(data.v2Layout || {}), editorHeaderHeightMm: Number(header.height) };
+  const number = state(data, ".tops.column.number");
+  const text = state(data, ".tops.column.text");
+  const meta = state(data, ".tops.column.meta");
+  const resolved = data?.tableLayouts?.protokoll_tops;
+  if (resolved?.effectiveLayout && number && text && meta) {
+    const effective = clone(resolved.effectiveLayout);
+    effective.pdf = effective.pdf || {};
+    effective.pdf.columns = effective.pdf.columns || {};
+    for (const [key, current] of [["number", number], ["text", text], ["meta", meta]]) {
+      effective.pdf.columns[key] = { ...(effective.pdf.columns[key] || {}), width: `${Number(current.width)}mm` };
+    }
+    data.tableLayouts = { ...(data.tableLayouts || {}), protokoll_tops: { ...resolved, effectiveLayout: effective } };
+  }
+  return data;
+}
+
+function nodesFor(root, entry) {
+  if (entry.id === "pdf.bbm.protocol") return [root];
+  try { return Array.from(root.querySelectorAll(entry.rendererKey)); }
+  catch (_error) { return []; }
+}
+
+function applyAttributes(node, entry) {
+  node.setAttribute(ATTRIBUTE_NAMES.id, entry.id);
+  node.setAttribute(ATTRIBUTE_NAMES.kind, entry.kind);
+  node.setAttribute(ATTRIBUTE_NAMES.label, entry.name);
+  node.setAttribute(ATTRIBUTE_NAMES.parent, entry.parentId || "");
+  node.setAttribute(ATTRIBUTE_NAMES.editable, String(entry.editable === true));
+  node.setAttribute(ATTRIBUTE_NAMES.operations, (entry.capabilities || []).join(","));
+}
+
+function changed(value, baseline) {
+  return Number.isFinite(Number(value)) && Number.isFinite(Number(baseline)) && Math.abs(Number(value) - Number(baseline)) > 0.000001;
+}
+
+function applyStyle(node, entry, current) {
+  const baseline = entry.baseline || {};
+  if (current.visible === false) node.style.display = "none";
+  if (entry.capabilities?.includes("move") && (changed(current.x, baseline.x) || changed(current.y, baseline.y))) {
+    node.style.position = "relative";
+    node.style.left = `${Number(current.x) - Number(baseline.x)}mm`;
+    node.style.top = `${Number(current.y) - Number(baseline.y)}mm`;
+  }
+  if ((entry.capabilities?.includes("resize") || entry.capabilities?.includes("resizeWidth")) && changed(current.width, baseline.width)) {
+    node.style.width = `${Number(current.width)}mm`;
+    node.style.maxWidth = `${Number(current.width)}mm`;
+  }
+  if ((entry.capabilities?.includes("resize") || entry.capabilities?.includes("resizeHeight")) && changed(current.height, baseline.height)) {
+    node.style.height = `${Number(current.height)}mm`;
+    node.style.minHeight = `${Number(current.height)}mm`;
+  }
+  if (entry.capabilities?.includes("textResize") && Number.isFinite(Number(current.fontSize))) node.style.fontSize = `${Number(current.fontSize)}pt`;
+  if (entry.capabilities?.includes("setTextAlignment") && current.textAlignment) node.style.textAlign = current.textAlignment;
+  if (entry.capabilities?.includes("setLineSpacing") && Number.isFinite(Number(current.lineSpacing))) node.style.lineHeight = String(Number(current.lineSpacing));
+}
+
+export function applyBbmPdfEditorLayout(root, data) {
+  if (!root || !data?.pdfEditorLayoutState || !data?.pdfEditorRegistry) return root;
+  const states = stateMap(data);
+  const page = states.get("pdf.bbm.protocol.page-template");
+  if (page) {
+    root.style.setProperty("--v2-pad-top", `${Number(page.marginTop)}mm`);
+    root.style.setProperty("--v2-pad-right", `${Number(page.marginRight)}mm`);
+    root.style.setProperty("--v2-pad-bottom", `${Number(page.marginBottom)}mm`);
+    root.style.setProperty("--v2-pad-left", `${Number(page.marginLeft)}mm`);
+  }
+  for (const entry of registryEntries(data)) {
+    const current = states.get(entry.id);
+    if (!current) continue;
+    for (const node of nodesFor(root, entry)) {
+      applyAttributes(node, entry);
+      applyStyle(node, entry, current);
+    }
+  }
+  return root;
+}
+
+function round(value) {
+  return Math.round(Number(value) * 1000) / 1000;
+}
+
+export function collectBbmPdfPreviewMetadata(root, data) {
+  if (!root || !data?.pdfEditorRegistry) return { pageCount: 0, renderBounds: [] };
+  const pages = Array.from(root.querySelectorAll(".page"));
+  const renderBounds = [];
+  for (const entry of registryEntries(data)) {
+    for (const node of nodesFor(root, entry)) {
+      if (node.style?.display === "none") continue;
+      const page = node.closest?.(".page") || pages[0];
+      if (!page) continue;
+      const pageNumber = Math.max(1, pages.indexOf(page) + 1);
+      const pageRect = page.getBoundingClientRect();
+      const rect = entry.id === "pdf.bbm.protocol" ? pageRect : node.getBoundingClientRect();
+      if (!(pageRect.width > 0 && pageRect.height > 0 && rect.width > 0 && rect.height > 0)) continue;
+      const pageWidthMm = String(data?.orientation || "portrait") === "landscape" ? 297 : 210;
+      const pageHeightMm = String(data?.orientation || "portrait") === "landscape" ? 210 : 297;
+      renderBounds.push({
+        elementId: entry.id,
+        pageNumber,
+        box: {
+          x: round((rect.left - pageRect.left) * pageWidthMm / pageRect.width),
+          y: round((rect.top - pageRect.top) * pageHeightMm / pageRect.height),
+          width: round(rect.width * pageWidthMm / pageRect.width),
+          height: round(rect.height * pageHeightMm / pageRect.height),
+        },
+      });
+    }
+  }
+  return { pageCount: pages.length, renderBounds };
+}

--- a/src/renderer/print/printApp.js
+++ b/src/renderer/print/printApp.js
@@ -4,6 +4,7 @@ import { renderHeaderTestPages } from "./headerTest/HeaderTestPages.js";
 import { renderV2GlobalHeader } from "./v2/header/GlobalHeader.js";
 import { renderV2FullHeader } from "./v2/header/FullHeader.js";
 import { renderV2MiniHeader } from "./v2/header/MiniHeader.js";
+import { applyBbmPdfEditorLayout, collectBbmPdfPreviewMetadata, prepareBbmPdfEditorLayout } from "./pdfEditorLayout.js";
 import { V2_LAYOUT } from "./v2/v2LayoutConfig.js";
 import {
   normalizeTopLongText,
@@ -1024,6 +1025,7 @@ function _measureTopsTailHeight(data) {
   const tail = _buildTopsTailElement(data);
   page.appendChild(tail);
   root.appendChild(page);
+  applyBbmPdfEditorLayout(root, data);
   const h = Math.ceil(tail.getBoundingClientRect().height || 0);
   root.remove();
   return h;
@@ -1153,6 +1155,7 @@ function _measurePreRemarksHeight(ctx, preRemarks) {
   const el = _buildPreRemarksElement(preRemarks);
   if (!el) return 0;
   ctx.root.querySelector(".page")?.appendChild(el);
+  applyBbmPdfEditorLayout(ctx.root, ctx.data);
   const rectH = el.getBoundingClientRect().height;
   const style = getComputedStyle(el);
   const marginTop = parseFloat(style.marginTop) || 0;
@@ -1167,6 +1170,7 @@ function _measureIntroHeight(ctx, intro) {
   const introEl = _buildParticipantsIntroElement(intro);
   if (!introEl) return 0;
   ctx.root.querySelector(".page")?.appendChild(introEl);
+  applyBbmPdfEditorLayout(ctx.root, ctx.data);
   const rectH = introEl.getBoundingClientRect().height;
   const style = getComputedStyle(introEl);
   const marginTop = parseFloat(style.marginTop) || 0;
@@ -1258,6 +1262,7 @@ function _createMeasureContext({ type, projectLabel, docLabel, data, headerKind 
   const tbody = document.createElement("tbody");
   table.appendChild(tbody);
   page.appendChild(table);
+  applyBbmPdfEditorLayout(root, data);
   const pageRect = page.getBoundingClientRect();
   const style = getComputedStyle(page);
   const padTop = parseFloat(style.paddingTop) || 0;
@@ -1287,6 +1292,7 @@ function _createMeasureContext({ type, projectLabel, docLabel, data, headerKind 
 
   return {
     root,
+    data,
     maxBodyHeight,
     measureRow,
     cleanup: () => root.remove(),
@@ -1772,6 +1778,7 @@ async function handleInit(payload) {
     }
 
     const data = res.data || {};
+    prepareBbmPdfEditorLayout(data);
     const topsLayout = _getTopLayout(data);
     // Version/Channel für PDF-Fußnote bereitstellen (falls nicht im Payload enthalten)
     if (!data.appVersion && window.bbmDb?.appGetVersion) {
@@ -1812,7 +1819,7 @@ async function handleInit(payload) {
     }
 
     const pages = _buildPages(data);
-    const root = renderPrint({ pages, data });
+    const root = applyBbmPdfEditorLayout(renderPrint({ pages, data }), data);
     root._bbmRuntimeData = data;
     if (root?.dataset) root.dataset.tableLayout = topsLayout.tableKey || "protokoll_tops";
     if (root?.dataset) root.dataset.orientation = orientation;
@@ -1878,7 +1885,7 @@ async function handleInit(payload) {
       });
     }
 
-    window.bbmPrint.ready({ jobId: payload?.jobId || null, ok: true });
+    window.bbmPrint.ready({ jobId: payload?.jobId || null, ok: true, previewMetadata: collectBbmPdfPreviewMetadata(root, data) });
   } catch (err) {
     setError(err?.message || "Daten konnten nicht geladen werden.");
     window.bbmPrint.ready({ jobId: payload?.jobId || null, ok: false });

--- a/src/renderer/print/v2/header/MiniHeader.js
+++ b/src/renderer/print/v2/header/MiniHeader.js
@@ -13,7 +13,11 @@ export function renderV2MiniHeader({ data, pageNo, totalPages, modeLabel } = {})
 
   const topRow = headerUtils.el("div", "v2MiniTopRow");
   const line1Project = headerUtils.el("div", "v2MiniProject", headerUtils.projectLabel(data?.project));
-  const rightPage = headerUtils.el("div", "v2MiniRight", "Seite " + pageNo + " / " + totalPages);
+  const rightPage = headerUtils.el("div", "v2MiniRight");
+  rightPage.append(
+    headerUtils.el("span", "v2MiniPageLabel", "Seite "),
+    headerUtils.el("span", "v2MiniPageValue", pageNo + " / " + totalPages)
+  );
   topRow.append(line1Project, rightPage);
 
   const line2Protocol = headerUtils.el("div", "v2MiniProtocolTitle", titleText);


### PR DESCRIPTION
## Ziel

M81 verbindet den realen BBM-Protokoll-PDF-Weg mit dem bestehenden nativen PDF-Arbeitsbereich des UI-Editors.

## Enthalten

- echter BBM-Protokoll-PDF-Pilot
- BBM-Druckdaten → bestehender Renderer/Paginierung → Electron `webContents.printToPDF`
- explizite PDF-Registry mit 28 Elementen
- getrennte Labels und Werte
- Dokumentwurzel, Seitenränder, Header, Footer, Titel, Teilnehmerbereich und TOP-Tabelle
- drei registrierte Tabellenspalten
- Breite, Schriftgröße, Ausrichtung, Sichtbarkeit und Spaltenbreite
- Vorschau wird nach Layoutänderung als veraltet markiert
- Neuerzeugung ausschließlich über `PDF neu erzeugen`
- Save, Restore, Discard, Element-/Gesamtreset und Rollback
- echte mehrseitige Vorschau
- Fachwerte bleiben unverändert
- Statusfortschreibung: M81 `[A]`, M82 offen

## Ausdrücklich nicht enthalten

- keine `ReferenceOrder`-PDF
- kein zweiter PDF-Editor, Core, Renderer oder Profilweg
- keine Änderung des fachlichen PDF-/Druckwegs außerhalb der Adaptergrenze
- keine Änderung von Fachwerten
- kein App-Starterpaket
- `docs/licensing.md` ist nicht Bestandteil dieses Commits
- ignorierte Pack-Ausgaben und temporäre PDFs/Profile sind nicht Bestandteil dieses Commits

## Prüfungen

- `npm test` – 8/8 Gruppen, kein OOM
- `npm run test:node` – 8/8 Gruppen
- Node ABI 127 vor dem Lauf, Electron ABI 123 danach wiederhergestellt
- M81-Einzelgruppe grün
- gezieltes ESLint für M81-Dateien fehlerfrei
- `npm run pack` erfolgreich
- `git diff --check`
- sichtbare Abnahme mit realer dreiseitiger BBM-Protokoll-PDF
- Regeneration, Save/Restore, Discard, Reset und Rollback praktisch bestätigt

Das globale Lint enthält weiterhin ausschließlich den bekannten Altbestand von 17 Fehlern und 371 Warnungen.

## Commit

`e9060f3260af9e894189aac184f0b15cfea34788`