### PR TITLE
M81.1 BBM-Editorstart bei inkompatiblen Profilen absichern

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ M80.1 ergänzt Registryversion und deterministischen Fingerprint, vollständige 
 
 M81 bindet die reale BBM-Protokoll-PDF über eine explizite 28-Element-Registry an den vorhandenen nativen M77-PDF-Arbeitsbereich an. BBM behält den bestehenden Paginierungs- und `printToPDF`-Fachweg; der Editor nutzt denselben PDF-Core, Profilweg, Readback und Rollback. Details: [M81-BBM-PDF-Adapter](docs/M81_BBM_PDF_ADAPTER.md).
 
+M81.1 trennt Profilinkompatibilität vom bereits erfolgreichen Editor-Handshake. Alte oder beschädigte UI-/PDF-Profile werden sicher klassifiziert, vor einem Baselinestart byte-identisch archiviert und nie still überschrieben; Abbruch lässt BBM und Profil unverändert. Details: [M81.1-Profil-Restore](docs/M81_1_PROFIL_RESTORE.md).
+
 Status M51: Core-Vertrag technisch angebunden und testbar; noch keine vollständige sichtbare Editor-Oberfläche und noch keine dauerhafte Layoutspeicherung.
 
 ## M52: Sichtbarer UI-Editor-Startpunkt

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,26 @@
 # STATUS.md — BBM-Produktiv
 
+### M81.1 – Editorstart bei inkompatiblen Benutzerprofilen repariert
+
+- Status: `[A] abgenommen`; gezielte Regressionen und reale Abnahme im normalen Benutzerprofilpfad sind abgeschlossen.
+- Ursache:
+  - Ein Profilfehler nach erfolgreichem Handshake wurde als `electron_restore_failed` in den generischen Verbindungsfehlerpfad geleitet.
+  - Das reale Altprofil besitzt eine frühere Editbox-Registry und keinen aktuellen Header-Scope; eine sichere Migration ist mangels vollständigem Altstrukturbeleg nicht beweisbar.
+- Ergebnis:
+  - UI-/PDF-Profilzustände und Fehlercodes bleiben getrennt; bewusster Abbruch erzeugt keine zweite generische BBM-Meldung.
+  - Baseline/Migration archivieren das Original zuerst byte-identisch mit Metadaten und SHA-256 unterhalb der vorhandenen Profilwurzel.
+  - Nur identische vorhandene Scopes plus ausschließlich neue Baseline-Scopes sind automatisch migrationsfähig.
+  - Erfolgreich normalisierte Zielzustände starten sauber, ohne falsches Dirty und ohne Autosave.
+- Praktische Prüfung:
+  - echter normaler Benutzerprofilpfad, sichtbarer Sicherheitsdialog und Details,
+  - Altprofil byte-identisch archiviert; Standardlayout sauber geöffnet,
+  - UI-Auswahl/Markierung, Save, vollständiger BBM-Neustart und sauberer Restore,
+  - echte zweiseitige BBM-Protokoll-PDF mit 28 Elementen, Save/Restore, Reset und Discard,
+  - genau eine Editorinstanz; Fachwerte unverändert.
+- Dokumentation: `docs/M81_1_PROFIL_RESTORE.md`.
+- Risiken / offen: M82 bleibt offen und wurde nicht begonnen.
+- Commit/PR: keiner; gemäß Nutzeranweisung weder Commit noch Push noch PR noch Merge.
+
 ### M81 – BBM-PDF an den bestehenden PDF-Arbeitsbereich angebunden
 
 - Status: `[A] abgenommen`; automatisierte Pflichtprüfungen und sichtbare native Abnahme sind abgeschlossen.

--- a/docs/M81_1_PROFIL_RESTORE.md
+++ b/docs/M81_1_PROFIL_RESTORE.md
@@ -1,0 +1,39 @@
+# M81.1 – Sicherer BBM-Editorstart bei inkompatiblen Benutzerprofilen
+
+## Ursache
+
+Der lokale Electron-Handshake, die Registry und die Pipe waren gültig. Der native Editor versuchte danach jedoch, das alte Layoutprofil unmittelbar anzuwenden. Eine veraltete Registrystruktur führte zu `electron_restore_failed`; BBM zeigte den Fehler dadurch fälschlich als „UI-Editor konnte nicht verbunden werden“ und schloss die bereits hergestellte Sitzung.
+
+Das reale Profil enthielt ein älteres `restarbeiten.edit.root`-Inventar und keinen aktuellen Header-Scope. Da das Altformat die früheren Parent-/Rolleninformationen nicht vollständig belegt, ist eine automatische Migration nicht sicher nachweisbar.
+
+## Neuer Startweg
+
+1. BBM stellt wie bisher den lokalen Electron-Vertrag, drei vollständige UI-Scopes und optional die 28-elementige PDF-Registry bereit.
+2. Das UI-Editor-kit klassifiziert UI und PDF getrennt.
+3. Ein kompatibles oder fehlendes Profil startet direkt. Ein inkompatibles oder beschädigtes Profil öffnet den nativen Sicherheitsdialog.
+4. `Abbrechen` lässt Datei und BBM unverändert. `Mit Standardlayout öffnen` archiviert zuerst das Original byte-identisch und startet danach sauber von der Ziel-App-Baseline. Migration erscheint nur bei strengem Positivnachweis.
+5. Profilfehler besitzen eigene `electron_profile_*`-, UI-Restore- und PDF-Restore-Codes. BBM meldet sie nicht mehr als Verbindungsfehler und zeigt bei bewusstem Abbruch keine zweite generische Fehlermeldung.
+
+## Archivvertrag
+
+Das Archiv liegt ausschließlich innerhalb der vorhandenen Profilwurzel:
+
+`ui-editor/profiles/archive/<applicationId>/<timestamp>_<reason>_<original>`
+
+Die Originalbytes bleiben unverändert. Eine atomar geschriebene `.metadata.json`-Datei enthält Originalname/-zeit, Archivzeit, Grund, Klassifikation, Schema-/Vertrags-/Registryversion, alte und aktuelle Fingerprints, Dokumenttyp und SHA-256. Kollisionen werden mit einem eindeutigen Namen aufgelöst; es gibt kein stilles Überschreiben oder Löschen.
+
+## Reale Abnahme
+
+- normaler BBM-Benutzerprofilpfad verwendet,
+- vorhandenes inkompatibles `standard.layout-profile.json` erkannt,
+- Dialog und technische Details einschließlich exaktem Profilpfad geprüft,
+- Altprofil mit identischer Länge, Zeit und SHA-256 archiviert,
+- Standardlayout sauber ohne Autosave geöffnet,
+- UI-Element in BBM ausgewählt und markiert,
+- 28 PDF-Elemente und echte zweiseitige Protokollvorschau geprüft,
+- UI- und PDF-Layout gespeichert, BBM vollständig neu gestartet und beide Profile sauber wiederhergestellt,
+- Elementreset, Gesamtreset und Discard geprüft,
+- erneuter Editoraufruf fokussiert dieselbe Managerinstanz.
+
+Fachwerte, Registry, Parent-/Operationsvertrag, PDF-Core, Paginierung und Druckweg blieben unverändert. M82 bleibt offen.
+

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -121,7 +121,7 @@ Der aktuell sinnvolle Hauptfokus liegt auf **Achse B und Achse C**, flankiert vo
 - M21-Einordnung: `Protokoll` ist noch nicht fertig bereinigt und wird fuer UI-Editor-Themen defensiv/read-only behandelt.
 - M21-Einordnung: BBM-Produktiv ist Beispiel-/Pilot-Zielapp fuer das generische UI-Editor-kit; die Ziel-App liefert die ElementRegistry, der Editor liest ausschliesslich diese Registry.
 - Keine Selbstuntersuchung der Ziel-App-Oberflaeche, keine automatische UI-Erkennung, kein UI-Scanning, kein DOM-Scan und keine automatische Registry-Befuellung.
-- M80.2 ist `[A]` abgenommen: tatsächlicher Restarbeiten-Header und stabiler Editbox-Root sind direkt größenfähig, der alte Splitpfad ist gesperrt und die Hauptliste als flexibler Scrollbereich gesichert. M80.2a stabilisiert ausschließlich Testharness und Node-/Electron-ABI-Wechsel. M81/M82 und der Fachausbau bleiben offen und wurden nicht begonnen.
+- M80.2 ist `[A]` abgenommen: tatsächlicher Restarbeiten-Header und stabiler Editbox-Root sind direkt größenfähig, der alte Splitpfad ist gesperrt und die Hauptliste als flexibler Scrollbereich gesichert. M80.2a stabilisiert ausschließlich Testharness und Node-/Electron-ABI-Wechsel. M81 und M81.1 sind abgenommen; M81.1 trennt alte/beschädigte Benutzerprofile vom gültigen Electron-Handshake und archiviert sie vor einem Baselinestart byte-identisch. M82 und der Fachausbau bleiben offen und wurden nicht begonnen.
 
 Der Kernrahmen bleibt weiter wichtig, aber die bereits erreichten kleinen Kernschritte sind fuer die naechsten Mini-Pakete nicht mehr der dominante erste Fokus.
 

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -143,6 +143,7 @@ const TEST_GROUPS = Object.freeze([
       ["m80-1RegistrationRefresh.test.cjs", "runM801RegistrationRefreshTests"],
       ["m80-2HeaderEditboxLayout.test.cjs", "runM802HeaderEditboxLayoutTests"],
       ["m81BbmPdfAdapter.test.cjs", "runM81BbmPdfAdapterTests"],
+      ["m81-1ProfileRestore.test.cjs", "runM811ProfileRestoreTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),
   }),

--- a/scripts/tests/m81-1ProfileRestore.test.cjs
+++ b/scripts/tests/m81-1ProfileRestore.test.cjs
@@ -1,0 +1,59 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { ELECTRON_EDITOR_ERROR_CODES } = require("ui-editor-kit");
+
+const ROOT = path.resolve(__dirname, "../..");
+const read = (file) => fs.readFileSync(path.join(ROOT, file), "utf8");
+
+async function runM811ProfileRestoreTests(run) {
+  await run("M81.1 Fehlercodes: UI, PDF, Archiv, Migration, Baseline und Abbruch bleiben getrennt", () => {
+    assert.equal(ELECTRON_EDITOR_ERROR_CODES.PROFILE_INCOMPATIBLE, "electron_profile_incompatible");
+    assert.equal(ELECTRON_EDITOR_ERROR_CODES.PROFILE_CORRUPT, "electron_profile_corrupt");
+    assert.equal(ELECTRON_EDITOR_ERROR_CODES.PROFILE_MIGRATION_AVAILABLE, "electron_profile_migration_available");
+    assert.equal(ELECTRON_EDITOR_ERROR_CODES.PROFILE_MIGRATION_FAILED, "electron_profile_migration_failed");
+    assert.equal(ELECTRON_EDITOR_ERROR_CODES.PROFILE_ARCHIVE_FAILED, "electron_profile_archive_failed");
+    assert.equal(ELECTRON_EDITOR_ERROR_CODES.PROFILE_BASELINE_STARTED, "electron_profile_baseline_started");
+    assert.equal(ELECTRON_EDITOR_ERROR_CODES.UI_PROFILE_RESTORE_FAILED, "electron_ui_profile_restore_failed");
+    assert.equal(ELECTRON_EDITOR_ERROR_CODES.PDF_PROFILE_RESTORE_FAILED, "electron_pdf_profile_restore_failed");
+    assert.equal(ELECTRON_EDITOR_ERROR_CODES.PROFILE_USER_CANCELLED, "electron_profile_user_cancelled");
+  });
+
+  await run("M81.1 BBM-Main: Profilfehler werden nicht mehr als pauschaler Verbindungsfehler gemeldet", () => {
+    const { publicError } = require("../../src/main/ui-editor/electronUiEditorSession.js");
+    assert.match(publicError({ code: ELECTRON_EDITOR_ERROR_CODES.PROFILE_INCOMPATIBLE }).message, /nicht mehr.*kompatibel/i);
+    assert.match(publicError({ code: ELECTRON_EDITOR_ERROR_CODES.UI_PROFILE_RESTORE_FAILED }).message, /Editorverbindung selbst ist verfügbar/);
+    assert.match(publicError({ code: ELECTRON_EDITOR_ERROR_CODES.PDF_PROFILE_RESTORE_FAILED }).message, /UI-Arbeitsbereich bleibt getrennt/);
+    assert.match(publicError({ code: ELECTRON_EDITOR_ERROR_CODES.PROFILE_ARCHIVE_FAILED }).message, /bleibt unverändert/);
+    assert.match(publicError({ code: ELECTRON_EDITOR_ERROR_CODES.PROFILE_USER_CANCELLED }).message, /BBM bleibt geöffnet/);
+  });
+
+  await run("M81.1 Renderer: Nutzerabbruch zeigt keinen zweiten Pauschaldialog", () => {
+    const navigation = read("src/renderer/app/coreShellNavigation.js");
+    assert.match(navigation, /errorCode\s*!==\s*"electron_profile_user_cancelled"/);
+  });
+
+  await run("M81.1 Profilwurzel: bestehender BBM-userData-Pfad bleibt führend", () => {
+    const session = read("src/main/ui-editor/electronUiEditorSession.js");
+    assert.match(session, /getPath\("userData"\),\s*"ui-editor",\s*"profiles"/);
+    assert.match(session, /--profile-root=/);
+    assert.doesNotMatch(session, /isolated-profile|test-profile-root|profileRoot.*tmpdir/i);
+  });
+
+  await run("M81.1 Produktgrenze: Fachwerte, Datenbank und PDF-Erzeugung bleiben außerhalb", () => {
+    const navigation = read("src/renderer/app/coreShellNavigation.js");
+    assert.doesNotMatch(navigation, /createRecord|updateRestarbeit|deleteRestarbeit|better-sqlite3|printToPDF/);
+  });
+}
+
+module.exports = { runM811ProfileRestoreTests };
+
+if (require.main === module) {
+  let failed = false;
+  runM811ProfileRestoreTests(async (name, fn) => {
+    try { await fn(); console.log(`PASS ${name}`); }
+    catch (error) { failed = true; console.error(`FAIL ${name}`); console.error(error); }
+  }).then(() => { if (failed) process.exitCode = 1; });
+}

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 98, "97 Suite-Einstiege plus Harness-Test einschliesslich M81");
+    assert.equal(suites.length, 99, "98 Suite-Einstiege plus Harness-Test einschliesslich M81.1");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/src/main/ui-editor/electronUiEditorSession.js
+++ b/src/main/ui-editor/electronUiEditorSession.js
@@ -93,6 +93,15 @@ function publicError(error) {
     [ELECTRON_EDITOR_ERROR_CODES.REGISTRY_INCOMPATIBLE]: "BBM-Registry und Editor-Adapter sind nicht kompatibel.",
     [ELECTRON_EDITOR_ERROR_CODES.REGISTRY_PROFILE_CONFLICT]: "Die Registry wurde geändert, aber im Editor bestehen ungespeicherte Änderungen.",
     [ELECTRON_EDITOR_ERROR_CODES.REGISTRY_PROFILE_MIGRATION_REQUIRED]: "Die Registryänderung benötigt wegen geänderter IDs oder Parents eine ausdrückliche Profilmigration.",
+    [ELECTRON_EDITOR_ERROR_CODES.PROFILE_INCOMPATIBLE]: "Das gespeicherte Editorlayout ist nicht mehr mit der aktuellen BBM-Version kompatibel.",
+    [ELECTRON_EDITOR_ERROR_CODES.PROFILE_CORRUPT]: "Das gespeicherte Editorlayout ist beschädigt und wurde nicht angewendet.",
+    [ELECTRON_EDITOR_ERROR_CODES.PROFILE_MIGRATION_AVAILABLE]: "Für das gespeicherte Editorlayout ist eine sichere Migration verfügbar.",
+    [ELECTRON_EDITOR_ERROR_CODES.PROFILE_MIGRATION_FAILED]: "Das gespeicherte Editorlayout konnte nicht sicher migriert werden; das Altprofil bleibt erhalten.",
+    [ELECTRON_EDITOR_ERROR_CODES.PROFILE_ARCHIVE_FAILED]: "Das Altprofil konnte nicht sicher archiviert werden und bleibt unverändert.",
+    [ELECTRON_EDITOR_ERROR_CODES.PROFILE_BASELINE_STARTED]: "Der Editor wurde mit dem Standardlayout geöffnet.",
+    [ELECTRON_EDITOR_ERROR_CODES.UI_PROFILE_RESTORE_FAILED]: "Das UI-Layout konnte nicht wiederhergestellt werden; die Editorverbindung selbst ist verfügbar.",
+    [ELECTRON_EDITOR_ERROR_CODES.PDF_PROFILE_RESTORE_FAILED]: "Das PDF-Layout konnte nicht wiederhergestellt werden; der UI-Arbeitsbereich bleibt getrennt.",
+    [ELECTRON_EDITOR_ERROR_CODES.PROFILE_USER_CANCELLED]: "Das Öffnen des Editors wurde abgebrochen. BBM bleibt geöffnet.",
   };
   return { ok: false, errorCode: code, message: messages[code] || "Der separate UI-Editor konnte nicht gestartet werden." };
 }

--- a/src/renderer/app/coreShellNavigation.js
+++ b/src/renderer/app/coreShellNavigation.js
@@ -32,7 +32,9 @@ export async function openNativeUiEditor(context = {}) {
   } else {
     showRegistryRefreshStatus(result?.message || "UI-Registry konnte nicht freigegeben werden.", "blocked");
   }
-  if (!result?.ok) alert(result?.message || "Der separate UI-Editor konnte nicht gestartet werden.");
+  if (!result?.ok && result?.errorCode !== "electron_profile_user_cancelled") {
+    alert(result?.message || "Der separate UI-Editor konnte nicht gestartet werden.");
+  }
   return result;
 }
 


### PR DESCRIPTION
## Ziel

M81.1 verhindert, dass inkompatible oder beschädigte UI-/PDF-Profile den BBM-Editorstart fälschlich als vollständigen Verbindungsfehler abbrechen.

## Enthalten

- getrennte Behandlung von Prozess-, Verbindungs-, Registry- und Profilfehlern
- verständlicher Recoverydialog statt pauschalem `electron_restore_failed`
- Start mit aktuellem Standardlayout bei inkompatiblem Profil
- Altprofil bleibt bytegleich archiviert
- UI- und PDF-Profile werden unabhängig behandelt
- erneuter Start nach Abbruch möglich
- Save und Neustart-Restore eines neuen kompatiblen Profils
- genau eine Editorinstanz
- Statusfortschreibung: M81.1 `[A]`, M82 offen

## Ausdrücklich nicht enthalten

- keine neue Registry-, Layout- oder PDF-Funktion
- keine Änderung von Fachwerten oder Fachaktionen
- kein App-Starterpaket
- `docs/licensing.md` ist nicht Bestandteil dieses Commits
- Profile, Archive, Sidecars und Pack-Ausgaben sind nicht Bestandteil dieses Commits

## Prüfungen

- `npm test` – 8/8 Gruppen, kein OOM
- `npm run test:node` – 8/8 Gruppen
- M81.1-Einzeltests – 5/5 bestanden
- gezieltes ESLint für M81.1-Dateien fehlerfrei
- `npm run pack` erfolgreich
- gepackte `BBM.exe` sichtbar gestartet und regulär beendet
- `git diff --check`
- praktische Abnahme mit normalem Benutzerprofil, UI-/PDF-Neustart und Restore

Das globale Lint enthält weiterhin ausschließlich den bekannten Altbestand von 17 Fehlern und 371 Warnungen.

## Commit

`4880ac0c2d4ed348a39d4c330c8baa85396bb663`