### PR TITLE
M82.3 BBM-Spacer und kompakte Editorbedienung integrieren

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -3536,3 +3536,14 @@ Wichtig:
 - Risiken/Hindernisse:
   - Praktische Computer-Use-/Electron-UI-Abnahme ist in dieser Umgebung nicht verfügbar und muss lokal/auf Zielsystem nachgeholt werden.
   - Im aktuellen Checkout ist kein Git-Remote `origin` eingerichtet; Veröffentlichung/PR hängt vom verfügbaren PR-Werkzeug ab.
+
+## M82.3 - Lokale Breitenwirkung und kompakte Editoroberflaeche
+
+- Status: `[A]`; Implementierung, Pflichtpruefungen und sichtbare native UI-/PDF-Abnahme sind abgeschlossen.
+- BBM registriert Breite, reservierten Platz, Spacer, Gruppenpadding und Kindabstaende explizit und bildet sie im vorhandenen Electron-HostAdapter ab.
+- Kurztext/Gegenstand behaelt bei reserviertem Platz Nachbarpositionen und Gruppengroesse; Nachruecken und Gruppenverkleinern bleiben getrennte Entscheidungen.
+- Responsive Gruppenbaselines werden vor Start-Restore einmalig erfasst und von Element-, Gruppen- und Gesamtreset korrekt wiederhergestellt.
+- Der gemeinsame Manager wurde sichtbar in 1/2/3 Spalten, mit fester Aktionsleiste, internem Baumscrollbereich und UI-/PDF-Tab geprueft.
+- Die reale Development-Abnahme belegte 28 PDF-Registryelemente und eine aktuelle zweitseitige A4-Vorschau; Fachwerte blieben unveraendert.
+- `docs/licensing.md` bleibt Fremdaenderung und unangetastet.
+- Commit/PR: keiner; gemaess Nutzeranweisung wurde weder committet noch gepusht.

--- a/docs/M82_3_BBM_SPACER_UND_EDITORBEDIENUNG.md
+++ b/docs/M82_3_BBM_SPACER_UND_EDITORBEDIENUNG.md
@@ -1,0 +1,29 @@
+# M82.3 - BBM-Spacer und Editorbedienung
+
+Status: `[A] abgenommen`
+
+## Rolle von BBM
+
+BBM ist Referenz- und Abnahme-App fuer den appuebergreifenden M82.3-Vertrag. Die neutralen Spacingziele, Entscheidungen bei frei werdendem Platz, Risikoauswertung und responsive Editoroberflaeche liegen im UI-Editor-kit. BBM enthaelt keine zweite Editor-, Registry-, Pipe- oder Profilimplementierung.
+
+## Kurztext/Gegenstand
+
+Die explizite Registryversion 5 erlaubt fuer die Bezeichnung Kurztext/Gegenstand eine eigene Breite sowie `beforeElement`, `afterElement` und `reservedWidth`. Die Gruppe Kurztext/Gegenstand erlaubt davon getrennt Breite, Hoehe, Innenabstaende und Kindabstaende.
+
+Der Electron-HostAdapter bildet `reservedWidth` auf den vorhandenen Grid-Slot ab. Bei **Freien Platz stehen lassen** wird der Slot um die frei werdende Breite erweitert; Restzeichenanzeige, Diktatbutton, Mikrofonsymbol, Kurztextaktionen und Gruppe bleiben stabil. **Nachbarelemente nachruecken lassen** verkleinert den Slot bewusst. **Gruppe entsprechend verkleinern** verwendet eine getrennte Gruppenoperation.
+
+Gruppenpadding und Gap werden auf die vorhandenen CSS-Eigenschaften abgebildet. Bei einem Content-Box-Ziel wird der horizontale Innenabstand von der Inhaltsbreite abgezogen, damit die bestaetigte aeussere Gruppenbreite stabil bleibt. Responsive Gruppenbreite und -hoehe werden einmalig vor dem Start-Restore erfasst; Reset stellt diesen echten Laufzeit-Ausgangszustand wieder her.
+
+## Speichern, Restore und Reset
+
+Spacing wird als neutraler Layoutzustand im vorhandenen UI-Profil gespeichert. Der normale Startdienst stellt Breite und abgeleiteten reservierten Platz gemeinsam wieder her. Editoroeffnung wendet denselben Zustand nicht doppelt an. Elementreset, Gruppenreset, Gesamtreset, Discard und Recovery verwenden den vorhandenen transaktionalen Profilweg.
+
+## Kompakte Oberflaeche und PDF
+
+Der vorhandene native Manager zeigt den gemeinsamen UI-Arbeitsbereich bei grosser, normaler und kleiner Inhaltsbreite in drei, zwei beziehungsweise einer Spalte. Speichern, Verwerfen, Reset, naechste Auswahl, Direktauswahl, Dirty-Status und Modus bleiben in der festen Aktionsleiste erreichbar. Der Elementbaum scrollt intern. Der PDF-Tab verwendet denselben responsiven Rahmen, aber seine getrennten PDF-Kontrollen.
+
+## Praktischer Nachweis
+
+Im gepackten Development-Build wurden Kurztext/Gegenstand, Textumbruch, reservierter Platz, bewusstes Nachruecken, Gruppenbreite, Padding/Gap, Save/Restart, Element-/Gruppen-/Gesamtreset, Discard, Direktauswahl mit Escape und 1/2/3-Spaltenmodus sichtbar geprueft. Die reale Projekt-PDF wurde ueber den unveraenderten BBM-`printToPDF`-Weg als zweitseitige A4-PDF erzeugt. Der native PDF-Arbeitsbereich zeigte 28 Registryelemente und die aktuelle Vorschau; reines Laden liess den bestehenden PDF-Profilhash unveraendert.
+
+Fachwerte, Datenbank, Kundendaten, Druckfachlogik, `docs/licensing.md` und die Benutzerlizenz wurden nicht veraendert.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -148,6 +148,7 @@ const TEST_GROUPS = Object.freeze([
       ["m82AppStarterPackage.test.cjs", "runM82AppStarterPackageTests"],
       ["m82-1BbmFeintuning.test.cjs", "runM821BbmFeintuningTests"],
       ["m82-2BbmGeometryRisks.test.cjs", "runM822BbmGeometryRiskTests"],
+      ["m82-3BbmSpacerCompactUi.test.cjs", "runM823BbmSpacerCompactUiTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),
   }),

--- a/scripts/tests/m80-1RegistrationRefresh.test.cjs
+++ b/scripts/tests/m80-1RegistrationRefresh.test.cjs
@@ -83,7 +83,7 @@ async function runM801RegistrationRefreshTests(run) {
       document.body.appendChild(rendered.root);
       const registration = rendered.registration;
       runtimeRegistration = structuredClone(registration);
-      assert.equal(registration.registryVersion, 4);
+      assert.equal(registration.registryVersion, 5);
       assert.equal(registration.registryStatus, "incomplete");
       assert.deepEqual(registration.activeScopes, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]);
       const complete = registration.registryScopes.filter((scope) => scope.status === "complete");

--- a/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
+++ b/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
@@ -15,7 +15,7 @@ async function runM802HeaderEditboxLayoutTests(run) {
   const elements = complete.flatMap((scope) => scope.elements);
 
   await run("M80.2 Registry: Header, Liste und Editbox sind direkt aktiv; Split ist gesperrt", () => {
-    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 4);
+    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 5);
     assert.deepEqual(registryModule.BBM_M80_ACTIVE_SCOPES, [
       "restarbeiten.header.root",
       "restarbeiten.list.root",

--- a/scripts/tests/m80ElectronUiEditor.test.cjs
+++ b/scripts/tests/m80ElectronUiEditor.test.cjs
@@ -63,7 +63,11 @@ async function runM80ElectronUiEditorTests(run) {
   const entries = scopes.flatMap((scope) => scope.elements);
   const registrationScopes = scopes.map((scope) => scope.status === "complete" ? {
     ...scope,
-    elements: scope.elements.map((entry) => ({ ...entry, referenceResolved: true })),
+    elements: scope.elements.map((entry) => ({
+      ...entry,
+      referenceResolved: true,
+      ...(entry.baseline?.width === null || entry.baseline?.height === null ? { capturedBaseline: { width: 640, height: 64 } } : {}),
+    })),
   } : scope);
   const registration = {
     applicationId: "bbm-produktiv", displayName: "BBM", framework: "electron",

--- a/scripts/tests/m82-1BbmFeintuning.test.cjs
+++ b/scripts/tests/m82-1BbmFeintuning.test.cjs
@@ -24,8 +24,8 @@ async function runM821BbmFeintuningTests(run) {
   const editbox = read("src/renderer/modules/restarbeiten/RestarbeitenEditbox.js");
   const css = read("src/renderer/modules/restarbeiten/styles/restarbeiten.css");
 
-  await run("M82.1 BBM 01: Registryversion 4 ist aktiv", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 4));
-  await run("M82.1 BBM 02: Manifestversion folgt der Registry", () => assert.equal(manifest.registryVersion, 4));
+  await run("M82.1 BBM 01: Registryversion 5 ist aktiv", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 5));
+  await run("M82.1 BBM 02: Manifestversion folgt der Registry", () => assert.equal(manifest.registryVersion, 5));
   await run("M82.1 BBM 03: Manifestfingerprint ist aktuell", () => assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)));
   await run("M82.1 BBM 04: genau drei Restarbeiten-Scopes bleiben aktiv", () => assert.deepEqual(registry.BBM_M80_ACTIVE_SCOPES, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]));
   await run("M82.1 BBM 05: Header behält 31 Elemente", () => assert.equal(byId.has("restarbeiten.header.root") && scopes.find((scope) => scope.scopeId === "restarbeiten.header.root").elements.length, 31));
@@ -81,7 +81,11 @@ async function runM821BbmFeintuningTests(run) {
     const profileRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-m82-1-startup-"));
     try {
       const registryScopes = scopes.map((scope) => scope.status === "complete"
-        ? { ...scope, elements: scope.elements.map((entry) => ({ ...entry, referenceResolved: true })) }
+        ? { ...scope, elements: scope.elements.map((entry) => ({
+            ...entry,
+            referenceResolved: true,
+            ...(entry.baseline?.width === null || entry.baseline?.height === null ? { capturedBaseline: { width: 640, height: 64 } } : {}),
+          })) }
         : scope);
       const registration = {
         applicationId: "bbm-produktiv", displayName: "BBM", framework: "electron",
@@ -95,11 +99,12 @@ async function runM821BbmFeintuningTests(run) {
         const saved = { elementId: entry.id, scopeId };
         const ops = new Set(entry.allowedOps);
         if (ops.has("move")) { saved.x = entry.baseline.x; saved.y = entry.baseline.y; }
-        if (ops.has("resize") || ops.has("resizeWidth")) saved.width = entry.baseline.width;
-        if (ops.has("resize") || ops.has("resizeHeight")) saved.height = entry.baseline.height;
+        if (ops.has("resize") || ops.has("resizeWidth")) saved.width = Number.isFinite(entry.baseline.width) ? entry.baseline.width : Math.max(entry.baseline.minWidth || 1, 640);
+        if (ops.has("resize") || ops.has("resizeHeight")) saved.height = Number.isFinite(entry.baseline.height) ? entry.baseline.height : Math.max(entry.baseline.minHeight || 1, 64);
         if (ops.has("textMove")) { saved.textOffsetX = entry.baseline.textOffsetX; saved.textOffsetY = entry.baseline.textOffsetY; }
         if (ops.has("textResize")) saved.fontSize = entry.baseline.fontSize;
         if (ops.has("setVisibility")) saved.visible = entry.baseline.visible;
+        if (["spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"].some((operation) => ops.has(operation))) saved.spacing = { ...(entry.baseline.spacing || {}) };
         return saved;
       };
       const document = {

--- a/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
+++ b/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
@@ -1,0 +1,115 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const { evaluateGeometryRisk, RISK_TYPES, RISK_ACTIONS, createRegistryFingerprint } = require("ui-editor-kit");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const ROOT = path.resolve(__dirname, "../..");
+const read = (file) => fs.readFileSync(path.join(ROOT, file), "utf8");
+
+class FakeElement {
+  constructor(width = 150, height = 24) {
+    this.dataset = {}; this.attributes = {}; this.className = ""; this.isConnected = true;
+    this.style = { width: `${width}px`, height: `${height}px`, setProperty(name, value) { this[name] = value; }, getPropertyValue(name) { return this[name] || ""; } };
+    this._rect = { left: 0, top: 0, width, height };
+    this.classList = { contains: () => false, toggle() {} };
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  getBoundingClientRect() { return { ...this._rect, width: parseFloat(this.style.width) || this._rect.width, height: parseFloat(this.style.height) || this._rect.height }; }
+}
+
+async function runM823BbmSpacerCompactUiTests(run) {
+  const registry = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Registry.js"));
+  const refs = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Refs.js"));
+  const hostModule = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80HostAdapter.js"));
+  const scopes = registry.listM80RegistryScopes();
+  const entries = scopes.flatMap((scope) => scope.elements);
+  const byId = new Map(entries.map((entry) => [entry.id, entry]));
+  const manifest = JSON.parse(read("ui-editor-target.json"));
+  const host = read("src/renderer/ui-editor/m80HostAdapter.js");
+  const refSource = read("src/renderer/ui-editor/m80Refs.js");
+  const editbox = read("src/renderer/modules/restarbeiten/RestarbeitenEditbox.js");
+  const restarbeitenCss = read("src/renderer/modules/restarbeiten/styles/restarbeiten.css");
+  const compactXaml = read("../UI-Editor-kit/reference-target-app/src/ReferenceTargetApp.Wpf/UI/Views/CompactEditorWorkspaceView.xaml");
+  const compactCode = read("../UI-Editor-kit/reference-target-app/src/ReferenceTargetApp.Wpf/UI/Views/CompactEditorWorkspaceView.xaml.cs");
+  const pdfCode = read("../UI-Editor-kit/reference-target-app/src/ReferenceTargetApp.Wpf/UI/Views/EditorWindow.xaml.cs");
+  const label = byId.get("restarbeiten.edit.short.label");
+  const group = byId.get("restarbeiten.edit.short");
+  let flowRow;
+  const widthRisk = (groupWidthEditable = true) => evaluateGeometryRisk({
+    operationId: "bbm-m82-3", operation: "resizeWidth", currentBounds: { left: 0, top: 0, width: 150, height: 24 }, targetBounds: { left: 0, top: 0, width: 130, height: 24 },
+    target: { elementId: label.id, displayName: label.name, elementType: label.type, bounds: { left: 0, top: 0, width: 150, height: 24 } },
+    group: { elementId: group.id, displayName: group.name, elementType: group.type, bounds: { left: 0, top: 0, width: 878, height: 50 } },
+    affectedNeighbors: [{ elementId: "restarbeiten.edit.short.remaining", displayName: "Restzeichenanzeige Kurztext", elementType: "label", previousBounds: { left: 190, top: 0, width: 40, height: 24 }, bounds: { left: 170, top: 0, width: 40, height: 24 }, geometryChanged: true }],
+    groupWidthEditable,
+  });
+
+  await run("M82.3 BBM 01: Registryversion 5 ist aktiv", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 5));
+  await run("M82.3 BBM 02: Manifest folgt Registry und Fingerprint", () => { assert.equal(manifest.registryVersion, 5); assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)); });
+  await run("M82.3 BBM 03: Kurztextbezeichnung besitzt reservierte Breite", () => assert.deepEqual(label.baseline.spacing, { reservedWidth: 40 }));
+  await run("M82.3 BBM 04: Kurztextbezeichnung erlaubt Spacer davor und danach", () => assert.deepEqual(label.spacingTargets, ["beforeElement", "afterElement", "reservedWidth"]));
+  await run("M82.3 BBM 05: Gruppenbreite ist getrennt freigegeben und nutzt die responsive Laufzeitbaseline", () => { assert.ok(group.allowedOps.includes("resizeWidth")); assert.equal(group.baseline.width, null); });
+  await run("M82.3 BBM 06: Gruppenhöhe ist getrennt freigegeben und nutzt die responsive Laufzeitbaseline", () => { assert.ok(group.allowedOps.includes("resizeHeight")); assert.equal(group.baseline.height, null); });
+  await run("M82.3 BBM 07: Gruppeninnenabstände sind explizit", () => assert.deepEqual(group.spacingTargets.slice(0, 4), ["groupPaddingLeft", "groupPaddingRight", "groupPaddingTop", "groupPaddingBottom"]));
+  await run("M82.3 BBM 08: Registry-Parents bleiben unverändert", () => { assert.equal(label.parentId, "restarbeiten.edit.short"); assert.equal(byId.get("restarbeiten.edit.short.dictation.icon").parentId, "restarbeiten.edit.short.dictation"); });
+  await run("M82.3 BBM 09: Bezeichnungsbreite nutzt einen expliziten Grid-Slot", () => assert.match(editbox, /registerM80FlowLabelRef[\s\S]*30px 24px minmax\(92px, auto\) auto/));
+  await run("M82.3 BBM 10: Electron-Abbildung speichert Spacing-Intent", () => assert.match(refSource, /uiEditorSpacing/));
+  await run("M82.3 BBM 11: reservierter Platz wird zur Trackbreite addiert", () => assert.match(refSource, /elementWidth = bounded[\s\S]*slotWidth = elementWidth \+ reservedWidth/));
+  await run("M82.3 BBM 12: generische Gruppenabstände bilden Padding und Gap ab", () => assert.match(refSource, /paddingLeft[\s\S]*columnGap[\s\S]*rowGap/));
+  await run("M82.3 BBM 12a: Gruppenpadding wird ohne fremdes Boxmodell von der Inhaltsbreite abgezogen", () => assert.match(refSource, /horizontalPadding[\s\S]*desiredWidth - horizontalPadding/));
+  await run("M82.3 BBM 12b: responsive Gruppenbaseline wird vor dem Start-Restore einmalig erfasst", () => assert.match(host, /capturedRuntimeBaselines[\s\S]*snapshotM80State[\s\S]*capturedBaseline/));
+  await run("M82.3 BBM 13: Freier Platz ist Standardentscheidung", () => assert.equal(widthRisk().suggestedActions[0], RISK_ACTIONS.PRESERVE_SPACE));
+  await run("M82.3 BBM 14: Nachrücken ist separate Entscheidung", () => assert.ok(widthRisk().suggestedActions.includes(RISK_ACTIONS.REFLOW_NEIGHBORS)));
+  await run("M82.3 BBM 15: Gruppenverkleinerung ist separate Entscheidung", () => assert.ok(widthRisk().suggestedActions.includes(RISK_ACTIONS.SHRINK_GROUP)));
+  await run("M82.3 BBM 16: nicht editierbare Gruppenbreite wird nicht angeboten", () => assert.equal(widthRisk(false).suggestedActions.includes(RISK_ACTIONS.SHRINK_GROUP), false));
+  await run("M82.3 BBM 17: Trotzdem anwenden koppelt kein Nachrücken", () => assert.equal(widthRisk().suggestedActions.includes(RISK_ACTIONS.APPLY_ANYWAY), false));
+  await run("M82.3 BBM 18: Hinweis nennt Kurztext/Gegenstand verständlich", () => { assert.equal(widthRisk().riskType, RISK_TYPES.FREED_SPACE); assert.match(widthRisk().message, /Bezeichnung Kurztext\/Gegenstand.*frei werdenden Platz/); });
+  await run("M82.3 BBM 19: Vorschau nennt Restzeichenanzeige und alte/neue Position", () => { const neighbor = widthRisk().affectedNeighbors[0]; assert.equal(neighbor.displayName, "Restzeichenanzeige Kurztext"); assert.equal(neighbor.previousBounds.left, 190); assert.equal(neighbor.bounds.left, 170); assert.match(host, /Bisherige Position von[\s\S]*Neue Position von/); });
+  await run("M82.3 BBM 19a: echte Gruppen-Nachbarn gelangen in die Risikobewertung", () => {
+    const before = new Map([[label.id, { left: 0, top: 0, width: 150, height: 24 }], ["restarbeiten.edit.short.remaining", { left: 190, top: 0, width: 30, height: 24 }]]);
+    const after = new Map([[label.id, { left: 0, top: 0, width: 130, height: 24 }], ["restarbeiten.edit.short.remaining", { left: 170, top: 0, width: 30, height: 24 }]]);
+    const neighbors = hostModule.collectM80GeometryNeighbors(label, before, after);
+    assert.equal(neighbors.find((item) => item.elementId === "restarbeiten.edit.short.remaining")?.geometryChanged, true);
+  });
+  await run("M82.3 BBM 20: lokaler Stabilitätsguard rollt unerwartete Änderungen zurück", () => assert.match(host, /electron_unexpected_layout_effect[\s\S]*unerwartet verändern/));
+  await run("M82.3 BBM 21: Gruppe wird beim Fehler ebenfalls zurückgerollt", () => assert.match(host, /groupRestore\?\.state[\s\S]*applyM80State\(groupRestore\.id/));
+  await run("M82.3 BBM 22: Start-Restore bleibt derselbe Profilweg", () => assert.match(host, /restoreM80StartupLayout/));
+  await run("M82.3 BBM 23: Manifest veröffentlicht alle vier Spacingoperationen", () => assert.deepEqual(manifest.supportedOperations.slice(-4), ["spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"]));
+  await run("M82.3 BBM 24: kompakter UI-Workspace hat Ein-Zwei-Drei-Modus", () => assert.match(compactCode, /width < 860 \? 1 : width < 1260 \? 2 : 3/));
+  await run("M82.3 BBM 25: feste Aktionen liegen vor den adaptiven Spalten", () => assert.ok(compactXaml.indexOf("Nächstes Element auswählen") < compactXaml.indexOf("AdaptiveColumns")));
+  await run("M82.3 BBM 26: Baum scrollt intern", () => assert.match(compactXaml, /CompactElementTree[\s\S]*VerticalScrollBarVisibility="Auto"/));
+  await run("M82.3 BBM 27: PDF-Workspace nutzt dieselben Breitenstufen", () => assert.match(pdfCode, /e\.NewSize\.Width < 860 \? 1 : e\.NewSize\.Width < 1260 \? 2 : 3/));
+  await run("M82.3 BBM 28: echter Flow-Ref hält den Slot bei 190 px stabil", () => {
+    refs.resetM80PilotWorkingStatesForDiagnostic();
+    const element = new FakeElement(150, 24); flowRow = new FakeElement(878, 50); flowRow.style.gridTemplateColumns = "190px 30px 24px minmax(92px, auto) auto";
+    refs.registerM80FlowLabelRef(label.id, element, flowRow, "30px 24px minmax(92px, auto) auto");
+    const initial = refs.readM80State(label.id); assert.equal(initial.spacing.reservedWidth, 40);
+    refs.applyM80State(label.id, { ...initial, width: 130, spacing: { reservedWidth: 60 } });
+    assert.match(flowRow.style.gridTemplateColumns, /^190px /);
+    assert.equal(element.style.justifySelf, "start");
+    assert.equal(element.style.minWidth, "130px");
+    assert.equal(element.style.maxWidth, "130px");
+    assert.equal(element.dataset.uiEditorFlowFixed, "true");
+    assert.equal(element.dataset.uiEditorFlowWidth, "130");
+    assert.equal(element.style["--bbm-ui-editor-flow-element-width"], "130px");
+    assert.match(restarbeitenCss, /data-ui-editor-flow-fixed="true"[\s\S]*--bbm-ui-editor-flow-element-width/);
+  });
+  await run("M82.3 BBM 29: bewusstes Nachrücken verkleinert den Slot", () => {
+    const current = refs.readM80State(label.id); refs.applyM80State(label.id, { ...current, width: 130, spacing: { reservedWidth: 40 } });
+    assert.match(flowRow.style.gridTemplateColumns, /^170px /);
+  });
+  await run("M82.3 BBM 29a: Start-Restore stellt abgeleiteten reservierten Platz wieder her", () => {
+    const startup = hostModule.createM80StartupRequests("restarbeiten.edit.root", {
+      ...refs.readM80State(label.id), width: 90, spacing: { reservedWidth: 100 },
+    }, { [label.id]: ["resizeWidth"] });
+    assert.deepEqual(startup.map((item) => item.request.operation), ["resizeWidth", "spacingSet"]);
+    assert.deepEqual(startup[1].request.payload.spacing, { target: "reservedWidth", value: 100 });
+  });
+  await run("M82.3 BBM 30: Fachwerte sind weiterhin verboten", () => assert.match(host, /FORBIDDEN_KEYS[\s\S]*businessData[\s\S]*domainData/));
+  await run("M82.3 BBM 31: docs/licensing.md bleibt hashgleich", () => assert.equal(crypto.createHash("sha256").update(fs.readFileSync(path.join(ROOT, "docs/licensing.md"))).digest("hex").toUpperCase(), "02AE66A8873C74869539F13F734B7CE43BC63B6EF37DA553A40C27A4F514D784"));
+}
+
+module.exports = { runM823BbmSpacerCompactUiTests };

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 103, "103 Suite-Einstiege einschließlich Entwicklungs-Lizenz und M82.2");
+    assert.equal(suites.length, 104, "104 Suite-Einstiege einschließlich Entwicklungs-Lizenz und M82.3");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/src/renderer/modules/restarbeiten/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenEditbox.js
@@ -5,7 +5,7 @@ import {
   getRestarbeitRequiredFieldSummary,
   normalizeRestarbeitStatus,
 } from "./domain/restarbeitenRules.js";
-import { registerM80Ref } from "../../ui-editor/m80Refs.js";
+import { registerM80FlowLabelRef, registerM80Ref } from "../../ui-editor/m80Refs.js";
 
 function createEl(tag, { className = "", text = "", uiId = "" } = {}) {
   const el = document.createElement(tag);
@@ -188,7 +188,9 @@ function createTextField({
   wrap.append(labelRow, input);
   registerM80Ref(editorGroupId, wrap);
   registerM80Ref(`${editorGroupId}.headerZone`, labelRow);
-  registerM80Ref(editorLabelId, labelElement);
+  if (editorGroupId === "restarbeiten.edit.short") {
+    registerM80FlowLabelRef(editorLabelId, labelElement, labelRow, "30px 24px minmax(92px, auto) auto");
+  } else registerM80Ref(editorLabelId, labelElement);
   registerM80Ref(editorFieldId, input);
   registerM80Ref(`${editorGroupId}.remaining`, remaining);
   registerM80Ref(`${editorGroupId}.dictation`, dictation);

--- a/src/renderer/modules/restarbeiten/styles/restarbeiten.css
+++ b/src/renderer/modules/restarbeiten/styles/restarbeiten.css
@@ -752,6 +752,13 @@
   line-height: 1.1;
 }
 
+.bbm-restarbeiten-text-label__row > span:first-child[data-ui-editor-flow-fixed="true"] {
+  width: var(--bbm-ui-editor-flow-element-width) !important;
+  min-width: var(--bbm-ui-editor-flow-element-width) !important;
+  max-width: var(--bbm-ui-editor-flow-element-width) !important;
+  justify-self: start;
+}
+
 .bbm-ui-editor-hidden {
   visibility: hidden !important;
 }

--- a/src/renderer/ui-editor/m80HostAdapter.js
+++ b/src/renderer/ui-editor/m80HostAdapter.js
@@ -42,6 +42,16 @@ let startupRestorePromise = null;
 let startupRestoreStatus = { state: "pending", applied: false, editorProcessRequired: false };
 let diagnosticRegistryRevision = 0;
 const pendingGeometryRisks = new Map();
+const capturedRuntimeBaselines = new Map();
+
+function capturedRuntimeBaseline(entry) {
+  if (entry?.baseline?.width !== null && entry?.baseline?.height !== null) return null;
+  if (!capturedRuntimeBaselines.has(entry.id)) {
+    const current = snapshotM80State(entry.id);
+    if (current) capturedRuntimeBaselines.set(entry.id, Object.freeze({ width: current.width, height: current.height }));
+  }
+  return capturedRuntimeBaselines.get(entry.id) || null;
+}
 
 function hasForbidden(value) {
   if (Array.isArray(value)) return value.some(hasForbidden);
@@ -58,7 +68,7 @@ function number(value, field, { positive = false, nonNegative = false } = {}) {
 }
 
 function desiredState(previous, operation, payload) {
-  const next = { ...previous };
+  const next = { ...previous, spacing: { ...(previous.spacing || {}) } };
   if (!payload || typeof payload !== "object" || Array.isArray(payload) || hasForbidden(payload)) throw Object.assign(new Error("Layout-Payload ist ungültig."), { code: "electron_editor_message_invalid" });
   if (operation === "move") {
     const keys = Object.keys(payload); if (!keys.length || keys.some((key) => !["x", "y"].includes(key))) throw new Error("move-Payload ist ungültig.");
@@ -85,6 +95,17 @@ function desiredState(previous, operation, payload) {
   } else if (operation === "setVisibility") {
     if (Object.keys(payload).length !== 1 || typeof payload.visible !== "boolean") throw new Error("setVisibility-Payload ist ungültig.");
     next.visible = payload.visible;
+  } else if (["spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"].includes(operation)) {
+    if (Object.keys(payload).length !== 1 || !payload.spacing || typeof payload.spacing !== "object" || Array.isArray(payload.spacing)) throw new Error("spacing-Payload ist ungültig.");
+    const target = String(payload.spacing.target || "");
+    const entry = getM80RegistryEntry(previous.elementId);
+    if (!entry?.spacingTargets?.includes(target) || Object.keys(payload.spacing).some((key) => !["target", "value"].includes(key))) throw Object.assign(new Error("Abstandsziel ist nicht freigegeben."), { code: "electron_operation_not_allowed" });
+    const current = number(next.spacing[target] || 0, target, { nonNegative: true });
+    if (operation === "spacingReset") delete next.spacing[target];
+    else {
+      const value = number(payload.spacing.value, "spacing.value", { nonNegative: true });
+      next.spacing[target] = operation === "spacingIncrease" ? current + value : operation === "spacingDecrease" ? Math.max(0, current - value) : value;
+    }
   } else throw Object.assign(new Error("Operation ist nicht erlaubt."), { code: "electron_operation_not_allowed" });
   return next;
 }
@@ -162,19 +183,22 @@ function isAncestor(candidateId, elementId) {
   while (current?.parentId) { if (current.parentId === candidateId) return true; current = getM80RegistryEntry(current.parentId); }
   return false;
 }
-function sensibleNeighbors(entry, beforeGeometry, afterGeometry, unexpected) {
+export function collectM80GeometryNeighbors(entry, beforeGeometry, afterGeometry, unexpected = []) {
   const parent = entry.parentId ? getM80RegistryEntry(entry.parentId) : null;
   const contextId = parent?.parentId || entry.parentId;
+  const flowGroup = ancestor(entry, (candidate) => ["group", "fieldGroup"].includes(candidate.type));
   return allEntries().filter((candidate) => {
     if (candidate.id === entry.id || isAncestor(candidate.id, entry.id) || isAncestor(entry.id, candidate.id)) return false;
     if (!beforeGeometry.get(candidate.id) || !afterGeometry.get(candidate.id)) return false;
-    return unexpected.includes(candidate.id) || candidate.parentId === entry.parentId || candidate.parentId === contextId || candidate.id === contextId;
+    return unexpected.includes(candidate.id) || candidate.parentId === entry.parentId || candidate.parentId === contextId ||
+      candidate.id === contextId || (flowGroup && isAncestor(flowGroup.id, candidate.id));
   }).map((candidate) => ({
     elementId: candidate.id,
     displayName: candidate.name,
     elementType: candidate.type,
     bounds: afterGeometry.get(candidate.id),
-    geometryChanged: unexpected.includes(candidate.id),
+    previousBounds: beforeGeometry.get(candidate.id),
+    geometryChanged: geometryChanged(beforeGeometry.get(candidate.id), afterGeometry.get(candidate.id)),
   }));
 }
 function geometryRiskFor(entry, request, beforeGeometry, afterGeometry, effect) {
@@ -197,7 +221,9 @@ function geometryRiskFor(entry, request, beforeGeometry, afterGeometry, effect) 
     group: entryWithBounds(groupEntry, afterGeometry),
     parent: entryWithBounds(parentEntry, afterGeometry),
     editableArea: entryWithBounds(rootEntry, afterGeometry),
-    affectedNeighbors: sensibleNeighbors(entry, beforeGeometry, afterGeometry, effect.unexpected),
+    affectedNeighbors: collectM80GeometryNeighbors(entry, beforeGeometry, afterGeometry, effect.unexpected),
+    operation: request.operation,
+    groupWidthEditable: groupEntry?.allowedOps?.includes("resizeWidth") === true,
   });
 }
 function requestSignature(request) {
@@ -208,7 +234,7 @@ function confirmedRisk(request) {
   if (!confirmation || typeof confirmation !== "object") return null;
   const pending = pendingGeometryRisks.get(String(confirmation.operationId || ""));
   if (!pending || pending.signature !== requestSignature(request)) return null;
-  if (![RISK_ACTIONS.APPLY_ANYWAY, RISK_ACTIONS.CLAMP_TO_GROUP, RISK_ACTIONS.CLAMP_TO_AREA].includes(confirmation.action)) return null;
+  if (![RISK_ACTIONS.APPLY_ANYWAY, RISK_ACTIONS.CLAMP_TO_GROUP, RISK_ACTIONS.CLAMP_TO_AREA, RISK_ACTIONS.PRESERVE_SPACE, RISK_ACTIONS.REFLOW_NEIGHBORS, RISK_ACTIONS.SHRINK_GROUP].includes(confirmation.action)) return null;
   return { ...pending, action: confirmation.action };
 }
 function clampDesiredState(desired, risk, action) {
@@ -257,6 +283,10 @@ function renderGeometryRiskPreview(risk) {
   previewFrame(value, risk.preview.areaBounds, "border:3px dotted #0f766e;background:transparent", "Bereichsgrenze");
   risk.affectedNeighbors.filter((item) => item.overlapBounds).forEach((item) => previewFrame(value, item.overlapBounds,
     "border:4px double #b91c1c;background:repeating-linear-gradient(45deg,rgba(185,28,28,.28),rgba(185,28,28,.28) 5px,transparent 5px,transparent 10px)", `Überlappung mit ${item.displayName}`));
+  risk.affectedNeighbors.filter((item) => item.geometryChanged).forEach((item) => {
+    previewFrame(value, item.previousBounds, "border:2px dotted #475569;background:transparent", `Bisherige Position von ${item.displayName}`);
+    previewFrame(value, item.bounds, "border:2px dashed #c2410c;background:transparent", `Neue Position von ${item.displayName}`);
+  });
   value.style.display = "block";
   document.addEventListener("keydown", onRiskPreviewKey, true);
 }
@@ -270,6 +300,7 @@ function submitChange(changeRequest, scopeId) {
   if (!entry.allowedOps.includes(request.operation)) return failure(request, "electron_operation_not_allowed", "Operation ist nicht freigegeben.");
   const previous = snapshotM80State(entry.id);
   if (!previous) return failure(request, "electron_element_not_found", "Explizite Elementreferenz fehlt.");
+  let groupRestore = null;
   try {
     const beforeGeometry = snapshotM80Geometry();
     const ref = getM80Ref(entry.id);
@@ -279,9 +310,23 @@ function submitChange(changeRequest, scopeId) {
     }
     const confirmation = confirmedRisk(request);
     let desired = desiredState(previous, request.operation, request.payload);
-    if (confirmation && confirmation.action !== RISK_ACTIONS.APPLY_ANYWAY) desired = clampDesiredState(desired, confirmation.risk, confirmation.action);
+    if (confirmation && [RISK_ACTIONS.CLAMP_TO_GROUP, RISK_ACTIONS.CLAMP_TO_AREA].includes(confirmation.action)) desired = clampDesiredState(desired, confirmation.risk, confirmation.action);
+    if (confirmation?.action === RISK_ACTIONS.PRESERVE_SPACE || confirmation?.action === RISK_ACTIONS.SHRINK_GROUP) {
+      desired.spacing = { ...(desired.spacing || {}), reservedWidth: Number(desired.spacing?.reservedWidth || 0) + Number(confirmation.risk.technicalDetails?.freedWidth || 0) };
+    }
     const readback = applyM80State(entry.id, desired);
+    const affectedStates = [];
+    if (confirmation?.action === RISK_ACTIONS.SHRINK_GROUP) {
+      const groupEntry = ancestor(entry, (candidate) => ["group", "fieldGroup"].includes(candidate.type));
+      if (!groupEntry?.allowedOps?.includes("resizeWidth")) throw Object.assign(new Error("Die Breite dieser Gruppe kann nicht direkt verändert werden."), { code: "electron_operation_not_allowed" });
+      groupRestore = { id: groupEntry.id, state: snapshotM80State(groupEntry.id) };
+      affectedStates.push(applyM80State(groupEntry.id, { ...groupRestore.state, width: Math.max(groupEntry.baseline.minWidth || 1, groupRestore.state.width - Number(confirmation.risk.technicalDetails?.freedWidth || 0)) }));
+    }
     const afterGeometry = snapshotM80Geometry();
+    if (confirmation?.action === RISK_ACTIONS.PRESERVE_SPACE) {
+      const unexpectedLocal = [...beforeGeometry].filter(([id, before]) => id !== entry.id && geometryChanged(before, afterGeometry.get(id))).map(([id]) => id);
+      if (unexpectedLocal.length) throw Object.assign(new Error("Die Position weiterer Elemente würde sich unerwartet verändern."), { code: "electron_unexpected_layout_effect" });
+    }
     const affected = inspectGeometryEffect(entry, request.operation, beforeGeometry, afterGeometry);
     const interactive = request.source === "ui-editor-panel";
     const risk = interactive ? geometryRiskFor(entry, request, beforeGeometry, afterGeometry, affected) : null;
@@ -293,9 +338,10 @@ function submitChange(changeRequest, scopeId) {
     }
     clearGeometryRiskPreview();
     if (confirmation) pendingGeometryRisks.delete(confirmation.risk.operationId);
-    return { success: true, changeId: request.changeId, elementId: entry.id, operation: request.operation, effectScope: affected.effect, affectedElementIds: [...affected.ids], errorCode: null, message: "Layoutänderung angewandt, geometrisch geprüft und zurückgelesen.", previousState: previous, newState: readback, rollbackSucceeded: true };
+    return { success: true, changeId: request.changeId, elementId: entry.id, operation: request.operation, effectScope: affected.effect, affectedElementIds: [...affected.ids], affectedStates, errorCode: null, message: confirmation?.action === RISK_ACTIONS.PRESERVE_SPACE ? "Elementbreite geändert; frei gewordener Platz bleibt reserviert." : "Layoutänderung angewandt, geometrisch geprüft und zurückgelesen.", previousState: previous, newState: readback, rollbackSucceeded: true };
   } catch (error) {
     try {
+      if (groupRestore?.state) applyM80State(groupRestore.id, groupRestore.state);
       const restored = applyM80State(entry.id, previous);
       return failure(request, error?.code || "electron_change_apply_failed", `Layoutänderung wurde sicher abgewiesen und zurückgerollt: ${error?.message || "Unbekannte Geometrieverletzung."}`, restored, true);
     } catch (_rollbackError) {
@@ -322,7 +368,7 @@ export function createM80RegistrationDescriptor() {
   const registryScopes = listM80RegistryScopes().map((scope) => {
     if (scope.status !== "complete") return scope;
     const elements = scope.elements.map((entry) => {
-      const resolved = { ...entry, ...getM80ReferenceStatus(entry.id) };
+      const resolved = { ...entry, ...getM80ReferenceStatus(entry.id), capturedBaseline: capturedRuntimeBaseline(entry) };
       if (diagnosticRegistryRevision > 0 && entry.id === "restarbeiten.edit.validation") {
         return {
           ...resolved,
@@ -350,7 +396,7 @@ export function createM80RegistrationDescriptor() {
     registryVersion: BBM_M80_REGISTRY_VERSION + diagnosticRegistryRevision,
     registryStatus: BBM_M80_REGISTRY_STATUS,
     activeScopes,
-    supportedOperations: ["move", "resize", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility"],
+    supportedOperations: ["move", "resize", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility", "spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"],
     uiCapability: "layout",
     pdfCapability: "unavailable",
     labelFieldSeparation: true,
@@ -541,7 +587,7 @@ export function handleM80EditorRequest(request = {}) {
   }, request.scopeId) };
 }
 
-function startupRequests(scopeId, element, explicitOperations = null) {
+export function createM80StartupRequests(scopeId, element, explicitOperations = null) {
   const entry = getM80RegistryEntry(element.elementId);
   if (!entry) throw Object.assign(new Error("Startprofil enthält ein unbekanntes Element."), { code: "electron_element_not_found" });
   const current = snapshotM80State(entry.id);
@@ -567,6 +613,14 @@ function startupRequests(scopeId, element, explicitOperations = null) {
   if (Object.keys(text).length) push("textMove", { text });
   if (changed(element.fontSize, current.fontSize)) push("textResize", { text: { fontSize: element.fontSize } });
   if (present(element.visible) && Boolean(element.visible) !== current.visible) push("setVisibility", { visible: element.visible });
+  const desiredSpacing = element.spacing && typeof element.spacing === "object" && !Array.isArray(element.spacing) ? element.spacing : {};
+  for (const target of entry.spacingTargets || []) {
+    const desiredValue = Number(desiredSpacing[target] || 0);
+    const currentValue = Number(current.spacing?.[target] || 0);
+    if (Math.abs(desiredValue - currentValue) > 0.01 && entry.allowedOps.includes("spacingSet")) {
+      requests.push({ changeId: `startup-${requests.length + 1}-${entry.id}`, elementId: entry.id, operation: "spacingSet", payload: { spacing: { target, value: desiredValue } }, source: "target-app-start" });
+    }
+  }
   return requests.map((request) => ({ scopeId, request }));
 }
 
@@ -592,7 +646,7 @@ export function restoreM80StartupLayout() {
     try {
       for (const scope of loaded.scopes) {
         for (const element of scope.elements) {
-          for (const item of startupRequests(scope.scopeId, element, scope.explicitOperations)) {
+          for (const item of createM80StartupRequests(scope.scopeId, element, scope.explicitOperations)) {
             const result = submitChange(item.request, item.scopeId);
             if (!result.success) throw Object.assign(new Error(`${item.request.elementId}/${item.request.operation}: ${result.message}`), { code: result.errorCode || "startup_layout_apply_failed" });
           }

--- a/src/renderer/ui-editor/m80Refs.js
+++ b/src/renderer/ui-editor/m80Refs.js
@@ -24,6 +24,17 @@ function getCustomProperty(style, name) { return typeof style?.getPropertyValue 
 function applyAttributes(target, id) {
   for (const [name, value] of Object.entries(m80EditorAttributes(id))) target.setAttribute(name, value);
 }
+function readSpacing(element) {
+  try {
+    const value = JSON.parse(element.dataset.uiEditorSpacing || "{}");
+    return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {};
+  } catch { return {}; }
+}
+function writeSpacing(element, spacing = {}) {
+  const normalized = Object.fromEntries(Object.entries(spacing).filter(([, value]) => Number.isFinite(Number(value)) && Number(value) >= 0).map(([key, value]) => [key, Number(value)]));
+  element.dataset.uiEditorSpacing = JSON.stringify(normalized);
+  return normalized;
+}
 
 function readGeneric(element, id) {
   const rect = rectOf(element);
@@ -38,6 +49,7 @@ function readGeneric(element, id) {
     textOffsetY: finite(element.dataset.uiEditorTextY, finite(parseFloat(style.paddingTop))),
     fontSize: positive(parseFloat(style.fontSize), 12),
     visible: !hasClass(element, HIDDEN_CLASS),
+    spacing: readSpacing(element),
   };
 }
 
@@ -54,7 +66,12 @@ function applyGeneric(element, state, entry) {
     element.dataset.uiEditorY = String(finite(state.y));
     element.style.translate = `${px(state.x)} ${px(state.y)}`;
   }
-  if (operations.has("resize") || operations.has("resizeWidth")) element.style.width = px(bounded(entry, "width", state.width, 1));
+  if (operations.has("resize") || operations.has("resizeWidth")) {
+    const desiredWidth = bounded(entry, "width", state.width, 1);
+    const horizontalPadding = finite(state.spacing?.groupPaddingLeft) + finite(state.spacing?.groupPaddingRight);
+    const contentWidth = styleOf(element).boxSizing === "border-box" ? desiredWidth : Math.max(1, desiredWidth - horizontalPadding);
+    element.style.width = px(contentWidth);
+  }
   if (operations.has("resize") || operations.has("resizeHeight")) element.style.height = px(bounded(entry, "height", state.height, 1));
   if (operations.has("textMove") && state.textOffsetX !== null && state.textOffsetX !== undefined) {
     element.dataset.uiEditorTextX = String(state.textOffsetX);
@@ -66,6 +83,17 @@ function applyGeneric(element, state, entry) {
   }
   if (operations.has("textResize") && state.fontSize !== null && state.fontSize !== undefined) element.style.fontSize = px(positive(state.fontSize, 1));
   if (operations.has("setVisibility")) toggleClass(element, HIDDEN_CLASS, state.visible === false);
+  if (["spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"].some((operation) => operations.has(operation))) {
+    const spacing = writeSpacing(element, state.spacing || {});
+    element.style.marginLeft = px(finite(spacing.beforeElement));
+    element.style.marginRight = px(finite(spacing.afterElement) + finite(spacing.reservedWidth));
+    element.style.paddingLeft = px(finite(spacing.groupPaddingLeft));
+    element.style.paddingRight = px(finite(spacing.groupPaddingRight));
+    element.style.paddingTop = px(finite(spacing.groupPaddingTop));
+    element.style.paddingBottom = px(finite(spacing.groupPaddingBottom));
+    element.style.columnGap = px(finite(spacing.childGapHorizontal));
+    element.style.rowGap = px(finite(spacing.childGapVertical));
+  }
 }
 
 export function beginM80PilotRender() {
@@ -130,6 +158,38 @@ export function registerM80TableColumnRef(id, headerCell, tableElement, cssVaria
       headerCell.style.fontSize = px(positive(state.fontSize, 1));
       toggleClass(tableElement, `${HIDDEN_CLASS}-${id.split(".").pop()}`, state.visible === false);
       toggleClass(headerCell, HIDDEN_CLASS, state.visible === false);
+    },
+  });
+}
+
+export function registerM80FlowLabelRef(id, element, layoutRow, trailingColumns) {
+  const entry = getM80RegistryEntry(id);
+  return registerM80Ref(id, element, {
+    read: () => {
+      const state = readGeneric(element, id);
+      const configuredWidth = positive(element.dataset.uiEditorFlowWidth, positive(entry?.baseline?.width, state.width));
+      const spacing = readSpacing(element);
+      if (!Object.hasOwn(spacing, "reservedWidth")) {
+        const firstTrack = parseFloat(styleOf(layoutRow).gridTemplateColumns);
+        spacing.reservedWidth = Math.max(0, finite(firstTrack, configuredWidth) - configuredWidth);
+      }
+      return { ...state, width: configuredWidth, spacing };
+    },
+    apply: (state) => {
+      const spacing = { ...(state.spacing || {}) };
+      const reservedWidth = Math.max(0, finite(spacing.reservedWidth));
+      const genericSpacing = { ...spacing, reservedWidth: 0 };
+      applyGeneric(element, { ...state, spacing: genericSpacing }, entry);
+      const elementWidth = bounded(entry, "width", state.width, 1);
+      element.dataset.uiEditorFlowFixed = "true";
+      element.dataset.uiEditorFlowWidth = String(elementWidth);
+      setCustomProperty(element.style, "--bbm-ui-editor-flow-element-width", px(elementWidth));
+      element.style.justifySelf = "start";
+      element.style.minWidth = px(elementWidth);
+      element.style.maxWidth = px(elementWidth);
+      writeSpacing(element, spacing);
+      const slotWidth = elementWidth + reservedWidth;
+      layoutRow.style.gridTemplateColumns = `${px(slotWidth)} ${trailingColumns}`;
     },
   });
 }

--- a/src/renderer/ui-editor/m80Registry.js
+++ b/src/renderer/ui-editor/m80Registry.js
@@ -1,4 +1,4 @@
-export const BBM_M80_REGISTRY_VERSION = 4;
+export const BBM_M80_REGISTRY_VERSION = 5;
 export const BBM_M80_REGISTRY_STATUS = "incomplete";
 
 const GROUP_LAYOUT = Object.freeze(["move", "setVisibility"]);
@@ -9,12 +9,13 @@ const BUTTON_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "set
 const ICON_LAYOUT = Object.freeze(["resizeWidth", "resizeHeight", "setVisibility"]);
 const TABLE_LAYOUT = Object.freeze(["resizeHeight", "setVisibility"]);
 const COLUMN_LAYOUT = Object.freeze(["resizeWidth", "textResize", "setVisibility"]);
+const SPACING_LAYOUT = Object.freeze(["spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"]);
 const DOMAIN_LOCKS = Object.freeze(["executeTargetAction", "modifyDomainData", "createRecord", "deleteRecord"]);
 
 function defaultBaseline(values = {}) {
   return Object.freeze({
     x: 0, y: 0, width: 100, height: 24, textOffsetX: 0, textOffsetY: 0,
-    fontSize: 12, visible: true, minWidth: 8, maxWidth: 2400, minHeight: 8, maxHeight: 1600,
+    fontSize: 12, visible: true, spacing: {}, minWidth: 8, maxWidth: 2400, minHeight: 8, maxHeight: 1600,
     ...values,
   });
 }
@@ -36,6 +37,7 @@ function element(values) {
     baseline: defaultBaseline(values.baseline),
     selectionKind,
     selectionLevels: Object.freeze([...(values.selectionLevels || [selectionKind])]),
+    spacingTargets: Object.freeze([...(values.spacingTargets || [])]),
     operationEffects: Object.freeze({
       ...Object.fromEntries(allowedOps.map((operation) => [operation,
         selectionKind === "group" ? "groupWithChildren" : selectionKind === "layoutZone" ? "layoutZone" : "elementOnly"])),
@@ -117,9 +119,9 @@ const editElements = [
   element({ id: "restarbeiten.edit.header", name: "Gruppe Editbox-Kopf", type: "group", role: "layoutGroup", parentId: "restarbeiten.edit.area", order: 20, allowedOps: GROUP_LAYOUT, componentKind: "header" }),
   element({ id: "restarbeiten.edit.header.current", name: "Status aktueller Datensatz", type: "label", role: "status", parentId: "restarbeiten.edit.header", order: 21, allowedOps: ["setVisibility"], componentKind: "label" }),
   element({ id: "restarbeiten.edit.fields", name: "Layoutzone Textfelder", type: "group", role: "fieldCollection", parentId: "restarbeiten.edit.area", order: 30, allowedOps: [], componentKind: "fieldCollection", selectionKind: "layoutZone" }),
-  element({ id: "restarbeiten.edit.short", name: "Gruppe Kurztext/Gegenstand", type: "group", role: "formFieldGroup", parentId: "restarbeiten.edit.fields", order: 40, allowedOps: GROUP_LAYOUT, componentKind: "fieldGroup" }),
-  element({ id: "restarbeiten.edit.short.headerZone", name: "Kopfzeile Kurztext/Gegenstand", type: "group", role: "layoutGroup", parentId: "restarbeiten.edit.short", order: 41, allowedOps: [], componentKind: "layoutZone", selectionKind: "layoutZone" }),
-  element({ id: "restarbeiten.edit.short.label", name: "Bezeichnung Kurztext/Gegenstand", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.short", order: 42, allowedOps: TEXT_LAYOUT, componentKind: "label", baseline: { width: 150, height: 22, minWidth: 74, maxWidth: 190, minHeight: 18, maxHeight: 48 }, operationEffects: { resizeWidth: "parentReflowRequired", resizeHeight: "parentReflowRequired" }, operationAffectedIds: { resizeWidth: ["restarbeiten.edit.short.headerZone", "restarbeiten.edit.short.field"], resizeHeight: ["restarbeiten.edit.short.headerZone", "restarbeiten.edit.short.field"] } }),
+  element({ id: "restarbeiten.edit.short", name: "Gruppe Kurztext/Gegenstand", type: "group", role: "formFieldGroup", parentId: "restarbeiten.edit.fields", order: 40, allowedOps: [...GROUP_LAYOUT, "resizeWidth", "resizeHeight", ...SPACING_LAYOUT], spacingTargets: ["groupPaddingLeft", "groupPaddingRight", "groupPaddingTop", "groupPaddingBottom", "childGapHorizontal", "childGapVertical"], componentKind: "fieldGroup", baseline: { width: null, height: null, minWidth: 320, maxWidth: 1400, minHeight: 42, maxHeight: 96 } }),
+  element({ id: "restarbeiten.edit.short.headerZone", name: "Kopfzeile Kurztext/Gegenstand", type: "group", role: "layoutGroup", parentId: "restarbeiten.edit.short", order: 41, allowedOps: SPACING_LAYOUT, spacingTargets: ["groupPaddingLeft", "groupPaddingRight", "groupPaddingTop", "groupPaddingBottom", "childGapHorizontal"], componentKind: "layoutZone", selectionKind: "layoutZone" }),
+  element({ id: "restarbeiten.edit.short.label", name: "Bezeichnung Kurztext/Gegenstand", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.short", order: 42, allowedOps: [...TEXT_LAYOUT, ...SPACING_LAYOUT], spacingTargets: ["beforeElement", "afterElement", "reservedWidth"], componentKind: "label", baseline: { width: 150, height: 22, spacing: { reservedWidth: 40 }, minWidth: 74, maxWidth: 190, minHeight: 18, maxHeight: 48 }, operationEffects: { resizeWidth: "parentReflowRequired", resizeHeight: "parentReflowRequired" }, operationAffectedIds: { resizeWidth: ["restarbeiten.edit.short.headerZone", "restarbeiten.edit.short.field"], resizeHeight: ["restarbeiten.edit.short.headerZone", "restarbeiten.edit.short.field"] } }),
   element({ id: "restarbeiten.edit.short.remaining", name: "Restzeichenanzeige Kurztext", type: "label", role: "status", parentId: "restarbeiten.edit.short.headerZone", order: 43, allowedOps: ["setVisibility"], componentKind: "counter" }),
   domainButton({ id: "restarbeiten.edit.short.dictation", name: "Diktatbutton Kurztext", parentId: "restarbeiten.edit.short.headerZone", order: 44, actionKind: "domainDictation", baseline: { width: 22, height: 22, minWidth: 20, maxWidth: 32, minHeight: 20, maxHeight: 32 }, operationEffects: { move: "groupWithChildren" }, operationAffectedIds: { move: ["restarbeiten.edit.short.dictation.icon"] } }),
   element({ id: "restarbeiten.edit.short.dictation.icon", name: "Mikrofonsymbol Kurztext", type: "componentPart", role: "layout", parentId: "restarbeiten.edit.short.dictation", order: 45, allowedOps: ICON_LAYOUT, componentKind: "icon", baseline: { width: 17, height: 17, minWidth: 12, maxWidth: 22, minHeight: 12, maxHeight: 22 } }),
@@ -193,7 +195,7 @@ export function listM80RegistryScopes() {
   return BBM_M80_REGISTRY_SCOPES.map((scope) => ({
     ...scope,
     expectedElementIds: [...scope.expectedElementIds],
-    elements: scope.elements.map((entry) => ({ ...entry, baseline: { ...entry.baseline }, allowedOps: [...entry.allowedOps], lockedOps: [...entry.lockedOps] })),
+    elements: scope.elements.map((entry) => ({ ...entry, baseline: { ...entry.baseline, spacing: { ...(entry.baseline?.spacing || {}) } }, spacingTargets: [...(entry.spacingTargets || [])], allowedOps: [...entry.allowedOps], lockedOps: [...entry.lockedOps] })),
   }));
 }
 

--- a/ui-editor-target.json
+++ b/ui-editor-target.json
@@ -7,8 +7,8 @@
   "integrationMode": "existing-app",
   "contractVersion": "1.2",
   "adapterVersion": "1.2",
-  "registryVersion": 4,
-  "registryFingerprint": "sha256:f53c95218c899854a10bcda691ccff22f50b4af3591018f1c87d3ae5d41b54c2",
+  "registryVersion": 5,
+  "registryFingerprint": "sha256:0ab12fdfe93a920f27d6842a5fd4e4f1ae0db3c296d4681355dabd0d8c6eeba0",
   "registryStatus": "incomplete",
   "activeScopes": [
     "restarbeiten.header.root",
@@ -25,7 +25,11 @@
     "resizeHeight",
     "textMove",
     "textResize",
-    "setVisibility"
+    "setVisibility",
+    "spacingIncrease",
+    "spacingDecrease",
+    "spacingSet",
+    "spacingReset"
   ],
   "selectionCapability": "bidirectional",
   "visibilityCapability": true,


### PR DESCRIPTION
## Ziel

M82.3 integriert den appübergreifenden Spacingvertrag in den bestehenden BBM-Editorpfad und stabilisiert lokale Breitenänderungen, reservierten Platz, Nachrücken, Gruppenoperationen und die kompakte Editorbedienung.

## Enthalten

- isolierte Breitenänderung für „Kurztext/Gegenstand“
- reservierter Platz bleibt bestehen, ohne Nachbarelemente automatisch zu verschieben
- bewusst getrennte Aktion zum Nachrücken
- getrennte Gruppenbreite, Padding, Gap und Spacer
- stabile Positionen für Restzeichen, Diktatbutton, Mikrofonsymbol und Kurztextbutton
- Speicherung und Neustart-Restore über den vorhandenen Profilweg
- bestehende Geführt/Frei-, Direktauswahl-, Reset-, Discard- und Recovery-Pfade bleiben erhalten
- kompakte Editoroberfläche mit 1/2/3-Spaltenmodus und sichtbarer Aktionsleiste
- echter PDF-Pfad mit 28 Registryelementen regressionsgesichert
- Statusfortschreibung: M82.3 `[A]`

## Ausdrücklich nicht enthalten

- keine BBM-Sonderlogik im gemeinsamen Core
- keine neue Fachlogik oder Fachwertänderung
- keine zweite Registry, Bridge, Pipe oder Editorintegration
- `docs/licensing.md` ist nicht Bestandteil dieses Commits
- Benutzerlizenz, Profile, Archive, PDFs, Pack- und Diagnoseausgaben sind nicht Bestandteil dieses Commits

## Prüfungen

- M82.3-Testgruppe grün
- `npm test` – 8/8 Gruppen, kein OOM
- `npm run test:node` – 8/8 Gruppen
- gezieltes ESLint der M82.3-Dateien fehlerfrei
- `npm run pack` erfolgreich
- sichtbare Abnahme für isolierte Breite, reservierten Platz, Nachrücken, Gruppenoperationen, Spacer/Padding und 1/2/3-Spaltenmodus
- echte zweiseitige A4-PDF mit 28 Registryelementen geprüft
- `git diff --check`

Das globale Lint enthält weiterhin ausschließlich den bekannten Altbestand von 17 Fehlern und 371 Warnungen.

## Commit

`dcf3e713ff110d9d74335146b2f0d2002c67601c`