### PR TITLE
M82.4 BBM-Restarbeitenliste als editierbare Tabelle integrieren

### DIFF
--- a/.ui-editor-kit/starter-installation.json
+++ b/.ui-editor-kit/starter-installation.json
@@ -10,7 +10,7 @@
   "files": [
     {
       "relativePath": "ui-editor-target.json",
-      "installedHash": "0cdaa0c676f18bd4edf4cdb435dd174c3244de58c0061a62d5095698da97618a",
+      "installedHash": "fbfb0d155b5f707edc0c584da3c5dbc6912c84b654935a27546df4a23fd98753",
       "preserveOnUninstall": false
     },
     {

--- a/STATUS.md
+++ b/STATUS.md
@@ -3547,3 +3547,17 @@ Wichtig:
 - Die reale Development-Abnahme belegte 28 PDF-Registryelemente und eine aktuelle zweitseitige A4-Vorschau; Fachwerte blieben unveraendert.
 - `docs/licensing.md` bleibt Fremdaenderung und unangetastet.
 - Commit/PR: keiner; gemaess Nutzeranweisung wurde weder committet noch gepusht.
+
+## M82.4 – Tabellen- und Spaltenbearbeitung der Restarbeitenliste
+
+- Status: `[A]`; Implementierung, Pflichtprüfungen und sichtbare Abnahme der gepackten Development-Version sind abgeschlossen.
+- Die bestehende Kartenliste bleibt die sichtbare UI-Inhaltstabelle; es wurde keine neue Ansicht erzeugt und kein Fachwert verändert.
+- Registriert sind Liste, Kopf, Datenbereich, Scrollbereich, Zeilentemplate sowie die drei bestätigten Spalten jeweils mit Header- und Datenbereich.
+- Header und Kartenzeilen verwenden dieselben drei CSS-Grid-Track-Variablen. Viewport, tatsächliche Tabellenbreite, Überlauf, Fit, Wrap/Ellipsis und begrenzte Zeilenhöhe werden über den appübergreifenden Tabellenvertrag gesteuert.
+- Start-Restore, Save, Spalten-/Tabellen-/Scope-/Gesamtreset, Discard und Rollback verwenden weiterhin den bestehenden UI-Profilweg.
+- Die sichtbare Abnahme belegte die drei zusammengefassten Spalten, gemeinsame Header-/Datenbreiten, echte Ellipsis der sichtbaren Unterzeilen, begrenzten horizontalen Überlauf bei 900/1400/Full-HD sowie Spaltenreset und Discard (`fixed/ellipsis` → `proportional/wordWrap` → `fixed/ellipsis`).
+- Der vollständige interaktive Tabellenreset und der nach eigener Tabellen-Vorschau bestätigte Fit verwenden ihre validierten Tabellenwerte ohne erneute generische Risikosperre; sichtbar resultierten beim Reset `proportional/wordWrap/clip`, 718 DIP Tabellenbreite und 0,45 DIP Rundungsüberlauf sowie beim Fit 795 DIP Tabellenbreite bei 795,26 DIP Viewport und 0 DIP Überlauf.
+- Die reale Projekt-12-Abnahme erzeugte anschließend eine aktuelle, zweiseitige BBM-Protokoll-PDF mit 28 registrierten Elementen.
+- Tabellenmetriken und betroffene Spaltenzustände bleiben im Editorprozess erhalten; Tabellenrollen erzeugen in JavaScript und WPF denselben Scope-Fingerprint. Ein gespeichertes Tabellenprofil wird beim Neustart ohne Recovery-Marker einmalig wiederhergestellt.
+- `docs/licensing.md` bleibt Fremdänderung und unangetastet.
+- Commit/PR: keiner; gemäß Nutzeranweisung wurde weder committet noch gepusht.

--- a/docs/M82_4_BBM_RESTARBEITENLISTE.md
+++ b/docs/M82_4_BBM_RESTARBEITENLISTE.md
@@ -1,0 +1,43 @@
+# M82.4 – BBM-Restarbeitenliste
+
+## Bestätigte Inhaltstabelle
+
+Die vorhandene Restarbeiten-Kartenliste bleibt unverändert sichtbar und fachlich bedienbar. Für die Tabellen- und Breitensteuerung ist sie ausdrücklich als UI-Inhaltstabelle mit drei zusammengefassten Hauptspalten bestätigt:
+
+| Reihenfolge | Anzeigename | Technische Spalten-ID | Baseline | Grenzen | Modus | Umbruch / Überlauf |
+|---:|---|---|---:|---:|---|---|
+| 1 | Nr. / Datum / Klasse / Fotos | `restarbeiten.list.table.number` | 82 px | 50–240 px | fixed | noWrap / clip |
+| 2 | Gegenstand – Verortung / Kurztext / Langtext | `restarbeiten.list.table.subject` | 560 px | 160–1200 px | proportional | wordWrap / clip |
+| 3 | Fertig bis / Ampel / Status / Verantwortlich | `restarbeiten.list.table.meta` | 172 px | 110–420 px | fixed | wordWrap / clip |
+
+Die vorhandenen Unterelemente bleiben einzeln registriert und auswählbar. Die drei Spalten ändern weder Fachwerte noch deren Zuordnung und erzeugen keine neue Tabellenansicht.
+
+## Struktur und Direktauswahl
+
+Der vollständige Listenscope enthält zusätzlich zu Root, Bereich und Blatt: Viewport, horizontalen Scrollbereich, Tabelle, drei Spalten, Tabellenkopf, Datenbereich, Zeilentemplate sowie je Spalte eine Header- und Datenreferenz. Tabelle, Kopf, Datenbereich, Zeile, Spalte, Überschrift, Datenbereich der Spalte, Viewport und Scrollbereich sind damit im bestehenden Baum und über die vorhandene Direktauswahl unterscheidbar. Header- und Datenziel bieten den Wechsel zur ganzen Spalte.
+
+## Gemeinsame Breitenquelle
+
+Die CSS-Grid-Tracks `--bbm-restarbeiten-number-column`, `--bbm-restarbeiten-subject-column` und `--bbm-restarbeiten-meta-column` sind je Spalte die einzige Breitenquelle. Derselbe `grid-template-columns`-Ausdruck steuert Tabellenkopf und jede vorhandene Kartenzeile. Der Adapter bindet Überschrift und alle sichtbaren Zellen an dieselbe Spaltenreferenz; eine Headerzelle besitzt keine eigenständige Resize-Operation.
+
+## Viewport, Überlauf und Scrollen
+
+Der sichtbare Listenbereich ist auf den verfügbaren BBM-Inhaltsbereich begrenzt. Der innere Scrollbereich trägt bewusst den horizontalen Überlauf, während die Tabelle selbst eine bounded width policy mit 320–1600 px und 44 px reservierter Aktionsbreite deklariert. Laufzeitmessungen liefern tatsächliche Viewport-, Tabellen- und Überlaufbreite; die Oberfläche benennt die verursachenden Spalten.
+
+Bei normaler Breite ist „An sichtbaren Bereich anpassen“ das Standardziel. Die flexible Gegenstandsspalte wird vor den festen Randspalten verkleinert, soweit ihre Mindestbreite dies erlaubt. Bei schmaleren Fenstern bleibt ein nicht vermeidbarer Restüberlauf bewusst scrollbar; bei breiten Fenstern darf die Hauptspalte proportional Raum nutzen.
+
+## Umbruch, Ellipsis und Zeilenhöhe
+
+Für jede zusammengefasste Spalte können Breitenmodus, Textumbruch und Ellipsis separat gesetzt werden. Zellinhalte besitzen `min-width: 0`; lange Texte dürfen dadurch keinen Grid-Track intrinsisch verbreitern. `wordWrap` bricht innerhalb der Spalte um, `ellipsis` begrenzt den sichtbaren Text. Die Zeilenhöhe bleibt mit 54–180 px kontrolliert; Buttons, Fotos, Ampel- und Statusanzeigen werden nicht skaliert.
+
+## Save, Restore, Reset und Discard
+
+Spaltenbreiten und Tabellenmodi verwenden das vorhandene BBM-UI-Profil. Der Start-Restore läuft vor dem Öffnen des Editors und wendet die Werte einmal an. Spaltenreset setzt Breite, Header, Daten und Textmodus gemeinsam auf die Registry-Baseline zurück; Tabellenreset stellt alle drei Spalten und den Tabellenmodus wieder her. Scope-/Gesamtreset, Discard und Fehlerrollback verwenden unverändert den bestehenden transaktionalen Weg und berühren keine Restarbeitendaten.
+
+## Abnahmenachweis
+
+Automatisiert werden Registrystruktur, direkte Auswahl, Breitenkopplung, Viewportmessung, Überlauf, Fit, Mindestbreiten, feste/flexible Spalten, Umbruch, Ellipsis, Start-Restore, Reset, Discard, M82.3 sowie UI-/PDF-Regression geprüft.
+
+Die sichtbare gepackte Development-Abnahme ergab bei ausgewählter Gegenstandsspalte unter anderem `795,46 DIP` Viewport, `864 DIP` Tabellenbreite und `68,54 DIP` bewussten horizontalen Überlauf. Schmale (900 px), mittlere (1400 px) und maximierte Fenster hielten die Liste im vorhandenen Inhaltsbereich; nicht vermeidbarer Überlauf blieb im inneren Scrollbereich. Die gespeicherte Kombination `fixed/ellipsis` wurde nach Neustart ohne Recovery-Marker wiederhergestellt. Ein Spaltenreset wechselte auf `proportional/wordWrap`; anschließendes Verwerfen stellte `fixed/ellipsis` wieder her. Die Unterzeilen zeigten sichtbar echte Ellipsis.
+
+Die abschließende Wiederholung deckte auf, dass der interaktive Tabellenreset die validierte Ziel-App-Baseline irrtümlich erneut als Geometrierisiko bewertete und sicher zurückrollte. Der HostAdapter nimmt den vollständigen Tabellenreset sowie einen nach der eigenen Tabellen-Vorschau bestätigten Fit von dieser erneuten Laufzeit-Risikobewertung aus; freie Breiten- und Geometrieänderungen bleiben unverändert geschützt. Nach Neu-Packen meldete „Tabelle Original“ Erfolg und stellte `proportional/wordWrap/clip` sowie `718 DIP` Tabellenbreite bei `717,55 DIP` Viewport wieder her. Der bestätigte Fit meldete ebenfalls Erfolg und begrenzte die Tabelle anschließend auf `795 DIP` bei `795,26 DIP` Viewport und `0 DIP` Überlauf. Im realen Projekt 12 wurde außerdem die echte BBM-Protokoll-PDF neu erzeugt: 28 Registryelemente, aktuelle native Vorschau und zwei auswählbare A4-Seiten.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -149,6 +149,7 @@ const TEST_GROUPS = Object.freeze([
       ["m82-1BbmFeintuning.test.cjs", "runM821BbmFeintuningTests"],
       ["m82-2BbmGeometryRisks.test.cjs", "runM822BbmGeometryRiskTests"],
       ["m82-3BbmSpacerCompactUi.test.cjs", "runM823BbmSpacerCompactUiTests"],
+      ["m82-4BbmTableColumnEditing.test.cjs", "runM824BbmTableColumnEditingTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),
   }),

--- a/scripts/tests/m80-1RegistrationRefresh.test.cjs
+++ b/scripts/tests/m80-1RegistrationRefresh.test.cjs
@@ -83,7 +83,7 @@ async function runM801RegistrationRefreshTests(run) {
       document.body.appendChild(rendered.root);
       const registration = rendered.registration;
       runtimeRegistration = structuredClone(registration);
-      assert.equal(registration.registryVersion, 5);
+      assert.equal(registration.registryVersion, 6);
       assert.equal(registration.registryStatus, "incomplete");
       assert.deepEqual(registration.activeScopes, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]);
       const complete = registration.registryScopes.filter((scope) => scope.status === "complete");
@@ -118,7 +118,7 @@ async function runM801RegistrationRefreshTests(run) {
       assert.deepEqual(columns.map((entry) => entry.name), [
         "Nr. / Datum / Klasse / Fotos",
         "Gegenstand – Verortung / Kurztext / Langtext",
-        "Status-Metaspalte – Fertig bis / Ampel / Status / Verantwortlich",
+        "Fertig bis / Ampel / Status / Verantwortlich",
       ]);
 
       const fingerprint = createRegistryFingerprint(registration.registryScopes);

--- a/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
+++ b/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
@@ -15,7 +15,7 @@ async function runM802HeaderEditboxLayoutTests(run) {
   const elements = complete.flatMap((scope) => scope.elements);
 
   await run("M80.2 Registry: Header, Liste und Editbox sind direkt aktiv; Split ist gesperrt", () => {
-    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 5);
+    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 6);
     assert.deepEqual(registryModule.BBM_M80_ACTIVE_SCOPES, [
       "restarbeiten.header.root",
       "restarbeiten.list.root",
@@ -33,7 +33,7 @@ async function runM802HeaderEditboxLayoutTests(run) {
     assert.equal(header.elements.length, 31);
     assert.equal(edit.elements.length, 53);
     assert.equal(header.elements.find((entry) => entry.id === "restarbeiten.filterbar").type, "area");
-    const nativeTypes = new Set(["root", "area", "group", "fieldGroup", "label", "field", "button", "table", "tableColumn", "statusIndicator", "componentPart"]);
+    const nativeTypes = new Set(["root", "area", "group", "fieldGroup", "label", "field", "button", "table", "tableHeader", "tableBody", "tableRow", "tableColumn", "tableHeaderCell", "tableDataCell", "tableViewport", "horizontalScrollArea", "statusIndicator", "componentPart"]);
     const nativeLockedOps = new Set(["executeTargetAction", "modifyDomainData", "createRecord", "deleteRecord"]);
     for (const entry of elements) {
       assert.ok(nativeTypes.has(entry.type), `${entry.id}: nativer Elementtyp`);

--- a/scripts/tests/m80ElectronUiEditor.test.cjs
+++ b/scripts/tests/m80ElectronUiEditor.test.cjs
@@ -142,7 +142,7 @@ async function runM80ElectronUiEditorTests(run) {
     assert.deepEqual(columns.map((entry) => entry.name), [
       "Nr. / Datum / Klasse / Fotos",
       "Gegenstand – Verortung / Kurztext / Langtext",
-      "Status-Metaspalte – Fertig bis / Ampel / Status / Verantwortlich",
+      "Fertig bis / Ampel / Status / Verantwortlich",
     ]);
     assert.equal(columns[2].columnRole, "metaColumn");
   });

--- a/scripts/tests/m82-1BbmFeintuning.test.cjs
+++ b/scripts/tests/m82-1BbmFeintuning.test.cjs
@@ -24,8 +24,8 @@ async function runM821BbmFeintuningTests(run) {
   const editbox = read("src/renderer/modules/restarbeiten/RestarbeitenEditbox.js");
   const css = read("src/renderer/modules/restarbeiten/styles/restarbeiten.css");
 
-  await run("M82.1 BBM 01: Registryversion 5 ist aktiv", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 5));
-  await run("M82.1 BBM 02: Manifestversion folgt der Registry", () => assert.equal(manifest.registryVersion, 5));
+  await run("M82.1 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 6));
+  await run("M82.1 BBM 02: Manifestversion folgt der Registry", () => assert.equal(manifest.registryVersion, registry.BBM_M80_REGISTRY_VERSION));
   await run("M82.1 BBM 03: Manifestfingerprint ist aktuell", () => assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)));
   await run("M82.1 BBM 04: genau drei Restarbeiten-Scopes bleiben aktiv", () => assert.deepEqual(registry.BBM_M80_ACTIVE_SCOPES, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]));
   await run("M82.1 BBM 05: Header behält 31 Elemente", () => assert.equal(byId.has("restarbeiten.header.root") && scopes.find((scope) => scope.scopeId === "restarbeiten.header.root").elements.length, 31));
@@ -91,7 +91,7 @@ async function runM821BbmFeintuningTests(run) {
         applicationId: "bbm-produktiv", displayName: "BBM", framework: "electron",
         registryVersion: registry.BBM_M80_REGISTRY_VERSION, registryStatus: "incomplete",
         activeScopes: [...registry.BBM_M80_ACTIVE_SCOPES],
-        supportedOperations: ["move", "resize", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility"],
+        supportedOperations: ["move", "resize", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility", "spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset", "fitTableToViewport", "resizeColumnsProportionally", "setHorizontalOverflowMode", "setColumnWidthMode", "setColumnWrapMode", "setColumnOverflowMode", "setRowHeightMode", "resetTableColumn", "resetTable"],
         uiCapability: "layout", pdfCapability: "unavailable", labelFieldSeparation: true, visibilityCapability: true,
         registryScopes,
       };
@@ -105,6 +105,8 @@ async function runM821BbmFeintuningTests(run) {
         if (ops.has("textResize")) saved.fontSize = entry.baseline.fontSize;
         if (ops.has("setVisibility")) saved.visible = entry.baseline.visible;
         if (["spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"].some((operation) => ops.has(operation))) saved.spacing = { ...(entry.baseline.spacing || {}) };
+        if (entry.tableColumnLayout) saved.table = { tableId: entry.tableBinding.tableId, columnId: entry.id, widthMode: entry.tableColumnLayout.widthMode, wrapMode: entry.tableColumnLayout.wrapMode, overflowMode: entry.tableColumnLayout.overflowMode };
+        if (entry.tableLayout) saved.table = { tableId: entry.id, horizontalOverflowMode: entry.tableLayout.horizontalOverflowMode, rowHeightMode: entry.tableLayout.rowHeightMode };
         return saved;
       };
       const document = {

--- a/scripts/tests/m82-2BbmGeometryRisks.test.cjs
+++ b/scripts/tests/m82-2BbmGeometryRisks.test.cjs
@@ -68,7 +68,7 @@ async function runM822BbmGeometryRiskTests(run) {
   await run("M82.2 BBM 32: genau eine gemeinsame Risikovertragsdatei wird importiert", () => { assert.match(host, /ui-editor-kit\/dist\/geometry-risk-contract\.mjs/); assert.doesNotMatch(read("../UI-Editor-kit/src/core/geometry-risk-contract.cjs"), /restarbeiten\.|bbm\./i); });
   await run("M82.2 BBM 33: docs/licensing.md bleibt hashgleich", () => assert.equal(crypto.createHash("sha256").update(fs.readFileSync(path.join(ROOT, "docs/licensing.md"))).digest("hex").toUpperCase(), "02AE66A8873C74869539F13F734B7CE43BC63B6EF37DA553A40C27A4F514D784"));
   await run("M82.2 BBM 34: Start- und Restorepfade öffnen keinen interaktiven Risikodialog", () => {
-    assert.match(host, /const interactive = request\.source === "ui-editor-panel";\s*const risk = interactive \? geometryRiskFor/);
+    assert.match(host, /const interactive = request\.source === "ui-editor-panel";[\s\S]*const risk = interactive && !usesValidatedTableGeometry/);
     assert.match(host, /source: "target-app-start"/);
   });
   await run("M82.2 BBM 35: Pack enthält das bestehende Ziel-App-Manifest", () => {

--- a/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
+++ b/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
@@ -47,8 +47,8 @@ async function runM823BbmSpacerCompactUiTests(run) {
     groupWidthEditable,
   });
 
-  await run("M82.3 BBM 01: Registryversion 5 ist aktiv", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 5));
-  await run("M82.3 BBM 02: Manifest folgt Registry und Fingerprint", () => { assert.equal(manifest.registryVersion, 5); assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)); });
+  await run("M82.3 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 6));
+  await run("M82.3 BBM 02: Manifest folgt Registry und Fingerprint", () => { assert.equal(manifest.registryVersion, registry.BBM_M80_REGISTRY_VERSION); assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)); });
   await run("M82.3 BBM 03: Kurztextbezeichnung besitzt reservierte Breite", () => assert.deepEqual(label.baseline.spacing, { reservedWidth: 40 }));
   await run("M82.3 BBM 04: Kurztextbezeichnung erlaubt Spacer davor und danach", () => assert.deepEqual(label.spacingTargets, ["beforeElement", "afterElement", "reservedWidth"]));
   await run("M82.3 BBM 05: Gruppenbreite ist getrennt freigegeben und nutzt die responsive Laufzeitbaseline", () => { assert.ok(group.allowedOps.includes("resizeWidth")); assert.equal(group.baseline.width, null); });
@@ -77,7 +77,7 @@ async function runM823BbmSpacerCompactUiTests(run) {
   await run("M82.3 BBM 20: lokaler Stabilitätsguard rollt unerwartete Änderungen zurück", () => assert.match(host, /electron_unexpected_layout_effect[\s\S]*unerwartet verändern/));
   await run("M82.3 BBM 21: Gruppe wird beim Fehler ebenfalls zurückgerollt", () => assert.match(host, /groupRestore\?\.state[\s\S]*applyM80State\(groupRestore\.id/));
   await run("M82.3 BBM 22: Start-Restore bleibt derselbe Profilweg", () => assert.match(host, /restoreM80StartupLayout/));
-  await run("M82.3 BBM 23: Manifest veröffentlicht alle vier Spacingoperationen", () => assert.deepEqual(manifest.supportedOperations.slice(-4), ["spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"]));
+  await run("M82.3 BBM 23: Manifest veröffentlicht alle vier Spacingoperationen", () => assert.deepEqual(manifest.supportedOperations.filter((operation) => operation.startsWith("spacing")), ["spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"]));
   await run("M82.3 BBM 24: kompakter UI-Workspace hat Ein-Zwei-Drei-Modus", () => assert.match(compactCode, /width < 860 \? 1 : width < 1260 \? 2 : 3/));
   await run("M82.3 BBM 25: feste Aktionen liegen vor den adaptiven Spalten", () => assert.ok(compactXaml.indexOf("Nächstes Element auswählen") < compactXaml.indexOf("AdaptiveColumns")));
   await run("M82.3 BBM 26: Baum scrollt intern", () => assert.match(compactXaml, /CompactElementTree[\s\S]*VerticalScrollBarVisibility="Auto"/));

--- a/scripts/tests/m82-4BbmTableColumnEditing.test.cjs
+++ b/scripts/tests/m82-4BbmTableColumnEditing.test.cjs
@@ -1,0 +1,144 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+const {
+  createUiScopeFingerprint,
+  validateTableElementBindings,
+  validateTableLayout,
+} = require("ui-editor-kit");
+
+const ROOT = path.resolve(__dirname, "../..");
+const read = (relativePath) => fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+
+class FakeElement {
+  constructor(width = 100, height = 40) {
+    this.attributes = {}; this.dataset = {}; this.className = ""; this.parentElement = null; this.isConnected = true;
+    this.children = [];
+    this._rect = { left: 0, top: 0, width, height };
+    this.style = {
+      setProperty(name, value) { this[name] = value; },
+      getPropertyValue(name) { return this[name] || ""; },
+    };
+    this.classList = {
+      contains: (name) => this.className.split(/\s+/).includes(name),
+      toggle: (name, active) => { const names = new Set(this.className.split(/\s+/).filter(Boolean)); if (active) names.add(name); else names.delete(name); this.className = [...names].join(" "); },
+    };
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  getBoundingClientRect() {
+    const configured = typeof this._widthSource === "function" ? this._widthSource() : NaN;
+    return { ...this._rect, width: Number.isFinite(configured) ? configured : parseFloat(this.style.width) || this._rect.width, height: parseFloat(this.style.height) || this._rect.height };
+  }
+}
+
+async function createRuntime(refs, host) {
+  const previous = { document: global.document, window: global.window, Element: global.Element };
+  global.Element = FakeElement;
+  global.document = { querySelector: () => null, createElement: () => new FakeElement(), addEventListener() {}, removeEventListener() {} };
+  global.window = {
+    getComputedStyle: (element) => ({ ...element.style, width: element.style.width || `${element._rect.width}px`, height: element.style.height || `${element._rect.height}px`, paddingLeft: element.style.paddingLeft || "0px", paddingTop: element.style.paddingTop || "0px", fontSize: element.style.fontSize || "12px" }),
+    dispatchEvent() {},
+  };
+  refs.resetM80PilotWorkingStatesForDiagnostic();
+  refs.beginM80PilotRender();
+
+  const root = new FakeElement(900, 700);
+  const area = new FakeElement(900, 700);
+  const paper = new FakeElement(900, 720);
+  const viewport = new FakeElement(600, 680);
+  const scrollArea = new FakeElement(600, 680);
+  const table = new FakeElement(858, 680);
+  const header = new FakeElement(858, 28);
+  const body = new FakeElement(858, 400);
+  const row = new FakeElement(858, 80);
+  const headers = [new FakeElement(82, 28), new FakeElement(560, 28), new FakeElement(172, 28)];
+  const cells = [new FakeElement(82, 80), new FakeElement(560, 80), new FakeElement(172, 80)];
+  const variables = ["--bbm-restarbeiten-number-column", "--bbm-restarbeiten-subject-column", "--bbm-restarbeiten-meta-column"];
+  const minimums = [50, 160, 110];
+  headers.forEach((element, index) => {
+    element._widthSource = () => {
+      const value = table.style[variables[index]];
+      if (!value) return element._rect.width;
+      if (String(value).startsWith("minmax")) return Math.max(minimums[index], viewport._rect.width - 44 - headers.filter((_item, candidate) => candidate !== index).reduce((sum, other, candidate) => {
+        const actualIndex = candidate >= index ? candidate + 1 : candidate;
+        const configured = parseFloat(table.style[variables[actualIndex]]);
+        return sum + (Number.isFinite(configured) ? configured : other._rect.width);
+      }, 0));
+      return parseFloat(value);
+    };
+  });
+
+  refs.registerM80Ref("restarbeiten.list.root", root);
+  refs.registerM80Ref("restarbeiten.list.area", area);
+  refs.registerM80Ref("restarbeiten.list.paper", paper);
+  refs.registerM80Ref("restarbeiten.list.viewport", viewport);
+  refs.registerM80Ref("restarbeiten.list.scrollArea", scrollArea);
+  refs.registerM80TableRef("restarbeiten.list.table", table, viewport, scrollArea);
+  refs.registerM80Ref("restarbeiten.list.table.header", header);
+  refs.registerM80Ref("restarbeiten.list.table.body", body);
+  refs.registerM80Ref("restarbeiten.list.table.row", row);
+  const ids = ["number", "subject", "meta"];
+  ids.forEach((key, index) => refs.registerM80TableColumnRef(`restarbeiten.list.table.${key}`, headers[index], [cells[index]], table, viewport, variables[index], headers[index]._rect.width));
+  refs.completeM80PilotRender();
+
+  const submit = (elementId, operation, payload, changeId = `${elementId}-${operation}`, source = "target-app-start") => host.handleM80EditorRequest({
+    action: "submitChange", scopeId: "restarbeiten.list.root",
+    changeRequest: { changeId, elementId, operation, payload, source },
+  }).changeResult;
+  return { table, viewport, scrollArea, headers, cells, submit, cleanup: () => { refs.resetM80PilotWorkingStatesForDiagnostic(); global.document = previous.document; global.window = previous.window; global.Element = previous.Element; } };
+}
+
+async function runM824BbmTableColumnEditingTests(run) {
+  const registry = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Registry.js"));
+  const refs = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Refs.js"));
+  const host = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80HostAdapter.js"));
+  const scope = registry.listM80RegistryScopes().find((entry) => entry.scopeId === "restarbeiten.list.root");
+  const byId = new Map(scope.elements.map((entry) => [entry.id, entry]));
+  const tableEntry = byId.get("restarbeiten.list.table");
+  const columns = scope.elements.filter((entry) => entry.type === "tableColumn");
+
+  await run("M82.4 BBM 01: bestaetigte Restarbeiten-Liste ist UI-Inhaltstabelle", () => assert.equal(tableEntry.role, "contentTable"));
+  await run("M82.4 BBM 02: exakt drei bestaetigte Hauptspalten bleiben erhalten", () => assert.deepEqual(columns.map((entry) => entry.name), ["Nr. / Datum / Klasse / Fotos", "Gegenstand – Verortung / Kurztext / Langtext", "Fertig bis / Ampel / Status / Verantwortlich"]));
+  await run("M82.4 BBM 03: Tabelle besitzt Viewport und horizontalen Scrollbereich", () => { assert.equal(byId.get("restarbeiten.list.viewport").type, "tableViewport"); assert.equal(byId.get("restarbeiten.list.scrollArea").type, "horizontalScrollArea"); });
+  await run("M82.4 BBM 04: Tabellenvertrag ist fachneutral gueltig", () => assert.equal(validateTableLayout(tableEntry.tableLayout).ok, true));
+  await run("M82.4 BBM 05: Header und Datenbereiche nutzen dieselbe Breitenquelle", () => assert.equal(validateTableElementBindings(scope.elements).ok, true));
+  await run("M82.4 BBM 06: Tabellenkopf, Body, Zeile und Zellen sind direkt registriert", () => ["tableHeader", "tableBody", "tableRow", "tableHeaderCell", "tableDataCell"].forEach((type) => assert.ok(scope.elements.some((entry) => entry.type === type), type)));
+  await run("M82.4 BBM 07: bestehende Unterelemente bleiben im Renderer einzeln markiert", () => { const source = read("src/renderer/modules/restarbeiten/RestarbeitenList.js"); assert.match(source, /restarbeiten\.record\.number/); assert.match(source, /restarbeiten\.record\.shortText/); assert.match(source, /restarbeiten\.record\.responsible/); });
+  await run("M82.4 BBM 08: keine neue Tabellenansicht wird eingefuehrt", () => assert.match(read("src/renderer/modules/restarbeiten/RestarbeitenMainBody.js"), /buildRestarbeitenList\(options\)/));
+  await run("M82.4 BBM 09: Kopf und Datenzeilen verwenden dieselben drei CSS-Variablen", () => { const css = read("src/renderer/modules/restarbeiten/styles/restarbeiten.css"); assert.equal((css.match(/grid-template-columns: var\(--bbm-restarbeiten-number-column\) var\(--bbm-restarbeiten-subject-column\) var\(--bbm-restarbeiten-meta-column\)/g) || []).length, 2); });
+  await run("M82.4 BBM 10: sichtbarer Inhaltsbereich begrenzt die Listenbreite", () => assert.match(read("src/renderer/modules/restarbeiten/styles/restarbeiten.css"), /\.bbm-restarbeiten-table-viewport[\s\S]*max-width:\s*100%[\s\S]*overflow:\s*hidden/));
+  await run("M82.4 BBM 10a: JavaScript- und WPF-Fingerprint stimmen fuer alle Tabellenrollen ueberein", () => assert.equal(createUiScopeFingerprint(scope), "sha256:dcdef2f965e7e3c6d71695e6e028874ac11432e8e47aac01a6963ed7e3e36d55"));
+
+  const runtime = await createRuntime(refs, host);
+  try {
+    await run("M82.4 BBM 11: Laufzeit meldet Viewport und Ueberlauf", () => { const state = refs.snapshotM80State("restarbeiten.list.table"); assert.equal(state.table.viewportWidth, 600); assert.ok(state.table.overflow > 250); });
+    await run("M82.4 BBM 11a: Spaltenauswahl meldet dieselbe Tabellengeometrie", () => { const state = refs.snapshotM80State("restarbeiten.list.table.subject"); assert.equal(state.table.viewportWidth, 600); assert.ok(state.table.tableWidth > state.table.viewportWidth); assert.ok(state.table.overflow > 250); });
+    await run("M82.4 BBM 12: exakte Breite schaltet die Spalte kontrolliert auf fest", () => { const result = runtime.submit("restarbeiten.list.table.subject", "resizeWidth", { width: 420 }); assert.equal(result.success, true); assert.equal(result.newState.width, 420); assert.equal(result.newState.table.widthMode, "fixed"); });
+    await run("M82.4 BBM 13: Kopfbreite stammt aus derselben CSS-Quelle", () => assert.equal(runtime.table.style["--bbm-restarbeiten-subject-column"], "420px"));
+    await run("M82.4 BBM 14: Wortumbruch gilt fuer Kopf und Datenbereich", () => { const result = runtime.submit("restarbeiten.list.table.subject", "setColumnWrapMode", { table: { wrapMode: "wordWrap" } }); assert.equal(result.success, true); assert.equal(runtime.headers[1].style.overflowWrap, "break-word"); assert.equal(runtime.cells[1].style.overflowWrap, "break-word"); });
+    await run("M82.4 BBM 15: Ellipsis gilt fuer Kopf, Datenbereich und sichtbare Unterelemente", () => { const line = new FakeElement(); runtime.cells[1].children.push(line); runtime.submit("restarbeiten.list.table.subject", "setColumnOverflowMode", { table: { overflowMode: "ellipsis" } }); assert.equal(runtime.headers[1].style.textOverflow, "ellipsis"); assert.equal(runtime.cells[1].style.textOverflow, "ellipsis"); assert.equal(line.style.textOverflow, "ellipsis"); });
+    await run("M82.4 BBM 16: Fit ohne bestaetigte Vorschau wird abgewiesen", () => assert.equal(runtime.submit("restarbeiten.list.table", "fitTableToViewport", { table: { strategy: "fit" } }).errorCode, "electron_editor_message_invalid"));
+    await run("M82.4 BBM 17: Fit mit bestaetigter Vorschau begrenzt auf den Viewport", () => { runtime.submit("restarbeiten.list.table.subject", "resetTableColumn", { table: {} }); const result = runtime.submit("restarbeiten.list.table", "fitTableToViewport", { table: { strategy: "fit", previewAccepted: true } }); assert.equal(result.success, true); assert.ok(result.newState.table.overflow <= 0.5); });
+    await run("M82.4 BBM 18: flexible Hauptspalte traegt den Fit vor festen Spalten", () => { assert.equal(refs.snapshotM80State("restarbeiten.list.table.number").width, 82); assert.equal(refs.snapshotM80State("restarbeiten.list.table.meta").width, 172); });
+    await run("M82.4 BBM 19: horizontaler Scrollmodus bleibt explizit steuerbar", () => { const result = runtime.submit("restarbeiten.list.table", "setHorizontalOverflowMode", { table: { horizontalOverflowMode: "scroll" } }); assert.equal(result.success, true); assert.equal(runtime.scrollArea.style.overflowX, "scroll"); });
+    await run("M82.4 BBM 20: ungueltiger Modus wird ohne Zustandsaenderung abgewiesen", () => { const before = refs.snapshotM80State("restarbeiten.list.table.subject"); const result = runtime.submit("restarbeiten.list.table.subject", "setColumnWidthMode", { table: { widthMode: "domain" } }); assert.equal(result.success, false); assert.deepEqual(refs.snapshotM80State("restarbeiten.list.table.subject").table, before.table); });
+    await run("M82.4 BBM 21: Spaltenreset stellt Breiten- und Textmodus wieder her", () => { const result = runtime.submit("restarbeiten.list.table.subject", "resetTableColumn", { table: {} }); assert.equal(result.success, true); assert.equal(result.newState.table.widthMode, "proportional"); assert.equal(result.newState.table.wrapMode, "wordWrap"); assert.equal(result.newState.table.overflowMode, "clip"); });
+    await run("M82.4 BBM 22: Tabellenreset stellt alle drei Spalten und Tabellenmodi wieder her", () => { const result = runtime.submit("restarbeiten.list.table", "resetTable", { table: {} }); assert.equal(result.success, true); assert.equal(result.affectedStates.length, 3); assert.equal(result.newState.table.horizontalOverflowMode, "auto"); assert.equal(result.newState.table.rowHeightMode, "bounded"); });
+    await run("M82.4 BBM 22a: interaktiver Tabellenreset vertraut der validierten Ziel-App-Baseline", () => { runtime.table._rect.width = 1224; const result = runtime.submit("restarbeiten.list.table", "resetTable", { table: {} }, "interactive-table-reset", "ui-editor-panel"); assert.equal(result.success, true); assert.equal(result.errorCode, null); assert.equal(result.affectedStates.length, 3); assert.equal(refs.snapshotM80State("restarbeiten.list.table.subject").table.wrapMode, "wordWrap"); });
+    await run("M82.4 BBM 22b: interaktiver Fit nutzt die bestaetigte Tabellenvorschau", () => { runtime.table._rect.width = 1224; const result = runtime.submit("restarbeiten.list.table", "fitTableToViewport", { table: { strategy: "fitViewport", previewAccepted: true } }, "interactive-table-fit", "ui-editor-panel"); assert.equal(result.success, true); assert.equal(result.errorCode, null); assert.ok(result.newState.table.overflow <= 0.5); });
+    await run("M82.4 BBM 23: Start-Restore erzeugt nur explizite Tabellenmodus-Requests", () => { const requests = host.createM80StartupRequests("restarbeiten.list.root", { elementId: "restarbeiten.list.table.subject", width: 360, table: { tableId: "restarbeiten.list.table", columnId: "restarbeiten.list.table.subject", widthMode: "fixed", wrapMode: "ellipsis", overflowMode: "ellipsis" } }); assert.ok(requests.some((item) => item.request.operation === "resizeWidth")); assert.ok(requests.some((item) => item.request.operation === "setColumnWrapMode")); assert.ok(requests.some((item) => item.request.operation === "setColumnOverflowMode")); });
+    await run("M82.4 BBM 24: Tabellenpayload enthaelt keine Fachwertfelder", () => {
+      const keys = [];
+      const visit = (value) => { if (Array.isArray(value)) value.forEach(visit); else if (value && typeof value === "object") Object.entries(value).forEach(([key, nested]) => { keys.push(key); visit(nested); }); };
+      visit(tableEntry.tableLayout);
+      assert.equal(keys.some((key) => ["recordId", "domainData", "businessData", "dueDateValue", "responsibleValue", "photos", "rows", "values"].includes(key)), false);
+    });
+  } finally {
+    runtime.cleanup();
+  }
+}
+
+module.exports = { runM824BbmTableColumnEditingTests };

--- a/scripts/tests/m82AppStarterPackage.test.cjs
+++ b/scripts/tests/m82AppStarterPackage.test.cjs
@@ -46,7 +46,7 @@ async function runM82AppStarterPackageTests(run) {
     assert.equal(byId.get("restarbeiten.header.root").status, "complete");
     assert.equal(byId.get("restarbeiten.header.root").elementCount, 31);
     assert.equal(byId.get("restarbeiten.list.root").status, "complete");
-    assert.equal(byId.get("restarbeiten.list.root").elementCount, 7);
+    assert.equal(byId.get("restarbeiten.list.root").elementCount, 18);
     assert.equal(byId.get("restarbeiten.edit.root").status, "complete");
     assert.equal(byId.get("restarbeiten.edit.root").elementCount, 53);
     assert.equal(byId.get("bbm.remaining").status, "blocked");

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 104, "104 Suite-Einstiege einschließlich Entwicklungs-Lizenz und M82.3");
+    assert.equal(suites.length, 105, "105 Suite-Einstiege einschließlich Entwicklungs-Lizenz und M82.4");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/src/renderer/modules/restarbeiten/RestarbeitenList.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenList.js
@@ -47,6 +47,10 @@ export function buildRestarbeitenList({
     className: "bbm-restarbeiten-records",
     uiId: "restarbeiten.main.records",
   });
+  const rows = [];
+  const columnCells = [[], [], []];
+  records._m80Rows = rows;
+  records._m80ColumnCells = columnCells;
 
   if (!items.length) {
     records.appendChild(
@@ -111,6 +115,10 @@ export function buildRestarbeitenList({
     }
 
     row.append(numberColumn, contentColumn, metaColumn);
+    rows.push(row);
+    columnCells[0].push(numberColumn);
+    columnCells[1].push(contentColumn);
+    columnCells[2].push(metaColumn);
     records.appendChild(row);
   }
 

--- a/src/renderer/modules/restarbeiten/RestarbeitenMainBody.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenMainBody.js
@@ -1,5 +1,5 @@
 import { buildRestarbeitenList, buildRestarbeitenTableHeader } from "./RestarbeitenList.js";
-import { registerM80Ref, registerM80TableColumnRef } from "../../ui-editor/m80Refs.js";
+import { registerM80Ref, registerM80TableColumnRef, registerM80TableRef } from "../../ui-editor/m80Refs.js";
 
 function createEl(tag, { className = "", uiId = "" } = {}) {
   const el = document.createElement(tag);
@@ -25,37 +25,52 @@ export function buildRestarbeitenMainBody(options = {}) {
   const table = createEl("div", {
     className: "bbm-restarbeiten-table",
   });
+  const viewport = createEl("div", { className: "bbm-restarbeiten-table-viewport" });
+  const scrollArea = createEl("div", { className: "bbm-restarbeiten-table-scroll-area" });
   const header = buildRestarbeitenTableHeader();
   const records = buildRestarbeitenList(options);
 
   registerM80Ref("restarbeiten.list.root", main);
   registerM80Ref("restarbeiten.list.area", sheet);
   registerM80Ref("restarbeiten.list.paper", paper);
-  registerM80Ref("restarbeiten.list.table", table);
+  registerM80Ref("restarbeiten.list.viewport", viewport);
+  registerM80Ref("restarbeiten.list.scrollArea", scrollArea);
+  registerM80TableRef("restarbeiten.list.table", table, viewport, scrollArea);
+  registerM80Ref("restarbeiten.list.table.header", header);
+  registerM80Ref("restarbeiten.list.table.body", records);
+  registerM80Ref("restarbeiten.list.table.row", records._m80Rows[0] || records, { targets: records._m80Rows });
   registerM80TableColumnRef(
     "restarbeiten.list.table.number",
     header.children[0],
+    records._m80ColumnCells[0],
     table,
+    viewport,
     "--bbm-restarbeiten-number-column",
     82
   );
   registerM80TableColumnRef(
     "restarbeiten.list.table.subject",
     header.children[1],
+    records._m80ColumnCells[1],
     table,
+    viewport,
     "--bbm-restarbeiten-subject-column",
-    600
+    560
   );
   registerM80TableColumnRef(
     "restarbeiten.list.table.meta",
     header.children[2],
+    records._m80ColumnCells[2],
     table,
+    viewport,
     "--bbm-restarbeiten-meta-column",
     172
   );
 
   table.append(header, records);
-  paper.appendChild(table);
+  scrollArea.appendChild(table);
+  viewport.appendChild(scrollArea);
+  paper.appendChild(viewport);
   sheet.appendChild(paper);
   main.appendChild(sheet);
   return main;

--- a/src/renderer/modules/restarbeiten/styles/restarbeiten.css
+++ b/src/renderer/modules/restarbeiten/styles/restarbeiten.css
@@ -371,6 +371,7 @@
 
 .bbm-restarbeiten-paper {
   width: min(100%, 900px);
+  min-width: 0;
   min-height: 720px;
   aspect-ratio: 210 / 297;
   border: 1px solid var(--bbm-line);
@@ -380,10 +381,28 @@
   padding: 18px 20px;
 }
 
+.bbm-restarbeiten-table-viewport {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.bbm-restarbeiten-table-scroll-area {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: visible;
+}
+
 .bbm-restarbeiten-table {
   --bbm-restarbeiten-number-column: 82px;
   --bbm-restarbeiten-subject-column: minmax(0, 1fr);
   --bbm-restarbeiten-meta-column: 172px;
+  width: 100%;
+  min-width: 320px;
+  box-sizing: border-box;
 }
 
 .bbm-restarbeiten-records {
@@ -431,6 +450,23 @@
   font-size: var(--bbm-rest-short-font-size);
   line-height: var(--bbm-rest-line-height);
   text-align: left;
+}
+
+.bbm-restarbeiten-table[data-ui-editor-row-height-mode="fixed"] .bbm-restarbeiten-record {
+  height: 54px;
+  overflow: hidden;
+}
+
+.bbm-restarbeiten-table[data-ui-editor-row-height-mode="bounded"] .bbm-restarbeiten-record,
+.bbm-restarbeiten-table[data-ui-editor-row-height-mode="ellipsis"] .bbm-restarbeiten-record {
+  min-height: 54px;
+  max-height: 180px;
+  overflow: hidden;
+}
+
+.bbm-restarbeiten-table[data-ui-editor-row-height-mode="ellipsis"] .bbm-restarbeiten-record > * {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .bbm-restarbeiten-record[aria-selected="true"] {

--- a/src/renderer/ui-editor/m80HostAdapter.js
+++ b/src/renderer/ui-editor/m80HostAdapter.js
@@ -10,15 +10,21 @@ import {
   beginM80PilotRender,
   clearM80VisualState,
   completeM80PilotRender,
-  getM80IdFromTarget,
+  getM80IdsFromTarget,
   getM80ReferenceStatus,
   getM80Ref,
   listM80Refs,
   registerM80Ref,
+  fitM80Table,
+  resetM80Table,
   resetM80PilotWorkingStatesForDiagnostic,
   snapshotM80State,
   snapshotM80Geometry,
 } from "./m80Refs.js";
+import {
+  TABLE_LAYOUT_OPERATIONS,
+  validateTableLayoutIntent,
+} from "../../../node_modules/ui-editor-kit/dist/table-layout-contract.mjs";
 import {
   createDirectSelectionHierarchy,
   cycleDirectSelectionIndex,
@@ -32,6 +38,7 @@ import {
 } from "../../../node_modules/ui-editor-kit/dist/geometry-risk-contract.mjs";
 
 const ALLOWED_ACTIONS = new Set(["getRegistry", "getLayoutState", "submitChange"]);
+const SUPPORTED_OPERATIONS = Object.freeze(["move", "resize", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility", "spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset", ...TABLE_LAYOUT_OPERATIONS]);
 const REGISTRY_EVENT_ACTIONS = new Set(["registryChanged", "registryStatusChanged", "scopeAdded", "scopeChanged", "scopeRemoved"]);
 const FORBIDDEN_KEYS = new Set(["fachDaten", "businessData", "domainData", "recordId", "entity", "database", "sql", "status", "responsible", "dueDate", "photos", "rows", "values"]);
 let selectionMode = false;
@@ -81,6 +88,7 @@ function desiredState(previous, operation, payload) {
   } else if (operation === "resizeWidth") {
     if (Object.keys(payload).length !== 1 || !Object.hasOwn(payload, "width")) throw new Error("resizeWidth-Payload ist ungültig.");
     next.width = number(payload.width, "width", { positive: true });
+    if (previous.table?.columnId) next.table = { ...previous.table, widthMode: "fixed" };
   } else if (operation === "resizeHeight") {
     if (Object.keys(payload).length !== 1 || !Object.hasOwn(payload, "height")) throw new Error("resizeHeight-Payload ist ungültig.");
     next.height = number(payload.height, "height", { positive: true });
@@ -106,6 +114,15 @@ function desiredState(previous, operation, payload) {
       const value = number(payload.spacing.value, "spacing.value", { nonNegative: true });
       next.spacing[target] = operation === "spacingIncrease" ? current + value : operation === "spacingDecrease" ? Math.max(0, current - value) : value;
     }
+  } else if (TABLE_LAYOUT_OPERATIONS.includes(operation)) {
+    const validation = validateTableLayoutIntent(operation, payload);
+    if (!validation.ok) throw Object.assign(new Error(validation.errors[0]?.message || "Tabellenoperation ist ungÃ¼ltig."), { code: "electron_editor_message_invalid" });
+    next.table = { ...(previous.table || {}) };
+    if (operation === "setHorizontalOverflowMode") next.table.horizontalOverflowMode = validation.intent.horizontalOverflowMode;
+    if (operation === "setColumnWidthMode") next.table.widthMode = validation.intent.widthMode;
+    if (operation === "setColumnWrapMode") next.table.wrapMode = validation.intent.wrapMode;
+    if (operation === "setColumnOverflowMode") next.table.overflowMode = validation.intent.overflowMode;
+    if (operation === "setRowHeightMode") next.table.rowHeightMode = validation.intent.rowHeightMode;
   } else throw Object.assign(new Error("Operation ist nicht erlaubt."), { code: "electron_operation_not_allowed" });
   return next;
 }
@@ -301,6 +318,7 @@ function submitChange(changeRequest, scopeId) {
   const previous = snapshotM80State(entry.id);
   if (!previous) return failure(request, "electron_element_not_found", "Explizite Elementreferenz fehlt.");
   let groupRestore = null;
+  const tableRestore = new Map();
   try {
     const beforeGeometry = snapshotM80Geometry();
     const ref = getM80Ref(entry.id);
@@ -314,8 +332,26 @@ function submitChange(changeRequest, scopeId) {
     if (confirmation?.action === RISK_ACTIONS.PRESERVE_SPACE || confirmation?.action === RISK_ACTIONS.SHRINK_GROUP) {
       desired.spacing = { ...(desired.spacing || {}), reservedWidth: Number(desired.spacing?.reservedWidth || 0) + Number(confirmation.risk.technicalDetails?.freedWidth || 0) };
     }
-    const readback = applyM80State(entry.id, desired);
+    let readback;
     const affectedStates = [];
+    if (["fitTableToViewport", "resizeColumnsProportionally", "resetTable"].includes(request.operation)) {
+      tableRestore.set(entry.id, previous);
+      for (const column of entry.tableLayout?.columns || []) tableRestore.set(column.columnId, snapshotM80State(column.columnId));
+    }
+    if (["fitTableToViewport", "resizeColumnsProportionally"].includes(request.operation)) {
+      const fitted = fitM80Table(entry.id, request.payload?.table?.selectedColumnId || "");
+      affectedStates.push(...fitted.affectedStates);
+      readback = snapshotM80State(entry.id);
+    } else if (request.operation === "resetTable") {
+      const reset = resetM80Table(entry.id);
+      affectedStates.push(...reset.affectedStates);
+      readback = reset.newState;
+    } else if (request.operation === "resetTableColumn") {
+      const baseline = entry.tableColumnLayout;
+      readback = applyM80State(entry.id, { ...previous, width: baseline.currentWidth, visible: baseline.visibility, table: { tableId: entry.tableBinding.tableId, columnId: entry.id, widthMode: baseline.widthMode, wrapMode: baseline.wrapMode, overflowMode: baseline.overflowMode } });
+    } else {
+      readback = applyM80State(entry.id, desired);
+    }
     if (confirmation?.action === RISK_ACTIONS.SHRINK_GROUP) {
       const groupEntry = ancestor(entry, (candidate) => ["group", "fieldGroup"].includes(candidate.type));
       if (!groupEntry?.allowedOps?.includes("resizeWidth")) throw Object.assign(new Error("Die Breite dieser Gruppe kann nicht direkt verändert werden."), { code: "electron_operation_not_allowed" });
@@ -329,8 +365,17 @@ function submitChange(changeRequest, scopeId) {
     }
     const affected = inspectGeometryEffect(entry, request.operation, beforeGeometry, afterGeometry);
     const interactive = request.source === "ui-editor-panel";
-    const risk = interactive ? geometryRiskFor(entry, request, beforeGeometry, afterGeometry, affected) : null;
+    // Reset und bestaetigte Fit-Operationen sind bereits durch den
+    // Ziel-App-Vertrag und den Tabellen-Core begrenzt. Sie duerfen deshalb
+    // nicht an der Geometrie des aktuell ueberbreiten Laufzeitzustands
+    // haengen bleiben.
+    const usesValidatedTableGeometry = request.operation === "resetTable" ||
+      (["fitTableToViewport", "resizeColumnsProportionally"].includes(request.operation) && request.payload?.table?.previewAccepted === true);
+    const risk = interactive && !usesValidatedTableGeometry
+      ? geometryRiskFor(entry, request, beforeGeometry, afterGeometry, affected)
+      : null;
     if (risk?.hasRisks && !confirmation) {
+      for (const [id, state] of [...tableRestore].reverse()) if (state) applyM80State(id, state);
       const restored = applyM80State(entry.id, previous);
       pendingGeometryRisks.set(risk.operationId, { signature: requestSignature(request), risk });
       renderGeometryRiskPreview(risk);
@@ -342,6 +387,7 @@ function submitChange(changeRequest, scopeId) {
   } catch (error) {
     try {
       if (groupRestore?.state) applyM80State(groupRestore.id, groupRestore.state);
+      for (const [id, state] of [...tableRestore].reverse()) if (state) applyM80State(id, state);
       const restored = applyM80State(entry.id, previous);
       return failure(request, error?.code || "electron_change_apply_failed", `Layoutänderung wurde sicher abgewiesen und zurückgerollt: ${error?.message || "Unbekannte Geometrieverletzung."}`, restored, true);
     } catch (_rollbackError) {
@@ -396,7 +442,7 @@ export function createM80RegistrationDescriptor() {
     registryVersion: BBM_M80_REGISTRY_VERSION + diagnosticRegistryRevision,
     registryStatus: BBM_M80_REGISTRY_STATUS,
     activeScopes,
-    supportedOperations: ["move", "resize", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility", "spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"],
+    supportedOperations: [...SUPPORTED_OPERATIONS],
     uiCapability: "layout",
     pdfCapability: "unavailable",
     labelFieldSeparation: true,
@@ -437,9 +483,11 @@ function directChildCount(id) {
   return listM80RegistryScopes().flatMap((scope) => scope.elements).filter((entry) => entry.parentId === id).length;
 }
 
-function selectionCandidates(id) {
-  return createDirectSelectionHierarchy(listM80RegistryScopes().flatMap((scope) => scope.elements), id)
-    .filter((candidate) => getM80Ref(candidate.entry.id));
+function selectionCandidates(ids) {
+  const seen = new Set();
+  return (Array.isArray(ids) ? ids : [ids]).flatMap((id) =>
+    createDirectSelectionHierarchy(listM80RegistryScopes().flatMap((scope) => scope.elements), id))
+    .filter((candidate) => getM80Ref(candidate.entry.id) && !seen.has(candidate.entry.id) && seen.add(candidate.entry.id));
 }
 
 function frameStyle(level) {
@@ -493,9 +541,9 @@ function stopSelection({ clearHover = false } = {}) {
 
 function onSelectionHover(event) {
   if (!selectionMode) return;
-  const id = getM80IdFromTarget(event.target);
-  if (!id) { hoverCandidates = []; renderSelectionFrames([]); return; }
-  const candidates = selectionCandidates(id);
+  const ids = getM80IdsFromTarget(event.target);
+  if (!ids.length) { hoverCandidates = []; renderSelectionFrames([]); return; }
+  const candidates = selectionCandidates(ids);
   const same = candidates.map((candidate) => candidate.entry.id).join("|") === hoverCandidates.map((candidate) => candidate.entry.id).join("|");
   hoverCandidates = candidates;
   if (!same) hoverIndex = 0;
@@ -620,6 +668,14 @@ export function createM80StartupRequests(scopeId, element, explicitOperations = 
     if (Math.abs(desiredValue - currentValue) > 0.01 && entry.allowedOps.includes("spacingSet")) {
       requests.push({ changeId: `startup-${requests.length + 1}-${entry.id}`, elementId: entry.id, operation: "spacingSet", payload: { spacing: { target, value: desiredValue } }, source: "target-app-start" });
     }
+  }
+  const savedTable = element.table && typeof element.table === "object" && !Array.isArray(element.table) ? element.table : null;
+  if (savedTable && current.table) {
+    if (savedTable.widthMode && savedTable.widthMode !== current.table.widthMode) push("setColumnWidthMode", { table: { widthMode: savedTable.widthMode } });
+    if (savedTable.wrapMode && savedTable.wrapMode !== current.table.wrapMode) push("setColumnWrapMode", { table: { wrapMode: savedTable.wrapMode } });
+    if (savedTable.overflowMode && savedTable.overflowMode !== current.table.overflowMode) push("setColumnOverflowMode", { table: { overflowMode: savedTable.overflowMode } });
+    if (savedTable.horizontalOverflowMode && savedTable.horizontalOverflowMode !== current.table.horizontalOverflowMode) push("setHorizontalOverflowMode", { table: { horizontalOverflowMode: savedTable.horizontalOverflowMode } });
+    if (savedTable.rowHeightMode && savedTable.rowHeightMode !== current.table.rowHeightMode) push("setRowHeightMode", { table: { rowHeightMode: savedTable.rowHeightMode } });
   }
   return requests.map((request) => ({ scopeId, request }));
 }

--- a/src/renderer/ui-editor/m80Refs.js
+++ b/src/renderer/ui-editor/m80Refs.js
@@ -1,8 +1,14 @@
 import { getM80RegistryEntry, m80EditorAttributes } from "./m80Registry.js";
+import {
+  fitTableToViewport,
+  measureTableLayout,
+  normalizeTableLayout,
+} from "../../../node_modules/ui-editor-kit/dist/table-layout-contract.mjs";
 
 const refs = new Map();
 const elementIds = new WeakMap();
 const workingStates = new Map();
+const tableColumnRuntimeBindings = new Map();
 const HIDDEN_CLASS = "bbm-ui-editor-hidden";
 
 function finite(value, fallback = 0) { return Number.isFinite(Number(value)) ? Number(value) : fallback; }
@@ -23,6 +29,12 @@ function setCustomProperty(style, name, value) { if (typeof style?.setProperty =
 function getCustomProperty(style, name) { return typeof style?.getPropertyValue === "function" ? style.getPropertyValue(name) : style?.[name]; }
 function applyAttributes(target, id) {
   for (const [name, value] of Object.entries(m80EditorAttributes(id))) target.setAttribute(name, value);
+}
+function bindElementId(target, id) {
+  if (!isElementRef(target)) return;
+  const ids = elementIds.get(target) || new Set();
+  ids.add(id);
+  elementIds.set(target, ids);
 }
 function readSpacing(element) {
   try {
@@ -98,26 +110,30 @@ function applyGeneric(element, state, entry) {
 
 export function beginM80PilotRender() {
   refs.clear();
+  tableColumnRuntimeBindings.clear();
 }
 
 export function resetM80PilotWorkingStatesForDiagnostic() {
   refs.clear();
+  tableColumnRuntimeBindings.clear();
   workingStates.clear();
 }
 
 export function registerM80Ref(id, element, custom = {}) {
   const entry = getM80RegistryEntry(id);
   if (!entry || !isElementRef(element)) throw new Error(`Ungültige explizite M80-Referenz: ${id}`);
-  applyAttributes(element, id);
+  if (custom.applyPrimaryAttributes !== false) applyAttributes(element, id);
+  const targets = [...new Set([element, ...(Array.isArray(custom.targets) ? custom.targets : [])].filter(isElementRef))];
   const ref = {
     id,
     entry,
     element,
+    targets,
     read: custom.read || (() => readGeneric(element, id)),
     apply: custom.apply || ((state) => applyGeneric(element, state, entry)),
   };
   refs.set(id, ref);
-  elementIds.set(element, id);
+  targets.forEach((target) => bindElementId(target, id));
   if (workingStates.has(id)) ref.apply(workingStates.get(id));
   return element;
 }
@@ -135,31 +151,184 @@ export function completeM80PilotRender() {
   }
 }
 
-export function registerM80TableColumnRef(id, headerCell, tableElement, cssVariable, initialWidth) {
+function storedColumnState(tableElement, id, baseline) {
+  try {
+    const stored = JSON.parse(tableElement.dataset.uiEditorTableColumns || "{}")[id];
+    return stored && typeof stored === "object" ? { ...baseline, ...stored, tableId: baseline.tableId, columnId: id } : baseline;
+  } catch { return baseline; }
+}
+
+function writeColumnState(tableElement, id, value) {
+  let all = {};
+  try { all = JSON.parse(tableElement.dataset.uiEditorTableColumns || "{}"); } catch { all = {}; }
+  all[id] = value;
+  tableElement.dataset.uiEditorTableColumns = JSON.stringify(all);
+}
+
+function applyColumnTextMode(targets, tableState) {
+  for (const target of targets) {
+    const boundParts = [target, ...Array.from(target.children || [])];
+    for (const part of boundParts) {
+      const wrap = tableState.wrapMode;
+      part.style.whiteSpace = ["noWrap", "ellipsis"].includes(wrap) ? "nowrap" : "normal";
+      part.style.overflowWrap = wrap === "characterWrap" ? "anywhere" : wrap === "wordWrap" ? "break-word" : "normal";
+      const overflow = tableState.overflowMode;
+      part.style.overflow = overflow === "visible" ? "visible" : overflow === "scroll" ? "auto" : "hidden";
+      part.style.textOverflow = wrap === "ellipsis" || overflow === "ellipsis" ? "ellipsis" : "clip";
+    }
+  }
+}
+
+export function registerM80TableColumnRef(id, headerCell, dataCells, tableElement, viewportElement, cssVariable, initialWidth) {
   const entry = getM80RegistryEntry(id);
-  return registerM80Ref(id, headerCell, {
+  const layout = entry.tableColumnLayout;
+  const targets = [headerCell, ...(Array.isArray(dataCells) ? dataCells : [])];
+  tableColumnRuntimeBindings.set(id, { entry, headerCell, tableElement, viewportElement, cssVariable, initialWidth });
+  const baselineTable = {
+    tableId: entry.tableBinding.tableId, columnId: id, widthMode: layout.widthMode,
+    wrapMode: layout.wrapMode, overflowMode: layout.overflowMode,
+  };
+  registerM80Ref(id, headerCell, {
+    targets,
     read: () => {
       const style = styleOf(headerCell);
       const rect = rectOf(headerCell);
-      const width = positive(parseFloat(getCustomProperty(tableElement.style, cssVariable)), positive(rect.width, initialWidth));
+      const table = storedColumnState(tableElement, id, baselineTable);
+      const configured = parseFloat(getCustomProperty(tableElement.style, cssVariable));
+      const width = positive(configured, positive(rect.width, initialWidth));
+      const metrics = runtimeTableMetrics(entry.tableBinding.tableId, tableElement, viewportElement);
       return {
         elementId: id, x: 0, y: 0, width, height: positive(rect.height, 1),
         textOffsetX: finite(headerCell.dataset.uiEditorTextX, finite(parseFloat(style.paddingLeft))),
         textOffsetY: finite(headerCell.dataset.uiEditorTextY, finite(parseFloat(style.paddingTop))),
         fontSize: positive(parseFloat(style.fontSize), 12), visible: !hasClass(headerCell, HIDDEN_CLASS),
+        table: { ...table, ...metrics },
       };
     },
     apply: (state) => {
-      setCustomProperty(tableElement.style, cssVariable, px(bounded(entry, "width", state.width, initialWidth)));
+      const table = { ...baselineTable, ...(state.table || {}) };
+      const width = bounded(entry, "width", state.width, initialWidth);
+      const widthValue = table.widthMode === "proportional"
+        ? `minmax(${px(layout.minimumWidth)}, 1fr)`
+        : table.widthMode === "auto" ? `minmax(${px(layout.minimumWidth)}, max-content)` : px(width);
+      setCustomProperty(tableElement.style, cssVariable, widthValue);
+      writeColumnState(tableElement, id, table);
       headerCell.dataset.uiEditorTextX = String(finite(state.textOffsetX));
       headerCell.dataset.uiEditorTextY = String(finite(state.textOffsetY));
       headerCell.style.paddingLeft = px(Math.max(0, finite(state.textOffsetX)));
       headerCell.style.paddingTop = px(Math.max(0, finite(state.textOffsetY)));
       headerCell.style.fontSize = px(positive(state.fontSize, 1));
+      applyColumnTextMode(targets, table);
       toggleClass(tableElement, `${HIDDEN_CLASS}-${id.split(".").pop()}`, state.visible === false);
-      toggleClass(headerCell, HIDDEN_CLASS, state.visible === false);
+      targets.forEach((target) => toggleClass(target, HIDDEN_CLASS, state.visible === false));
     },
   });
+  registerM80Ref(layout.headerElementId, headerCell, { targets: [headerCell] });
+  registerM80Ref(layout.dataCellTemplateId, dataCells?.[0] || viewportElement, {
+    targets: dataCells,
+    applyPrimaryAttributes: Boolean(dataCells?.length),
+  });
+  return headerCell;
+}
+
+function runtimeTableMetrics(tableId, tableElement, viewportElement) {
+  const tableEntry = getM80RegistryEntry(tableId);
+  if (!tableEntry?.tableLayout) return {};
+  const tableRect = rectOf(tableElement);
+  const viewportRect = rectOf(viewportElement);
+  const columns = tableEntry.tableLayout.columns.map((column) => {
+    const binding = tableColumnRuntimeBindings.get(column.columnId);
+    const columnState = storedColumnState(tableElement, column.columnId, column);
+    return {
+      ...column,
+      currentWidth: positive(rectOf(binding?.headerCell || {}).width, binding?.initialWidth || column.currentWidth),
+      widthMode: columnState.widthMode || column.widthMode,
+      wrapMode: columnState.wrapMode || column.wrapMode,
+      overflowMode: columnState.overflowMode || column.overflowMode,
+      visibility: binding?.headerCell ? !hasClass(binding.headerCell, HIDDEN_CLASS) : column.visibility,
+    };
+  });
+  const layout = normalizeTableLayout({
+    ...tableEntry.tableLayout,
+    bounds: { left: tableRect.left, top: tableRect.top, width: tableRect.width, height: tableRect.height },
+    viewportBounds: { left: viewportRect.left, top: viewportRect.top, width: viewportRect.width, height: viewportRect.height },
+    contentBounds: { left: tableRect.left, top: tableRect.top, width: Math.max(finite(tableElement.scrollWidth), columns.filter((column) => column.visibility).reduce((sum, column) => sum + column.currentWidth, tableEntry.tableLayout.reservedWidth)), height: Math.max(tableRect.height, finite(tableElement.scrollHeight)) },
+    columns,
+  });
+  const metrics = measureTableLayout(layout);
+  return {
+    viewportWidth: metrics.viewportWidth,
+    tableWidth: metrics.tableWidth,
+    overflow: metrics.overflow,
+    overflowColumnIds: [...metrics.overflowColumnIds],
+  };
+}
+
+function runtimeTableLayout(entry, tableElement, viewportElement) {
+  const tableRect = rectOf(tableElement);
+  const viewportRect = rectOf(viewportElement);
+  const columns = entry.tableLayout.columns.map((column) => {
+    const state = getM80Ref(column.columnId)?.read();
+    return { ...column, currentWidth: positive(state?.width, column.currentWidth), widthMode: state?.table?.widthMode || column.widthMode, wrapMode: state?.table?.wrapMode || column.wrapMode, overflowMode: state?.table?.overflowMode || column.overflowMode, visibility: state?.visible !== false };
+  });
+  return normalizeTableLayout({
+    ...entry.tableLayout,
+    bounds: { left: tableRect.left, top: tableRect.top, width: tableRect.width, height: tableRect.height },
+    viewportBounds: { left: viewportRect.left, top: viewportRect.top, width: viewportRect.width, height: viewportRect.height },
+    contentBounds: { left: tableRect.left, top: tableRect.top, width: Math.max(finite(tableElement.scrollWidth), columns.filter((column) => column.visibility).reduce((sum, column) => sum + column.currentWidth, entry.tableLayout.reservedWidth)), height: Math.max(tableRect.height, finite(tableElement.scrollHeight)) },
+    horizontalOverflowMode: tableElement.dataset.uiEditorHorizontalOverflowMode || entry.tableLayout.horizontalOverflowMode,
+    rowHeightMode: tableElement.dataset.uiEditorRowHeightMode || entry.tableLayout.rowHeightMode,
+    columns,
+  });
+}
+
+export function registerM80TableRef(id, tableElement, viewportElement, scrollAreaElement) {
+  const entry = getM80RegistryEntry(id);
+  return registerM80Ref(id, tableElement, {
+    read: () => {
+      const generic = readGeneric(tableElement, id);
+      const layout = runtimeTableLayout(entry, tableElement, viewportElement);
+      const metrics = measureTableLayout(layout);
+      return { ...generic, table: { tableId: id, horizontalOverflowMode: layout.horizontalOverflowMode, rowHeightMode: layout.rowHeightMode, viewportWidth: metrics.viewportWidth, tableWidth: metrics.tableWidth, overflow: metrics.overflow, overflowColumnIds: [...metrics.overflowColumnIds] } };
+    },
+    apply: (state) => {
+      applyGeneric(tableElement, state, entry);
+      const table = state.table || {};
+      const horizontal = table.horizontalOverflowMode || entry.tableLayout.horizontalOverflowMode;
+      const rowHeight = table.rowHeightMode || entry.tableLayout.rowHeightMode;
+      tableElement.dataset.uiEditorHorizontalOverflowMode = horizontal;
+      tableElement.dataset.uiEditorRowHeightMode = rowHeight;
+      scrollAreaElement.style.overflowX = horizontal === "scroll" ? "scroll" : horizontal === "none" || horizontal === "fitViewport" ? "hidden" : "auto";
+      tableElement.style.maxWidth = horizontal === "fitViewport" ? "100%" : "none";
+    },
+  });
+}
+
+export function fitM80Table(id, selectedColumnId = "") {
+  const entry = getM80RegistryEntry(id);
+  const ref = getM80Ref(id);
+  if (!entry?.tableLayout || !ref) throw Object.assign(new Error("Tabellenreferenz fehlt."), { code: "electron_element_not_found" });
+  const layout = runtimeTableLayout(entry, ref.element, getM80Ref("restarbeiten.list.viewport")?.element || ref.element);
+  const result = fitTableToViewport(layout, selectedColumnId ? { selectedColumnId } : {});
+  if (!result.ok) throw Object.assign(new Error("Tabelle kann nicht an den sichtbaren Bereich angepasst werden."), { code: "electron_invalid_geometry" });
+  const affectedStates = [];
+  for (const column of result.model.columns) {
+    const current = snapshotM80State(column.columnId);
+    affectedStates.push(applyM80State(column.columnId, { ...current, width: column.currentWidth, table: { ...current.table, widthMode: column.widthMode } }));
+  }
+  return { result, affectedStates };
+}
+
+export function resetM80Table(id) {
+  const entry = getM80RegistryEntry(id);
+  const affectedStates = [];
+  for (const column of entry?.tableLayout?.columns || []) {
+    const current = snapshotM80State(column.columnId);
+    affectedStates.push(applyM80State(column.columnId, { ...current, width: column.currentWidth, visible: column.visibility, table: { tableId: id, columnId: column.columnId, widthMode: column.widthMode, wrapMode: column.wrapMode, overflowMode: column.overflowMode } }));
+  }
+  const current = snapshotM80State(id);
+  const newState = applyM80State(id, { ...current, table: { tableId: id, horizontalOverflowMode: entry.tableLayout.horizontalOverflowMode, rowHeightMode: entry.tableLayout.rowHeightMode } });
+  return { newState, affectedStates };
 }
 
 export function registerM80FlowLabelRef(id, element, layoutRow, trailingColumns) {
@@ -203,13 +372,16 @@ export function snapshotM80Geometry() {
   }));
 }
 export function getM80IdFromTarget(target) {
+  return getM80IdsFromTarget(target)[0] || null;
+}
+export function getM80IdsFromTarget(target) {
   let current = isElementRef(target) ? target : null;
   while (current) {
-    const id = elementIds.get(current);
-    if (id) return id;
+    const ids = elementIds.get(current);
+    if (ids?.size) return [...ids];
     current = current.parentElement;
   }
-  return null;
+  return [];
 }
 export function readM80State(id) {
   const ref = getM80Ref(id);

--- a/src/renderer/ui-editor/m80Registry.js
+++ b/src/renderer/ui-editor/m80Registry.js
@@ -1,4 +1,4 @@
-export const BBM_M80_REGISTRY_VERSION = 5;
+export const BBM_M80_REGISTRY_VERSION = 6;
 export const BBM_M80_REGISTRY_STATUS = "incomplete";
 
 const GROUP_LAYOUT = Object.freeze(["move", "setVisibility"]);
@@ -7,8 +7,8 @@ const TEXT_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "textR
 const FIELD_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "textResize", "setVisibility"]);
 const BUTTON_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "setVisibility"]);
 const ICON_LAYOUT = Object.freeze(["resizeWidth", "resizeHeight", "setVisibility"]);
-const TABLE_LAYOUT = Object.freeze(["resizeHeight", "setVisibility"]);
-const COLUMN_LAYOUT = Object.freeze(["resizeWidth", "textResize", "setVisibility"]);
+const TABLE_LAYOUT = Object.freeze(["resizeHeight", "setVisibility", "fitTableToViewport", "resizeColumnsProportionally", "setHorizontalOverflowMode", "setRowHeightMode", "resetTable"]);
+const COLUMN_LAYOUT = Object.freeze(["resizeWidth", "textResize", "setVisibility", "setColumnWidthMode", "setColumnWrapMode", "setColumnOverflowMode", "resetTableColumn"]);
 const SPACING_LAYOUT = Object.freeze(["spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"]);
 const DOMAIN_LOCKS = Object.freeze(["executeTargetAction", "modifyDomainData", "createRecord", "deleteRecord"]);
 
@@ -25,7 +25,10 @@ function element(values) {
   const selectionKind = values.selectionKind || ({
     root: "layoutZone", area: "layoutZone", group: "group", fieldGroup: "group",
     label: values.role === "status" ? "statusText" : "label", field: "field", button: "button",
-    componentPart: "icon", statusIndicator: "icon", table: "table", tableColumn: "column",
+    componentPart: "icon", statusIndicator: "icon", table: "table", tableHeader: "tableHeader",
+    tableBody: "tableBody", tableRow: "tableRow", tableColumn: "column", tableHeaderCell: "tableHeaderCell",
+    tableDataCell: "tableDataCell", tableFooter: "tableFooter", tableViewport: "tableViewport",
+    horizontalScrollArea: "horizontalScrollArea",
   }[values.type] || "element");
   return Object.freeze({
     visible: true,
@@ -103,14 +106,61 @@ const headerElements = [
   domainButton({ id: "restarbeiten.filterbar.action.close", name: "Schließen", parentId: "restarbeiten.filterbar.actions", order: 71, actionKind: "domainNavigation" }),
 ];
 
+const listTableColumns = Object.freeze([
+  Object.freeze({
+    columnId: "restarbeiten.list.table.number", displayName: "Nr. / Datum / Klasse / Fotos",
+    headerElementId: "restarbeiten.list.table.number.header", dataCellTemplateId: "restarbeiten.list.table.number.cells",
+    cellElementIds: Object.freeze([]), currentWidth: 82, minimumWidth: 50, maximumWidth: 240, widthMode: "fixed",
+    resizable: true, wrapMode: "noWrap", overflowMode: "clip", alignment: "stretch", visibility: true,
+    order: 1, lockedOps: Object.freeze([...DOMAIN_LOCKS]), widthSourceId: "restarbeiten.list.table.number", flexible: false, priority: 10,
+  }),
+  Object.freeze({
+    columnId: "restarbeiten.list.table.subject", displayName: "Gegenstand – Verortung / Kurztext / Langtext",
+    headerElementId: "restarbeiten.list.table.subject.header", dataCellTemplateId: "restarbeiten.list.table.subject.cells",
+    cellElementIds: Object.freeze([]), currentWidth: 560, minimumWidth: 160, maximumWidth: 1200, widthMode: "proportional",
+    resizable: true, wrapMode: "wordWrap", overflowMode: "clip", alignment: "stretch", visibility: true,
+    order: 2, lockedOps: Object.freeze([...DOMAIN_LOCKS]), widthSourceId: "restarbeiten.list.table.subject", flexible: true, priority: 100,
+  }),
+  Object.freeze({
+    columnId: "restarbeiten.list.table.meta", displayName: "Fertig bis / Ampel / Status / Verantwortlich",
+    headerElementId: "restarbeiten.list.table.meta.header", dataCellTemplateId: "restarbeiten.list.table.meta.cells",
+    cellElementIds: Object.freeze([]), currentWidth: 172, minimumWidth: 110, maximumWidth: 420, widthMode: "fixed",
+    resizable: true, wrapMode: "wordWrap", overflowMode: "clip", alignment: "stretch", visibility: true,
+    order: 3, lockedOps: Object.freeze([...DOMAIN_LOCKS]), widthSourceId: "restarbeiten.list.table.meta", flexible: false, priority: 20,
+  }),
+]);
+
+const listTableLayout = Object.freeze({
+  tableId: "restarbeiten.list.table", displayName: "Restarbeiten-Hauptliste",
+  bounds: Object.freeze({ left: 0, top: 0, width: 858, height: 680 }),
+  viewportBounds: Object.freeze({ left: 0, top: 0, width: 858, height: 680 }),
+  contentBounds: Object.freeze({ left: 0, top: 0, width: 858, height: 680 }),
+  parentId: "restarbeiten.list.scrollArea",
+  columnIds: Object.freeze(listTableColumns.map((column) => column.columnId)),
+  rowTemplateId: "restarbeiten.list.table.row", horizontalOverflowMode: "auto", verticalOverflowMode: "auto",
+  widthPolicy: "bounded", minimumWidth: 320, maximumWidth: 1600, reservedWidth: 44, scrollbarWidth: 0,
+  rowHeightMode: "bounded", minimumRowHeight: 54, maximumRowHeight: 180, columns: listTableColumns,
+});
+
+function tableBinding(columnId, part) {
+  return Object.freeze({ tableId: "restarbeiten.list.table", columnId, widthSourceId: columnId, part });
+}
+
 const listElements = [
   element({ id: "restarbeiten.list.root", name: "Restarbeiten · Liste", type: "root", role: "scopeRoot", parentId: null, order: 0, editable: false, allowedOps: [], componentKind: "scope" }),
   element({ id: "restarbeiten.list.area", name: "Restarbeiten-Liste", type: "area", role: "contentArea", parentId: "restarbeiten.list.root", order: 10, allowedOps: GROUP_LAYOUT, componentKind: "contentArea", baseline: { width: 900, height: 420, minWidth: 320, minHeight: 180 } }),
   element({ id: "restarbeiten.list.paper", name: "Gruppe Listenblatt", type: "group", role: "layoutGroup", parentId: "restarbeiten.list.area", order: 20, allowedOps: GROUP_LAYOUT, componentKind: "paper", baseline: { width: 900, height: 720, minWidth: 320, minHeight: 240 } }),
-  element({ id: "restarbeiten.list.table", name: "Restarbeiten-Hauptliste", type: "table", role: "contentTable", parentId: "restarbeiten.list.paper", order: 30, allowedOps: TABLE_LAYOUT, componentKind: "contentTable", baseline: { width: 858, height: 680, minWidth: 320, minHeight: 160, maxHeight: 12000 } }),
-  element({ id: "restarbeiten.list.table.number", name: "Nr. / Datum / Klasse / Fotos", type: "tableColumn", role: "contentColumn", parentId: "restarbeiten.list.table", order: 31, allowedOps: COLUMN_LAYOUT, columnRole: "contentColumn", baseline: { width: 82, height: 28, minWidth: 50, maxWidth: 240 } }),
-  element({ id: "restarbeiten.list.table.subject", name: "Gegenstand – Verortung / Kurztext / Langtext", type: "tableColumn", role: "contentColumn", parentId: "restarbeiten.list.table", order: 32, allowedOps: COLUMN_LAYOUT, columnRole: "contentColumn", baseline: { width: 600, height: 28, minWidth: 160, maxWidth: 1200 } }),
-  element({ id: "restarbeiten.list.table.meta", name: "Status-Metaspalte – Fertig bis / Ampel / Status / Verantwortlich", type: "tableColumn", role: "metaColumn", parentId: "restarbeiten.list.table", order: 33, allowedOps: COLUMN_LAYOUT, columnRole: "metaColumn", baseline: { width: 172, height: 28, minWidth: 110, maxWidth: 420 } }),
+  element({ id: "restarbeiten.list.viewport", name: "Sichtbarer Inhaltsbereich der Restarbeiten-Liste", type: "tableViewport", role: "tableViewport", parentId: "restarbeiten.list.paper", order: 21, allowedOps: [], componentKind: "tableViewport" }),
+  element({ id: "restarbeiten.list.scrollArea", name: "Horizontaler Scrollbereich der Restarbeiten-Liste", type: "horizontalScrollArea", role: "horizontalScrollArea", parentId: "restarbeiten.list.viewport", order: 22, allowedOps: [], componentKind: "scrollArea" }),
+  element({ id: "restarbeiten.list.table", name: "Restarbeiten-Hauptliste", type: "table", role: "contentTable", parentId: "restarbeiten.list.scrollArea", order: 30, allowedOps: TABLE_LAYOUT, componentKind: "contentTable", tableLayout: listTableLayout, baseline: { width: 858, height: 680, minWidth: 320, maxWidth: 1600, minHeight: 160, maxHeight: 12000 } }),
+  ...listTableColumns.map((column, index) => element({ id: column.columnId, name: column.displayName, type: "tableColumn", role: index === 2 ? "metaColumn" : "contentColumn", parentId: "restarbeiten.list.table", order: 31 + index, allowedOps: COLUMN_LAYOUT, columnRole: index === 2 ? "metaColumn" : "contentColumn", tableColumnLayout: column, tableBinding: tableBinding(column.columnId, "column"), baseline: { width: column.currentWidth, height: 28, minWidth: column.minimumWidth, maxWidth: column.maximumWidth } })),
+  element({ id: "restarbeiten.list.table.header", name: "Tabellenkopf der Restarbeiten-Liste", type: "tableHeader", role: "tableHeader", parentId: "restarbeiten.list.table", order: 40, allowedOps: [], componentKind: "tableHeader" }),
+  element({ id: "restarbeiten.list.table.body", name: "Datenbereich der Restarbeiten-Liste", type: "tableBody", role: "tableBody", parentId: "restarbeiten.list.table", order: 50, allowedOps: [], componentKind: "tableBody" }),
+  element({ id: "restarbeiten.list.table.row", name: "Restarbeiten-Zeile", type: "tableRow", role: "tableRow", parentId: "restarbeiten.list.table.body", order: 51, allowedOps: [], componentKind: "rowTemplate", rowLayout: { heightMode: "bounded", minimumHeight: 54, maximumHeight: 180 } }),
+  ...listTableColumns.flatMap((column, index) => [
+    element({ id: column.headerElementId, name: `${column.displayName} · Überschrift`, type: "tableHeaderCell", role: "tableHeaderCell", parentId: column.columnId, order: 60 + index * 2, allowedOps: [], componentKind: "tableHeaderCell", tableBinding: tableBinding(column.columnId, "header") }),
+    element({ id: column.dataCellTemplateId, name: `${column.displayName} · Datenbereich`, type: "tableDataCell", role: "tableDataCell", parentId: column.columnId, order: 61 + index * 2, allowedOps: [], componentKind: "dataCellTemplate", tableBinding: tableBinding(column.columnId, "data") }),
+  ]),
 ];
 
 const editElements = [

--- a/ui-editor-target.json
+++ b/ui-editor-target.json
@@ -7,8 +7,8 @@
   "integrationMode": "existing-app",
   "contractVersion": "1.2",
   "adapterVersion": "1.2",
-  "registryVersion": 5,
-  "registryFingerprint": "sha256:0ab12fdfe93a920f27d6842a5fd4e4f1ae0db3c296d4681355dabd0d8c6eeba0",
+  "registryVersion": 6,
+  "registryFingerprint": "sha256:b130497bc6213660f8b81a1d6dbf1d3c2ea741efa80cf394a4ff134c6b060e08",
   "registryStatus": "incomplete",
   "activeScopes": [
     "restarbeiten.header.root",
@@ -29,7 +29,16 @@
     "spacingIncrease",
     "spacingDecrease",
     "spacingSet",
-    "spacingReset"
+    "spacingReset",
+    "fitTableToViewport",
+    "resizeColumnsProportionally",
+    "setHorizontalOverflowMode",
+    "setColumnWidthMode",
+    "setColumnWrapMode",
+    "setColumnOverflowMode",
+    "setRowHeightMode",
+    "resetTableColumn",
+    "resetTable"
   ],
   "selectionCapability": "bidirectional",
   "visibilityCapability": true,
@@ -37,7 +46,7 @@
   "transportProtocolVersion": "1.0",
   "scopes": [
     { "scopeId": "restarbeiten.header.root", "status": "complete", "reason": null, "elementCount": 31, "missingReferenceCount": 0 },
-    { "scopeId": "restarbeiten.list.root", "status": "complete", "reason": null, "elementCount": 7, "missingReferenceCount": 0 },
+    { "scopeId": "restarbeiten.list.root", "status": "complete", "reason": null, "elementCount": 18, "missingReferenceCount": 0 },
     { "scopeId": "restarbeiten.edit.root", "status": "complete", "reason": null, "elementCount": 53, "missingReferenceCount": 0 },
     { "scopeId": "bbm.remaining", "status": "blocked", "reason": "registration_inventory_pending", "elementCount": 0, "missingReferenceCount": 0 },
     { "scopeId": "pdf.bbm.protocol", "status": "complete", "reason": null, "elementCount": 28, "missingReferenceCount": 0 }


### PR DESCRIPTION
## Ziel

M82.4 integriert die bestehende Restarbeiten-Liste als echte editierbare UI-Inhaltstabelle in den gemeinsamen Tabellenlayout-Editor.

## Enthalten

- genau drei bestätigte Hauptspalten:
  1. Nr. / Datum / Klasse / Fotos
  2. Gegenstand – Verortung / Kurztext / Langtext
  3. Fertig bis / Ampel / Status / Verantwortlich
- bestehende Unterelemente bleiben einzeln registriert und auswählbar
- gemeinsame CSS-Breitenquelle für Kopf und Datenbereich jeder Spalte
- Viewportbegrenzung, Überlaufmessung und Fit auf sichtbaren Bereich
- feste und flexible Breiten, Word-Wrap, Ellipsis und horizontaler Scrollmodus
- Spalten- und Tabellenreset, Save, Discard und Neustart-Restore
- bestehende Geführt/Frei-, Direktauswahl-, Spacer-, Recovery- und PDF-Pfade bleiben erhalten
- echte BBM-PDF mit 28 Registryelementen regressionsgesichert
- Statusfortschreibung: M82.4 `[A]`

## Ausdrücklich nicht enthalten

- keine neue Tabellenansicht
- keine Fachlogik oder Änderung von Restarbeitendaten
- keine zweite Registry, Bridge, Pipe oder Editorintegration
- `docs/licensing.md` ist nicht Bestandteil dieses Commits
- Benutzerlizenz, Benutzerdatenbank, Profile, PDFs, Pack- und Diagnoseausgaben sind nicht Bestandteil dieses Commits

## Prüfungen

- M82.4-Einzeltests – 28/28 bestanden
- `npm test` – 8/8 Gruppen, kein OOM
- `npm run test:node` – 8/8 Gruppen
- gezieltes ESLint fehlerfrei
- `npm run pack` erfolgreich
- sichtbare Abnahme bei kleiner, normaler und großer Fensterbreite
- Save, Neustart-Restore, Discard, Reset und echte PDF-Vorschau geprüft
- `git diff --check`

Das globale Lint enthält weiterhin ausschließlich den bekannten Altbestand von 17 Fehlern und 371 Warnungen.

## Commit

`58968563f367d2ceaa5d3d4bf5fa8300fe5bec26`