### PR TITLE
M82.5 BBM-Einfachmodus für schnelle Layoutänderungen integrieren

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,15 @@
 # STATUS.md — BBM-Produktiv
 
+### M82.5 – Radikal vereinfachter Einfachmodus
+
+- Status: `[A] abgenommen`; Implementierung, vollständige Pflichtläufe und sichtbare paketierte UI-/PDF-Abnahme sind abgeschlossen.
+- Die bestehende Restarbeiten-Inhaltstabelle behält ihre drei M82.4-Hauptspalten und alle einzeln registrierten Unterelemente.
+- Direkte Spaltenbreite, `-10/-1/+1/+10`, Umbruch, Ellipsis, Original und Viewport-Fit verwenden dieselbe Spaltenbreitenquelle für Header und Daten.
+- Die drei Spaltenüberschriften sind capability-gesteuert in der Schriftgröße bearbeitbar; Breite und Fachwerte bleiben davon unberührt.
+- Save, Session-Undo, Neustart-Restore, Discard und Reset verwenden den vorhandenen Profil-/HostAdapterweg.
+- Sichtbar belegt sind Direktauswahl, Text-/Element-/Gruppenänderung, Save und Neustart-Restore, zwei exakte Undo-Schritte, Tabellen-Fit, bedienbare Managerbreiten von 760/1180/1550 Pixel sowie eine echte zweiseitige BBM-PDF mit 28 Registryelementen.
+- Detaildokument: `docs/M82_5_BBM_EINFACHMODUS.md`.
+
 ### M82.2 – Verständliche Geometriehinweise in BBM
 
 - Status: `[A] abgenommen`; die vollständige sichtbare UI-/PDF-Abnahme und der kontrollierte Development-Lizenznachweis sind abgeschlossen.

--- a/docs/M82_5_BBM_EINFACHMODUS.md
+++ b/docs/M82_5_BBM_EINFACHMODUS.md
@@ -1,0 +1,42 @@
+# M82.5 – BBM-Einfachmodus
+
+Status: `[A]` – Implementierung, vollständige Pflichtprüfungen und sichtbare paketierte Endabnahme sind abgeschlossen.
+
+## Wiederverwendeter Ziel-App-Weg
+
+BBM bleibt Electron-Referenzapp des gemeinsamen nativen UI-Editors. Der bestehende lokale Vertrag, die M80-Registry, der Electron-HostAdapter, die M82.1-Direktauswahl, der M82.2-Risikoweg, die M82.3-Spacing-/Kompaktfunktionen, die M82.4-Tabellenspalten und der atomare Profilweg werden unverändert weiterverwendet. Es gibt keine zweite Registry, Bridge, Pipe, Editoroberfläche oder Profilablage.
+
+## Restarbeiten-Auswahl
+
+Die sichtbare Restarbeiten-Liste bleibt dieselbe Inhaltstabelle mit drei bestätigten Hauptspalten:
+
+1. Nr. / Datum / Klasse / Fotos
+2. Gegenstand – Verortung / Kurztext / Langtext
+3. Fertig bis / Ampel / Status / Verantwortlich
+
+Jede Spalte bleibt die gemeinsame Breitenquelle für Überschrift und Datenbereich. Die vorhandenen Unterelemente bleiben einzeln registriert und auswählbar. Anzeigenamen erscheinen im Hauptbereich; technische IDs und Rollen stehen nur unter **Erweitert / Details anzeigen**.
+
+## Einfache Bedienung
+
+- **Element:** Die aktuelle Spaltenbreite ist in DIP sichtbar und kann mit `-10`, `-1`, `+1`, `+10` oder direkt geändert werden. Header und Daten verwenden automatisch denselben CSS-Grid-Track. Nachbarspalten ändern sich nicht ungefragt.
+- **Text:** Die drei registrierten Spaltenüberschriften geben `textResize` mit Baseline und Grenzen frei. Kleiner/größer und direkte Schriftgröße wirken über den vorhandenen HostAdapter unmittelbar auf die Überschrift, ohne die Spaltenbreite oder Fachdaten zu verändern.
+- **Tabelle:** Umbruch, Ellipsis, Original und **An sichtbaren Bereich anpassen** verwenden die vorhandenen M82.4-Operationen. Langer Inhalt darf die definierte Spaltenbreite nicht selbst vergrößern.
+- **Steuerkreuz und Schrittweite:** Registrierte Einzel- und Gruppenziele verwenden dieselben capability-gesteuerten Pfeile sowie 1, 5, 10 oder freie DIP-Schritte wie WPF.
+- **Save, Undo und Restore:** Jede erfolgreiche Einzeländerung aktiviert Dirty, Save und Session-Undo. Speichern und Neustart-Restore laufen über den bestehenden Layoutprofilpfad; Discard und Reset bleiben unter **Erweitert** verfügbar.
+
+Normale Text-, Element-, Gruppen- und Tabellenänderungen benötigen im Einfachmodus keine modale Rückfrage. Technisch unmögliche Werte, nicht registrierte Operationen und unerwartete Seiteneffekte bleiben blockiert beziehungsweise werden zurückgerollt.
+
+## Sicherheit
+
+Die Registry enthält ausschließlich Layoutmetadaten. Restarbeitenwerte, Kundendaten, Datenbankinhalte und Fachaktionen werden weder gelesen noch geändert. Druck- und PDF-Fachlogik bleiben unverändert. `docs/licensing.md` und die Benutzerlizenz sind ausdrücklich ausgeschlossen.
+
+## Prüfung
+
+- BBM-Einzeltest: `scripts/tests/m82-5BbmSimpleEditorMode.test.cjs`
+- Gemeinsame Core-/WPF-Tests im UI-Editor-kit
+- BBM-Gesamttests, Node-Test, gezieltes ESLint, globales Lint und Pack
+- Sichtbare Abnahme mit paketierter BBM und normalem Benutzerprofil
+
+Die paketierte Development-Abnahme belegte den standardmäßig geöffneten Einfachmodus, geschlossene erweiterte Angaben, verständliche Anzeigenamen und technische IDs ausschließlich unter **Details anzeigen**. Spaltenbreite, Überschriftenschrift, Gruppe, Tabelle und Fit wurden über den vorhandenen HostAdapter geändert. Save, vollständiger Neustart-Restore und zwei exakte Undo-Schritte blieben ohne Doppelanwendung stabil; die Auswahl blieb auch nach dem erforderlichen Registry-Refresh erhalten. Bei 760, 1180 und 1550 Pixel Managerbreite blieben Einfachmodus, Undo und Save erreichbar.
+
+Im normalen Benutzerprofil wurde anschließend über den unveränderten BBM-Druckweg eine echte zweiseitige Protokoll-PDF erzeugt. Der PDF-Arbeitsbereich lud 28 Registryelemente und zeigte beide Seiten als aktuelle Vorschau. Fachwerte, Datenbank, Benutzerlizenz und `docs/licensing.md` blieben bytegleich; die erzeugte temporäre PDF und Abnahmescreenshots wurden entfernt.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -150,6 +150,7 @@ const TEST_GROUPS = Object.freeze([
       ["m82-2BbmGeometryRisks.test.cjs", "runM822BbmGeometryRiskTests"],
       ["m82-3BbmSpacerCompactUi.test.cjs", "runM823BbmSpacerCompactUiTests"],
       ["m82-4BbmTableColumnEditing.test.cjs", "runM824BbmTableColumnEditingTests"],
+      ["m82-5BbmSimpleEditorMode.test.cjs", "runM825BbmSimpleEditorModeTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),
   }),

--- a/scripts/tests/m80-1RegistrationRefresh.test.cjs
+++ b/scripts/tests/m80-1RegistrationRefresh.test.cjs
@@ -83,7 +83,7 @@ async function runM801RegistrationRefreshTests(run) {
       document.body.appendChild(rendered.root);
       const registration = rendered.registration;
       runtimeRegistration = structuredClone(registration);
-      assert.equal(registration.registryVersion, 6);
+      assert.equal(registration.registryVersion, 7);
       assert.equal(registration.registryStatus, "incomplete");
       assert.deepEqual(registration.activeScopes, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]);
       const complete = registration.registryScopes.filter((scope) => scope.status === "complete");

--- a/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
+++ b/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
@@ -15,7 +15,7 @@ async function runM802HeaderEditboxLayoutTests(run) {
   const elements = complete.flatMap((scope) => scope.elements);
 
   await run("M80.2 Registry: Header, Liste und Editbox sind direkt aktiv; Split ist gesperrt", () => {
-    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 6);
+    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 7);
     assert.deepEqual(registryModule.BBM_M80_ACTIVE_SCOPES, [
       "restarbeiten.header.root",
       "restarbeiten.list.root",

--- a/scripts/tests/m82-1BbmFeintuning.test.cjs
+++ b/scripts/tests/m82-1BbmFeintuning.test.cjs
@@ -24,7 +24,7 @@ async function runM821BbmFeintuningTests(run) {
   const editbox = read("src/renderer/modules/restarbeiten/RestarbeitenEditbox.js");
   const css = read("src/renderer/modules/restarbeiten/styles/restarbeiten.css");
 
-  await run("M82.1 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 6));
+  await run("M82.1 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 7));
   await run("M82.1 BBM 02: Manifestversion folgt der Registry", () => assert.equal(manifest.registryVersion, registry.BBM_M80_REGISTRY_VERSION));
   await run("M82.1 BBM 03: Manifestfingerprint ist aktuell", () => assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)));
   await run("M82.1 BBM 04: genau drei Restarbeiten-Scopes bleiben aktiv", () => assert.deepEqual(registry.BBM_M80_ACTIVE_SCOPES, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]));

--- a/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
+++ b/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
@@ -47,7 +47,7 @@ async function runM823BbmSpacerCompactUiTests(run) {
     groupWidthEditable,
   });
 
-  await run("M82.3 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 6));
+  await run("M82.3 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 7));
   await run("M82.3 BBM 02: Manifest folgt Registry und Fingerprint", () => { assert.equal(manifest.registryVersion, registry.BBM_M80_REGISTRY_VERSION); assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)); });
   await run("M82.3 BBM 03: Kurztextbezeichnung besitzt reservierte Breite", () => assert.deepEqual(label.baseline.spacing, { reservedWidth: 40 }));
   await run("M82.3 BBM 04: Kurztextbezeichnung erlaubt Spacer davor und danach", () => assert.deepEqual(label.spacingTargets, ["beforeElement", "afterElement", "reservedWidth"]));

--- a/scripts/tests/m82-4BbmTableColumnEditing.test.cjs
+++ b/scripts/tests/m82-4BbmTableColumnEditing.test.cjs
@@ -110,7 +110,7 @@ async function runM824BbmTableColumnEditingTests(run) {
   await run("M82.4 BBM 08: keine neue Tabellenansicht wird eingefuehrt", () => assert.match(read("src/renderer/modules/restarbeiten/RestarbeitenMainBody.js"), /buildRestarbeitenList\(options\)/));
   await run("M82.4 BBM 09: Kopf und Datenzeilen verwenden dieselben drei CSS-Variablen", () => { const css = read("src/renderer/modules/restarbeiten/styles/restarbeiten.css"); assert.equal((css.match(/grid-template-columns: var\(--bbm-restarbeiten-number-column\) var\(--bbm-restarbeiten-subject-column\) var\(--bbm-restarbeiten-meta-column\)/g) || []).length, 2); });
   await run("M82.4 BBM 10: sichtbarer Inhaltsbereich begrenzt die Listenbreite", () => assert.match(read("src/renderer/modules/restarbeiten/styles/restarbeiten.css"), /\.bbm-restarbeiten-table-viewport[\s\S]*max-width:\s*100%[\s\S]*overflow:\s*hidden/));
-  await run("M82.4 BBM 10a: JavaScript- und WPF-Fingerprint stimmen fuer alle Tabellenrollen ueberein", () => assert.equal(createUiScopeFingerprint(scope), "sha256:dcdef2f965e7e3c6d71695e6e028874ac11432e8e47aac01a6963ed7e3e36d55"));
+  await run("M82.4 BBM 10a: JavaScript- und WPF-Fingerprint stimmen fuer alle Tabellenrollen ueberein", () => assert.equal(createUiScopeFingerprint(scope), "sha256:caa59d5066b584e6b7a5354156ed269341db52184d1f3f85a645019f92fd8f15"));
 
   const runtime = await createRuntime(refs, host);
   try {

--- a/scripts/tests/m82-5BbmSimpleEditorMode.test.cjs
+++ b/scripts/tests/m82-5BbmSimpleEditorMode.test.cjs
@@ -1,0 +1,98 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const ROOT = path.resolve(__dirname, "../..");
+
+class FakeElement {
+  constructor(width = 180, height = 28) {
+    this.attributes = {}; this.dataset = {}; this.className = ""; this.isConnected = true;
+    this.children = [];
+    this._rect = { left: 0, top: 0, width, height };
+    this.style = { setProperty(name, value) { this[name] = value; }, getPropertyValue(name) { return this[name] || ""; } };
+    this.classList = { contains: () => false, toggle: () => {} };
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  appendChild(value) { this.children.push(value); return value; }
+  replaceChildren(...values) { this.children = values; }
+  getBoundingClientRect() { const width = typeof this._widthSource === "function" ? this._widthSource() : parseFloat(this.style.width); const left = typeof this._leftSource === "function" ? this._leftSource() : this._rect.left; return { ...this._rect, left, width: Number.isFinite(width) ? width : this._rect.width, height: parseFloat(this.style.height) || this._rect.height }; }
+}
+
+async function runM825BbmSimpleEditorModeTests(run) {
+  const registry = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Registry.js"));
+  const refs = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Refs.js"));
+  const host = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80HostAdapter.js"));
+  const scope = registry.listM80RegistryScopes().find((entry) => entry.scopeId === "restarbeiten.list.root");
+  const byId = new Map(scope.elements.map((entry) => [entry.id, entry]));
+  const headerIds = ["number", "subject", "meta"].map((name) => `restarbeiten.list.table.${name}.header`);
+
+  await run("M82.5 BBM 01: drei sichtbare Tabellenüberschriften bleiben registriert", () => assert.equal(headerIds.filter((id) => byId.has(id)).length, 3));
+  await run("M82.5 BBM 02: jede Überschrift ist capability-gesteuert textgrößenfähig", () => headerIds.forEach((id) => assert.deepEqual(byId.get(id).allowedOps, ["textResize"])));
+  await run("M82.5 BBM 03: Überschriften bleiben Kinder ihrer bestätigten Hauptspalte", () => headerIds.forEach((id) => assert.equal(byId.get(id).parentId, id.slice(0, -".header".length))));
+  await run("M82.5 BBM 04: Spaltenbreite bleibt eine getrennte Capability", () => headerIds.forEach((id) => assert.equal(byId.get(id).allowedOps.includes("resizeWidth"), false)));
+  await run("M82.5 BBM 05: drei bestätigte Spaltennamen bleiben unverändert", () => assert.deepEqual(scope.elements.filter((entry) => entry.type === "tableColumn").map((entry) => entry.name), ["Nr. / Datum / Klasse / Fotos", "Gegenstand – Verortung / Kurztext / Langtext", "Fertig bis / Ampel / Status / Verantwortlich"]));
+
+  const previous = { document: global.document, window: global.window, Element: global.Element };
+  global.Element = FakeElement;
+  const body = new FakeElement();
+  let riskOverlay = null;
+  global.document = {
+    body,
+    querySelector: (selector) => selector === "[data-bbm-ui-editor-risk-preview]" ? riskOverlay : null,
+    createElement: () => { const value = new FakeElement(); const original = value.setAttribute.bind(value); value.setAttribute = (name, entry) => { original(name, entry); if (name === "data-bbm-ui-editor-risk-preview") riskOverlay = value; }; return value; },
+    addEventListener() {}, removeEventListener() {},
+  };
+  global.window = { getComputedStyle: (element) => ({ ...element.style, width: `${element._rect.width}px`, height: `${element._rect.height}px`, paddingLeft: "0px", paddingTop: "0px", fontSize: element.style.fontSize || "12px" }), dispatchEvent() {} };
+  refs.resetM80PilotWorkingStatesForDiagnostic();
+  refs.beginM80PilotRender();
+  const root = new FakeElement(900, 700);
+  const viewport = new FakeElement(718, 680);
+  const scrollArea = new FakeElement(718, 680);
+  const table = new FakeElement(718, 680);
+  const tableHeaders = [new FakeElement(82, 28), new FakeElement(464, 28), new FakeElement(172, 28)];
+  const cells = [new FakeElement(82, 80), new FakeElement(464, 80), new FakeElement(172, 80)];
+  const variables = ["--bbm-restarbeiten-number-column", "--bbm-restarbeiten-subject-column", "--bbm-restarbeiten-meta-column"];
+  tableHeaders.forEach((element, index) => { element._widthSource = () => parseFloat(table.style[variables[index]]) || element._rect.width; });
+  tableHeaders[1]._leftSource = () => tableHeaders[0].getBoundingClientRect().width;
+  tableHeaders[2]._leftSource = () => tableHeaders[0].getBoundingClientRect().width + tableHeaders[1].getBoundingClientRect().width;
+  cells.forEach((element, index) => { element._widthSource = tableHeaders[index]._widthSource; element._leftSource = tableHeaders[index]._leftSource; });
+  refs.registerM80Ref("restarbeiten.list.root", root);
+  refs.registerM80TableRef("restarbeiten.list.table", table, viewport, scrollArea);
+  ["number", "subject", "meta"].forEach((key, index) => refs.registerM80TableColumnRef(
+    `restarbeiten.list.table.${key}`, tableHeaders[index], [cells[index]], table, viewport, variables[index], tableHeaders[index]._rect.width));
+  const header = new FakeElement(560, 28);
+  refs.registerM80Ref("restarbeiten.list.table.subject.header", header);
+  refs.completeM80PilotRender();
+  try {
+    await run("M82.5 BBM 06: Direktauswahl markiert die verständliche Überschrift", () => assert.equal(header.attributes["data-ui-inspector-id"], "restarbeiten.list.table.subject.header"));
+    const result = host.handleM80EditorRequest({
+      action: "submitChange", scopeId: "restarbeiten.list.root",
+      changeRequest: { changeId: "m82-5-header-font", elementId: "restarbeiten.list.table.subject.header", operation: "textResize", payload: { text: { fontSize: 18 } }, source: "target-app-start" },
+    }).changeResult;
+    await run("M82.5 BBM 07: Überschrift nimmt direkte Schriftgröße an", () => { assert.equal(result.success, true); assert.equal(header.style.fontSize, "18px"); });
+    await run("M82.5 BBM 08: Schriftänderung verändert keine Spaltenbreite", () => assert.equal(header.getBoundingClientRect().width, 560));
+    await run("M82.5 BBM 09: Rücklesung liefert die neue Schriftgröße", () => assert.equal(refs.snapshotM80State("restarbeiten.list.table.subject.header").fontSize, 18));
+    await run("M82.5 BBM 10: Änderung enthält keine Fachwerte", () => assert.equal(["recordId", "dueDate", "responsible", "status"].some((key) => key in result.newState), false));
+    const request = { changeId: "m82-5-confirmed-width", elementId: "restarbeiten.list.table.subject", operation: "resizeWidth", payload: { width: 369 }, source: "ui-editor-panel" };
+    const first = host.handleM80EditorRequest({ action: "submitChange", scopeId: "restarbeiten.list.root", changeRequest: request }).changeResult;
+    const confirmed = host.handleM80EditorRequest({
+      action: "submitChange", scopeId: "restarbeiten.list.root", changeRequest: request,
+      editMode: "free", riskConfirmation: { operationId: first.geometryRisk?.operationId, action: "reflowNeighbors" },
+    }).changeResult;
+    await run("M82.5 BBM 11: identische Breitenänderung wird nach Risikobestätigung angewandt", () => {
+      assert.equal(first.errorCode, "geometry_risk_confirmation_required");
+      assert.equal(first.geometryRisk.riskType, "freedSpace");
+      assert.equal(confirmed.success, true, JSON.stringify(confirmed));
+      assert.equal(confirmed.newState.width, 369);
+      assert.equal(refs.snapshotM80State("restarbeiten.list.table.number").width, 82);
+      assert.equal(refs.snapshotM80State("restarbeiten.list.table.meta").width, 172);
+    });
+  } finally {
+    refs.resetM80PilotWorkingStatesForDiagnostic();
+    global.document = previous.document; global.window = previous.window; global.Element = previous.Element;
+  }
+}
+
+module.exports = { runM825BbmSimpleEditorModeTests };

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 105, "105 Suite-Einstiege einschließlich Entwicklungs-Lizenz und M82.4");
+    assert.equal(suites.length, 106, "106 Suite-Einstiege einschließlich Entwicklungs-Lizenz, M82.4 und M82.5");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/src/renderer/ui-editor/m80Registry.js
+++ b/src/renderer/ui-editor/m80Registry.js
@@ -1,4 +1,4 @@
-export const BBM_M80_REGISTRY_VERSION = 6;
+export const BBM_M80_REGISTRY_VERSION = 7;
 export const BBM_M80_REGISTRY_STATUS = "incomplete";
 
 const GROUP_LAYOUT = Object.freeze(["move", "setVisibility"]);
@@ -158,7 +158,7 @@ const listElements = [
   element({ id: "restarbeiten.list.table.body", name: "Datenbereich der Restarbeiten-Liste", type: "tableBody", role: "tableBody", parentId: "restarbeiten.list.table", order: 50, allowedOps: [], componentKind: "tableBody" }),
   element({ id: "restarbeiten.list.table.row", name: "Restarbeiten-Zeile", type: "tableRow", role: "tableRow", parentId: "restarbeiten.list.table.body", order: 51, allowedOps: [], componentKind: "rowTemplate", rowLayout: { heightMode: "bounded", minimumHeight: 54, maximumHeight: 180 } }),
   ...listTableColumns.flatMap((column, index) => [
-    element({ id: column.headerElementId, name: `${column.displayName} · Überschrift`, type: "tableHeaderCell", role: "tableHeaderCell", parentId: column.columnId, order: 60 + index * 2, allowedOps: [], componentKind: "tableHeaderCell", tableBinding: tableBinding(column.columnId, "header") }),
+    element({ id: column.headerElementId, name: `${column.displayName} · Überschrift`, type: "tableHeaderCell", role: "tableHeaderCell", parentId: column.columnId, order: 60 + index * 2, allowedOps: ["textResize"], componentKind: "tableHeaderCell", tableBinding: tableBinding(column.columnId, "header"), baseline: { fontSize: 12, minFontSize: 8, maxFontSize: 32 } }),
     element({ id: column.dataCellTemplateId, name: `${column.displayName} · Datenbereich`, type: "tableDataCell", role: "tableDataCell", parentId: column.columnId, order: 61 + index * 2, allowedOps: [], componentKind: "dataCellTemplate", tableBinding: tableBinding(column.columnId, "data") }),
   ]),
 ];

--- a/ui-editor-target.json
+++ b/ui-editor-target.json
@@ -7,8 +7,8 @@
   "integrationMode": "existing-app",
   "contractVersion": "1.2",
   "adapterVersion": "1.2",
-  "registryVersion": 6,
-  "registryFingerprint": "sha256:b130497bc6213660f8b81a1d6dbf1d3c2ea741efa80cf394a4ff134c6b060e08",
+  "registryVersion": 7,
+  "registryFingerprint": "sha256:755b22065dc4cc23ad8274521e5f1e59be5750014e805e2bd9593554827d0c37",
   "registryStatus": "incomplete",
   "activeScopes": [
     "restarbeiten.header.root",


### PR DESCRIPTION
## Ziel

M82.5 bindet den radikal vereinfachten Standardarbeitsweg des UI-Editors in BBM ein. Der Nutzer wählt ein sichtbares Ziel, bearbeitet Text oder Element über Steuerkreuz und direkte Werte und kann sofort speichern oder rückgängig machen.

## Enthalten

- Einfachmodus startet sofort; **Erweitert** ist geschlossen
- verständliche Auswahl für Bezeichnung, Feld, Gruppe, Tabelle, Spalte und Spaltenüberschrift
- direkte Schriftgrößen-, Positions-, Größen- und Spaltenbreiteneingabe
- Steuerkreuz mit Schrittweiten 1, 5, 10 und freier Eingabe
- normale Änderungen ohne modale Rückfrage
- sofort aktives Save und mehrstufiges Undo
- Restarbeiten-Spalten und Spaltenüberschriften bleiben gekoppelt
- Gruppen können bei Bedarf wachsen; Nachbarn werden nicht ungefragt verschoben
- bestehende M82.2-/M82.3-/M82.4-Funktionen bleiben unter **Erweitert** erhalten
- PDF- und Registry-Regression bleiben erhalten
- M82.5 `[A] abgenommen`

## Ausdrücklich nicht enthalten

- keine Änderung von Fachlogik oder Restarbeitendaten
- keine neue Restarbeitenansicht
- keine zweite Registry, Bridge, Pipe oder Editorintegration
- `docs/licensing.md` ist nicht Bestandteil dieses Commits
- Benutzerlizenz, Benutzerdatenbank, Benutzerprofil, PDFs, Pack- und Diagnoseausgaben sind nicht Bestandteil dieses Commits

## Prüfungen

- M82.5-Einzeltests – 11/11 bestanden
- `npm test` – 8/8 Gruppen, kein OOM
- `npm run test:node` – 8/8 Gruppen
- gezieltes ESLint fehlerfrei
- `npm run pack` erfolgreich
- sichtbare Abnahme mit direkter Spaltenbreite, Schriftgröße, Undo, Save und Neustart-Restore
- `git diff --check`

Das globale Lint enthält weiterhin ausschließlich den bekannten Altbestand von 17 Fehlern und 371 Warnungen.

## Commit

`55f6546702371453726f688e5d1c2345203afbd7`