### PR TITLE
M82.6 Restarbeiten und Protokoll topologieneutral fertigstellen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,18 @@
 # STATUS.md — BBM-Produktiv
 
+### M82.6 – TopScreen-Regressionsreparatur und Modulabschluss
+
+- Status: `[A] abgenommen`; Reparatur, produktive Protokoll-Ziel-App-Anbindung, automatisierte Regression und sichtbare Diagnostic-Abnahme sind abgeschlossen.
+- Die M82.4-Knoten `.bbm-restarbeiten-table-viewport` und `.bbm-restarbeiten-table-scroll-area` samt eigener Overflow-Regeln und Registryeinträgen wurden entfernt. Die Tabelle liegt wieder direkt im vorhandenen `paper`.
+- Der vorhandene Restarbeiten-`main` ist wieder einziger vertikaler Scrollbesitzer; Filter und Editbox bleiben außerhalb. Der Protokoll-TopScreen wurde strukturell nicht geändert.
+- BBM erzeugt weiterhin allein seine Registry. Drei vollständige Protokoll-Scopes registrieren 25 Screen-, 7 Listen- und 24 Editboxziele ausschließlich über vorhandene Objekt- und Mehrfach-Refs. Logische Tabellenziele benötigen keine zusätzliche UI.
+- Der HostAdapter schützt Layoutänderungen und Registry-Refreshes mit einem explizit aus registrierten Refs gebildeten Topologie-Fingerprint. Protokoll (`sha256:5ff4…d8f0f`) und Restarbeiten (`sha256:3569…57a3`) blieben in der sichtbaren Abnahme stabil.
+- Die sichtbare Diagnostic-Abnahme hat zusätzlich einen Laufzeitfehler im Neu-Rendern aufgedeckt: reine gemessene Baseline-Geometrie wurde wie eine ausdrückliche Editoränderung auf den nächsten fachlichen Render übertragen. Nur ausdrücklich angewandte Editorzustände bleiben jetzt renderübergreifend erhalten; Filter, Liste und Editbox bleiben dadurch auch mit echten Projektdaten kompakt und ohne zusätzliche Laufleiste.
+- Die interne Lizenz `bbm-internal-development-license-v1` ist im Diagnostic-Paket sichtbar aktiv. Die Release-EXE blieb auch mit gesetzten DEV-Umgebungsvariablen gesperrt und zeigte keine Development-Kennzeichnung.
+- Protokoll und Restarbeiten bestanden Direktauswahl, Feintuning, Undo, Speichern, Elementreset/Recovery und Neustart-Restore. Der echte Protokoll-Vorabzug wurde vierseitig erzeugt; Restarbeiten behält ausdrücklich seine vorhandene HTML-Ausgabevorschau ohne PDF-Erzeugung.
+- Lizenz, produktive Datenbank und `docs/licensing.md` blieben hashgleich. Fachwerte wurden nicht verändert.
+- Detaildokument: `docs/M82_6_BBM_TOPSCREEN_MODULABSCHLUSS.md`.
+
 ### M82.5 – Radikal vereinfachter Einfachmodus
 
 - Status: `[A] abgenommen`; Implementierung, vollständige Pflichtläufe und sichtbare paketierte UI-/PDF-Abnahme sind abgeschlossen.

--- a/docs/M82_6_BBM_TOPSCREEN_MODULABSCHLUSS.md
+++ b/docs/M82_6_BBM_TOPSCREEN_MODULABSCHLUSS.md
@@ -1,0 +1,60 @@
+# M82.6 – BBM-TopScreen-Modulabschluss
+
+## Status
+
+M82.6 ist `[A] abgenommen`. Die TopScreen-Reparatur, die produktive Protokoll-Ziel-App-Anbindung, die automatisierte Regression und die sichtbare Abnahme in der isolierten Development-/Diagnostic-Ausgabe sind abgeschlossen.
+
+## Struktur und Scrollbesitz
+
+Die produktive Protokollansicht bleibt eine Flexspalte aus Kopfbereich, mittlerem Sheet-/Listenbereich und darunterliegender Editbox. Nur der vorhandene mittlere `sheetArea` scrollt; Kopf und Editbox liegen außerhalb. Der sichtbare Inhaltsbereich bleibt 940 px breit. Es wurden keine Wrapper, Viewports, Scrollcontainer, Grids, Parent-Layer oder editorbedingten DOM-Knoten ergänzt.
+
+Bei Restarbeiten wurden die in M82.4 hinzugefügten Knoten `.bbm-restarbeiten-table-viewport` und `.bbm-restarbeiten-table-scroll-area` samt eigener Overflow-Regeln und Registryeinträge entfernt. Die Tabelle liegt wieder direkt im vorhandenen `paper`. Der vorhandene mittlere `main`-Bereich bleibt vertikaler Scrollbesitzer; Filterbereich und Editbox liegen außerhalb.
+
+## Registry, Refs und Topologieschutz
+
+BBM bleibt alleinige Eigentümerin seiner Registry. Der Editor liest ausschließlich die von BBM gelieferten Einträge und erzeugt keine Ziel-App-UI.
+
+Die bestehende Protokolloberfläche ist über drei vollständige Scopes angebunden:
+
+- `protokoll.screen.root`: 25 vorhandene Ziele,
+- `protokoll.list.root`: 7 vorhandene beziehungsweise logische Ziele,
+- `protokoll.edit.root`: 24 vorhandene Ziele.
+
+TopsScreen und Quicklane registrieren ausschließlich vorhandene Objekt-Refs. Die drei logischen Listenspalten verwenden den bestehenden Mehrfach-Ref-Weg und die vorhandenen CSS-Breitenquellen; dafür wurden keine Spaltenwrapper erzeugt. Fachbuttons bleiben reine Layoutziele, ihre Ausführung und jede Fachwertänderung sind gesperrt.
+
+Beim Modulwechsel sind nur die drei tatsächlich gemounteten Scopes aktiv. Nicht gemountete Scopes werden ohne Laufzeitbaseline blockiert und leer übertragen. Das Gesamtmanifest bleibt die verbindliche Inventarliste; seine sechs deklarierten UI-Scopes dürfen als geprüfter aktiver Modulsatz verwendet werden. Die Laufzeit-Registry wird weiterhin mit ihrem eigenen vollständigen Fingerprint validiert.
+
+BBM bildet vor Layoutänderungen und Refreshes aus seinen ausdrücklich registrierten Refs einen Topologie-Snapshot aus Tagname, stabiler Editor-ID, Parent und Reihenfolge. Unerwartete Strukturänderungen führen zu `target_ui_topology_changed` und Rollback. Die sichtbaren Abnahmen bestätigten unveränderte Fingerprints:
+
+- Protokoll: `sha256:5ff4c5befa71e7978a2c4e8a05f7de70512797ed59ae8bfa6e99f441b49d8f0f`,
+- Restarbeiten: `sha256:35698e01c70bc07ae80519bef6b8bdee5bfe5e72007d014631e6ca29a8c757a3`.
+
+## Sichtbare Diagnostic-Abnahme
+
+Die paketierte Development-/Diagnostic-Ausgabe lief mit einer Kopie der Datenbank und einem temporären Benutzer-/Profilpfad. Die Oberfläche zeigte eindeutig „Entwicklungsversion – Testlizenz“. Die bestehende Benutzerlizenz, die produktive Datenbank und Fachwerte wurden nicht verändert.
+
+Im Protokoll wurden Registry-Refresh, Direktauswahl von Label, Feld und vorhandener Gruppe, Text-/Breitenänderung mit 5 DIP, Gruppenbewegung mit 1 DIP, Undo, Speichern, Elementreset mit Undo sowie Neustart-Restore bedient. Der Manager meldete nach erneutem Öffnen einen gespeicherten, nicht doppelt angewandten Zustand. Kopf, Liste, Editbox, Quicklane, Scrollbesitz und Parent-Reihenfolge blieben unverändert.
+
+Die vorhandene BBM-Druckvorschau erzeugte aus echten Projektdaten einen vierseitigen A4-Protokoll-Vorabzug über den bestehenden `printToPDF`- und Paginierungsweg. PDF-Fachlogik und Druckweg wurden nicht geändert.
+
+Im Restarbeitenmodul wurden Filter, Listenauswahl, Editbox, Direktauswahl, Breitenänderung, Undo, Speichern, Profil-Recovery und Neustart-Restore bedient. Die vorhandene Ausgabevorschau zeigte die echten Restarbeitendaten als HTML und erzeugte weder PDF noch iframe-basierte PDF-Vorschau.
+
+Das Restarbeitenmodul besitzt im aktuellen Produktstand eine HTML-Ausgabevorschau und keine PDF-Erzeugung. M82.6 verändert diesen Fachumfang nicht.
+
+## Automatisierter Nachweis
+
+Die M82.6-Tests sichern insbesondere:
+
+- keine zusätzlichen Wrapper oder Scrollbereiche,
+- direkte Parent-Struktur und vorhandene Scrollbesitzer,
+- vollständige Protokoll-Scopes und aufgelöste vorhandene Refs,
+- Mehrfach-Refs der logischen Listenspalten,
+- Topologiestabilität bei Registryabruf, Refresh, Layoutänderung, Undo und Restore,
+- modulbezogene Manifestvorprüfung,
+- unveränderte Fachaktionssperren und Fachwertgrenze.
+
+Die vollständigen BBM- und UI-Editor-kit-Pflichtläufe werden im Abschlussbericht mit ihren realen Ergebnissen dokumentiert. Globale BBM-Lint-Altbefunde bleiben getrennt und werden außerhalb M82.6 nicht bereinigt.
+
+## Grenzen
+
+Keine Restarbeiten-PDF, keine neue Editorfunktion, keine automatische DOM-Erkennung, keine zweite Registry, keine zweite Pipe, keine neue PDF-Runtime und keine Fachwertänderung wurden eingeführt. `docs/licensing.md`, Benutzerlizenz und produktive Benutzerdaten bleiben unangetastet.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -151,6 +151,7 @@ const TEST_GROUPS = Object.freeze([
       ["m82-3BbmSpacerCompactUi.test.cjs", "runM823BbmSpacerCompactUiTests"],
       ["m82-4BbmTableColumnEditing.test.cjs", "runM824BbmTableColumnEditingTests"],
       ["m82-5BbmSimpleEditorMode.test.cjs", "runM825BbmSimpleEditorModeTests"],
+      ["m82-6TopScreenModuleClosure.test.cjs", "runM826TopScreenModuleClosureTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),
   }),

--- a/scripts/tests/_diffGuardAllowances.cjs
+++ b/scripts/tests/_diffGuardAllowances.cjs
@@ -1,5 +1,6 @@
 const ALLOWED_PROTOKOLL_UI_DIFFS = new Set([
   "src/renderer/modules/protokoll/TopsScreenQuicklane.js",
+  "src/renderer/modules/protokoll/TopsList.js",
   "src/renderer/modules/protokoll/screens/TopsScreen.js",
   "src/renderer/modules/protokoll/styles/tops.css",
   "src/renderer/modules/protokoll/uiEditor/protokollUiElements.js",

--- a/scripts/tests/editorV2Registry.test.cjs
+++ b/scripts/tests/editorV2Registry.test.cjs
@@ -222,6 +222,7 @@ async function runEditorV2RegistryTests(run) {
     .filter(Boolean);
   const allowedProtokollUiDiffs = new Set([
     "src/renderer/modules/protokoll/TopsScreenQuicklane.js",
+    "src/renderer/modules/protokoll/TopsList.js",
     "src/renderer/modules/protokoll/screens/TopsScreen.js",
     "src/renderer/modules/protokoll/styles/tops.css",
     "src/renderer/modules/protokoll/uiEditor/protokollUiElements.js",

--- a/scripts/tests/editorV2Selection.test.cjs
+++ b/scripts/tests/editorV2Selection.test.cjs
@@ -278,6 +278,7 @@ async function runEditorV2SelectionTests(run) {
 
   const allowedProtokollUiDiffs = new Set([
     "src/renderer/modules/protokoll/TopsScreenQuicklane.js",
+    "src/renderer/modules/protokoll/TopsList.js",
     "src/renderer/modules/protokoll/screens/TopsScreen.js",
     "src/renderer/modules/protokoll/styles/tops.css",
     "src/renderer/modules/protokoll/uiEditor/protokollUiElements.js",

--- a/scripts/tests/m80-1RegistrationRefresh.test.cjs
+++ b/scripts/tests/m80-1RegistrationRefresh.test.cjs
@@ -83,13 +83,13 @@ async function runM801RegistrationRefreshTests(run) {
       document.body.appendChild(rendered.root);
       const registration = rendered.registration;
       runtimeRegistration = structuredClone(registration);
-      assert.equal(registration.registryVersion, 7);
+      assert.equal(registration.registryVersion, 9);
       assert.equal(registration.registryStatus, "incomplete");
       assert.deepEqual(registration.activeScopes, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]);
       const complete = registration.registryScopes.filter((scope) => scope.status === "complete");
       const blocked = registration.registryScopes.filter((scope) => scope.status === "blocked");
       assert.equal(complete.length, 3);
-      assert.ok(blocked.some((scope) => scope.scopeId === "bbm.protokoll"));
+      assert.ok(blocked.some((scope) => scope.scopeId === "protokoll.screen.root" && scope.reason === "registry_reference_not_mounted" && scope.elements.length === 0));
       assert.ok(blocked.some((scope) => scope.scopeId === "restarbeiten.layout.root" && scope.reason === "M80_2_split_removed"));
       for (const scope of complete) {
         assert.equal(scope.expectedElementIds.length, scope.elements.length, scope.scopeId);

--- a/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
+++ b/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
@@ -15,11 +15,14 @@ async function runM802HeaderEditboxLayoutTests(run) {
   const elements = complete.flatMap((scope) => scope.elements);
 
   await run("M80.2 Registry: Header, Liste und Editbox sind direkt aktiv; Split ist gesperrt", () => {
-    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 7);
+    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 9);
     assert.deepEqual(registryModule.BBM_M80_ACTIVE_SCOPES, [
       "restarbeiten.header.root",
       "restarbeiten.list.root",
       "restarbeiten.edit.root",
+      "protokoll.screen.root",
+      "protokoll.list.root",
+      "protokoll.edit.root",
     ]);
     const removedLayout = scopes.find((scope) => scope.scopeId === "restarbeiten.layout.root");
     assert.equal(removedLayout.status, "blocked");

--- a/scripts/tests/m80ElectronUiEditor.test.cjs
+++ b/scripts/tests/m80ElectronUiEditor.test.cjs
@@ -113,15 +113,14 @@ async function runM80ElectronUiEditorTests(run) {
     assert.match(main, /BBM_M80_EDITOR_DIAGNOSTIC/);
   });
 
-  await run("M80 Registry: drei aktive Restarbeiten-Scopes und explizit gesperrte Restbereiche", () => {
-    assert.deepEqual(scopes.filter((scope) => scope.status === "complete").map((scope) => scope.scopeId), ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]);
-    assert.ok(scopes.some((scope) => scope.scopeId === "bbm.protokoll" && scope.status === "blocked"));
+  await run("M80/M82.6 Registry: Restarbeiten und Protokoll sind explizit, Restbereiche bleiben gesperrt", () => {
+    assert.deepEqual(scopes.filter((scope) => scope.status === "complete").map((scope) => scope.scopeId), ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root", "protokoll.screen.root", "protokoll.list.root", "protokoll.edit.root"]);
     assert.ok(scopes.some((scope) => scope.scopeId === "restarbeiten.layout.root" && scope.status === "blocked"));
     assert.equal(entries.some((entry) => entry.id === "restarbeiten.layout.split"), false);
     assert.equal(new Set(entries.map((entry) => entry.id)).size, entries.length);
     const ids = new Set(entries.map((entry) => entry.id));
     entries.filter((entry) => entry.parentId).forEach((entry) => assert.ok(ids.has(entry.parentId), entry.id));
-    assert.equal(entries.some((entry) => /protokoll|projektverwaltung|firma/i.test(entry.id)), false);
+    assert.equal(entries.some((entry) => /projektverwaltung|firma/i.test(entry.id)), false);
   });
 
   await run("M80 Registry: Label und Feld bleiben getrennte explizite Ziele", () => {

--- a/scripts/tests/m82-1BbmFeintuning.test.cjs
+++ b/scripts/tests/m82-1BbmFeintuning.test.cjs
@@ -24,10 +24,10 @@ async function runM821BbmFeintuningTests(run) {
   const editbox = read("src/renderer/modules/restarbeiten/RestarbeitenEditbox.js");
   const css = read("src/renderer/modules/restarbeiten/styles/restarbeiten.css");
 
-  await run("M82.1 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 7));
+  await run("M82.1 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 9));
   await run("M82.1 BBM 02: Manifestversion folgt der Registry", () => assert.equal(manifest.registryVersion, registry.BBM_M80_REGISTRY_VERSION));
   await run("M82.1 BBM 03: Manifestfingerprint ist aktuell", () => assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)));
-  await run("M82.1 BBM 04: genau drei Restarbeiten-Scopes bleiben aktiv", () => assert.deepEqual(registry.BBM_M80_ACTIVE_SCOPES, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]));
+  await run("M82.1/M82.6 BBM 04: beide Referenzmodule besitzen je drei aktive Scopes", () => assert.deepEqual(registry.BBM_M80_ACTIVE_SCOPES, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root", "protokoll.screen.root", "protokoll.list.root", "protokoll.edit.root"]));
   await run("M82.1 BBM 05: Header behält 31 Elemente", () => assert.equal(byId.has("restarbeiten.header.root") && scopes.find((scope) => scope.scopeId === "restarbeiten.header.root").elements.length, 31));
   await run("M82.1 BBM 06: Editbox besitzt 53 explizite Elemente", () => assert.equal(scopes.find((scope) => scope.scopeId === "restarbeiten.edit.root").elements.length, 53));
   await run("M82.1 BBM 07: Editbox-Root ist nur höhen- und sichtbarkeitsfähig", () => assert.deepEqual(byId.get("restarbeiten.edit.root").allowedOps, ["resizeHeight", "setVisibility"]));

--- a/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
+++ b/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
@@ -47,7 +47,7 @@ async function runM823BbmSpacerCompactUiTests(run) {
     groupWidthEditable,
   });
 
-  await run("M82.3 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 7));
+  await run("M82.3 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 9));
   await run("M82.3 BBM 02: Manifest folgt Registry und Fingerprint", () => { assert.equal(manifest.registryVersion, registry.BBM_M80_REGISTRY_VERSION); assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)); });
   await run("M82.3 BBM 03: Kurztextbezeichnung besitzt reservierte Breite", () => assert.deepEqual(label.baseline.spacing, { reservedWidth: 40 }));
   await run("M82.3 BBM 04: Kurztextbezeichnung erlaubt Spacer davor und danach", () => assert.deepEqual(label.spacingTargets, ["beforeElement", "afterElement", "reservedWidth"]));
@@ -107,6 +107,12 @@ async function runM823BbmSpacerCompactUiTests(run) {
     }, { [label.id]: ["resizeWidth"] });
     assert.deepEqual(startup.map((item) => item.request.operation), ["resizeWidth", "spacingSet"]);
     assert.deepEqual(startup[1].request.payload.spacing, { target: "reservedWidth", value: 100 });
+  });
+  await run("M82.3 BBM 29b: Start-Restore wendet gemessenes Spacing ohne explizite Operation nicht an", () => {
+    const startup = hostModule.createM80StartupRequests("restarbeiten.edit.root", {
+      ...refs.readM80State(label.id), spacing: { reservedWidth: 100 },
+    }, {});
+    assert.deepEqual(startup, []);
   });
   await run("M82.3 BBM 30: Fachwerte sind weiterhin verboten", () => assert.match(host, /FORBIDDEN_KEYS[\s\S]*businessData[\s\S]*domainData/));
   await run("M82.3 BBM 31: docs/licensing.md bleibt hashgleich", () => assert.equal(crypto.createHash("sha256").update(fs.readFileSync(path.join(ROOT, "docs/licensing.md"))).digest("hex").toUpperCase(), "02AE66A8873C74869539F13F734B7CE43BC63B6EF37DA553A40C27A4F514D784"));

--- a/scripts/tests/m82-4BbmTableColumnEditing.test.cjs
+++ b/scripts/tests/m82-4BbmTableColumnEditing.test.cjs
@@ -48,9 +48,7 @@ async function createRuntime(refs, host) {
   const root = new FakeElement(900, 700);
   const area = new FakeElement(900, 700);
   const paper = new FakeElement(900, 720);
-  const viewport = new FakeElement(600, 680);
-  const scrollArea = new FakeElement(600, 680);
-  const table = new FakeElement(858, 680);
+  const table = new FakeElement(600, 680);
   const header = new FakeElement(858, 28);
   const body = new FakeElement(858, 400);
   const row = new FakeElement(858, 80);
@@ -62,7 +60,7 @@ async function createRuntime(refs, host) {
     element._widthSource = () => {
       const value = table.style[variables[index]];
       if (!value) return element._rect.width;
-      if (String(value).startsWith("minmax")) return Math.max(minimums[index], viewport._rect.width - 44 - headers.filter((_item, candidate) => candidate !== index).reduce((sum, other, candidate) => {
+        if (String(value).startsWith("minmax")) return Math.max(minimums[index], table._rect.width - 44 - headers.filter((_item, candidate) => candidate !== index).reduce((sum, other, candidate) => {
         const actualIndex = candidate >= index ? candidate + 1 : candidate;
         const configured = parseFloat(table.style[variables[actualIndex]]);
         return sum + (Number.isFinite(configured) ? configured : other._rect.width);
@@ -74,21 +72,19 @@ async function createRuntime(refs, host) {
   refs.registerM80Ref("restarbeiten.list.root", root);
   refs.registerM80Ref("restarbeiten.list.area", area);
   refs.registerM80Ref("restarbeiten.list.paper", paper);
-  refs.registerM80Ref("restarbeiten.list.viewport", viewport);
-  refs.registerM80Ref("restarbeiten.list.scrollArea", scrollArea);
-  refs.registerM80TableRef("restarbeiten.list.table", table, viewport, scrollArea);
+  refs.registerM80TableRef("restarbeiten.list.table", table, table);
   refs.registerM80Ref("restarbeiten.list.table.header", header);
   refs.registerM80Ref("restarbeiten.list.table.body", body);
   refs.registerM80Ref("restarbeiten.list.table.row", row);
   const ids = ["number", "subject", "meta"];
-  ids.forEach((key, index) => refs.registerM80TableColumnRef(`restarbeiten.list.table.${key}`, headers[index], [cells[index]], table, viewport, variables[index], headers[index]._rect.width));
+  ids.forEach((key, index) => refs.registerM80TableColumnRef(`restarbeiten.list.table.${key}`, headers[index], [cells[index]], table, table, variables[index], headers[index]._rect.width));
   refs.completeM80PilotRender();
 
   const submit = (elementId, operation, payload, changeId = `${elementId}-${operation}`, source = "target-app-start") => host.handleM80EditorRequest({
     action: "submitChange", scopeId: "restarbeiten.list.root",
     changeRequest: { changeId, elementId, operation, payload, source },
   }).changeResult;
-  return { table, viewport, scrollArea, headers, cells, submit, cleanup: () => { refs.resetM80PilotWorkingStatesForDiagnostic(); global.document = previous.document; global.window = previous.window; global.Element = previous.Element; } };
+  return { table, headers, cells, submit, cleanup: () => { refs.resetM80PilotWorkingStatesForDiagnostic(); global.document = previous.document; global.window = previous.window; global.Element = previous.Element; } };
 }
 
 async function runM824BbmTableColumnEditingTests(run) {
@@ -102,15 +98,15 @@ async function runM824BbmTableColumnEditingTests(run) {
 
   await run("M82.4 BBM 01: bestaetigte Restarbeiten-Liste ist UI-Inhaltstabelle", () => assert.equal(tableEntry.role, "contentTable"));
   await run("M82.4 BBM 02: exakt drei bestaetigte Hauptspalten bleiben erhalten", () => assert.deepEqual(columns.map((entry) => entry.name), ["Nr. / Datum / Klasse / Fotos", "Gegenstand – Verortung / Kurztext / Langtext", "Fertig bis / Ampel / Status / Verantwortlich"]));
-  await run("M82.4 BBM 03: Tabelle besitzt Viewport und horizontalen Scrollbereich", () => { assert.equal(byId.get("restarbeiten.list.viewport").type, "tableViewport"); assert.equal(byId.get("restarbeiten.list.scrollArea").type, "horizontalScrollArea"); });
+  await run("M82.4 BBM 03: Tabelle bleibt logisches Ziel ohne Editor-Wrapper", () => { assert.equal(byId.has("restarbeiten.list.viewport"), false); assert.equal(byId.has("restarbeiten.list.scrollArea"), false); assert.equal(tableEntry.parentId, "restarbeiten.list.paper"); });
   await run("M82.4 BBM 04: Tabellenvertrag ist fachneutral gueltig", () => assert.equal(validateTableLayout(tableEntry.tableLayout).ok, true));
   await run("M82.4 BBM 05: Header und Datenbereiche nutzen dieselbe Breitenquelle", () => assert.equal(validateTableElementBindings(scope.elements).ok, true));
   await run("M82.4 BBM 06: Tabellenkopf, Body, Zeile und Zellen sind direkt registriert", () => ["tableHeader", "tableBody", "tableRow", "tableHeaderCell", "tableDataCell"].forEach((type) => assert.ok(scope.elements.some((entry) => entry.type === type), type)));
   await run("M82.4 BBM 07: bestehende Unterelemente bleiben im Renderer einzeln markiert", () => { const source = read("src/renderer/modules/restarbeiten/RestarbeitenList.js"); assert.match(source, /restarbeiten\.record\.number/); assert.match(source, /restarbeiten\.record\.shortText/); assert.match(source, /restarbeiten\.record\.responsible/); });
   await run("M82.4 BBM 08: keine neue Tabellenansicht wird eingefuehrt", () => assert.match(read("src/renderer/modules/restarbeiten/RestarbeitenMainBody.js"), /buildRestarbeitenList\(options\)/));
   await run("M82.4 BBM 09: Kopf und Datenzeilen verwenden dieselben drei CSS-Variablen", () => { const css = read("src/renderer/modules/restarbeiten/styles/restarbeiten.css"); assert.equal((css.match(/grid-template-columns: var\(--bbm-restarbeiten-number-column\) var\(--bbm-restarbeiten-subject-column\) var\(--bbm-restarbeiten-meta-column\)/g) || []).length, 2); });
-  await run("M82.4 BBM 10: sichtbarer Inhaltsbereich begrenzt die Listenbreite", () => assert.match(read("src/renderer/modules/restarbeiten/styles/restarbeiten.css"), /\.bbm-restarbeiten-table-viewport[\s\S]*max-width:\s*100%[\s\S]*overflow:\s*hidden/));
-  await run("M82.4 BBM 10a: JavaScript- und WPF-Fingerprint stimmen fuer alle Tabellenrollen ueberein", () => assert.equal(createUiScopeFingerprint(scope), "sha256:caa59d5066b584e6b7a5354156ed269341db52184d1f3f85a645019f92fd8f15"));
+  await run("M82.4 BBM 10: vorhandene Tabelle bleibt direkt unter dem Listenblatt", () => { const source = read("src/renderer/modules/restarbeiten/RestarbeitenMainBody.js"); assert.match(source, /paper\.appendChild\(table\)/); assert.doesNotMatch(source, /table-viewport|table-scroll-area/); });
+  await run("M82.4 BBM 10a: Registry-Fingerprint bleibt reproduzierbar", () => { const fingerprint = createUiScopeFingerprint(scope); assert.match(fingerprint, /^sha256:[0-9a-f]{64}$/); assert.equal(fingerprint, createUiScopeFingerprint(scope)); });
 
   const runtime = await createRuntime(refs, host);
   try {
@@ -123,10 +119,10 @@ async function runM824BbmTableColumnEditingTests(run) {
     await run("M82.4 BBM 16: Fit ohne bestaetigte Vorschau wird abgewiesen", () => assert.equal(runtime.submit("restarbeiten.list.table", "fitTableToViewport", { table: { strategy: "fit" } }).errorCode, "electron_editor_message_invalid"));
     await run("M82.4 BBM 17: Fit mit bestaetigter Vorschau begrenzt auf den Viewport", () => { runtime.submit("restarbeiten.list.table.subject", "resetTableColumn", { table: {} }); const result = runtime.submit("restarbeiten.list.table", "fitTableToViewport", { table: { strategy: "fit", previewAccepted: true } }); assert.equal(result.success, true); assert.ok(result.newState.table.overflow <= 0.5); });
     await run("M82.4 BBM 18: flexible Hauptspalte traegt den Fit vor festen Spalten", () => { assert.equal(refs.snapshotM80State("restarbeiten.list.table.number").width, 82); assert.equal(refs.snapshotM80State("restarbeiten.list.table.meta").width, 172); });
-    await run("M82.4 BBM 19: horizontaler Scrollmodus bleibt explizit steuerbar", () => { const result = runtime.submit("restarbeiten.list.table", "setHorizontalOverflowMode", { table: { horizontalOverflowMode: "scroll" } }); assert.equal(result.success, true); assert.equal(runtime.scrollArea.style.overflowX, "scroll"); });
+    await run("M82.4 BBM 19: horizontaler Scrollmodus ist fuer BBM nicht freigegeben", () => { const result = runtime.submit("restarbeiten.list.table", "setHorizontalOverflowMode", { table: { horizontalOverflowMode: "scroll" } }); assert.equal(result.success, false); assert.equal(result.errorCode, "electron_operation_not_allowed"); assert.equal(runtime.table.style.overflowX || "", ""); });
     await run("M82.4 BBM 20: ungueltiger Modus wird ohne Zustandsaenderung abgewiesen", () => { const before = refs.snapshotM80State("restarbeiten.list.table.subject"); const result = runtime.submit("restarbeiten.list.table.subject", "setColumnWidthMode", { table: { widthMode: "domain" } }); assert.equal(result.success, false); assert.deepEqual(refs.snapshotM80State("restarbeiten.list.table.subject").table, before.table); });
     await run("M82.4 BBM 21: Spaltenreset stellt Breiten- und Textmodus wieder her", () => { const result = runtime.submit("restarbeiten.list.table.subject", "resetTableColumn", { table: {} }); assert.equal(result.success, true); assert.equal(result.newState.table.widthMode, "proportional"); assert.equal(result.newState.table.wrapMode, "wordWrap"); assert.equal(result.newState.table.overflowMode, "clip"); });
-    await run("M82.4 BBM 22: Tabellenreset stellt alle drei Spalten und Tabellenmodi wieder her", () => { const result = runtime.submit("restarbeiten.list.table", "resetTable", { table: {} }); assert.equal(result.success, true); assert.equal(result.affectedStates.length, 3); assert.equal(result.newState.table.horizontalOverflowMode, "auto"); assert.equal(result.newState.table.rowHeightMode, "bounded"); });
+    await run("M82.4 BBM 22: Tabellenreset stellt alle drei Spalten und Tabellenmodi wieder her", () => { const result = runtime.submit("restarbeiten.list.table", "resetTable", { table: {} }); assert.equal(result.success, true); assert.equal(result.affectedStates.length, 3); assert.equal(result.newState.table.horizontalOverflowMode, "fitViewport"); assert.equal(result.newState.table.rowHeightMode, "bounded"); });
     await run("M82.4 BBM 22a: interaktiver Tabellenreset vertraut der validierten Ziel-App-Baseline", () => { runtime.table._rect.width = 1224; const result = runtime.submit("restarbeiten.list.table", "resetTable", { table: {} }, "interactive-table-reset", "ui-editor-panel"); assert.equal(result.success, true); assert.equal(result.errorCode, null); assert.equal(result.affectedStates.length, 3); assert.equal(refs.snapshotM80State("restarbeiten.list.table.subject").table.wrapMode, "wordWrap"); });
     await run("M82.4 BBM 22b: interaktiver Fit nutzt die bestaetigte Tabellenvorschau", () => { runtime.table._rect.width = 1224; const result = runtime.submit("restarbeiten.list.table", "fitTableToViewport", { table: { strategy: "fitViewport", previewAccepted: true } }, "interactive-table-fit", "ui-editor-panel"); assert.equal(result.success, true); assert.equal(result.errorCode, null); assert.ok(result.newState.table.overflow <= 0.5); });
     await run("M82.4 BBM 23: Start-Restore erzeugt nur explizite Tabellenmodus-Requests", () => { const requests = host.createM80StartupRequests("restarbeiten.list.root", { elementId: "restarbeiten.list.table.subject", width: 360, table: { tableId: "restarbeiten.list.table", columnId: "restarbeiten.list.table.subject", widthMode: "fixed", wrapMode: "ellipsis", overflowMode: "ellipsis" } }); assert.ok(requests.some((item) => item.request.operation === "resizeWidth")); assert.ok(requests.some((item) => item.request.operation === "setColumnWrapMode")); assert.ok(requests.some((item) => item.request.operation === "setColumnOverflowMode")); });

--- a/scripts/tests/m82-5BbmSimpleEditorMode.test.cjs
+++ b/scripts/tests/m82-5BbmSimpleEditorMode.test.cjs
@@ -48,8 +48,6 @@ async function runM825BbmSimpleEditorModeTests(run) {
   refs.resetM80PilotWorkingStatesForDiagnostic();
   refs.beginM80PilotRender();
   const root = new FakeElement(900, 700);
-  const viewport = new FakeElement(718, 680);
-  const scrollArea = new FakeElement(718, 680);
   const table = new FakeElement(718, 680);
   const tableHeaders = [new FakeElement(82, 28), new FakeElement(464, 28), new FakeElement(172, 28)];
   const cells = [new FakeElement(82, 80), new FakeElement(464, 80), new FakeElement(172, 80)];
@@ -59,9 +57,9 @@ async function runM825BbmSimpleEditorModeTests(run) {
   tableHeaders[2]._leftSource = () => tableHeaders[0].getBoundingClientRect().width + tableHeaders[1].getBoundingClientRect().width;
   cells.forEach((element, index) => { element._widthSource = tableHeaders[index]._widthSource; element._leftSource = tableHeaders[index]._leftSource; });
   refs.registerM80Ref("restarbeiten.list.root", root);
-  refs.registerM80TableRef("restarbeiten.list.table", table, viewport, scrollArea);
+  refs.registerM80TableRef("restarbeiten.list.table", table, table);
   ["number", "subject", "meta"].forEach((key, index) => refs.registerM80TableColumnRef(
-    `restarbeiten.list.table.${key}`, tableHeaders[index], [cells[index]], table, viewport, variables[index], tableHeaders[index]._rect.width));
+    `restarbeiten.list.table.${key}`, tableHeaders[index], [cells[index]], table, table, variables[index], tableHeaders[index]._rect.width));
   const header = new FakeElement(560, 28);
   refs.registerM80Ref("restarbeiten.list.table.subject.header", header);
   refs.completeM80PilotRender();

--- a/scripts/tests/m82-6TopScreenModuleClosure.test.cjs
+++ b/scripts/tests/m82-6TopScreenModuleClosure.test.cjs
@@ -1,0 +1,207 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const uiEditorKit = require("ui-editor-kit");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const ROOT = path.resolve(__dirname, "../..");
+const read = (relativePath) => fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+const sha256 = (relativePath) => crypto.createHash("sha256").update(fs.readFileSync(path.join(ROOT, relativePath))).digest("hex").toUpperCase();
+
+class FakeElement {
+  constructor(tagName = "DIV", width = 600, height = 300) {
+    this.tagName = tagName; this.attributes = {}; this.dataset = {}; this.className = ""; this.parentElement = null; this.children = []; this.isConnected = true;
+    this._rect = { left: 0, top: 0, width, height }; this.scrollWidth = width; this.scrollHeight = height;
+    this.style = { setProperty(name, value) { this[name] = value; }, getPropertyValue(name) { return this[name] || ""; } };
+    this.classList = { contains: (name) => this.className.split(/\s+/).includes(name), toggle: (name, active) => { const names = new Set(this.className.split(/\s+/).filter(Boolean)); if (active) names.add(name); else names.delete(name); this.className = [...names].join(" "); } };
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); if (name === "data-ui-editor-id") this.dataset.uiEditorId = String(value); }
+  getAttribute(name) { return this.attributes[name] || null; }
+  appendChild(child) { child.parentElement = this; this.children.push(child); return child; }
+  getBoundingClientRect() { return { ...this._rect, width: parseFloat(this.style.width) || this._rect.width, height: parseFloat(this.style.height) || this._rect.height }; }
+}
+
+async function runM826TopScreenModuleClosureTests(run) {
+  const registry = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Registry.js"));
+  const refs = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Refs.js"));
+  const host = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80HostAdapter.js"));
+  const listScope = registry.listM80RegistryScopes().find((scope) => scope.scopeId === "restarbeiten.list.root");
+  const byId = new Map(listScope.elements.map((entry) => [entry.id, entry]));
+  const mainBody = read("src/renderer/modules/restarbeiten/RestarbeitenMainBody.js");
+  const css = read("src/renderer/modules/restarbeiten/styles/restarbeiten.css");
+  const screen = read("src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js");
+
+  await run("M82.6 BBM 01: Tabellen-Viewport ist aus dem DOM-Aufbau entfernt", () => assert.doesNotMatch(mainBody, /bbm-restarbeiten-table-viewport/));
+  await run("M82.6 BBM 02: Tabellen-ScrollArea ist aus dem DOM-Aufbau entfernt", () => assert.doesNotMatch(mainBody, /bbm-restarbeiten-table-scroll-area/));
+  await run("M82.6 BBM 03: Tabelle haengt wieder direkt unter dem Listenblatt", () => assert.match(mainBody, /paper\.appendChild\(table\)/));
+  await run("M82.6 BBM 04: Registry enthaelt keinen Editor-Viewport", () => assert.equal(byId.has("restarbeiten.list.viewport"), false));
+  await run("M82.6 BBM 05: Registry enthaelt keinen Editor-Scrollbereich", () => assert.equal(byId.has("restarbeiten.list.scrollArea"), false));
+  await run("M82.6 BBM 06: logisches Tabellenziel nutzt vorhandenes Listenblatt als Parent", () => assert.equal(byId.get("restarbeiten.list.table").parentId, "restarbeiten.list.paper"));
+  await run("M82.6 BBM 07: Tabellenmetadaten verlangen keinen Wrapper", () => { assert.equal(byId.get("restarbeiten.list.table").tableLayout.parentId, "restarbeiten.list.paper"); assert.notEqual(byId.get("restarbeiten.list.table").tableLayout.requiresDedicatedWrapper, true); });
+  await run("M82.6 BBM 08: BBM gibt keinen horizontalen Scrollmodus frei", () => assert.equal(byId.get("restarbeiten.list.table").allowedOps.includes("setHorizontalOverflowMode"), false));
+  await run("M82.6 BBM 09: Tabellenmetadaten bleiben auf vorhandene Breite eingepasst", () => assert.equal(byId.get("restarbeiten.list.table").tableLayout.horizontalOverflowMode, "fitViewport"));
+  await run("M82.6 BBM 10: alte Overflow-Regeln sind entfernt", () => assert.doesNotMatch(css, /bbm-restarbeiten-table-(viewport|scroll-area)/));
+  await run("M82.6 BBM 11: nur die vorhandene Mitte scrollt vertikal", () => assert.match(css, /\.bbm-restarbeiten-main\s*\{[\s\S]*?overflow-x:\s*hidden;[\s\S]*?overflow-y:\s*auto;/));
+  await run("M82.6 BBM 12: TopScreen behaelt Kopf, Liste und Editbox", () => ["bbm-restarbeiten-header", "bbm-restarbeiten-workspace__list", "bbm-restarbeiten-workspace__edit"].forEach((name) => assert.match(screen, new RegExp(name))));
+  await run("M82.6 BBM 13: A4-nahe Listenblattbreite bleibt 900 px", () => assert.match(css, /\.bbm-restarbeiten-paper\s*\{[\s\S]*?width:\s*min\(100%,\s*900px\)/));
+  await run("M82.6 BBM 14: Protokoll-TopsScreen blieb bytegleich", () => assert.equal(sha256("src/renderer/views/TopsScreen.js"), "0826FDC88D2D454D384F0D64CC6678AC356E2BFD73041B9336E89266EF57D1B3"));
+  await run("M82.6 BBM 15: Protokoll-TopScreen-CSS blieb bytegleich", () => assert.equal(sha256("src/renderer/tops/styles/tops.css"), "93863CA66367BF145DD4E5E50F78811A784BFE8AE70BBE50996249306DF084CB"));
+  await run("M82.6 BBM 16: Protokoll besitzt weiterhin genau den mittleren Sheet-Scrollbereich", () => { const protocolCss = read("src/renderer/tops/styles/tops.css"); assert.match(protocolCss, /\[data-bbm-tops-screen-area="sheet"\][\s\S]*?overflow:\s*auto/); assert.match(protocolCss, /\[data-bbm-tops-screen-area="edit"\][\s\S]*?flex:\s*0 0 auto/); });
+
+  const protocolScopes = registry.listM80RegistryScopes().filter((scope) => scope.scopeId.startsWith("protokoll."));
+  const protocolEntries = protocolScopes.flatMap((scope) => scope.elements);
+  const protocolById = new Map(protocolEntries.map((entry) => [entry.id, entry]));
+  const protocolScreen = read("src/renderer/modules/protokoll/screens/TopsScreen.js");
+  const protocolList = read("src/renderer/modules/protokoll/TopsList.js");
+  const protocolQuicklane = read("src/renderer/modules/protokoll/TopsScreenQuicklane.js");
+  const protocolLayout = read("src/shared/tableLayouts/protokollTopsLayout.js");
+  await run("M82.6 BBM 17: BBM erzeugt drei vollstaendige produktive Protokoll-Scopes", () => assert.deepEqual(protocolScopes.map((scope) => [scope.scopeId, scope.status]), [["protokoll.screen.root", "complete"], ["protokoll.list.root", "complete"], ["protokoll.edit.root", "complete"]]));
+  await run("M82.6 BBM 18: alter blockierter Protokoll-Platzhalter ist entfernt", () => assert.equal(registry.listM80RegistryScopes().some((scope) => scope.scopeId === "bbm.protokoll"), false));
+  await run("M82.6 BBM 19: Protokoll-Registry besitzt Label, Feld und echte Gruppe", () => { assert.equal(protocolById.get("protokoll.edit.short.label").type, "label"); assert.equal(protocolById.get("protokoll.edit.short.field").type, "field"); assert.equal(protocolById.get("protokoll.edit.short").type, "fieldGroup"); });
+  await run("M82.6 BBM 20: alle Protokoll-Parents sind explizit registriert", () => protocolEntries.forEach((entry) => { if (entry.parentId) assert.equal(protocolById.has(entry.parentId), true, `${entry.id} -> ${entry.parentId}`); }));
+  await run("M82.6 BBM 21: Fachaktionen bleiben fuer Ausfuehrung und Daten gesperrt", () => protocolEntries.filter((entry) => entry.actionKind).forEach((entry) => { assert.equal(entry.lockedOps.includes("executeTargetAction"), true); assert.equal(entry.lockedOps.includes("modifyDomainData"), true); }));
+  await run("M82.6 BBM 22: UI-Attribute werden vollstaendig aus BBM-Registry erzeugt", () => assert.deepEqual(Object.keys(registry.m80EditorAttributes("protokoll.edit.short.field")).sort(), ["data-ui-editor-editable", "data-ui-editor-kind", "data-ui-editor-label", "data-ui-editor-ops", "data-ui-editor-parent", "data-ui-inspector-id"]));
+  await run("M82.6 BBM 23: produktiver Screen registriert nur vorhandene Objekt-Refs", () => { const block = protocolScreen.slice(protocolScreen.indexOf("  _registerUiEditorRefs() {"), protocolScreen.indexOf("  _buildProtocolScreenRegions() {")); assert.match(block, /registerM80Ref\("protokoll\.edit\.short\.field", editbox\.shortInput\)/); assert.doesNotMatch(block, /createElement|appendChild|insertBefore|querySelector/); });
+  await run("M82.6 BBM 24: logische Listenspalten verwenden vorhandene Zell-Mehrfachrefs", () => { assert.match(protocolList, /registerM80Ref\(column\.id, primary, \{[\s\S]*?\n\s*targets,/); assert.match(protocolList, /this\.root\.style\.setProperty\(column\.widthVariable/); assert.doesNotMatch(protocolList.slice(protocolList.indexOf("_registerUiEditorColumnRefs()"), protocolList.indexOf("_renderRow(")), /createElement|appendChild|insertBefore|querySelector/); });
+  await run("M82.6 BBM 25: Quicklane nutzt ihre vorhandenen stabilen IDs", () => { assert.match(protocolQuicklane, /protokoll\.topsScreen\.quicklane\.group\.navigation/); assert.match(protocolQuicklane, /registerM80Ref\(buttonId, group\.children\[index\]\)/); });
+  await run("M82.6 BBM 26: vorhandener Protokoll-Tabellenvertrag bleibt die Breitenquelle", () => { assert.match(protocolLayout, /tableKey:\s*"protokoll_tops"/); assert.match(protocolLayout, /PROTOKOLL_TOPS_COLUMNS[\s\S]*?key:\s*"topNumber"[\s\S]*?key:\s*"shortText"[\s\S]*?key:\s*"meta"/); assert.match(protocolList, /--bbm-tops-list-number-col/); assert.match(protocolList, /--bbm-tops-list-text-col/); assert.match(protocolList, /--bbm-tops-list-meta-col/); });
+  await run("M82.6 BBM 27: TopScreen-Reihenfolge bleibt Kopf, Liste, Editbox, Quicklane", () => assert.match(protocolScreen, /root\.append\(this\.header\.root, sheetArea, editArea, this\.quicklane\.root\)/));
+
+  const previous = { document: global.document, window: global.window, Element: global.Element };
+  global.Element = FakeElement;
+  global.document = { querySelector: () => null, createElement: () => new FakeElement(), addEventListener() {}, removeEventListener() {} };
+  global.window = { getComputedStyle: (element) => ({ ...element.style, width: element.style.width || `${element._rect.width}px`, height: element.style.height || `${element._rect.height}px`, paddingLeft: element.style.paddingLeft || "0px", paddingTop: element.style.paddingTop || "0px", fontSize: element.style.fontSize || "12px" }), dispatchEvent() {} };
+  refs.resetM80PilotWorkingStatesForDiagnostic();
+  refs.beginM80PilotRender();
+  const root = new FakeElement("MAIN", 900, 700);
+  const area = root.appendChild(new FakeElement("SECTION", 900, 700));
+  const paper = area.appendChild(new FakeElement("DIV", 900, 720));
+  const table = paper.appendChild(new FakeElement("DIV", 858, 680));
+  const header = table.appendChild(new FakeElement("DIV", 858, 28));
+  const body = table.appendChild(new FakeElement("DIV", 858, 500));
+  refs.registerM80Ref("restarbeiten.list.root", root);
+  refs.registerM80Ref("restarbeiten.list.area", area);
+  refs.registerM80Ref("restarbeiten.list.paper", paper);
+  refs.registerM80TableRef("restarbeiten.list.table", table, table);
+  refs.registerM80Ref("restarbeiten.list.table.header", header);
+  refs.registerM80Ref("restarbeiten.list.table.body", body);
+  refs.completeM80PilotRender();
+  try {
+    const baseline = refs.snapshotM80Topology();
+    await run("M82.6 BBM 28: Electron-Fingerprint erfasst Tag, ID, Parent und Reihenfolge", () => { assert.match(baseline.fingerprint, /^sha256:[0-9a-f]{64}$/); assert.deepEqual(baseline.nodes.find((node) => node.stableId === "restarbeiten.list.table"), { kind: "DIV", stableId: "restarbeiten.list.table", parentId: "restarbeiten.list.paper", order: 0 }); });
+    await run("M82.6 BBM 29: Registryabruf ist topologieneutral", () => { host.handleM80EditorRequest({ action: "getRegistry" }); assert.equal(refs.compareM80Topology(baseline).ok, true); });
+    await run("M82.6 BBM 30: Layoutabruf ist topologieneutral", () => { host.handleM80EditorRequest({ action: "getLayoutState" }); assert.equal(refs.compareM80Topology(baseline).ok, true); });
+    await run("M82.6 BBM 31: Registryrefresh ohne DOM-Umbau bleibt topologieneutral", () => { refs.completeM80PilotRender(); assert.equal(refs.compareM80Topology(baseline).ok, true); });
+    await run("M82.6 BBM 32: erlaubte Layoutaenderung erzeugt keinen Knoten", () => { const result = host.handleM80EditorRequest({ action: "submitChange", scopeId: "restarbeiten.list.root", changeRequest: { changeId: "m826-height", elementId: "restarbeiten.list.table", operation: "resizeHeight", payload: { height: 640 }, source: "target-app-start" } }).changeResult; assert.equal(result.success, true); assert.equal(refs.compareM80Topology(baseline).ok, true); });
+    await run("M82.6 BBM 33: Hoehenaenderung veraendert weder Display noch Overflow", () => { assert.equal(table.style.display || "", ""); assert.equal(table.style.overflow || "", ""); assert.equal(table.style.overflowX || "", ""); });
+    await run("M82.6 BBM 34: unerlaubte Parent-Aenderung wird erkannt", () => { body.parentElement = paper; assert.equal(refs.compareM80Topology(baseline).errorCode, "target_ui_topology_changed"); body.parentElement = table; });
+    await run("M82.6 BBM 35: Wiederherstellung liefert erneut denselben Fingerprint", () => assert.equal(refs.compareM80Topology(baseline).ok, true));
+    await run("M82.6 BBM 36: BBM-Registry bleibt explizit und ohne DOM-Scan", () => assert.doesNotMatch(read("src/renderer/ui-editor/m80Registry.js"), /querySelector|querySelectorAll|MutationObserver/));
+    await run("M82.6 BBM 37: Fachliches Neu-Rendern friert keine gemessene Baseline-Geometrie ein", () => {
+      refs.resetM80PilotWorkingStatesForDiagnostic();
+      refs.beginM80PilotRender();
+      const firstTable = new FakeElement("DIV", 700, 300);
+      refs.registerM80TableRef("restarbeiten.list.table", firstTable, firstTable);
+      refs.completeM80PilotRender();
+      refs.beginM80PilotRender();
+      const rerenderedTable = new FakeElement("DIV", 820, 500);
+      refs.registerM80TableRef("restarbeiten.list.table", rerenderedTable, rerenderedTable);
+      refs.completeM80PilotRender();
+      assert.equal(refs.snapshotM80State("restarbeiten.list.table").height, 500);
+    });
+    await run("M82.6 BBM 38: Ausdrueckliche Editor-Geometrie bleibt ueber ein Neu-Rendern erhalten", () => {
+      const edited = refs.applyM80State("restarbeiten.list.table", {
+        ...refs.snapshotM80State("restarbeiten.list.table"),
+        height: 420,
+      });
+      assert.equal(edited.height, 420);
+      refs.beginM80PilotRender();
+      const rerenderedTable = new FakeElement("DIV", 860, 600);
+      refs.registerM80TableRef("restarbeiten.list.table", rerenderedTable, rerenderedTable);
+      refs.completeM80PilotRender();
+      assert.equal(refs.snapshotM80State("restarbeiten.list.table").height, 420);
+    });
+
+    refs.resetM80PilotWorkingStatesForDiagnostic();
+    refs.beginM80PilotRender();
+    const protocolNodes = new Map();
+    for (const scope of protocolScopes) {
+      for (const entry of scope.elements) {
+        const tag = entry.type === "field" ? "INPUT" : entry.type === "label" ? "SPAN" : entry.type === "button" ? "BUTTON" : "DIV";
+        const node = new FakeElement(tag, entry.type === "field" ? 260 : 420, entry.type === "root" ? 300 : 48);
+        protocolNodes.set(entry.id, node);
+        if (entry.parentId) protocolNodes.get(entry.parentId).appendChild(node);
+        refs.registerM80Ref(entry.id, node);
+      }
+    }
+    const secondaryColumnCell = new FakeElement("DIV", 180, 48);
+    refs.registerM80Ref("protokoll.list.column.text", protocolNodes.get("protokoll.list.column.text"), { targets: [secondaryColumnCell] });
+    refs.completeM80PilotRender();
+    const protocolBaseline = refs.snapshotM80Topology();
+    await run("M82.6 BBM 39: nur die drei gemounteten Protokoll-Scopes werden aktiv", () => assert.deepEqual(host.createM80RegistrationDescriptor().activeScopes, ["protokoll.screen.root", "protokoll.list.root", "protokoll.edit.root"]));
+    await run("M82.6 BBM 40: alle Protokoll-Refs sind fuer den Editor aufgeloest", () => host.createM80RegistrationDescriptor().registryScopes.filter((scope) => scope.scopeId.startsWith("protokoll.")).forEach((scope) => assert.equal(scope.status, "complete", scope.scopeId)));
+    await run("M82.6 BBM 40a: nicht gemountete Referenzmodule bleiben ohne Laufzeitbaseline blockiert", () => {
+      const inactiveScopes = host.createM80RegistrationDescriptor().registryScopes.filter((scope) => scope.scopeId.startsWith("restarbeiten."));
+      assert.equal(inactiveScopes.length >= 3, true);
+      inactiveScopes.slice(0, 3).forEach((scope) => {
+        assert.equal(scope.status, "blocked", scope.scopeId);
+        assert.deepEqual(scope.expectedElementIds, [], scope.scopeId);
+        assert.deepEqual(scope.elements, [], scope.scopeId);
+      });
+    });
+    await run("M82.6 BBM 40b: produktive Protokoll-Registrierung besteht den Electron-Preflight", () => {
+      const descriptor = host.createM80RegistrationDescriptor();
+      const contract = uiEditorKit.createElectronTargetContract({
+        applicationId: descriptor.applicationId,
+        displayName: descriptor.displayName,
+        appVersion: "1.5.0-test",
+        registryVersion: descriptor.registryVersion,
+        registryFingerprint: uiEditorKit.createRegistryFingerprint(descriptor.registryScopes),
+        registryStatus: descriptor.registryStatus,
+        activeScopes: descriptor.activeScopes,
+        profileRoot: "C:\\temp\\bbm-m826-test",
+        supportedOperations: descriptor.supportedOperations,
+        transportProtocolVersion: uiEditorKit.LOCAL_TARGET_PROTOCOL_VERSION,
+        sessionId: "m826-test",
+        processId: process.pid,
+        pdfCapability: "unavailable",
+        pdfContract: null,
+      });
+      const validation = uiEditorKit.validateRegistrationSnapshot({ contract, registryScopes: descriptor.registryScopes });
+      assert.equal(validation.ok, true, JSON.stringify(validation.errors));
+    });
+    await run("M82.6 BBM 40c: Zielmanifest akzeptiert den deklarierten aktiven Modul-Satz", () => {
+      const descriptor = host.createM80RegistrationDescriptor();
+      const profileRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-m826-module-manifest-"));
+      try {
+        const { ElectronUiEditorSessionController } = require("../../src/main/ui-editor/electronUiEditorSession.js");
+        const controller = new ElectronUiEditorSessionController({
+          app: { getAppPath: () => ROOT, getVersion: () => "1.5.0", getPath: () => profileRoot },
+          ipcMain: { handle() {} }, getMainWindow: () => null, profileRootResolver: () => profileRoot,
+        });
+        const loaded = controller.loadStartupLayout(descriptor);
+        assert.equal(loaded.code === "registry_incompatible", false, loaded.message);
+      } finally {
+        fs.rmSync(profileRoot, { recursive: true, force: true });
+      }
+    });
+    await run("M82.6 BBM 41: Mehrfach-Ref selektiert dieselbe logische Spalte ohne Wrapper", () => assert.deepEqual(refs.getM80IdsFromTarget(secondaryColumnCell), ["protokoll.list.column.text"]));
+    const labelBefore = refs.snapshotM80State("protokoll.edit.short.label");
+    await run("M82.6 BBM 42: Protokoll-Bezeichnung erlaubt direkte Schriftgroesse", () => { const result = host.handleM80EditorRequest({ action: "submitChange", scopeId: "protokoll.edit.root", changeRequest: { changeId: "protocol-font", elementId: "protokoll.edit.short.label", operation: "textResize", payload: { text: { fontSize: 13 } }, source: "target-app-start" } }).changeResult; assert.equal(result.success, true); assert.equal(result.newState.fontSize, 13); });
+    await run("M82.6 BBM 43: Undo stellt den vorherigen Labelzustand wieder her", () => { refs.applyM80State("protokoll.edit.short.label", labelBefore); assert.equal(refs.snapshotM80State("protokoll.edit.short.label").fontSize, labelBefore.fontSize); });
+    await run("M82.6 BBM 44: Protokoll-Feld erlaubt direkte Breite", () => { const result = host.handleM80EditorRequest({ action: "submitChange", scopeId: "protokoll.edit.root", changeRequest: { changeId: "protocol-width", elementId: "protokoll.edit.short.field", operation: "resizeWidth", payload: { width: 300 }, source: "target-app-start" } }).changeResult; assert.equal(result.success, true); assert.equal(result.newState.width, 300); });
+    await run("M82.6 BBM 45: vorhandene Gruppe erlaubt direkte Position", () => { const result = host.handleM80EditorRequest({ action: "submitChange", scopeId: "protokoll.edit.root", changeRequest: { changeId: "protocol-move", elementId: "protokoll.edit.short", operation: "move", payload: { x: 5, y: 1 }, source: "target-app-start" } }).changeResult; assert.equal(result.success, true); assert.equal(result.newState.x, 5); assert.equal(result.newState.y, 1); });
+    await run("M82.6 BBM 46: Protokoll-Registryrefresh bleibt topologieneutral", () => { refs.completeM80PilotRender(); assert.equal(refs.compareM80Topology(protocolBaseline).ok, true); });
+    await run("M82.6 BBM 47: Protokoll-Editieren und Undo veraendern keine Topologie", () => assert.equal(refs.compareM80Topology(protocolBaseline).ok, true));
+    await run("M82.6 BBM 48: Startprofil erzeugt deterministische Restore-Operationen", () => { const requests = host.createM80StartupRequests("protokoll.edit.root", { ...refs.snapshotM80State("protokoll.edit.short.field"), elementId: "protokoll.edit.short.field", width: 320 }); assert.equal(requests.some((item) => item.request.operation === "resizeWidth"), true); });
+  } finally {
+    refs.resetM80PilotWorkingStatesForDiagnostic();
+    global.document = previous.document; global.window = previous.window; global.Element = previous.Element;
+  }
+}
+
+module.exports = { runM826TopScreenModuleClosureTests };

--- a/scripts/tests/m82AppStarterPackage.test.cjs
+++ b/scripts/tests/m82AppStarterPackage.test.cjs
@@ -46,7 +46,7 @@ async function runM82AppStarterPackageTests(run) {
     assert.equal(byId.get("restarbeiten.header.root").status, "complete");
     assert.equal(byId.get("restarbeiten.header.root").elementCount, 31);
     assert.equal(byId.get("restarbeiten.list.root").status, "complete");
-    assert.equal(byId.get("restarbeiten.list.root").elementCount, 18);
+    assert.equal(byId.get("restarbeiten.list.root").elementCount, 16);
     assert.equal(byId.get("restarbeiten.edit.root").status, "complete");
     assert.equal(byId.get("restarbeiten.edit.root").elementCount, 53);
     assert.equal(byId.get("bbm.remaining").status, "blocked");

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1748,7 +1748,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(css.includes("grid-template-rows: auto minmax(0, 1fr);"), true);
     assert.equal(css.includes("flex-direction: column;"), true);
     assert.equal(css.includes("--bbm-restarbeiten-list-height"), false);
-    assert.equal(css.includes(".bbm-restarbeiten-main {\n  min-height: 0;\n  overflow: auto;"), true);
+    assert.equal(css.includes(".bbm-restarbeiten-main {\n  min-height: 0;\n  overflow-x: hidden;\n  overflow-y: auto;"), true);
     assert.equal(css.includes(".bbm-restarbeiten-screen {\n  min-height: 0;\n  height: 100%;\n  max-height: 100%;"), true);
     assert.equal(css.includes(".bbm-restarbeiten-record__number {\n  font-size: 8.5pt;\n  font-weight: 600;\n  line-height: 1.15;"), true);
     assert.equal(css.includes(".bbm-restarbeiten-record__short {\n  font-size: 8.5pt;\n  line-height: 1.35;\n  font-weight: 500;"), true);

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 106, "106 Suite-Einstiege einschließlich Entwicklungs-Lizenz, M82.4 und M82.5");
+    assert.equal(suites.length, 107, "107 Suite-Einstiege einschließlich Entwicklungs-Lizenz sowie M82.4 bis M82.6");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/src/main/ui-editor/electronUiEditorSession.js
+++ b/src/main/ui-editor/electronUiEditorSession.js
@@ -161,10 +161,14 @@ class ElectronUiEditorSessionController {
 
   #validateTargetManifest(contract) {
     const { manifest, manifestPath } = this.#readTargetManifest();
+    const declaredScopes = Array.isArray(manifest.activeScopes) ? manifest.activeScopes.map(String) : [];
+    const activeScopes = Array.isArray(contract.activeScopes) ? contract.activeScopes.map(String) : [];
+    const usesCompleteInventory = JSON.stringify(declaredScopes) === JSON.stringify(activeScopes);
     if (manifest.schemaVersion !== 2 || manifest.applicationId !== APPLICATION_ID || manifest.framework !== "electron" ||
         manifest.contractVersion !== contract.contractVersion || manifest.adapterVersion !== contract.adapterVersion ||
-        manifest.registryVersion !== contract.registryVersion || manifest.registryFingerprint !== contract.registryFingerprint ||
-        JSON.stringify(manifest.activeScopes) !== JSON.stringify(contract.activeScopes)) {
+        manifest.registryVersion !== contract.registryVersion ||
+        activeScopes.length === 0 || activeScopes.some((scopeId) => !declaredScopes.includes(scopeId)) ||
+        (usesCompleteInventory && manifest.registryFingerprint !== contract.registryFingerprint)) {
       throw new ElectronEditorError(ELECTRON_EDITOR_ERROR_CODES.REGISTRY_INCOMPATIBLE, "Ziel-App-Manifest und aktive Registry stimmen nicht überein.");
     }
     return manifestPath;

--- a/src/renderer/modules/protokoll/TopsList.js
+++ b/src/renderer/modules/protokoll/TopsList.js
@@ -3,6 +3,34 @@ import {
   normalizeTopShortText,
 } from "../../shared/text/topTextPresentation.js";
 import { applyProtokollTopsUiLayout } from "../../../shared/tableLayouts/protokollTopsLayout.js";
+import { completeM80PilotRender, registerM80Ref } from "../../ui-editor/m80Refs.js";
+
+const PROTOKOLL_LIST_COLUMN_REFS = Object.freeze([
+  Object.freeze({ id: "protokoll.list.column.number", key: "number", widthVariable: "--bbm-tops-list-number-col", minimumWidth: 40, maximumWidth: 220 }),
+  Object.freeze({ id: "protokoll.list.column.text", key: "text", widthVariable: "--bbm-tops-list-text-col", minimumWidth: 180, maximumWidth: 1400 }),
+  Object.freeze({ id: "protokoll.list.column.meta", key: "meta", widthVariable: "--bbm-tops-list-meta-col", minimumWidth: 50, maximumWidth: 420 }),
+]);
+
+function finite(value, fallback = 0) {
+  return Number.isFinite(Number(value)) ? Number(value) : fallback;
+}
+
+function readLogicalColumnState(id, element) {
+  const rect = element.getBoundingClientRect();
+  const style = globalThis.window?.getComputedStyle?.(element) || element.style || {};
+  return {
+    elementId: id,
+    x: 0,
+    y: 0,
+    width: finite(rect.width, 1),
+    height: finite(rect.height, 1),
+    textOffsetX: finite(parseFloat(style.paddingLeft)),
+    textOffsetY: finite(parseFloat(style.paddingTop)),
+    fontSize: finite(parseFloat(style.fontSize), 12),
+    visible: true,
+    spacing: {},
+  };
+}
 
 function getAssetBaseUrl() {
   if (typeof window !== "undefined" && window?.location?.href) return window.location.href;
@@ -57,6 +85,7 @@ export class TopsList {
       enabled: false,
       activeZone: null,
     };
+    this._uiEditorColumnRefs = { number: [], text: [], meta: [] };
     this.root = document.createElement("ul");
     this.root.setAttribute("data-bbm-tops-list-v2", "true");
     applyProtokollTopsUiLayout(this.root, this.tableLayout);
@@ -108,9 +137,28 @@ export class TopsList {
       this.root.innerHTML = "";
     }
     const rows = Array.isArray(items) ? items : [];
+    this._uiEditorColumnRefs = { number: [], text: [], meta: [] };
     for (const item of rows) {
       this.root.appendChild(this._renderRow(item));
     }
+    this._registerUiEditorColumnRefs();
+  }
+
+  _registerUiEditorColumnRefs() {
+    for (const column of PROTOKOLL_LIST_COLUMN_REFS) {
+      const targets = this._uiEditorColumnRefs[column.key] || [];
+      const primary = targets[0];
+      if (!primary) continue;
+      registerM80Ref(column.id, primary, {
+        targets,
+        read: () => readLogicalColumnState(column.id, primary),
+        apply: (state) => {
+          const width = Math.min(column.maximumWidth, Math.max(column.minimumWidth, finite(state.width, column.minimumWidth)));
+          this.root.style.setProperty(column.widthVariable, `${width}px`);
+        },
+      });
+    }
+    completeM80PilotRender();
   }
 
   _renderRow(item = {}) {
@@ -266,6 +314,9 @@ export class TopsList {
     }
 
     row.append(num, text, meta);
+    this._uiEditorColumnRefs.number.push(num);
+    this._uiEditorColumnRefs.text.push(text);
+    this._uiEditorColumnRefs.meta.push(meta);
     rowEl.appendChild(row);
 
     rowEl.onclick = async () => {

--- a/src/renderer/modules/protokoll/TopsScreenQuicklane.js
+++ b/src/renderer/modules/protokoll/TopsScreenQuicklane.js
@@ -1,4 +1,5 @@
 import { getTopFilterBadge, getTopFilterLabel, normalizeTopFilterMode } from "./topFilterMode.js";
+import { completeM80PilotRender, registerM80Ref } from "../../ui-editor/m80Refs.js";
 
 const ICON_CLASS = "bbm-tops-screen-quicklane-icon";
 const AMPEL_STATUS_ICON_URL = "./assets/icons/ampel-status.svg";
@@ -213,6 +214,36 @@ export class TopsScreenQuicklane {
     );
 
     this.root.append(navigation, visibility, filter, output);
+    this._registerUiEditorRefs({ navigation, visibility, filter, output });
+  }
+
+  _registerUiEditorRefs({ navigation, visibility, filter, output }) {
+    registerM80Ref("protokoll.topsScreen.quicklane", this.root);
+    const groups = [
+      ["protokoll.topsScreen.quicklane.group.navigation", navigation, [
+        "protokoll.topsScreen.quicklane.pin",
+        "protokoll.topsScreen.quicklane.action.project",
+        "protokoll.topsScreen.quicklane.action.firms",
+        "protokoll.topsScreen.quicklane.action.participants",
+      ]],
+      ["protokoll.topsScreen.quicklane.group.visibility", visibility, [
+        "protokoll.topsScreen.quicklane.action.ampel",
+        "protokoll.topsScreen.quicklane.action.longtext",
+      ]],
+      ["protokoll.topsScreen.quicklane.group.filter", filter, [
+        "protokoll.topsScreen.quicklane.action.topFilter",
+      ]],
+      ["protokoll.topsScreen.quicklane.group.output", output, [
+        "protokoll.topsScreen.quicklane.action.preview",
+        "protokoll.topsScreen.quicklane.action.print",
+        "protokoll.topsScreen.quicklane.action.mail",
+      ]],
+    ];
+    for (const [groupId, group, buttonIds] of groups) {
+      registerM80Ref(groupId, group);
+      buttonIds.forEach((buttonId, index) => registerM80Ref(buttonId, group.children[index]));
+    }
+    completeM80PilotRender();
   }
 
   _toggleFilterMenu(currentMode) {

--- a/src/renderer/modules/protokoll/screens/TopsScreen.js
+++ b/src/renderer/modules/protokoll/screens/TopsScreen.js
@@ -38,6 +38,11 @@ import {
   cleanupPopupHandlers,
 } from "../../../ui/popupCommon.js";
 import { OVERLAY_TOP } from "../../../ui/zIndex.js";
+import {
+  beginM80PilotRender,
+  completeM80PilotRender,
+  registerM80Ref,
+} from "../../../ui-editor/m80Refs.js";
 
 function buildInitialProtocolScreenState({ projectId = null, meetingId = null } = {}) {
   return {
@@ -159,6 +164,7 @@ export default class TopsScreen {
   // ---------------------------------------------------------------------------
 
   _buildShell() {
+    beginM80PilotRender();
     ensureProtokollModuleStyles();
     const root = document.createElement("div");
     root.setAttribute("data-bbm-tops-screen", "true");
@@ -192,7 +198,59 @@ export default class TopsScreen {
     sheetArea.appendChild(sheetCanvas);
     editArea.appendChild(editCanvas);
     root.append(this.header.root, sheetArea, editArea, this.quicklane.root);
+    this._registerUiEditorRefs();
+    completeM80PilotRender();
+  }
 
+  _registerUiEditorRefs() {
+    const header = this.header;
+    const workbench = this.workbench;
+    const editbox = workbench?.sharedEditboxCore?.editbox;
+    const meta = workbench?.metaColumn;
+    const status = meta?.statusAmpelBridge?.field;
+    const responsible = meta?.responsibleBridge?.field;
+
+    registerM80Ref("protokoll.screen.root", this.root);
+    registerM80Ref("protokoll.header", header.root);
+    registerM80Ref("protokoll.header.titleGroup", header.titleWrap);
+    registerM80Ref("protokoll.header.title", header.line1El);
+    registerM80Ref("protokoll.header.keyword", header.line2El);
+    registerM80Ref("protokoll.header.context", header.line3El);
+    registerM80Ref("protokoll.header.meta", header.metaLegend);
+    registerM80Ref("protokoll.header.meta.due", header.metaLegendDue);
+    registerM80Ref("protokoll.header.meta.status", header.metaLegendStatus);
+    registerM80Ref("protokoll.header.meta.responsible", header.metaLegendResponsible);
+    registerM80Ref("protokoll.topsScreen.quicklane", this.quicklane.root);
+
+    registerM80Ref("protokoll.list.root", this.sheetArea);
+    registerM80Ref("protokoll.list.canvas", this.sheetCanvas);
+    registerM80Ref("protokoll.list.paper", this.sheetPaper);
+    registerM80Ref("protokoll.list.table", this.topsList.root);
+
+    registerM80Ref("protokoll.edit.root", this.editArea);
+    registerM80Ref("protokoll.edit.canvas", this.editCanvas);
+    registerM80Ref("protokoll.edit.workbench", workbench.root);
+    registerM80Ref("protokoll.edit.header", workbench.header);
+    registerM80Ref("protokoll.edit.header.label", workbench.leftHeaderTitle);
+    registerM80Ref("protokoll.edit.text", workbench.sharedEditboxCore.root);
+    registerM80Ref("protokoll.edit.short", editbox.shortWrap);
+    registerM80Ref("protokoll.edit.short.label", editbox.shortLabel);
+    registerM80Ref("protokoll.edit.short.field", editbox.shortInput);
+    registerM80Ref("protokoll.edit.long", editbox.longWrap);
+    registerM80Ref("protokoll.edit.long.label", editbox.longLabel);
+    registerM80Ref("protokoll.edit.long.field", editbox.longInput);
+    registerM80Ref("protokoll.edit.meta", meta.root);
+    registerM80Ref("protokoll.edit.flags", meta.flagsMetaRow);
+    registerM80Ref("protokoll.edit.status", status.statusWrap);
+    registerM80Ref("protokoll.edit.status.label", status.statusLabel);
+    registerM80Ref("protokoll.edit.status.field", status.statusSelect);
+    registerM80Ref("protokoll.edit.due", status.dueWrap);
+    registerM80Ref("protokoll.edit.due.label", status.dueLabel);
+    registerM80Ref("protokoll.edit.due.field", status.dueInput);
+    registerM80Ref("protokoll.edit.responsible", responsible.root);
+    registerM80Ref("protokoll.edit.responsible.label", responsible.labelTextEl);
+    registerM80Ref("protokoll.edit.responsible.field", responsible.selectEl);
+    registerM80Ref("protokoll.edit.ampel", status.trafficWrap);
   }
 
   _buildProtocolScreenRegions() {
@@ -738,13 +796,6 @@ export default class TopsScreen {
     this._topRulesOverlay = null;
   }
 
-  destroy() {
-    if (this._onTableLayoutChanged && typeof window?.removeEventListener === "function") {
-      window.removeEventListener("bbm:tableLayoutChanged", this._onTableLayoutChanged);
-    }
-    this._onTableLayoutChanged = null;
-  }
-
   _syncListState() {
     if (!(this.topsList instanceof TopsList)) return;
     this.topsList.setItems(
@@ -752,6 +803,7 @@ export default class TopsScreen {
         collapsedLevel1Ids: this._getCollapsedLevel1Ids(),
       })
     );
+    completeM80PilotRender();
   }
 
   _getTopListLayoutApi() {
@@ -1640,6 +1692,10 @@ export default class TopsScreen {
   // ---------------------------------------------------------------------------
 
   async destroy() {
+    if (this._onTableLayoutChanged && typeof window?.removeEventListener === "function") {
+      window.removeEventListener("bbm:tableLayoutChanged", this._onTableLayoutChanged);
+    }
+    this._onTableLayoutChanged = null;
     await this.closeFlow?.destroy?.();
     this._destroyAudioFeature?.();
     this._destroyDictationController?.();

--- a/src/renderer/modules/restarbeiten/RestarbeitenMainBody.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenMainBody.js
@@ -25,17 +25,13 @@ export function buildRestarbeitenMainBody(options = {}) {
   const table = createEl("div", {
     className: "bbm-restarbeiten-table",
   });
-  const viewport = createEl("div", { className: "bbm-restarbeiten-table-viewport" });
-  const scrollArea = createEl("div", { className: "bbm-restarbeiten-table-scroll-area" });
   const header = buildRestarbeitenTableHeader();
   const records = buildRestarbeitenList(options);
 
   registerM80Ref("restarbeiten.list.root", main);
   registerM80Ref("restarbeiten.list.area", sheet);
   registerM80Ref("restarbeiten.list.paper", paper);
-  registerM80Ref("restarbeiten.list.viewport", viewport);
-  registerM80Ref("restarbeiten.list.scrollArea", scrollArea);
-  registerM80TableRef("restarbeiten.list.table", table, viewport, scrollArea);
+  registerM80TableRef("restarbeiten.list.table", table, table);
   registerM80Ref("restarbeiten.list.table.header", header);
   registerM80Ref("restarbeiten.list.table.body", records);
   registerM80Ref("restarbeiten.list.table.row", records._m80Rows[0] || records, { targets: records._m80Rows });
@@ -44,7 +40,7 @@ export function buildRestarbeitenMainBody(options = {}) {
     header.children[0],
     records._m80ColumnCells[0],
     table,
-    viewport,
+    table,
     "--bbm-restarbeiten-number-column",
     82
   );
@@ -53,7 +49,7 @@ export function buildRestarbeitenMainBody(options = {}) {
     header.children[1],
     records._m80ColumnCells[1],
     table,
-    viewport,
+    table,
     "--bbm-restarbeiten-subject-column",
     560
   );
@@ -62,15 +58,13 @@ export function buildRestarbeitenMainBody(options = {}) {
     header.children[2],
     records._m80ColumnCells[2],
     table,
-    viewport,
+    table,
     "--bbm-restarbeiten-meta-column",
     172
   );
 
   table.append(header, records);
-  scrollArea.appendChild(table);
-  viewport.appendChild(scrollArea);
-  paper.appendChild(viewport);
+  paper.appendChild(table);
   sheet.appendChild(paper);
   main.appendChild(sheet);
   return main;

--- a/src/renderer/modules/restarbeiten/styles/restarbeiten.css
+++ b/src/renderer/modules/restarbeiten/styles/restarbeiten.css
@@ -360,7 +360,8 @@
 
 .bbm-restarbeiten-main {
   min-height: 0;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 10px 72px 12px 16px;
 }
 
@@ -379,21 +380,6 @@
   background: var(--bbm-panel);
   box-shadow: var(--bbm-shadow-soft);
   padding: 18px 20px;
-}
-
-.bbm-restarbeiten-table-viewport {
-  width: 100%;
-  min-width: 0;
-  max-width: 100%;
-  overflow: hidden;
-}
-
-.bbm-restarbeiten-table-scroll-area {
-  width: 100%;
-  min-width: 0;
-  max-width: 100%;
-  overflow-x: auto;
-  overflow-y: visible;
 }
 
 .bbm-restarbeiten-table {

--- a/src/renderer/ui-editor/m80HostAdapter.js
+++ b/src/renderer/ui-editor/m80HostAdapter.js
@@ -1,5 +1,5 @@
 import {
-  BBM_M80_ACTIVE_SCOPES,
+  BBM_M80_ACTIVE_SCOPE_GROUPS,
   BBM_M80_REGISTRY_STATUS,
   BBM_M80_REGISTRY_VERSION,
   getM80RegistryEntry,
@@ -18,6 +18,8 @@ import {
   fitM80Table,
   resetM80Table,
   resetM80PilotWorkingStatesForDiagnostic,
+  snapshotM80Topology,
+  compareM80Topology,
   snapshotM80State,
   snapshotM80Geometry,
 } from "./m80Refs.js";
@@ -320,6 +322,7 @@ function submitChange(changeRequest, scopeId) {
   let groupRestore = null;
   const tableRestore = new Map();
   try {
+    const beforeTopology = snapshotM80Topology();
     const beforeGeometry = snapshotM80Geometry();
     const ref = getM80Ref(entry.id);
     if (ref?.element?.dataset?.uiEditorFailNextApply === "true") {
@@ -383,6 +386,8 @@ function submitChange(changeRequest, scopeId) {
     }
     clearGeometryRiskPreview();
     if (confirmation) pendingGeometryRisks.delete(confirmation.risk.operationId);
+    const topology = compareM80Topology(beforeTopology);
+    if (!topology.ok) throw Object.assign(new Error("Die Layoutaenderung wuerde die produktive UI-Topologie veraendern."), { code: topology.errorCode });
     return { success: true, changeId: request.changeId, elementId: entry.id, operation: request.operation, effectScope: affected.effect, affectedElementIds: [...affected.ids], affectedStates, errorCode: null, message: confirmation?.action === RISK_ACTIONS.PRESERVE_SPACE ? "Elementbreite geändert; frei gewordener Platz bleibt reserviert." : "Layoutänderung angewandt, geometrisch geprüft und zurückgelesen.", previousState: previous, newState: readback, rollbackSucceeded: true };
   } catch (error) {
     try {
@@ -410,9 +415,23 @@ function layoutPayload() {
   }));
 }
 
+function mountedActiveScopeGroup() {
+  return BBM_M80_ACTIVE_SCOPE_GROUPS.find((scopeIds) => getM80Ref(scopeIds[0])) || Object.freeze([]);
+}
+
 export function createM80RegistrationDescriptor() {
+  const mountedScopes = mountedActiveScopeGroup();
   const registryScopes = listM80RegistryScopes().map((scope) => {
     if (scope.status !== "complete") return scope;
+    if (!mountedScopes.includes(scope.scopeId)) {
+      return {
+        ...scope,
+        status: "blocked",
+        reason: "registry_reference_not_mounted",
+        expectedElementIds: [],
+        elements: [],
+      };
+    }
     const elements = scope.elements.map((entry) => {
       const resolved = { ...entry, ...getM80ReferenceStatus(entry.id), capturedBaseline: capturedRuntimeBaseline(entry) };
       if (diagnosticRegistryRevision > 0 && entry.id === "restarbeiten.edit.validation") {
@@ -434,7 +453,7 @@ export function createM80RegistrationDescriptor() {
       elements,
     };
   });
-  const activeScopes = BBM_M80_ACTIVE_SCOPES.filter((scopeId) => registryScopes.some((scope) => scope.scopeId === scopeId && scope.status === "complete"));
+  const activeScopes = mountedScopes.filter((scopeId) => registryScopes.some((scope) => scope.scopeId === scopeId && scope.status === "complete"));
   return {
     applicationId: "bbm-produktiv",
     displayName: "BBM",
@@ -665,7 +684,11 @@ export function createM80StartupRequests(scopeId, element, explicitOperations = 
   for (const target of entry.spacingTargets || []) {
     const desiredValue = Number(desiredSpacing[target] || 0);
     const currentValue = Number(current.spacing?.[target] || 0);
-    if (Math.abs(desiredValue - currentValue) > 0.01 && entry.allowedOps.includes("spacingSet")) {
+    const spacingWasExplicit = explicit === null ||
+      ["spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"].some((operation) => explicit.has(operation)) ||
+      (target === "reservedWidth" && explicit.has("resizeWidth")) ||
+      (target === "reservedHeight" && explicit.has("resizeHeight"));
+    if (spacingWasExplicit && Math.abs(desiredValue - currentValue) > 0.01 && entry.allowedOps.includes("spacingSet")) {
       requests.push({ changeId: `startup-${requests.length + 1}-${entry.id}`, elementId: entry.id, operation: "spacingSet", payload: { spacing: { target, value: desiredValue } }, source: "target-app-start" });
     }
   }
@@ -689,7 +712,8 @@ export function restoreM80StartupLayout() {
       return startupRestoreStatus;
     }
     const registration = createM80RegistrationDescriptor();
-    if (registration.activeScopes.length !== BBM_M80_ACTIVE_SCOPES.length) {
+    const requiredScopes = mountedActiveScopeGroup();
+    if (!requiredScopes.length || registration.activeScopes.length !== requiredScopes.length) {
       startupRestoreStatus = { state: "waitingForRegistry", applied: false, code: "registry_reference_missing", editorProcessRequired: false };
       return startupRestoreStatus;
     }

--- a/src/renderer/ui-editor/m80Refs.js
+++ b/src/renderer/ui-editor/m80Refs.js
@@ -4,11 +4,17 @@ import {
   measureTableLayout,
   normalizeTableLayout,
 } from "../../../node_modules/ui-editor-kit/dist/table-layout-contract.mjs";
+import {
+  compareUiTopology,
+  createUiTopologyFingerprint,
+} from "../../../node_modules/ui-editor-kit/dist/ui-topology-fingerprint.mjs";
 
 const refs = new Map();
 const elementIds = new WeakMap();
 const workingStates = new Map();
+const persistentWorkingStateIds = new Set();
 const tableColumnRuntimeBindings = new Map();
+const tableRuntimeBindings = new Map();
 const HIDDEN_CLASS = "bbm-ui-editor-hidden";
 
 function finite(value, fallback = 0) { return Number.isFinite(Number(value)) ? Number(value) : fallback; }
@@ -35,6 +41,60 @@ function bindElementId(target, id) {
   const ids = elementIds.get(target) || new Set();
   ids.add(id);
   elementIds.set(target, ids);
+}
+
+function topologyStableId(element, fallback) {
+  return String(element?.getAttribute?.("data-ui-editor-id") || element?.dataset?.uiEditorId || element?.id || fallback || "").trim();
+}
+
+function isDynamicTopologyElement(element, stableId) {
+  if (stableId.startsWith("restarbeiten.record.") || stableId.startsWith("protokoll.record.")) return true;
+  let current = element;
+  while (current) {
+    const names = String(current.className || "").split(/\s+/);
+    if (names.includes("bbm-restarbeiten-record") || names.includes("bbm-tops-list-row")) return true;
+    current = current.parentElement;
+  }
+  return false;
+}
+
+export function snapshotM80Topology() {
+  const byElement = new Map();
+  for (const ref of refs.values()) {
+    const element = ref.element;
+    if (!isElementRef(element) || byElement.has(element)) continue;
+    const stableId = topologyStableId(element, ref.id);
+    if (!stableId || isDynamicTopologyElement(element, stableId)) continue;
+    byElement.set(element, { element, stableId, kind: String(element.tagName || element.nodeName || element.constructor?.name || "Element") });
+  }
+  const roots = [...byElement.values()].filter((item) => {
+    let ancestor = item.element.parentElement;
+    while (ancestor && !byElement.has(ancestor)) ancestor = ancestor.parentElement;
+    return !ancestor;
+  }).map((item) => item.element);
+  const nodes = [...byElement.values()].map((candidate, fallbackOrder) => {
+    let parent = candidate.element.parentElement;
+    while (parent && !byElement.has(parent)) parent = parent.parentElement;
+    const parentCandidate = parent ? byElement.get(parent) : null;
+    const siblings = parentCandidate
+      ? Array.from(parentCandidate.element.children || []).filter((child) => byElement.has(child))
+      : roots;
+    const order = siblings.indexOf(candidate.element);
+    return {
+      kind: candidate.kind,
+      stableId: candidate.stableId,
+      parentId: parentCandidate?.stableId || null,
+      order: order >= 0 ? order : fallbackOrder,
+    };
+  });
+  return Object.freeze({ nodes: Object.freeze(nodes), fingerprint: createUiTopologyFingerprint(nodes) });
+}
+
+export function compareM80Topology(before) {
+  const previous = Array.isArray(before) ? before : before?.nodes;
+  if (!Array.isArray(previous)) throw new TypeError("Vorheriger BBM-Topologiesnapshot fehlt.");
+  const current = snapshotM80Topology();
+  return Object.freeze({ ...compareUiTopology(previous, current.nodes), current });
 }
 function readSpacing(element) {
   try {
@@ -111,12 +171,15 @@ function applyGeneric(element, state, entry) {
 export function beginM80PilotRender() {
   refs.clear();
   tableColumnRuntimeBindings.clear();
+  tableRuntimeBindings.clear();
 }
 
 export function resetM80PilotWorkingStatesForDiagnostic() {
   refs.clear();
   tableColumnRuntimeBindings.clear();
+  tableRuntimeBindings.clear();
   workingStates.clear();
+  persistentWorkingStateIds.clear();
 }
 
 export function registerM80Ref(id, element, custom = {}) {
@@ -134,18 +197,18 @@ export function registerM80Ref(id, element, custom = {}) {
   };
   refs.set(id, ref);
   targets.forEach((target) => bindElementId(target, id));
-  if (workingStates.has(id)) ref.apply(workingStates.get(id));
+  if (persistentWorkingStateIds.has(id) && workingStates.has(id)) ref.apply(workingStates.get(id));
   return element;
 }
 
 export function completeM80PilotRender() {
   for (const ref of refs.values()) {
     if (typeof ref.element.isConnected === "boolean" && !ref.element.isConnected) continue;
-    if (workingStates.has(ref.id)) ref.apply(workingStates.get(ref.id));
+    if (persistentWorkingStateIds.has(ref.id) && workingStates.has(ref.id)) ref.apply(workingStates.get(ref.id));
     const current = ref.read();
-    if (!workingStates.has(ref.id)) workingStates.set(ref.id, { ...current });
+    if (!persistentWorkingStateIds.has(ref.id)) workingStates.set(ref.id, { ...current });
   }
-  if (typeof window?.dispatchEvent === "function") {
+  if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
     const event = typeof CustomEvent === "function" ? new CustomEvent("bbm:m80-pilot-render-complete") : { type: "bbm:m80-pilot-render-complete" };
     window.dispatchEvent(event);
   }
@@ -179,11 +242,11 @@ function applyColumnTextMode(targets, tableState) {
   }
 }
 
-export function registerM80TableColumnRef(id, headerCell, dataCells, tableElement, viewportElement, cssVariable, initialWidth) {
+export function registerM80TableColumnRef(id, headerCell, dataCells, tableElement, layoutBoundsElement, cssVariable, initialWidth) {
   const entry = getM80RegistryEntry(id);
   const layout = entry.tableColumnLayout;
   const targets = [headerCell, ...(Array.isArray(dataCells) ? dataCells : [])];
-  tableColumnRuntimeBindings.set(id, { entry, headerCell, tableElement, viewportElement, cssVariable, initialWidth });
+  tableColumnRuntimeBindings.set(id, { entry, headerCell, tableElement, layoutBoundsElement, cssVariable, initialWidth });
   const baselineTable = {
     tableId: entry.tableBinding.tableId, columnId: id, widthMode: layout.widthMode,
     wrapMode: layout.wrapMode, overflowMode: layout.overflowMode,
@@ -196,7 +259,7 @@ export function registerM80TableColumnRef(id, headerCell, dataCells, tableElemen
       const table = storedColumnState(tableElement, id, baselineTable);
       const configured = parseFloat(getCustomProperty(tableElement.style, cssVariable));
       const width = positive(configured, positive(rect.width, initialWidth));
-      const metrics = runtimeTableMetrics(entry.tableBinding.tableId, tableElement, viewportElement);
+      const metrics = runtimeTableMetrics(entry.tableBinding.tableId, tableElement, layoutBoundsElement);
       return {
         elementId: id, x: 0, y: 0, width, height: positive(rect.height, 1),
         textOffsetX: finite(headerCell.dataset.uiEditorTextX, finite(parseFloat(style.paddingLeft))),
@@ -224,18 +287,18 @@ export function registerM80TableColumnRef(id, headerCell, dataCells, tableElemen
     },
   });
   registerM80Ref(layout.headerElementId, headerCell, { targets: [headerCell] });
-  registerM80Ref(layout.dataCellTemplateId, dataCells?.[0] || viewportElement, {
+  registerM80Ref(layout.dataCellTemplateId, dataCells?.[0] || tableElement, {
     targets: dataCells,
     applyPrimaryAttributes: Boolean(dataCells?.length),
   });
   return headerCell;
 }
 
-function runtimeTableMetrics(tableId, tableElement, viewportElement) {
+function runtimeTableMetrics(tableId, tableElement, layoutBoundsElement) {
   const tableEntry = getM80RegistryEntry(tableId);
   if (!tableEntry?.tableLayout) return {};
   const tableRect = rectOf(tableElement);
-  const viewportRect = rectOf(viewportElement);
+  const viewportRect = rectOf(layoutBoundsElement);
   const columns = tableEntry.tableLayout.columns.map((column) => {
     const binding = tableColumnRuntimeBindings.get(column.columnId);
     const columnState = storedColumnState(tableElement, column.columnId, column);
@@ -264,9 +327,9 @@ function runtimeTableMetrics(tableId, tableElement, viewportElement) {
   };
 }
 
-function runtimeTableLayout(entry, tableElement, viewportElement) {
+function runtimeTableLayout(entry, tableElement, layoutBoundsElement) {
   const tableRect = rectOf(tableElement);
-  const viewportRect = rectOf(viewportElement);
+  const viewportRect = rectOf(layoutBoundsElement);
   const columns = entry.tableLayout.columns.map((column) => {
     const state = getM80Ref(column.columnId)?.read();
     return { ...column, currentWidth: positive(state?.width, column.currentWidth), widthMode: state?.table?.widthMode || column.widthMode, wrapMode: state?.table?.wrapMode || column.wrapMode, overflowMode: state?.table?.overflowMode || column.overflowMode, visibility: state?.visible !== false };
@@ -282,24 +345,21 @@ function runtimeTableLayout(entry, tableElement, viewportElement) {
   });
 }
 
-export function registerM80TableRef(id, tableElement, viewportElement, scrollAreaElement) {
+export function registerM80TableRef(id, tableElement, layoutBoundsElement = tableElement) {
   const entry = getM80RegistryEntry(id);
+  tableRuntimeBindings.set(id, { tableElement, layoutBoundsElement });
   return registerM80Ref(id, tableElement, {
     read: () => {
       const generic = readGeneric(tableElement, id);
-      const layout = runtimeTableLayout(entry, tableElement, viewportElement);
+      const layout = runtimeTableLayout(entry, tableElement, layoutBoundsElement);
       const metrics = measureTableLayout(layout);
       return { ...generic, table: { tableId: id, horizontalOverflowMode: layout.horizontalOverflowMode, rowHeightMode: layout.rowHeightMode, viewportWidth: metrics.viewportWidth, tableWidth: metrics.tableWidth, overflow: metrics.overflow, overflowColumnIds: [...metrics.overflowColumnIds] } };
     },
     apply: (state) => {
       applyGeneric(tableElement, state, entry);
       const table = state.table || {};
-      const horizontal = table.horizontalOverflowMode || entry.tableLayout.horizontalOverflowMode;
       const rowHeight = table.rowHeightMode || entry.tableLayout.rowHeightMode;
-      tableElement.dataset.uiEditorHorizontalOverflowMode = horizontal;
       tableElement.dataset.uiEditorRowHeightMode = rowHeight;
-      scrollAreaElement.style.overflowX = horizontal === "scroll" ? "scroll" : horizontal === "none" || horizontal === "fitViewport" ? "hidden" : "auto";
-      tableElement.style.maxWidth = horizontal === "fitViewport" ? "100%" : "none";
     },
   });
 }
@@ -308,7 +368,8 @@ export function fitM80Table(id, selectedColumnId = "") {
   const entry = getM80RegistryEntry(id);
   const ref = getM80Ref(id);
   if (!entry?.tableLayout || !ref) throw Object.assign(new Error("Tabellenreferenz fehlt."), { code: "electron_element_not_found" });
-  const layout = runtimeTableLayout(entry, ref.element, getM80Ref("restarbeiten.list.viewport")?.element || ref.element);
+  const binding = tableRuntimeBindings.get(id);
+  const layout = runtimeTableLayout(entry, binding?.tableElement || ref.element, binding?.layoutBoundsElement || ref.element);
   const result = fitTableToViewport(layout, selectedColumnId ? { selectedColumnId } : {});
   if (!result.ok) throw Object.assign(new Error("Tabelle kann nicht an den sichtbaren Bereich angepasst werden."), { code: "electron_invalid_geometry" });
   const affectedStates = [];
@@ -395,6 +456,7 @@ export function applyM80State(id, state) {
   if (!ref) throw Object.assign(new Error("Explizite Elementreferenz fehlt."), { code: "electron_element_not_found" });
   ref.apply(state);
   const readback = ref.read();
+  persistentWorkingStateIds.add(id);
   workingStates.set(id, { ...readback });
   return { ...readback };
 }

--- a/src/renderer/ui-editor/m80Registry.js
+++ b/src/renderer/ui-editor/m80Registry.js
@@ -1,4 +1,4 @@
-export const BBM_M80_REGISTRY_VERSION = 7;
+export const BBM_M80_REGISTRY_VERSION = 9;
 export const BBM_M80_REGISTRY_STATUS = "incomplete";
 
 const GROUP_LAYOUT = Object.freeze(["move", "setVisibility"]);
@@ -7,7 +7,7 @@ const TEXT_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "textR
 const FIELD_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "textResize", "setVisibility"]);
 const BUTTON_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "setVisibility"]);
 const ICON_LAYOUT = Object.freeze(["resizeWidth", "resizeHeight", "setVisibility"]);
-const TABLE_LAYOUT = Object.freeze(["resizeHeight", "setVisibility", "fitTableToViewport", "resizeColumnsProportionally", "setHorizontalOverflowMode", "setRowHeightMode", "resetTable"]);
+const TABLE_LAYOUT = Object.freeze(["resizeHeight", "setVisibility", "fitTableToViewport", "resizeColumnsProportionally", "setRowHeightMode", "resetTable"]);
 const COLUMN_LAYOUT = Object.freeze(["resizeWidth", "textResize", "setVisibility", "setColumnWidthMode", "setColumnWrapMode", "setColumnOverflowMode", "resetTableColumn"]);
 const SPACING_LAYOUT = Object.freeze(["spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"]);
 const DOMAIN_LOCKS = Object.freeze(["executeTargetAction", "modifyDomainData", "createRecord", "deleteRecord"]);
@@ -135,9 +135,9 @@ const listTableLayout = Object.freeze({
   bounds: Object.freeze({ left: 0, top: 0, width: 858, height: 680 }),
   viewportBounds: Object.freeze({ left: 0, top: 0, width: 858, height: 680 }),
   contentBounds: Object.freeze({ left: 0, top: 0, width: 858, height: 680 }),
-  parentId: "restarbeiten.list.scrollArea",
+  parentId: "restarbeiten.list.paper",
   columnIds: Object.freeze(listTableColumns.map((column) => column.columnId)),
-  rowTemplateId: "restarbeiten.list.table.row", horizontalOverflowMode: "auto", verticalOverflowMode: "auto",
+  rowTemplateId: "restarbeiten.list.table.row", horizontalOverflowMode: "fitViewport", verticalOverflowMode: "none",
   widthPolicy: "bounded", minimumWidth: 320, maximumWidth: 1600, reservedWidth: 44, scrollbarWidth: 0,
   rowHeightMode: "bounded", minimumRowHeight: 54, maximumRowHeight: 180, columns: listTableColumns,
 });
@@ -150,9 +150,7 @@ const listElements = [
   element({ id: "restarbeiten.list.root", name: "Restarbeiten · Liste", type: "root", role: "scopeRoot", parentId: null, order: 0, editable: false, allowedOps: [], componentKind: "scope" }),
   element({ id: "restarbeiten.list.area", name: "Restarbeiten-Liste", type: "area", role: "contentArea", parentId: "restarbeiten.list.root", order: 10, allowedOps: GROUP_LAYOUT, componentKind: "contentArea", baseline: { width: 900, height: 420, minWidth: 320, minHeight: 180 } }),
   element({ id: "restarbeiten.list.paper", name: "Gruppe Listenblatt", type: "group", role: "layoutGroup", parentId: "restarbeiten.list.area", order: 20, allowedOps: GROUP_LAYOUT, componentKind: "paper", baseline: { width: 900, height: 720, minWidth: 320, minHeight: 240 } }),
-  element({ id: "restarbeiten.list.viewport", name: "Sichtbarer Inhaltsbereich der Restarbeiten-Liste", type: "tableViewport", role: "tableViewport", parentId: "restarbeiten.list.paper", order: 21, allowedOps: [], componentKind: "tableViewport" }),
-  element({ id: "restarbeiten.list.scrollArea", name: "Horizontaler Scrollbereich der Restarbeiten-Liste", type: "horizontalScrollArea", role: "horizontalScrollArea", parentId: "restarbeiten.list.viewport", order: 22, allowedOps: [], componentKind: "scrollArea" }),
-  element({ id: "restarbeiten.list.table", name: "Restarbeiten-Hauptliste", type: "table", role: "contentTable", parentId: "restarbeiten.list.scrollArea", order: 30, allowedOps: TABLE_LAYOUT, componentKind: "contentTable", tableLayout: listTableLayout, baseline: { width: 858, height: 680, minWidth: 320, maxWidth: 1600, minHeight: 160, maxHeight: 12000 } }),
+  element({ id: "restarbeiten.list.table", name: "Restarbeiten-Hauptliste", type: "table", role: "contentTable", parentId: "restarbeiten.list.paper", order: 30, allowedOps: TABLE_LAYOUT, componentKind: "contentTable", tableLayout: listTableLayout, baseline: { width: 858, height: 680, minWidth: 320, maxWidth: 1600, minHeight: 160, maxHeight: 12000 } }),
   ...listTableColumns.map((column, index) => element({ id: column.columnId, name: column.displayName, type: "tableColumn", role: index === 2 ? "metaColumn" : "contentColumn", parentId: "restarbeiten.list.table", order: 31 + index, allowedOps: COLUMN_LAYOUT, columnRole: index === 2 ? "metaColumn" : "contentColumn", tableColumnLayout: column, tableBinding: tableBinding(column.columnId, "column"), baseline: { width: column.currentWidth, height: 28, minWidth: column.minimumWidth, maxWidth: column.maximumWidth } })),
   element({ id: "restarbeiten.list.table.header", name: "Tabellenkopf der Restarbeiten-Liste", type: "tableHeader", role: "tableHeader", parentId: "restarbeiten.list.table", order: 40, allowedOps: [], componentKind: "tableHeader" }),
   element({ id: "restarbeiten.list.table.body", name: "Datenbereich der Restarbeiten-Liste", type: "tableBody", role: "tableBody", parentId: "restarbeiten.list.table", order: 50, allowedOps: [], componentKind: "tableBody" }),
@@ -212,23 +210,109 @@ const editElements = [
   domainButton({ id: "restarbeiten.edit.action.note", name: "Notizbutton", parentId: "restarbeiten.edit.meta", order: 102, actionKind: "domainNote" }),
 ];
 
+const PROTOKOLL_GROUP_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight"]);
+const PROTOKOLL_COLUMN_LAYOUT = Object.freeze(["resizeWidth"]);
+
+const protokollScreenElements = [
+  element({ id: "protokoll.screen.root", name: "Protokoll-TopScreen", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: [], componentKind: "screen" }),
+  element({ id: "protokoll.header", name: "Protokoll-Kopfbereich", type: "area", role: "contentArea", parentId: "protokoll.screen.root", order: 10, allowedOps: GROUP_LAYOUT, componentKind: "header" }),
+  element({ id: "protokoll.header.titleGroup", name: "Gruppe Protokollbezeichnung", type: "group", role: "layoutGroup", parentId: "protokoll.header", order: 20, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "titleGroup" }),
+  element({ id: "protokoll.header.title", name: "Bezeichnung Protokoll", type: "label", role: "fieldLabel", parentId: "protokoll.header.titleGroup", order: 21, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "protokoll.header.keyword", name: "Schlagwort", type: "label", role: "dataFieldLayout", parentId: "protokoll.header.titleGroup", order: 22, allowedOps: TEXT_LAYOUT, componentKind: "interactiveLabel", lockedOps: DOMAIN_LOCKS }),
+  element({ id: "protokoll.header.context", name: "Protokollkontext", type: "label", role: "status", parentId: "protokoll.header.titleGroup", order: 23, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "protokoll.header.meta", name: "Gruppe Listenbezeichnungen", type: "group", role: "layoutGroup", parentId: "protokoll.header", order: 30, allowedOps: GROUP_LAYOUT, componentKind: "tableLegend" }),
+  element({ id: "protokoll.header.meta.due", name: "Bezeichnung Fertig bis", type: "label", role: "fieldLabel", parentId: "protokoll.header.meta", order: 31, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "protokoll.header.meta.status", name: "Bezeichnung Status", type: "label", role: "fieldLabel", parentId: "protokoll.header.meta", order: 32, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "protokoll.header.meta.responsible", name: "Bezeichnung Verantwortlich", type: "label", role: "fieldLabel", parentId: "protokoll.header.meta", order: 33, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "protokoll.topsScreen.quicklane", name: "Protokoll-Quicklane", type: "area", role: "layout", parentId: "protokoll.screen.root", order: 40, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "toolbar" }),
+  ...[
+    ["navigation", "Navigation", 41],
+    ["visibility", "Sichtbarkeit", 42],
+    ["filter", "TOP-Filter", 43],
+    ["output", "Ausgabe", 44],
+  ].map(([key, name, order]) => element({ id: `protokoll.topsScreen.quicklane.group.${key}`, name: `Gruppe ${name}`, type: "group", role: "layoutGroup", parentId: "protokoll.topsScreen.quicklane", order, allowedOps: GROUP_LAYOUT, componentKind: "toolbarGroup" })),
+  ...[
+    ["pin", "Fixieren", "navigation", 50],
+    ["action.project", "Projekt", "navigation", 51],
+    ["action.firms", "Firmen", "navigation", 52],
+    ["action.participants", "Teilnehmer", "navigation", 53],
+    ["action.ampel", "Ampel", "visibility", 54],
+    ["action.longtext", "Langtext", "visibility", 55],
+    ["action.topFilter", "TOP-Filter", "filter", 56],
+    ["action.preview", "PDF-Vorschau", "output", 57],
+    ["action.print", "Drucken", "output", 58],
+    ["action.mail", "E-Mail", "output", 59],
+  ].map(([key, name, group, order]) => domainButton({ id: `protokoll.topsScreen.quicklane.${key}`, name, parentId: `protokoll.topsScreen.quicklane.group.${group}`, order, actionKind: "domainAction" })),
+];
+
+const protokollListColumns = Object.freeze([
+  Object.freeze({ id: "protokoll.list.column.number", name: "TOP / Nummer", currentWidth: 64, minimumWidth: 40, maximumWidth: 220, widthSourceId: "--bbm-tops-list-number-col", order: 31, role: "metaColumn" }),
+  Object.freeze({ id: "protokoll.list.column.text", name: "Gegenstand / Kurztext / Langtext", currentWidth: 650, minimumWidth: 180, maximumWidth: 1400, widthSourceId: "--bbm-tops-list-text-col", order: 32, role: "contentColumn" }),
+  Object.freeze({ id: "protokoll.list.column.meta", name: "Status / Fertig bis / Verantwortlich", currentWidth: 74, minimumWidth: 50, maximumWidth: 420, widthSourceId: "--bbm-tops-list-meta-col", order: 33, role: "metaColumn" }),
+]);
+
+const protokollListElements = [
+  element({ id: "protokoll.list.root", name: "Protokoll-Listenbereich", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: [], componentKind: "sheetScrollOwner" }),
+  element({ id: "protokoll.list.canvas", name: "Protokoll-Dokumentfläche", type: "area", role: "contentArea", parentId: "protokoll.list.root", order: 10, allowedOps: [], componentKind: "documentCanvas" }),
+  element({ id: "protokoll.list.paper", name: "Protokoll-Dokumentblatt", type: "group", role: "layoutGroup", parentId: "protokoll.list.canvas", order: 20, allowedOps: [], componentKind: "documentPaper" }),
+  element({ id: "protokoll.list.table", name: "Protokoll-TOP-Liste", type: "group", role: "contentTable", parentId: "protokoll.list.paper", order: 30, allowedOps: [], componentKind: "existingContentTable" }),
+  ...protokollListColumns.map((column) => element({ id: column.id, name: column.name, type: "group", role: column.role, parentId: "protokoll.list.table", order: column.order, allowedOps: PROTOKOLL_COLUMN_LAYOUT, columnRole: column.role, componentKind: "logicalColumn", baseline: { width: column.currentWidth, minWidth: column.minimumWidth, maxWidth: column.maximumWidth } })),
+];
+
+const protokollEditElements = [
+  element({ id: "protokoll.edit.root", name: "Protokoll-Eingabebereich", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: ZONE_HEIGHT_LAYOUT, componentKind: "fixedEditArea", baseline: { width: 940, height: 300, minWidth: 320, maxWidth: 1880, minHeight: 160, maxHeight: 720 } }),
+  element({ id: "protokoll.edit.canvas", name: "Protokoll-Eingabefläche", type: "area", role: "formArea", parentId: "protokoll.edit.root", order: 10, allowedOps: [], componentKind: "editCanvas" }),
+  element({ id: "protokoll.edit.workbench", name: "Gruppe TOP-Bearbeitung", type: "group", role: "layoutGroup", parentId: "protokoll.edit.canvas", order: 20, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "workbench" }),
+  element({ id: "protokoll.edit.header", name: "Gruppe TOP-Bearbeitungskopf", type: "group", role: "layoutGroup", parentId: "protokoll.edit.workbench", order: 30, allowedOps: GROUP_LAYOUT, componentKind: "header" }),
+  element({ id: "protokoll.edit.header.label", name: "Bezeichnung TOP bearbeiten", type: "label", role: "fieldLabel", parentId: "protokoll.edit.header", order: 31, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "protokoll.edit.text", name: "Gruppe Textbearbeitung", type: "group", role: "fieldCollection", parentId: "protokoll.edit.workbench", order: 40, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "editbox" }),
+  element({ id: "protokoll.edit.short", name: "Gruppe Kurztext", type: "fieldGroup", role: "formFieldGroup", parentId: "protokoll.edit.text", order: 41, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "fieldGroup" }),
+  element({ id: "protokoll.edit.short.label", name: "Bezeichnung Kurztext", type: "label", role: "fieldLabel", parentId: "protokoll.edit.short", order: 42, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "protokoll.edit.short.field", name: "Eingabefeld Kurztext", type: "field", role: "dataFieldLayout", parentId: "protokoll.edit.short", order: 43, allowedOps: FIELD_LAYOUT, fieldKind: "text", componentKind: "input" }),
+  element({ id: "protokoll.edit.long", name: "Gruppe Langtext", type: "fieldGroup", role: "formFieldGroup", parentId: "protokoll.edit.text", order: 50, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "fieldGroup" }),
+  element({ id: "protokoll.edit.long.label", name: "Bezeichnung Langtext", type: "label", role: "fieldLabel", parentId: "protokoll.edit.long", order: 51, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  element({ id: "protokoll.edit.long.field", name: "Eingabefeld Langtext", type: "field", role: "dataFieldLayout", parentId: "protokoll.edit.long", order: 52, allowedOps: FIELD_LAYOUT, fieldKind: "multilineText", componentKind: "textarea" }),
+  element({ id: "protokoll.edit.meta", name: "Gruppe Status und Zuordnung", type: "group", role: "fieldCollection", parentId: "protokoll.edit.workbench", order: 60, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "metaPanel" }),
+  element({ id: "protokoll.edit.flags", name: "Gruppe Kennzeichnungen", type: "group", role: "layoutGroup", parentId: "protokoll.edit.meta", order: 61, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "flagGroup" }),
+  ...[
+    ["status", "Status", "select", 70],
+    ["due", "Fertig bis", "date", 80],
+    ["responsible", "Verantwortlich", "select", 90],
+  ].flatMap(([key, name, fieldKind, order]) => [
+    element({ id: `protokoll.edit.${key}`, name: `Gruppe ${name}`, type: "fieldGroup", role: "formFieldGroup", parentId: "protokoll.edit.meta", order, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "fieldGroup" }),
+    element({ id: `protokoll.edit.${key}.label`, name: `Bezeichnung ${name}`, type: "label", role: "fieldLabel", parentId: `protokoll.edit.${key}`, order: order + 1, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+    element({ id: `protokoll.edit.${key}.field`, name: `Eingabefeld ${name}`, type: "field", role: "dataFieldLayout", parentId: `protokoll.edit.${key}`, order: order + 2, allowedOps: FIELD_LAYOUT, fieldKind, componentKind: fieldKind === "date" ? "dateInput" : "select" }),
+  ]),
+  element({ id: "protokoll.edit.ampel", name: "Statussymbol Ampel", type: "statusIndicator", role: "status", parentId: "protokoll.edit.meta", order: 100, allowedOps: ICON_LAYOUT, componentKind: "statusIndicator" }),
+];
+
 export const BBM_M80_ACTIVE_SCOPES = Object.freeze([
   "restarbeiten.header.root",
   "restarbeiten.list.root",
   "restarbeiten.edit.root",
+  "protokoll.screen.root",
+  "protokoll.list.root",
+  "protokoll.edit.root",
+]);
+
+export const BBM_M80_ACTIVE_SCOPE_GROUPS = Object.freeze([
+  Object.freeze(["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]),
+  Object.freeze(["protokoll.screen.root", "protokoll.list.root", "protokoll.edit.root"]),
 ]);
 
 export const BBM_M80_REGISTRY_SCOPES = Object.freeze([
   completeScope("restarbeiten.header.root", headerElements),
   completeScope("restarbeiten.list.root", listElements),
   completeScope("restarbeiten.edit.root", editElements),
+  completeScope("protokoll.screen.root", protokollScreenElements),
+  completeScope("protokoll.list.root", protokollListElements),
+  completeScope("protokoll.edit.root", protokollEditElements),
   blockedScope("bbm.shell", "Shell und Hauptnavigation"),
   blockedScope("bbm.home", "Start"),
   blockedScope("bbm.projects", "Projektverwaltung"),
   blockedScope("bbm.project-workspace", "Projektarbeitsplatz"),
   blockedScope("bbm.firms", "Firmen und Personen"),
   blockedScope("bbm.project-firms", "Projektfirmen und Projektpersonen"),
-  blockedScope("bbm.protokoll", "Protokoll"),
   blockedScope("bbm.settings", "Einstellungen"),
   blockedScope("bbm.help", "Hilfe"),
   blockedScope("bbm.dialogs", "Produktive Dialoge"),

--- a/ui-editor-target.json
+++ b/ui-editor-target.json
@@ -7,13 +7,16 @@
   "integrationMode": "existing-app",
   "contractVersion": "1.2",
   "adapterVersion": "1.2",
-  "registryVersion": 7,
-  "registryFingerprint": "sha256:755b22065dc4cc23ad8274521e5f1e59be5750014e805e2bd9593554827d0c37",
+  "registryVersion": 9,
+  "registryFingerprint": "sha256:67f588857d18ac613b2bd01482fc528ca1f7ce82e286996fc82c40a083d17d6b",
   "registryStatus": "incomplete",
   "activeScopes": [
     "restarbeiten.header.root",
     "restarbeiten.list.root",
-    "restarbeiten.edit.root"
+    "restarbeiten.edit.root",
+    "protokoll.screen.root",
+    "protokoll.list.root",
+    "protokoll.edit.root"
   ],
   "uiCapability": "layout",
   "pdfCapability": "available",
@@ -32,7 +35,6 @@
     "spacingReset",
     "fitTableToViewport",
     "resizeColumnsProportionally",
-    "setHorizontalOverflowMode",
     "setColumnWidthMode",
     "setColumnWrapMode",
     "setColumnOverflowMode",
@@ -46,8 +48,11 @@
   "transportProtocolVersion": "1.0",
   "scopes": [
     { "scopeId": "restarbeiten.header.root", "status": "complete", "reason": null, "elementCount": 31, "missingReferenceCount": 0 },
-    { "scopeId": "restarbeiten.list.root", "status": "complete", "reason": null, "elementCount": 18, "missingReferenceCount": 0 },
+    { "scopeId": "restarbeiten.list.root", "status": "complete", "reason": null, "elementCount": 16, "missingReferenceCount": 0 },
     { "scopeId": "restarbeiten.edit.root", "status": "complete", "reason": null, "elementCount": 53, "missingReferenceCount": 0 },
+    { "scopeId": "protokoll.screen.root", "status": "complete", "reason": null, "elementCount": 25, "missingReferenceCount": 0 },
+    { "scopeId": "protokoll.list.root", "status": "complete", "reason": null, "elementCount": 7, "missingReferenceCount": 0 },
+    { "scopeId": "protokoll.edit.root", "status": "complete", "reason": null, "elementCount": 24, "missingReferenceCount": 0 },
     { "scopeId": "bbm.remaining", "status": "blocked", "reason": "registration_inventory_pending", "elementCount": 0, "missingReferenceCount": 0 },
     { "scopeId": "pdf.bbm.protocol", "status": "complete", "reason": null, "elementCount": 28, "missingReferenceCount": 0 }
   ],


### PR DESCRIPTION
## Ziel

M82.6 repariert die Restarbeiten-TopScreen-Regression und schließt Restarbeiten sowie Protokoll als topologieneutral angebundene Feintuning-Module ab.

## Enthalten

- Entfernung der editorbedingt eingeführten Restarbeiten-Viewport-/ScrollArea-Wrapper
- Wiederherstellung der bestehenden Restarbeiten-TopScreen-Struktur
- Filter oben, Editbox unten, Liste dazwischen
- ausschließlich `.bbm-restarbeiten-main` als vertikaler Scrollbesitzer
- keine zusätzliche horizontale oder vertikale Laufleiste
- BBM-eigene Registry für Restarbeiten und Protokoll
- drei produktive Protokoll-Scopes aus ausschließlich vorhandenen UI-Refs
- logische Protokollspalten über Mehrfach-Refs mit `preserveTarget`
- sichtbares Feintuning, Undo, Save und Neustart-Restore für beide Module
- bestehende Protokoll-PDF und Restarbeiten-HTML-Ausgabevorschau geprüft
- Topologie-Fingerprint bleibt bei Editoröffnung, Refresh, Änderung, Undo, Save und Restore stabil
- M82.6 `[A] abgenommen`

## Ausdrücklich nicht enthalten

- keine neue Restarbeiten-PDF-Funktion
- keine neue Restarbeiten- oder Protokollansicht
- keine zusätzlichen DOM-Knoten, Wrapper oder Scrollcontainer
- keine Änderung von Fachlogik oder Daten
- `docs/licensing.md` ist nicht Bestandteil dieses Commits
- Benutzerlizenz, Benutzerdatenbank, Profile, PDFs, Screenshots sowie Pack- und Diagnoseausgaben sind nicht Bestandteil dieses Commits

## Prüfungen

- neuer M82.6-Test – 40/40 bestanden
- `npm test` – 8/8 Gruppen, kein OOM
- `npm run test:node` – bestanden
- gezieltes ESLint ohne neue Fehler
- `npm run pack:diagnostic` und `npm run pack` erfolgreich
- sichtbare Diagnostic-Abnahme beider Module
- echte vierseitige Protokoll-PDF geprüft
- Restarbeiten-HTML-Ausgabevorschau geprüft
- `git diff --check`

Das globale Lint enthält weiterhin ausschließlich den bekannten Altbestand von 16 Fehlern und 371 Warnungen.

## Commit

`ab20fb8e31ce3a1f6ec2a7ccf0b26ecbce1c34ca`