### PR TITLE
M82.7.2 textResize in BBM generisch absichern

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -3601,3 +3601,14 @@ Wichtig:
 - Tabellenmetriken und betroffene Spaltenzustände bleiben im Editorprozess erhalten; Tabellenrollen erzeugen in JavaScript und WPF denselben Scope-Fingerprint. Ein gespeichertes Tabellenprofil wird beim Neustart ohne Recovery-Marker einmalig wiederhergestellt.
 - `docs/licensing.md` bleibt Fremdänderung und unangetastet.
 - Commit/PR: keiner; gemäß Nutzeranweisung wurde weder committet noch gepusht.
+## M82.7.2 – Generischer textResize-Weg für alle registrierten Textelemente
+
+- Status: `[A]`; zentrale Reparatur, Pflichtprüfungen und sichtbare paketierte Diagnostic-Abnahme sind abgeschlossen.
+- BBM inventarisiert 59 `textResize`-Ziele in fünf produktiven Restarbeiten-/Protokoll-Scopes; alle nutzen denselben expliziten Ref-/Computed-Style-Weg.
+- Der Host meldet Erfolg nur nach realer Änderung und passendem zurückgelesenem Istwert; Konflikt, Mismatch und No-op bleiben ohne Dirty, Undo oder Save.
+- Kurz-/Lang-Restzeichen, weitere Restarbeiten-Texte und drei echte Protokoll-Texte wurden sichtbar mit kleiner, größer, direkt, Undo, Save, Neustart-Restore und Reset geprüft.
+- Registryrefresh, Datensatz- und Modulwechsel erhielten explizite Werte ohne Doppelanwendung; freie Bewegung, Sichtbarkeit, Topologie und Scrollbesitzer blieben stabil.
+- `npm test` und `npm run test:node` liefen jeweils mit 8/8 Gruppen; gezieltes ESLint ist sauber; Diagnostic- und Release-Pack sind grün.
+- Globales Lint bleibt mit 16 bestehenden Fehlern und 371 Warnungen rot; M82.7.2 erzeugt keinen neuen Befund und es erfolgte keine Altbereinigung.
+- `docs/licensing.md` und Benutzerdateien blieben unangetastet.
+- Commit/PR: keiner; gemäß Nutzeranweisung wurde weder committet noch gepusht.

--- a/docs/M82_7_2_BBM_TEXTRESIZE_ABNAHME.md
+++ b/docs/M82_7_2_BBM_TEXTRESIZE_ABNAHME.md
@@ -1,0 +1,139 @@
+# M82.7.2 – BBM-`textResize`-Abnahme
+
+Status: `[A]`
+
+## Zentrale Ursache und Reparatur
+
+Der bisherige Electron-Host setzte den gewünschten Zustand und meldete anschließend pauschal Erfolg. Er verglich weder Ausgangs-, Ziel- und realen Computed-Style-Wert noch erkannte er CSS-Übersteuerung oder einen unveränderten Wert. Der WPF-Host hatte denselben fehlenden Istwertnachweis; außerdem fehlten `TextBlock`-Unterstützung und ein binding-erhaltender Applyweg.
+
+Der Editor sendet jetzt `fontSize`, `unit: "dip"` und den zuletzt gelesenen `expectedCurrentFontSize`. Der BBM-Host normalisiert und begrenzt den Wert, setzt ihn über den bestehenden expliziten Ref-Weg und liest danach `getComputedStyle(element).fontSize`. Erfolg wird nur gemeldet, wenn sich der reale Wert geändert hat und innerhalb 0,02 DIP zum akzeptierten Ziel passt. Bei Konflikt, Mismatch oder No-op erfolgt Rollback ohne Dirty, Undo oder Save.
+
+Es gibt keine Element-Sonderbehandlung, keine neue CSS-Klasse, keinen Wrapper, keine globale CSS-Variable und keine BBM-ID im gemeinsamen Core.
+
+## Vollständiges Inventar
+
+Programmgesteuert gefunden und geprüft: 59 Ziele in fünf produktiven Scopes.
+
+### `restarbeiten.header.root` – 14
+
+- `restarbeiten.filterbar.location.level1.label`
+- `restarbeiten.filterbar.location.level1.field`
+- `restarbeiten.filterbar.location.level2.label`
+- `restarbeiten.filterbar.location.level2.field`
+- `restarbeiten.filterbar.location.level3.label`
+- `restarbeiten.filterbar.location.level3.field`
+- `restarbeiten.filterbar.location.level4.label`
+- `restarbeiten.filterbar.location.level4.field`
+- `restarbeiten.filterbar.meta.status.label`
+- `restarbeiten.filterbar.meta.status.field`
+- `restarbeiten.filterbar.meta.dueDate.label`
+- `restarbeiten.filterbar.meta.dueDate.field`
+- `restarbeiten.filterbar.meta.responsible.label`
+- `restarbeiten.filterbar.meta.responsible.field`
+
+### `restarbeiten.list.root` – 6
+
+- `restarbeiten.list.table.number`
+- `restarbeiten.list.table.subject`
+- `restarbeiten.list.table.meta`
+- `restarbeiten.list.table.number.header`
+- `restarbeiten.list.table.subject.header`
+- `restarbeiten.list.table.meta.header`
+
+### `restarbeiten.edit.root` – 22
+
+- `restarbeiten.edit.short.label`
+- `restarbeiten.edit.short.remaining`
+- `restarbeiten.edit.class.label`
+- `restarbeiten.edit.class.control`
+- `restarbeiten.edit.short.field`
+- `restarbeiten.edit.long.label`
+- `restarbeiten.edit.long.remaining`
+- `restarbeiten.edit.long.field`
+- `restarbeiten.edit.location.1.label`
+- `restarbeiten.edit.location.1.field`
+- `restarbeiten.edit.location.2.label`
+- `restarbeiten.edit.location.2.field`
+- `restarbeiten.edit.location.3.label`
+- `restarbeiten.edit.location.3.field`
+- `restarbeiten.edit.location.4.label`
+- `restarbeiten.edit.location.4.field`
+- `restarbeiten.edit.meta.status.label`
+- `restarbeiten.edit.meta.status.field`
+- `restarbeiten.edit.meta.due.label`
+- `restarbeiten.edit.meta.due.field`
+- `restarbeiten.edit.meta.responsible.label`
+- `restarbeiten.edit.meta.responsible.field`
+
+### `protokoll.screen.root` – 6
+
+- `protokoll.header.title`
+- `protokoll.header.keyword`
+- `protokoll.header.context`
+- `protokoll.header.meta.due`
+- `protokoll.header.meta.status`
+- `protokoll.header.meta.responsible`
+
+### `protokoll.edit.root` – 11
+
+- `protokoll.edit.header.label`
+- `protokoll.edit.short.label`
+- `protokoll.edit.short.field`
+- `protokoll.edit.long.label`
+- `protokoll.edit.long.field`
+- `protokoll.edit.status.label`
+- `protokoll.edit.status.field`
+- `protokoll.edit.due.label`
+- `protokoll.edit.due.field`
+- `protokoll.edit.responsible.label`
+- `protokoll.edit.responsible.field`
+
+Für jedes Inventarziel wurden Ref, verbundener Zielknoten, lesbarer Ausgangswert, kleinerer, größerer und direkter Wert, No-op-Ablehnung, Undo/Reset, Save-/Start-Restore, Rerender und Registryrefresh programmgesteuert geprüft.
+
+## Sichtbare paketierte Diagnostic-Abnahme
+
+Die Abnahme lief ausschließlich mit `BBM (DEV).exe`, sichtbarer Kennzeichnung „Entwicklungsversion – Testlizenz“ und isolierten Testdatenbanken/-profilen unter `%TEMP%`.
+
+Restarbeiten:
+
+- Restzeichen Kurztext: 8,66667 → 7,667 → 8,667 → direkt 7,25 DIP
+- gespeicherter Kurztextwert 7,25 DIP blieb nach vollständigem BBM-Neustart erhalten
+- Profilhash vor/nach reinem Neustart-Restore blieb `B6AA5A7D8021872DBA0F21D947F36C8F3ADD14E78F4C9D717B3F3D5FC20B0A29`
+- Restzeichen Langtext: 8,66667 → direkt 7,5 DIP; Undo zurück auf 8,667 DIP, während Kurztext 7,25 DIP blieb
+- Kurztext-/Langtextbezeichnung und Haus-Bezeichnung: 10 → 2,75 → Undo 10 px (freie Diagnostic-Schrittweite 7,25 DIP)
+- Kurztextfeld: 10,667 → 3,417 → Undo 10,667 px
+- Elementreset Kurztext-Restzeichen: 7,25 → 8,667; Undo zurück auf 7,25 px
+- Bewegung: reale X-Position 423,5902 → 422,5902 → Undo 423,5902 px
+- Sichtbarkeit: `visible` → `hidden` → `visible`
+- Registryrefresh erhielt 7,25 px
+
+Protokoll mit drei isolierten Diagnostic-TOPs:
+
+- Kurztextbezeichnung: 11,3333 → 10,333 → Undo 11,333 px
+- Langtextbezeichnung: 11,3333 → 10,333 → Undo 11,333 px
+- Kurztextfeld: 13,3333 → 12,333 px
+- Datensatzwechsel auf TOP 2 erhielt 12,333 px; Registryrefresh ebenfalls
+- Elementreset setzte auf die registrierte 12-DIP-Baseline; Undo stellte 12,333 px wieder her
+
+## Rerender, Topologie und Scrollbesitzer
+
+Explizite `textResize`-Werte werden in `persistentWorkingStateOperations` nur für den registrierten Ref gehalten und beim Ref-Rerender erneut über denselben Operationstyp angewandt. Registryrefresh und Datensatzwechsel erzeugten keine Doppelanwendung.
+
+Die bestehenden Parentketten blieben erhalten. Sichtbar bestätigt wurden insbesondere:
+
+- Protokoll: `protokoll.list.root` bleibt der horizontale und vertikale Scrollbesitzer unter `protokoll.screen.root`
+- Restarbeiten: `restarbeiten.list.root` bleibt der vertikale Scrollbesitzer; `area`, `paper` und `table` behalten ihre vorhandene Parentkette
+- keine Fachtexte, TOPs, Restarbeitenwerte, Nachbargeometrien oder Scrollcontainer wurden durch `textResize` verändert
+
+## Automatisierte Prüfung
+
+- fokussierter M82.7.2-BBM-Test: grün, 59/59 Ziele
+- `npm test`: 8/8 Gruppen, kein OOM; größte UI-Gruppe ca. 77,9 MiB Heap
+- `npm run test:node`: 8/8 Gruppen; Node 22.21.1 / ABI 127, abschließend Electron-ABI 123 wiederhergestellt
+- gezieltes ESLint aller geänderten M82.7.2-JavaScriptdateien: 0 Fehler, 0 Warnungen
+- globales `npm run lint`: bekannter Altbestand, 16 Fehler und 371 Warnungen; keine neue M82.7.2-Datei betroffen
+- `npm run pack:diagnostic`: grün, `npmRebuild: false`
+- `npm run pack`: grün, Electron-ABI und `npmRebuild: false`
+- M80–M82.7.1, Tabellen-, Topologie-, Save-/Restore-/Reset- und Harness-Regressionen: grün
+
+`docs/licensing.md`, Benutzerlizenz, Benutzerdatenbank, Fachlogik, TopScreen, PDF- und Audiofunktionen blieben unverändert.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -153,6 +153,7 @@ const TEST_GROUPS = Object.freeze([
       ["m82-5BbmSimpleEditorMode.test.cjs", "runM825BbmSimpleEditorModeTests"],
       ["m82-6TopScreenModuleClosure.test.cjs", "runM826TopScreenModuleClosureTests"],
       ["m82-7RemainingIndicators.test.cjs", "runM827RemainingIndicatorTests"],
+      ["m82-7-2GenericTextResize.test.cjs", "runM8272GenericTextResizeTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),
   }),

--- a/scripts/tests/m82-7-2GenericTextResize.test.cjs
+++ b/scripts/tests/m82-7-2GenericTextResize.test.cjs
@@ -1,0 +1,227 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const ROOT = path.resolve(__dirname, "../..");
+const TARGET_ID = "restarbeiten.edit.short.remaining";
+
+class FakeElement {
+  constructor(tagName = "SPAN", baseFontSize = 12) {
+    this.tagName = tagName;
+    this.attributes = {};
+    this.dataset = {};
+    this.className = "";
+    this.parentElement = null;
+    this.children = [];
+    this.textContent = "";
+    this._baseFontSize = baseFontSize;
+    this._rect = { left: 0, top: 0, width: 120, height: 24 };
+    this.isConnected = true;
+    this.style = {};
+    this.classList = {
+      contains: (name) => this.className.split(/\s+/).includes(name),
+      toggle: (name, active) => {
+        const names = new Set(this.className.split(/\s+/).filter(Boolean));
+        if (active) names.add(name); else names.delete(name);
+        this.className = [...names].join(" ");
+      },
+    };
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  getAttribute(name) { return this.attributes[name] || null; }
+  appendChild(child) { child.parentElement = this; this.children.push(child); return child; }
+  getBoundingClientRect() { return { ...this._rect }; }
+}
+
+async function runM8272GenericTextResizeTests(run) {
+  const refs = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Refs.js"));
+  const registry = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Registry.js"));
+  const hostAdapter = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80HostAdapter.js"));
+  const previous = { document: global.document, window: global.window, Element: global.Element };
+  const target = new FakeElement();
+  const computedFontSize = "8.667px";
+  global.Element = FakeElement;
+  global.document = { querySelector: () => null, createElement: () => new FakeElement(), addEventListener() {}, removeEventListener() {} };
+  global.window = {
+    getComputedStyle: () => ({ width: "28px", height: "14px", paddingLeft: "0px", paddingTop: "0px", fontSize: computedFontSize }),
+    dispatchEvent() {},
+  };
+  refs.resetM80PilotWorkingStatesForDiagnostic();
+  refs.registerM80Ref(TARGET_ID, target);
+
+  try {
+    await run("M82.7.2 BBM: unveraenderter Computed Style darf keinen textResize-Erfolg melden", () => {
+      const result = hostAdapter.handleM80EditorRequest({
+        action: "submitChange",
+        scopeId: "restarbeiten.edit.root",
+        changeRequest: {
+          changeId: "computed-style-blocked",
+          elementId: TARGET_ID,
+          operation: "textResize",
+          payload: { text: { fontSize: 7.667 } },
+          source: "m82-7-2-test",
+        },
+      }).changeResult;
+      assert.equal(result.success, false);
+      assert.equal(result.errorCode, "text_resize_readback_mismatch");
+      assert.equal(result.rollbackSucceeded, true);
+      assert.equal(result.previousState.fontSize, 8.667);
+      assert.equal(result.newState.fontSize, 8.667);
+    });
+
+    await run("M82.7.2 BBM: erwarteter veralteter Istwert wird vor dem Apply abgewiesen", () => {
+      const result = hostAdapter.handleM80EditorRequest({
+        action: "submitChange", scopeId: "restarbeiten.edit.root",
+        changeRequest: { changeId: "stale-value", elementId: TARGET_ID, operation: "textResize",
+          payload: { text: { fontSize: 7.667, unit: "dip", expectedCurrentFontSize: 9 } }, source: "m82-7-2-test" },
+      }).changeResult;
+      assert.equal(result.success, false);
+      assert.equal(result.errorCode, "text_resize_expected_value_conflict");
+      assert.equal(target.style.fontSize, "8.667px");
+    });
+
+    refs.resetM80PilotWorkingStatesForDiagnostic();
+    const scopes = registry.listM80RegistryScopes();
+    const textEntries = scopes.flatMap((scope) => scope.elements)
+      .filter((entry) => entry.allowedOps.includes("textResize"));
+    const nodes = new Map();
+    for (const entry of scopes.flatMap((scope) => scope.elements)) {
+      const base = Number(entry.baseline?.fontSize) || 12;
+      nodes.set(entry.id, new FakeElement(entry.type === "field" ? "INPUT" : "SPAN", base));
+    }
+    for (const entry of scopes.flatMap((scope) => scope.elements)) {
+      if (entry.parentId) nodes.get(entry.parentId).appendChild(nodes.get(entry.id));
+      refs.registerM80Ref(entry.id, nodes.get(entry.id));
+    }
+    global.window.getComputedStyle = (element) => ({
+      width: `${element._rect.width}px`, height: `${element._rect.height}px`,
+      paddingLeft: element.style.paddingLeft || "0px", paddingTop: element.style.paddingTop || "0px",
+      fontSize: element._computedOverride || element.style.fontSize || `${element._baseFontSize}px`,
+    });
+
+    const topology = refs.snapshotM80Topology();
+    const initialStates = new Map(textEntries.map((entry) => [entry.id, refs.snapshotM80State(entry.id)]));
+    const values = new Map();
+    const submit = (entry, fontSize, suffix, expectedCurrentFontSize = refs.snapshotM80State(entry.id).fontSize) =>
+      hostAdapter.handleM80EditorRequest({
+        action: "submitChange", scopeId: scopes.find((scope) => scope.elements.some((candidate) => candidate.id === entry.id)).scopeId,
+        changeRequest: { changeId: `${suffix}-${entry.id}`, elementId: entry.id, operation: "textResize",
+          payload: { text: { fontSize, unit: "dip", expectedCurrentFontSize } }, source: "m82-7-2-inventory" },
+      }).changeResult;
+    const changeValues = (entry) => {
+      const current = initialStates.get(entry.id).fontSize;
+      const declaredMinimum = Number(entry.baseline.minFontSize);
+      const declaredMaximum = Number(entry.baseline.maxFontSize);
+      const minimum = Number.isFinite(declaredMinimum) ? declaredMinimum : 1;
+      const maximum = Number.isFinite(declaredMaximum) ? declaredMaximum : 512;
+      const lower = Math.round(Math.max(minimum, current - Math.min(1, Math.max(0.1, current - minimum))) * 1000) / 1000;
+      const higher = Math.round(Math.min(maximum, lower + Math.min(2, Math.max(0.1, maximum - lower))) * 1000) / 1000;
+      const direct = Math.round((lower + Math.min(0.25, (higher - lower) / 2)) * 1000) / 1000;
+      assert.ok(lower < current, `${entry.id}: kleinere Schriftgroesse fehlt innerhalb der Registrygrenzen`);
+      assert.ok(higher > lower, `${entry.id}: groessere Schriftgroesse fehlt innerhalb der Registrygrenzen`);
+      assert.notEqual(direct, higher, `${entry.id}: direkter Zwischenwert fehlt`);
+      return { lower, higher, direct };
+    };
+
+    await run("M82.7.2 BBM: Inventar umfasst exakt alle 59 textResize-Ziele in fuenf produktiven Scopes", () => {
+      assert.equal(textEntries.length, 59);
+      assert.deepEqual(Object.fromEntries(scopes.map((scope) => [scope.scopeId, scope.elements.filter((entry) => entry.allowedOps.includes("textResize")).length]).filter(([, count]) => count)), {
+        "restarbeiten.header.root": 14,
+        "restarbeiten.list.root": 6,
+        "restarbeiten.edit.root": 22,
+        "protokoll.screen.root": 6,
+        "protokoll.edit.root": 11,
+      });
+    });
+    await run("M82.7.2 BBM: jedes Inventarziel besitzt sichtbaren Ref und lesbaren Computed-Style-Istwert", () => {
+      for (const entry of textEntries) {
+        assert.equal(refs.getM80ReferenceStatus(entry.id).referenceResolved, true, entry.id);
+        assert.equal(nodes.get(entry.id).isConnected, true, entry.id);
+        assert.ok(Number.isFinite(initialStates.get(entry.id).fontSize), entry.id);
+      }
+    });
+    await run("M82.7.2 BBM: kleiner, groesser und direkter DIP-Wert wirken generisch auf alle 59 realen Refs", () => {
+      for (const entry of textEntries) {
+        const candidates = changeValues(entry);
+        const smaller = submit(entry, candidates.lower, "smaller");
+        assert.equal(smaller.success, true, `${entry.id}: ${smaller.message}`);
+        assert.equal(smaller.textResize.appliedFontSize, candidates.lower, entry.id);
+        const larger = submit(entry, candidates.higher, "larger");
+        assert.equal(larger.success, true, `${entry.id}: ${larger.message}`);
+        const direct = submit(entry, candidates.direct, "direct");
+        assert.equal(direct.success, true, `${entry.id}: ${direct.message}`);
+        assert.equal(refs.snapshotM80State(entry.id).fontSize, candidates.direct, entry.id);
+        values.set(entry.id, candidates);
+      }
+    });
+    await run("M82.7.2 BBM: unveraenderter direkter Istwert bleibt fuer jedes Ziel ohne Erfolg", () => {
+      for (const entry of textEntries) {
+        const current = refs.snapshotM80State(entry.id).fontSize;
+        const result = submit(entry, current, "no-effect", current);
+        assert.equal(result.success, false, entry.id);
+        assert.equal(result.errorCode, "text_resize_no_effect", entry.id);
+        assert.equal(refs.snapshotM80State(entry.id).fontSize, current, entry.id);
+      }
+    });
+    await run("M82.7.2 BBM: Kurz-/Lang-Restzeichen, Restarbeiten- und Protokolltexte nutzen denselben Weg", () => {
+      const required = [
+        "restarbeiten.edit.short.remaining", "restarbeiten.edit.long.remaining",
+        "restarbeiten.edit.short.label", "restarbeiten.edit.long.label", "restarbeiten.edit.meta.status.label",
+        "restarbeiten.edit.short.field", "restarbeiten.list.table.subject.header",
+        "protokoll.edit.short.label", "protokoll.edit.long.label", "protokoll.edit.short.field",
+      ];
+      for (const id of required) {
+        assert.ok(values.has(id), id);
+        assert.equal(refs.snapshotM80State(id).fontSize, values.get(id).direct, id);
+      }
+    });
+    await run("M82.7.2 BBM: Nachbarn, Fachtext, Topologie und Scrollstruktur bleiben unveraendert", () => {
+      for (const entry of textEntries) assert.equal(nodes.get(entry.id).textContent, "", entry.id);
+      assert.equal(refs.compareM80Topology(topology).ok, true);
+      assert.equal(nodes.get("restarbeiten.list.area").style.overflow || "", "");
+      assert.equal(nodes.get("protokoll.screen.root").style.overflow || "", "");
+    });
+    await run("M82.7.2 BBM: Undo und Elementreset stellen den exakten realen Ausgangswert wieder her", () => {
+      for (const entry of textEntries) {
+        refs.applyM80State(entry.id, initialStates.get(entry.id), "textResize");
+        assert.equal(refs.snapshotM80State(entry.id).fontSize, initialStates.get(entry.id).fontSize, entry.id);
+      }
+    });
+    await run("M82.7.2 BBM: Save-/Neustart-Restore erzeugt fuer jedes Ziel genau den freigegebenen textResize-Weg", () => {
+      for (const entry of textEntries) {
+        const saved = { ...initialStates.get(entry.id), fontSize: values.get(entry.id).direct, elementId: entry.id };
+        const scopeId = scopes.find((scope) => scope.elements.some((candidate) => candidate.id === entry.id)).scopeId;
+        const requests = hostAdapter.createM80StartupRequests(scopeId, saved).filter((item) => item.request.operation === "textResize");
+        assert.equal(requests.length, 1, entry.id);
+        const result = hostAdapter.handleM80EditorRequest({ action: "submitChange", scopeId, changeRequest: requests[0].request }).changeResult;
+        assert.equal(result.success, true, `${entry.id}: ${result.message}`);
+        assert.equal(result.newState.fontSize, values.get(entry.id).direct, entry.id);
+      }
+    });
+    await run("M82.7.2 BBM: Registryrefresh und fachlicher Ref-Rerender bewahren den expliziten Wert ohne Doppelanwendung", () => {
+      refs.completeM80PilotRender();
+      for (const entry of textEntries) {
+        refs.registerM80Ref(entry.id, nodes.get(entry.id));
+        assert.equal(refs.snapshotM80State(entry.id).fontSize, values.get(entry.id).direct, entry.id);
+      }
+      assert.equal(refs.compareM80Topology(topology).ok, true);
+    });
+  } finally {
+    refs.resetM80PilotWorkingStatesForDiagnostic();
+    global.document = previous.document;
+    global.window = previous.window;
+    global.Element = previous.Element;
+  }
+}
+
+if (require.main === module) {
+  let failed = false;
+  runM8272GenericTextResizeTests(async (name, action) => {
+    try { await action(); console.log(`OK ${name}`); }
+    catch (error) { failed = true; console.error(`FAIL ${name}`); throw error; }
+  }).catch((error) => { failed = true; console.error(error); }).finally(() => { if (failed) process.exitCode = 1; });
+}
+
+module.exports = { runM8272GenericTextResizeTests };

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 108, "108 Suite-Einstiege einschließlich Entwicklungs-Lizenz sowie M82.4 bis M82.7");
+    assert.equal(suites.length, 109, "109 Suite-Einstiege einschließlich Entwicklungs-Lizenz sowie M82.4 bis M82.7.2");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/src/renderer/ui-editor/m80HostAdapter.js
+++ b/src/renderer/ui-editor/m80HostAdapter.js
@@ -38,6 +38,10 @@ import {
   RISK_ACTIONS,
   evaluateGeometryRisk,
 } from "../../../node_modules/ui-editor-kit/dist/geometry-risk-contract.mjs";
+import {
+  normalizeTextResizeIntent,
+  verifyTextResizeReadback,
+} from "../../../node_modules/ui-editor-kit/dist/text-resize-contract.mjs";
 
 const ALLOWED_ACTIONS = new Set(["getRegistry", "getLayoutState", "submitChange"]);
 const SUPPORTED_OPERATIONS = Object.freeze(["move", "resize", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility", "spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset", ...TABLE_LAYOUT_OPERATIONS]);
@@ -67,8 +71,8 @@ function hasForbidden(value) {
   if (!value || typeof value !== "object") return false;
   return Object.entries(value).some(([key, nested]) => FORBIDDEN_KEYS.has(key) || hasForbidden(nested));
 }
-function failure(request, errorCode, message, previousState = null, rollbackSucceeded = true, geometryRisk = null) {
-  return { success: false, changeId: String(request?.changeId || ""), elementId: String(request?.elementId || ""), operation: String(request?.operation || ""), errorCode, message, previousState, newState: previousState, rollbackSucceeded, geometryRisk };
+function failure(request, errorCode, message, previousState = null, rollbackSucceeded = true, geometryRisk = null, textResize = null) {
+  return { success: false, changeId: String(request?.changeId || ""), elementId: String(request?.elementId || ""), operation: String(request?.operation || ""), errorCode, message, previousState, newState: previousState, rollbackSucceeded, geometryRisk, textResize };
 }
 function number(value, field, { positive = false, nonNegative = false } = {}) {
   const result = Number(value);
@@ -76,7 +80,7 @@ function number(value, field, { positive = false, nonNegative = false } = {}) {
   return result;
 }
 
-function desiredState(previous, entry, operation, payload) {
+function desiredState(previous, entry, operation, payload, textResizeIntent = null) {
   const next = { ...previous, spacing: { ...(previous.spacing || {}) } };
   if (!payload || typeof payload !== "object" || Array.isArray(payload) || hasForbidden(payload)) throw Object.assign(new Error("Layout-Payload ist ungültig."), { code: "electron_editor_message_invalid" });
   if (operation === "move") {
@@ -104,13 +108,8 @@ function desiredState(previous, entry, operation, payload) {
     if (Object.hasOwn(payload.text, "offsetX")) next.textOffsetX = number(payload.text.offsetX, "offsetX", { nonNegative: true });
     if (Object.hasOwn(payload.text, "offsetY")) next.textOffsetY = number(payload.text.offsetY, "offsetY", { nonNegative: true });
   } else if (operation === "textResize") {
-    if (Object.keys(payload).length !== 1 || !payload.text || Object.keys(payload.text).length !== 1 || !Object.hasOwn(payload.text, "fontSize")) throw new Error("textResize-Payload ist ungültig.");
-    next.fontSize = number(payload.text.fontSize, "fontSize", { positive: true });
-    const minimum = Number(entry?.baseline?.minFontSize);
-    const maximum = Number(entry?.baseline?.maxFontSize);
-    if ((Number.isFinite(minimum) && next.fontSize < minimum) || (Number.isFinite(maximum) && next.fontSize > maximum)) {
-      throw Object.assign(new Error("Schriftgröße liegt außerhalb der freigegebenen Ziel-App-Grenzen."), { code: "electron_editor_message_invalid" });
-    }
+    if (!textResizeIntent) throw Object.assign(new Error("textResize-Payload ist ungültig."), { code: "text_resize_invalid_intent" });
+    next.fontSize = textResizeIntent.requestedFontSize;
   } else if (operation === "setVisibility") {
     if (Object.keys(payload).length !== 1 || typeof payload.visible !== "boolean") throw new Error("setVisibility-Payload ist ungültig.");
     next.visible = payload.visible;
@@ -330,6 +329,7 @@ function submitChange(changeRequest, scopeId) {
   if (!previous) return failure(request, "electron_element_not_found", "Explizite Elementreferenz fehlt.");
   let groupRestore = null;
   const tableRestore = new Map();
+  let textResizeVerification = null;
   try {
     const beforeTopology = snapshotM80Topology();
     const beforeGeometry = snapshotM80Geometry();
@@ -339,7 +339,17 @@ function submitChange(changeRequest, scopeId) {
       throw Object.assign(new Error("Kontrollierter Diagnosefehler."), { code: "electron_change_apply_failed" });
     }
     const confirmation = confirmedRisk(request);
-    let desired = desiredState(previous, entry, request.operation, request.payload);
+    let textResizeIntent = null;
+    if (request.operation === "textResize") {
+      const normalized = normalizeTextResizeIntent(request.payload, {
+        minimumFontSize: entry?.baseline?.minFontSize,
+        maximumFontSize: entry?.baseline?.maxFontSize,
+        currentFontSize: previous.fontSize,
+      });
+      if (!normalized.ok) throw Object.assign(new Error(normalized.message), { code: normalized.code, textResize: normalized.readback });
+      textResizeIntent = normalized.intent;
+    }
+    let desired = desiredState(previous, entry, request.operation, request.payload, textResizeIntent);
     if (confirmation && [RISK_ACTIONS.CLAMP_TO_GROUP, RISK_ACTIONS.CLAMP_TO_AREA].includes(confirmation.action)) desired = clampDesiredState(desired, confirmation.risk, confirmation.action);
     if (confirmation?.action === RISK_ACTIONS.PRESERVE_SPACE || confirmation?.action === RISK_ACTIONS.SHRINK_GROUP) {
       desired.spacing = { ...(desired.spacing || {}), reservedWidth: Number(desired.spacing?.reservedWidth || 0) + Number(confirmation.risk.technicalDetails?.freedWidth || 0) };
@@ -363,6 +373,17 @@ function submitChange(changeRequest, scopeId) {
       readback = applyM80State(entry.id, { ...previous, width: baseline.currentWidth, visible: baseline.visibility, table: { tableId: entry.tableBinding.tableId, columnId: entry.id, widthMode: baseline.widthMode, wrapMode: baseline.wrapMode, overflowMode: baseline.overflowMode } });
     } else {
       readback = applyM80State(entry.id, desired, request.operation);
+    }
+    if (textResizeIntent) {
+      const verified = verifyTextResizeReadback({
+        requestedFontSize: textResizeIntent.requestedFontSize,
+        expectedCurrentFontSize: textResizeIntent.expectedCurrentFontSize,
+        previousFontSize: previous.fontSize,
+        appliedFontSize: readback?.fontSize,
+        tolerance: textResizeIntent.tolerance,
+      });
+      textResizeVerification = verified.readback;
+      if (!verified.ok) throw Object.assign(new Error(verified.message), { code: verified.code, textResize: verified.readback });
     }
     if (confirmation?.action === RISK_ACTIONS.SHRINK_GROUP) {
       const groupEntry = ancestor(entry, (candidate) => ["group", "fieldGroup"].includes(candidate.type));
@@ -397,13 +418,13 @@ function submitChange(changeRequest, scopeId) {
     if (confirmation) pendingGeometryRisks.delete(confirmation.risk.operationId);
     const topology = compareM80Topology(beforeTopology);
     if (!topology.ok) throw Object.assign(new Error("Die Layoutaenderung wuerde die produktive UI-Topologie veraendern."), { code: topology.errorCode });
-    return { success: true, changeId: request.changeId, elementId: entry.id, operation: request.operation, effectScope: affected.effect, affectedElementIds: [...affected.ids], affectedStates, errorCode: null, message: confirmation?.action === RISK_ACTIONS.PRESERVE_SPACE ? "Elementbreite geändert; frei gewordener Platz bleibt reserviert." : "Layoutänderung angewandt, geometrisch geprüft und zurückgelesen.", previousState: previous, newState: readback, rollbackSucceeded: true };
+    return { success: true, changeId: request.changeId, elementId: entry.id, operation: request.operation, effectScope: affected.effect, affectedElementIds: [...affected.ids], affectedStates, errorCode: null, message: confirmation?.action === RISK_ACTIONS.PRESERVE_SPACE ? "Elementbreite geändert; frei gewordener Platz bleibt reserviert." : "Layoutänderung angewandt, geometrisch geprüft und zurückgelesen.", previousState: previous, newState: readback, rollbackSucceeded: true, textResize: textResizeVerification };
   } catch (error) {
     try {
       if (groupRestore?.state) applyM80State(groupRestore.id, groupRestore.state);
       for (const [id, state] of [...tableRestore].reverse()) if (state) applyM80State(id, state);
       const restored = applyM80State(entry.id, previous);
-      return failure(request, error?.code || "electron_change_apply_failed", `Layoutänderung wurde sicher abgewiesen und zurückgerollt: ${error?.message || "Unbekannte Geometrieverletzung."}`, restored, true);
+      return failure(request, error?.code || "electron_change_apply_failed", `Layoutänderung wurde sicher abgewiesen und zurückgerollt: ${error?.message || "Unbekannte Geometrieverletzung."}`, restored, true, null, error?.textResize || textResizeVerification);
     } catch (_rollbackError) {
       return failure(request, "electron_change_rollback_failed", "Layoutänderung und Rollback sind fehlgeschlagen.", previous, false);
     }


### PR DESCRIPTION
## Ziel

M82.7.2 sichert `textResize` in BBM generisch ab. Der HostAdapter bestätigt eine Änderung nur, wenn der reale Computed-Style-Wert tatsächlich geändert wurde.

## Enthalten

- generischer Electron-HostAdapter-Weg für alle freigegebenen `textResize`-Ziele
- Computed-Style-Prüfung vor und nach dem Apply
- Konflikt-, Grenzen- und Rundungstoleranzprüfung
- Rollback bei nicht wirksamer Anwendung
- Inventar von 59 `textResize`-Zielen mit vorhandenen Refs
- sichtbare Abnahme von Restzeichenanzeigen sowie weiteren Restarbeiten- und Protokolltexten
- Save, Undo, Restore, Reset, Refresh und fachlicher Rerender
- freie Bewegung und Sichtbarkeit bleiben erhalten
- Topologie und Scrollstruktur bleiben unverändert
- M82.7.2 `[A]`

## Ausdrücklich nicht enthalten

- keine Element-Sonderlösung
- keine neue UI, Registry oder Topologie
- keine Änderung von Fachlogik oder Daten
- `docs/licensing.md` ist nicht Bestandteil dieses Commits
- Benutzerlizenz, Benutzerdatenbank, Profile sowie Pack- und Diagnoseausgaben sind nicht enthalten

## Prüfungen

- M82.7.2-Einzeltests grün
- `npm test` – 8/8 Gruppen
- `npm run test:node` – 8/8 Gruppen
- gezieltes ESLint fehlerfrei
- `npm run pack:diagnostic` und `npm run pack` erfolgreich
- sichtbare Diagnostic-Abnahme
- `git diff --check`

Das globale Lint enthält weiterhin ausschließlich den bekannten Altbestand von 16 Fehlern und 371 Warnungen.

## Commit

`299acee3546514d90bcd5d4014242a023f59fbef`