### PR TITLE
M82.7.3 textResize-Istwert und isolierte Abnahme absichern

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,14 @@
 # STATUS.md — BBM-Produktiv
 
+### M82.7.3 – textResize-Istwert und isolierte Entwicklungsabnahme
+
+- Status: `[A] abgenommen`; Istwertkorrektur, forensische Datenbankklärung, automatisierte Regression und sichtbare Zwei-Start-Abnahme sind abgeschlossen.
+- `npm run start:ui-editor:acceptance` setzt `userData` und `sessionData` vor jedem Datenbank-/IPC-Import auf ein markiertes Temp-Profil, startet zweimal gegen dasselbe isolierte Profil und entfernt dieses im `finally`. Normaler `npm start` bleibt unverändert.
+- Der Schalter wird in paketierten Builds abgewiesen. Freie Umgebungsvariablen aktivieren weder den isolierten Pfad noch eine Release-Freischaltung; verwendet wird ausschließlich der bestehende interne Provider `bbm-internal-development-license-v1` mit `DEV / development-diagnostic`.
+- Die sichtbare Abnahme bestätigte realen Schrift-Istwert, Kleiner/Größer, direkte Eingabe, Undo, Reset, Kurz-/Langtext, normale Bezeichnung, Feld, Bewegung, Sichtbarkeit sowie Save-/Neustart-Restore ohne Topologie- oder Scrolländerung.
+- Der forensische Vergleich von Kopien der echten `app.db` und `app.db.bak` ergab genau einen technischen Zeitstempelunterschied in `restarbeiten_items`; Fachwerte, Schema, Primärschlüssel und Zeilenzahlen sind identisch. Es wurde nichts zurückgespielt.
+- Detaildokument: `docs/M82_7_3_BBM_TEXTRESIZE_ISTWERT_UND_ISOLIERUNG.md`.
+
 ### M82.7.1 – Willkürliche Verschiebegrenze entfernen
 
 - Status: `[A] abgenommen`; gezielte Reparatur, Pflichtprüfungen und sichtbare isolierte Diagnostic-Abnahme sind abgeschlossen.

--- a/docs/M82_7_3_BBM_TEXTRESIZE_ISTWERT_UND_ISOLIERUNG.md
+++ b/docs/M82_7_3_BBM_TEXTRESIZE_ISTWERT_UND_ISOLIERUNG.md
@@ -1,0 +1,62 @@
+# M82.7.3 – BBM-`textResize`-Istwert und isolierte Abnahme
+
+Status: `[A]`
+
+## Forensischer Datenbankbefund
+
+Verglichen wurden ausschließlich temporäre Kopien von:
+
+- `app.db`, SHA-256 `8EA14AC75EB32F211EAFF8E548956573F8FB7FE1A9F21B6AE9E030B99C32EF24`
+- `app.db.bak`, SHA-256 `2088047224B31D1A3178D721156A3D84B6E3A9F1C79C38648B1AC83AFE6C93DD`
+
+Beide Dateien besitzen 57 Schemaobjekte, 31 Tabellen, identische Primärschlüssel und identische Zeilenzahlen. `PRAGMA integrity_check` ergab jeweils `ok`; die Fremdschlüsselprüfung blieb leer. Es wurde genau eine geänderte Zelle gefunden:
+
+- Tabelle: `restarbeiten_items`
+- Primärschlüssel: `07ac420e-0e4a-4d65-bb82-5666c7ad1542`
+- Spalte: `updated_at`
+- Sicherung: `2026-07-30T09:48:58.661Z`
+- aktuelle Datenbank: `2026-07-31T07:06:44.285Z`
+
+Es gibt keine hinzugefügte oder entfernte Zeile, keine Schemaänderung und keine Änderung an Fachwerten, Einstellungen, Session-, Fenster-, MRU-, Cache-, Registry-, Layout-, Profil- oder Lizenzdaten. Die aktuelle Datenbank ist logisch konsistent. Eine Rücksicherung ist nicht begründet und wurde nicht ausgeführt; über eine spätere Rücksicherung kann ausschließlich der Nutzer entscheiden.
+
+## Exakte Schreibursache
+
+Der normale Entwicklungsstart lief über `npm start` → `start:raw` → Electron → `src/main/main.js`. `getDbPaths()` in `src/main/db/database.js` bezog `app.db` mangels eines expliziten Abnahmeprofil-Schalters unmittelbar aus `app.getPath("userData")`. Der vorhandene Diagnostic-/DevelopmentLicense-Weg änderte nur Diagnoseoberfläche und Lizenzidentität, nicht den Electron-`userData`-Pfad.
+
+Der Electron-Main-Prozess öffnete diese Datenbank. Beim sichtbaren Auswählen eines Restarbeiten-Ziels verlor das vorhandene Kurztextfeld den Fokus. Sein bestehender Blur-/Autosave-Pfad sendete einen inhaltlich unveränderten Vollpatch über `restarbeiten:updateItem` an `restarbeitenRepo.updateRestarbeitItem`; dessen SQL-Update setzte `updated_at` neu. Start und Shutdown erzeugten im forensischen Vergleich keine weitere logische Änderung.
+
+## Isolierter Abnahmeweg
+
+Der eindeutige Befehl lautet:
+
+```text
+npm run start:ui-editor:acceptance
+```
+
+Der Launcher erzeugt ein markiertes Verzeichnis `bbm-ui-editor-acceptance-*` unter dem System-Tempordner. Vor allen Datenbank- und IPC-Imports setzt der Main-Prozess `userData` und `sessionData` auf dessen Unterordner. Zwei aufeinanderfolgende Starts verwenden dasselbe isolierte Profil, damit Save und Neustart-Restore real geprüft werden können. Anschließend wird nur dieses validierte Temp-Profil im `finally` entfernt.
+
+Der normale `npm start` setzt keine Electron-Pfade um. Paketierte Builds lehnen den Abnahmeschalter ab. Der Launcher entfernt frei gesetzte Lizenz-, Flavor-, Audio- und Netzwerkserver-Umgebungsvariablen und verwendet den vorhandenen internen Provider `bbm-internal-development-license-v1` mit der Buildidentität `DEV / development-diagnostic`. Die Benutzerlizenz wird weder gelesen noch erzeugt oder überschrieben.
+
+## Sichtbare Abnahme
+
+Im ersten isolierten Start wurden sichtbar geprüft:
+
+- Restzeichenanzeige Kurztext: Istwert `8,66667 DIP`, Kleiner `7,667`, Größer `8,667`, Direkteingabe `9,5`, Undo und Original/Reset
+- Restzeichenanzeige Langtext: Istwert `8,66667 DIP`
+- normale Bezeichnung: Istwert `10 DIP`
+- Kurztextfeld: Istwert `10,6667 DIP`
+- Bewegung und Sichtbarkeit am freigegebenen Restzeichen-Ziel
+- Speichern des Kurztextwerts `7,667 DIP`
+
+Nach vollständigem Schließen und erneutem Start meldete der Editor für dasselbe Ziel `Schriftgröße: 7,667 DIP`; der Startlog bestätigte `layout_profile_loaded` und `startup_layout_applied`. Topologie, vorhandener Scrollbesitz und Fachtexte blieben unverändert. Beide Abnahmestarts endeten mit Exitcode 0 und das isolierte Profil wurde entfernt.
+
+## Automatisierte Prüfung
+
+- M82.7.3 BBM: 13/13 grün
+- Isolations-/Sentineltests: 8/8 grün
+- `npm test`: 8/8 Gruppen, kein OOM
+- `npm run test:node`: 8/8 Gruppen; Node ABI 127, danach Electron ABI 123 wiederhergestellt
+- gezieltes ESLint: keine neuen Fehler
+- UI-Editor-kit: M82.7.3 10/10, M82.7.2 8/8, Einfachmodus 22/22, 103 Manager- und 106 Reference-App-Tests sowie `npm test` grün
+
+Die echte `app.db`, `app.db.bak`, Benutzerlizenz und `docs/licensing.md` blieben vor und nach den Abnahmeläufen bytegleich.

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "main": "src/main/main.js",
   "type": "commonjs",
   "scripts": {
-    "start": "npm run fix:electron-deps && npm run start:raw",
+    "start": "npm run fix:electron-deps && npm run prepare:ui-editor && npm run start:raw",
     "start:raw": "set ELECTRON_RUN_AS_NODE=&& electron .",
+    "start:ui-editor:acceptance": "npm run fix:electron-deps && npm run prepare:ui-editor && node scripts/runIsolatedUiEditorAcceptance.cjs",
     "prepare:ui-editor": "node scripts/prepareUiEditorManager.cjs",
     "pack": "npm run fix:electron-deps && npm run prepare:ui-editor && electron-builder --dir",
     "pack:diagnostic": "npm run fix:electron-deps && npm run prepare:ui-editor && node scripts/dist.cjs --diagnostic --dir",

--- a/scripts/runIsolatedUiEditorAcceptance.cjs
+++ b/scripts/runIsolatedUiEditorAcceptance.cjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawn } = require("child_process");
+const {
+  ACCEPTANCE_SWITCH,
+  ACCEPTANCE_PROFILE_PREFIX,
+  ACCEPTANCE_MARKER_FILE,
+  ACCEPTANCE_PURPOSE,
+  DEVELOPMENT_BUILD_CHANNEL,
+  DEVELOPMENT_BUILD_FLAVOR,
+  DEVELOPMENT_LICENSE_PROVIDER_ID,
+  isPathInside,
+} = require("../src/main/startup/uiEditorAcceptanceProfile");
+
+const REMOVED_ENV_KEYS = Object.freeze([
+  "ELECTRON_RUN_AS_NODE",
+  "BBM_DEVELOPMENT_LICENSE",
+  "BBM_BUILD_CHANNEL",
+  "BBM_BUILD_FLAVOR",
+  "BBM_CUSTOMER_LICENSE_FILE",
+  "BBM_CUSTOMER_SETUP_TYPE",
+  "BBM_DEV_UNLOCK_AUDIO",
+  "BBM_DEV_ENABLE_AUDIO_SUGGESTIONS",
+  "BBM_WHISPER_SERVER_HOST",
+  "BBM_WHISPER_SERVER_PORT",
+]);
+
+function createSanitizedEnvironment(source = process.env) {
+  const result = { ...source };
+  for (const key of REMOVED_ENV_KEYS) delete result[key];
+  return result;
+}
+
+function createAcceptanceProfile({ fsImpl = fs, osImpl = os, pathImpl = path } = {}) {
+  const rootPath = fsImpl.mkdtempSync(pathImpl.join(osImpl.tmpdir(), ACCEPTANCE_PROFILE_PREFIX));
+  const userDataPath = pathImpl.join(rootPath, "userData");
+  const sessionDataPath = pathImpl.join(rootPath, "sessionData");
+  fsImpl.mkdirSync(userDataPath, { recursive: true });
+  fsImpl.mkdirSync(sessionDataPath, { recursive: true });
+  const marker = {
+    schemaVersion: 1,
+    purpose: ACCEPTANCE_PURPOSE,
+    buildChannel: DEVELOPMENT_BUILD_CHANNEL,
+    buildFlavor: DEVELOPMENT_BUILD_FLAVOR,
+    developmentLicenseProvider: DEVELOPMENT_LICENSE_PROVIDER_ID,
+    createdAt: new Date().toISOString(),
+    nonce: crypto.randomUUID(),
+  };
+  fsImpl.writeFileSync(
+    pathImpl.join(rootPath, ACCEPTANCE_MARKER_FILE),
+    `${JSON.stringify(marker, null, 2)}\n`,
+    "utf8"
+  );
+  return Object.freeze({ rootPath, userDataPath, sessionDataPath, marker });
+}
+
+function buildElectronArguments({ repoRoot, profileRoot }) {
+  return Object.freeze([
+    repoRoot,
+    `${ACCEPTANCE_SWITCH}${profileRoot}`,
+    "--bbm-electron-editor-diagnostic",
+  ]);
+}
+
+function hashFileOrMissing(filePath, { fsImpl = fs } = {}) {
+  if (!fsImpl.existsSync(filePath)) return "MISSING";
+  return crypto.createHash("sha256").update(fsImpl.readFileSync(filePath)).digest("hex").toUpperCase();
+}
+
+function runElectronOnce({ electronExecutable, args, cwd, env, spawnImpl = spawn }) {
+  return new Promise((resolve, reject) => {
+    const child = spawnImpl(electronExecutable, args, {
+      cwd,
+      env,
+      stdio: "inherit",
+      windowsHide: false,
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code: Number(code ?? 1), signal: signal || "" }));
+  });
+}
+
+function removeAcceptanceProfile(profileRoot, { fsImpl = fs, osImpl = os, pathImpl = path } = {}) {
+  const tempRoot = pathImpl.resolve(osImpl.tmpdir());
+  const resolvedRoot = pathImpl.resolve(profileRoot);
+  if (!isPathInside(tempRoot, resolvedRoot, pathImpl) ||
+      !pathImpl.basename(resolvedRoot).startsWith(ACCEPTANCE_PROFILE_PREFIX)) {
+    throw new Error("UI_EDITOR_ACCEPTANCE_CLEANUP_REFUSED");
+  }
+  fsImpl.rmSync(resolvedRoot, { recursive: true, force: true });
+}
+
+async function runAcceptance({ runs = 2 } = {}) {
+  if (runs !== 2) throw new Error("UI_EDITOR_ACCEPTANCE_REQUIRES_TWO_RUNS");
+  const repoRoot = path.resolve(__dirname, "..");
+  const profile = createAcceptanceProfile();
+  const dbPath = path.join(profile.userDataPath, "app.db");
+  const electronExecutable = require("electron");
+  const args = buildElectronArguments({ repoRoot, profileRoot: profile.rootPath });
+  const env = createSanitizedEnvironment();
+  let exitCode = 0;
+
+  console.log(`[ui-editor-acceptance] isolated root: ${profile.rootPath}`);
+  console.log(`[ui-editor-acceptance] identity: ${DEVELOPMENT_BUILD_CHANNEL} / ${DEVELOPMENT_BUILD_FLAVOR}`);
+  console.log(`[ui-editor-acceptance] license provider: ${DEVELOPMENT_LICENSE_PROVIDER_ID}`);
+  console.log("[ui-editor-acceptance] two runs use the same isolated profile for restart/restore.");
+
+  try {
+    for (let index = 0; index < runs; index += 1) {
+      console.log(`[ui-editor-acceptance] starting run ${index + 1}/${runs}`);
+      const result = await runElectronOnce({ electronExecutable, args, cwd: repoRoot, env });
+      console.log(`[ui-editor-acceptance] run ${index + 1}/${runs} exit=${result.code} dbSha256=${hashFileOrMissing(dbPath)}`);
+      if (result.code !== 0) {
+        exitCode = result.code || 1;
+        break;
+      }
+    }
+    return exitCode;
+  } finally {
+    removeAcceptanceProfile(profile.rootPath);
+    console.log(`[ui-editor-acceptance] isolated root removed: ${profile.rootPath}`);
+  }
+}
+
+async function main() {
+  try {
+    process.exitCode = await runAcceptance();
+  } catch (error) {
+    console.error("[ui-editor-acceptance] failed:", error?.stack || error?.message || error);
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) void main();
+
+module.exports = Object.freeze({
+  REMOVED_ENV_KEYS,
+  createSanitizedEnvironment,
+  createAcceptanceProfile,
+  buildElectronArguments,
+  hashFileOrMissing,
+  runElectronOnce,
+  removeAcceptanceProfile,
+  runAcceptance,
+});

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -154,6 +154,8 @@ const TEST_GROUPS = Object.freeze([
       ["m82-6TopScreenModuleClosure.test.cjs", "runM826TopScreenModuleClosureTests"],
       ["m82-7RemainingIndicators.test.cjs", "runM827RemainingIndicatorTests"],
       ["m82-7-2GenericTextResize.test.cjs", "runM8272GenericTextResizeTests"],
+      ["m82-7-3TextResizeCurrentValue.test.cjs", "runM8273TextResizeCurrentValueTests"],
+      ["uiEditorAcceptanceIsolation.test.cjs", "runUiEditorAcceptanceIsolationTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),
   }),

--- a/scripts/tests/m82-7-3TextResizeCurrentValue.test.cjs
+++ b/scripts/tests/m82-7-3TextResizeCurrentValue.test.cjs
@@ -1,0 +1,151 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const ROOT = path.resolve(__dirname, "../..");
+const SHORT = "restarbeiten.edit.short.remaining";
+const LONG = "restarbeiten.edit.long.remaining";
+
+class FakeElement {
+  constructor(tagName = "SPAN", baseFontSize = 12) {
+    this.tagName = tagName;
+    this.attributes = {};
+    this.dataset = {};
+    this.className = "";
+    this.parentElement = null;
+    this.children = [];
+    this.textContent = "Fachwert";
+    this._baseFontSize = baseFontSize;
+    this._rect = { left: 0, top: 0, width: 120, height: 24 };
+    this.isConnected = true;
+    this.style = {};
+    this.classList = {
+      contains: (name) => this.className.split(/\s+/).includes(name),
+      toggle: (name, active) => {
+        const names = new Set(this.className.split(/\s+/).filter(Boolean));
+        if (active) names.add(name); else names.delete(name);
+        this.className = [...names].join(" ");
+      },
+    };
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  getAttribute(name) { return this.attributes[name] || null; }
+  appendChild(child) { child.parentElement = this; this.children.push(child); return child; }
+  getBoundingClientRect() { return { ...this._rect }; }
+}
+
+async function runM8273TextResizeCurrentValueTests(run) {
+  const refs = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Refs.js"));
+  const registry = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Registry.js"));
+  const host = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80HostAdapter.js"));
+  const previous = { document: global.document, window: global.window, Element: global.Element };
+  const scopes = registry.listM80RegistryScopes();
+  const entries = scopes.flatMap((scope) => scope.elements);
+  const nodes = new Map(entries.map((entry) => [entry.id, new FakeElement(entry.type === "field" ? "INPUT" : "SPAN", Number(entry.baseline?.fontSize) || 12)]));
+  global.Element = FakeElement;
+  global.document = { querySelector: () => null, createElement: () => new FakeElement(), addEventListener() {}, removeEventListener() {} };
+  global.window = {
+    getComputedStyle: (element) => ({
+      width: `${element._rect.width}px`, height: `${element._rect.height}px`,
+      paddingLeft: element.style.paddingLeft || "0px", paddingTop: element.style.paddingTop || "0px",
+      fontSize: element.style.fontSize || `${element._baseFontSize}px`,
+    }),
+    dispatchEvent() {},
+  };
+  refs.resetM80PilotWorkingStatesForDiagnostic();
+  for (const entry of entries) {
+    if (entry.parentId) nodes.get(entry.parentId)?.appendChild(nodes.get(entry.id));
+    refs.registerM80Ref(entry.id, nodes.get(entry.id));
+  }
+  const scopeIdFor = (id) => scopes.find((scope) => scope.elements.some((entry) => entry.id === id)).scopeId;
+  const currentFromPayload = (id) => host.handleM80EditorRequest({ action: "getLayoutState" }).scopeStates
+    .find((scope) => scope.scopeId === scopeIdFor(id)).elements.find((entry) => entry.elementId === id);
+  const resize = (id, fontSize, changeId) => host.handleM80EditorRequest({
+    action: "submitChange", scopeId: scopeIdFor(id),
+    changeRequest: { changeId, elementId: id, operation: "textResize",
+      payload: { text: { fontSize, unit: "dip", expectedCurrentFontSize: currentFromPayload(id).fontSize } }, source: "m82-7-3-real-payload" },
+  }).changeResult;
+
+  try {
+    await run("M82.7.3 BBM 01: npm start baut den aktuellen Manager vor start:raw", () => {
+      const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+      assert.equal(pkg.scripts.start, "npm run fix:electron-deps && npm run prepare:ui-editor && npm run start:raw");
+    });
+    await run("M82.7.3 BBM 02: bestehender Prepare-Weg publiziert aus dem lokalen UI-Editor-kit", () => {
+      const source = fs.readFileSync(path.join(ROOT, "scripts/prepareUiEditorManager.cjs"), "utf8");
+      assert.match(source, /UI-Editor-kit/);
+      assert.match(source, /dotnet[\s\S]*publish/);
+      assert.match(source, /ui-editor-manager/);
+    });
+    await run("M82.7.3 BBM 03: Restzeichen Kurztext liefert den realen Computed-Style-Istwert", () => assert.equal(currentFromPayload(SHORT).fontSize, 8.667));
+    await run("M82.7.3 BBM 04: Restzeichen Langtext liefert den realen Computed-Style-Istwert", () => assert.equal(currentFromPayload(LONG).fontSize, 8.667));
+    await run("M82.7.3 BBM 05: normale Bezeichnung nutzt denselben Istwert-Payload", () => {
+      const state = currentFromPayload("restarbeiten.edit.short.label");
+      assert.equal(state.fontSize, Number.parseFloat(global.window.getComputedStyle(nodes.get(state.elementId)).fontSize));
+    });
+    await run("M82.7.3 BBM 06: Feld nutzt denselben Istwert-Payload", () => {
+      const state = currentFromPayload("restarbeiten.edit.short.field");
+      assert.equal(state.fontSize, Number.parseFloat(global.window.getComputedStyle(nodes.get(state.elementId)).fontSize));
+    });
+
+    const baseline = currentFromPayload(SHORT);
+    await run("M82.7.3 BBM 07: Kleiner veraendert reales Element und Ruecklesewert sichtbar", () => {
+      const result = resize(SHORT, 7.667, "m8273-smaller");
+      assert.equal(result.success, true, result.message);
+      assert.equal(nodes.get(SHORT).style.fontSize, "7.667px");
+      assert.equal(currentFromPayload(SHORT).fontSize, 7.667);
+    });
+    await run("M82.7.3 BBM 08: Groesser berechnet vom bestaetigten Istwert", () => {
+      const result = resize(SHORT, 8.667, "m8273-larger");
+      assert.equal(result.success, true, result.message);
+      assert.equal(result.textResize.previousFontSize, 7.667);
+      assert.equal(result.textResize.appliedFontSize, 8.667);
+    });
+    await run("M82.7.3 BBM 09: direkte Eingabe verwendet denselben Vertrag", () => {
+      const result = resize(SHORT, 9.25, "m8273-direct");
+      assert.equal(result.success, true, result.message);
+      assert.equal(result.textResize.unit, "dip");
+      assert.equal(currentFromPayload(SHORT).fontSize, 9.25);
+    });
+    await run("M82.7.3 BBM 10: Editor-Payload stimmt nach Apply mit getComputedStyle ueberein", () => {
+      assert.equal(currentFromPayload(SHORT).fontSize, Number.parseFloat(global.window.getComputedStyle(nodes.get(SHORT)).fontSize));
+    });
+    await run("M82.7.3 BBM 11: Undo- und Reset-Readback stellen den realen Baselinewert bereit", () => {
+      refs.applyM80State(SHORT, baseline, "textResize");
+      assert.equal(currentFromPayload(SHORT).fontSize, 8.667);
+    });
+    await run("M82.7.3 BBM 12: Verschieben und Sichtbarkeit lassen den Schrift-Istwert unveraendert", () => {
+      const before = currentFromPayload(SHORT).fontSize;
+      const moved = host.handleM80EditorRequest({ action: "submitChange", scopeId: scopeIdFor(SHORT), changeRequest: { changeId: "m8273-move", elementId: SHORT, operation: "move", payload: { x: 4, y: -2 }, source: "m82-7-3-real-payload" } }).changeResult;
+      assert.equal(moved.success, true, moved.message);
+      const hidden = host.handleM80EditorRequest({ action: "submitChange", scopeId: scopeIdFor(SHORT), changeRequest: { changeId: "m8273-hide", elementId: SHORT, operation: "setVisibility", payload: { visible: false }, source: "m82-7-3-real-payload" } }).changeResult;
+      assert.equal(hidden.success, true, hidden.message);
+      assert.equal(currentFromPayload(SHORT).fontSize, before);
+      assert.equal(currentFromPayload(SHORT).visible, false);
+    });
+    await run("M82.7.3 BBM 13: Fachwerte, Topologie und Scrollstruktur bleiben unveraendert", () => {
+      assert.equal(nodes.get(SHORT).textContent, "Fachwert");
+      const topology = refs.snapshotM80Topology();
+      assert.equal(refs.compareM80Topology(topology).ok, true);
+      assert.equal(nodes.get("restarbeiten.list.area").style.overflow || "", "");
+    });
+  } finally {
+    refs.resetM80PilotWorkingStatesForDiagnostic();
+    global.document = previous.document;
+    global.window = previous.window;
+    global.Element = previous.Element;
+  }
+}
+
+if (require.main === module) {
+  let failed = false;
+  runM8273TextResizeCurrentValueTests(async (name, action) => {
+    try { await action(); console.log(`OK ${name}`); }
+    catch (error) { failed = true; console.error(`FAIL ${name}`); throw error; }
+  }).catch((error) => { failed = true; console.error(error); }).finally(() => { if (failed) process.exitCode = 1; });
+}
+
+module.exports = { runM8273TextResizeCurrentValueTests };

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 109, "109 Suite-Einstiege einschließlich Entwicklungs-Lizenz sowie M82.4 bis M82.7.2");
+    assert.equal(suites.length, 111, "111 Suite-Einstiege einschließlich Entwicklungs-Lizenz sowie M82.4 bis M82.7.3-Isolation");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/scripts/tests/uiEditorAcceptanceIsolation.test.cjs
+++ b/scripts/tests/uiEditorAcceptanceIsolation.test.cjs
@@ -1,0 +1,125 @@
+const assert = require("assert");
+const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const {
+  ACCEPTANCE_SWITCH,
+  DEVELOPMENT_BUILD_CHANNEL,
+  DEVELOPMENT_BUILD_FLAVOR,
+  DEVELOPMENT_LICENSE_PROVIDER_ID,
+  configureUiEditorAcceptanceProfile,
+} = require("../../src/main/startup/uiEditorAcceptanceProfile");
+const {
+  REMOVED_ENV_KEYS,
+  createSanitizedEnvironment,
+  createAcceptanceProfile,
+  buildElectronArguments,
+  hashFileOrMissing,
+  removeAcceptanceProfile,
+} = require("../runIsolatedUiEditorAcceptance.cjs");
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex").toUpperCase();
+}
+
+async function runUiEditorAcceptanceIsolationTests(run) {
+  await run("M82.7.3 Isolation: normaler Start aendert ohne expliziten Schalter keinen Electron-Pfad", () => {
+    const calls = [];
+    const result = configureUiEditorAcceptanceProfile({
+      electronApp: { isPackaged: false, setPath: (...args) => calls.push(args) },
+      argv: ["electron", "."],
+    });
+    assert.deepEqual(result, { enabled: false });
+    assert.deepEqual(calls, []);
+  });
+
+  await run("M82.7.3 Isolation: Abnahme setzt userData und sessionData ausschliesslich auf das Temp-Profil", () => {
+    const profile = createAcceptanceProfile();
+    const calls = [];
+    try {
+      const result = configureUiEditorAcceptanceProfile({
+        electronApp: { isPackaged: false, setPath: (...args) => calls.push(args) },
+        argv: ["electron", ".", `${ACCEPTANCE_SWITCH}${profile.rootPath}`],
+      });
+      assert.equal(result.enabled, true);
+      assert.deepEqual(calls, [
+        ["userData", profile.userDataPath],
+        ["sessionData", profile.sessionDataPath],
+      ]);
+      assert.equal(result.marker.buildChannel, DEVELOPMENT_BUILD_CHANNEL);
+      assert.equal(result.marker.buildFlavor, DEVELOPMENT_BUILD_FLAVOR);
+      assert.equal(result.marker.developmentLicenseProvider, DEVELOPMENT_LICENSE_PROVIDER_ID);
+    } finally {
+      removeAcceptanceProfile(profile.rootPath);
+    }
+  });
+
+  await run("M82.7.3 Isolation: paketierter Release-Build lehnt den Abnahmeschalter ab", () => {
+    const profile = createAcceptanceProfile();
+    try {
+      assert.throws(() => configureUiEditorAcceptanceProfile({
+        electronApp: { isPackaged: true, setPath: () => assert.fail("setPath darf nicht laufen") },
+        argv: ["BBM.exe", `${ACCEPTANCE_SWITCH}${profile.rootPath}`],
+      }), /UI_EDITOR_ACCEPTANCE_REQUIRES_SOURCE_BUILD/);
+    } finally {
+      removeAcceptanceProfile(profile.rootPath);
+    }
+  });
+
+  await run("M82.7.3 Isolation: freie Umgebungsvariablen werden nicht als Development-Unlock weitergereicht", () => {
+    const source = Object.fromEntries(REMOVED_ENV_KEYS.map((key) => [key, "1"]));
+    source.PATH = "sentinel";
+    const sanitized = createSanitizedEnvironment(source);
+    assert.equal(sanitized.PATH, "sentinel");
+    for (const key of REMOVED_ENV_KEYS) assert.equal(Object.hasOwn(sanitized, key), false, key);
+  });
+
+  await run("M82.7.3 Isolation: Startargumente aktivieren Diagnose ohne vorzeitigen Editorstart", () => {
+    const args = buildElectronArguments({ repoRoot: "C:\\repo", profileRoot: "C:\\temp\\profile" });
+    assert.equal(args[0], "C:\\repo");
+    assert.equal(args.includes("--bbm-electron-editor-diagnostic"), true);
+    assert.equal(args.includes("--open-ui-editor"), false);
+    assert.equal(args.some((arg) => arg === `${ACCEPTANCE_SWITCH}C:\\temp\\profile`), true);
+  });
+
+  await run("M82.7.3 Isolation: Sentinel-Benutzerdateien bleiben bei isoliertem DB-Schreiben bytegleich", () => {
+    const sentinelRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-ui-editor-sentinel-"));
+    const profile = createAcceptanceProfile();
+    const realDbSentinel = path.join(sentinelRoot, "app.db");
+    const realLicenseSentinel = path.join(sentinelRoot, "license.json");
+    try {
+      fs.writeFileSync(realDbSentinel, "REAL-DB-SENTINEL", "utf8");
+      fs.writeFileSync(realLicenseSentinel, "REAL-LICENSE-SENTINEL", "utf8");
+      const beforeDb = hashFileOrMissing(realDbSentinel);
+      const beforeLicense = hashFileOrMissing(realLicenseSentinel);
+      fs.writeFileSync(path.join(profile.userDataPath, "app.db"), "ISOLATED-TEST-DB", "utf8");
+      assert.equal(hashFileOrMissing(realDbSentinel), beforeDb);
+      assert.equal(hashFileOrMissing(realLicenseSentinel), beforeLicense);
+      assert.equal(hashFileOrMissing(path.join(profile.userDataPath, "app.db")), sha256("ISOLATED-TEST-DB"));
+    } finally {
+      removeAcceptanceProfile(profile.rootPath);
+      fs.rmSync(sentinelRoot, { recursive: true, force: true });
+    }
+  });
+
+  await run("M82.7.3 Isolation: Main konfiguriert das Profil vor allen DB- und IPC-Imports", () => {
+    const main = fs.readFileSync(path.join(process.cwd(), "src/main/main.js"), "utf8");
+    const configureIndex = main.indexOf("configureUiEditorAcceptanceProfile({ electronApp: app })");
+    const databaseImportIndex = main.indexOf('require("./db/database")');
+    const firstIpcImportIndex = main.indexOf('require("./ipc/projectsIpc")');
+    assert.equal(configureIndex > 0, true);
+    assert.equal(configureIndex < databaseImportIndex, true);
+    assert.equal(configureIndex < firstIpcImportIndex, true);
+  });
+
+  await run("M82.7.3 Isolation: package bietet einen eindeutigen zweifachen Abnahmestart", () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8"));
+    assert.equal(pkg.scripts["start:ui-editor:acceptance"], "npm run fix:electron-deps && npm run prepare:ui-editor && node scripts/runIsolatedUiEditorAcceptance.cjs");
+    const runner = fs.readFileSync(path.join(process.cwd(), "scripts/runIsolatedUiEditorAcceptance.cjs"), "utf8");
+    assert.match(runner, /async function runAcceptance\(\{ runs = 2 \}/);
+    assert.match(runner, /UI_EDITOR_ACCEPTANCE_REQUIRES_TWO_RUNS/);
+  });
+}
+
+module.exports = { runUiEditorAcceptanceIsolationTests };

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -7,6 +7,13 @@ const { app, BrowserWindow, ipcMain, dialog, shell, Menu } = require("electron")
 const path = require("path");
 const fs = require("fs");
 const { spawn } = require("child_process");
+const { configureUiEditorAcceptanceProfile } = require("./startup/uiEditorAcceptanceProfile");
+
+const uiEditorAcceptanceProfile = configureUiEditorAcceptanceProfile({ electronApp: app });
+if (uiEditorAcceptanceProfile.enabled) {
+  console.log("[ui-editor-acceptance] userData", uiEditorAcceptanceProfile.userDataPath);
+  console.log("[ui-editor-acceptance] sessionData", uiEditorAcceptanceProfile.sessionDataPath);
+}
 
 // IPCs
 const { registerProjectsIpc } = require("./ipc/projectsIpc");

--- a/src/main/startup/uiEditorAcceptanceProfile.js
+++ b/src/main/startup/uiEditorAcceptanceProfile.js
@@ -1,0 +1,84 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const ACCEPTANCE_SWITCH = "--bbm-ui-editor-acceptance-root=";
+const ACCEPTANCE_PROFILE_PREFIX = "bbm-ui-editor-acceptance-";
+const ACCEPTANCE_MARKER_FILE = ".bbm-ui-editor-acceptance.json";
+const ACCEPTANCE_PURPOSE = "ui-editor-isolated-acceptance";
+const DEVELOPMENT_BUILD_CHANNEL = "DEV";
+const DEVELOPMENT_BUILD_FLAVOR = "development-diagnostic";
+const DEVELOPMENT_LICENSE_PROVIDER_ID = "bbm-internal-development-license-v1";
+
+function isPathInside(parentPath, candidatePath, pathImpl = path) {
+  const relative = pathImpl.relative(pathImpl.resolve(parentPath), pathImpl.resolve(candidatePath));
+  return relative !== "" && relative !== ".." && !relative.startsWith(`..${pathImpl.sep}`) && !pathImpl.isAbsolute(relative);
+}
+
+function readAcceptanceMarker(rootPath, { fsImpl = fs, pathImpl = path } = {}) {
+  const markerPath = pathImpl.join(rootPath, ACCEPTANCE_MARKER_FILE);
+  const marker = JSON.parse(fsImpl.readFileSync(markerPath, "utf8"));
+  const valid = marker?.schemaVersion === 1 &&
+    marker?.purpose === ACCEPTANCE_PURPOSE &&
+    marker?.buildChannel === DEVELOPMENT_BUILD_CHANNEL &&
+    marker?.buildFlavor === DEVELOPMENT_BUILD_FLAVOR &&
+    marker?.developmentLicenseProvider === DEVELOPMENT_LICENSE_PROVIDER_ID;
+  if (!valid) throw new Error("UI_EDITOR_ACCEPTANCE_MARKER_INVALID");
+  return Object.freeze({ ...marker, markerPath });
+}
+
+function resolveAcceptanceRoot(argv = process.argv, { osImpl = os, pathImpl = path } = {}) {
+  const argument = argv.find((value) => String(value || "").startsWith(ACCEPTANCE_SWITCH));
+  if (!argument) return "";
+  const rootPath = pathImpl.resolve(String(argument).slice(ACCEPTANCE_SWITCH.length));
+  const tempRoot = pathImpl.resolve(osImpl.tmpdir());
+  if (!isPathInside(tempRoot, rootPath, pathImpl) ||
+      !pathImpl.basename(rootPath).startsWith(ACCEPTANCE_PROFILE_PREFIX)) {
+    throw new Error("UI_EDITOR_ACCEPTANCE_ROOT_NOT_ISOLATED");
+  }
+  return rootPath;
+}
+
+function configureUiEditorAcceptanceProfile({
+  electronApp,
+  argv = process.argv,
+  fsImpl = fs,
+  osImpl = os,
+  pathImpl = path,
+} = {}) {
+  const rootPath = resolveAcceptanceRoot(argv, { osImpl, pathImpl });
+  if (!rootPath) return Object.freeze({ enabled: false });
+  if (!electronApp || electronApp.isPackaged) {
+    throw new Error("UI_EDITOR_ACCEPTANCE_REQUIRES_SOURCE_BUILD");
+  }
+
+  const marker = readAcceptanceMarker(rootPath, { fsImpl, pathImpl });
+  const userDataPath = pathImpl.join(rootPath, "userData");
+  const sessionDataPath = pathImpl.join(rootPath, "sessionData");
+  fsImpl.mkdirSync(userDataPath, { recursive: true });
+  fsImpl.mkdirSync(sessionDataPath, { recursive: true });
+  electronApp.setPath("userData", userDataPath);
+  electronApp.setPath("sessionData", sessionDataPath);
+
+  return Object.freeze({
+    enabled: true,
+    rootPath,
+    userDataPath,
+    sessionDataPath,
+    marker,
+  });
+}
+
+module.exports = Object.freeze({
+  ACCEPTANCE_SWITCH,
+  ACCEPTANCE_PROFILE_PREFIX,
+  ACCEPTANCE_MARKER_FILE,
+  ACCEPTANCE_PURPOSE,
+  DEVELOPMENT_BUILD_CHANNEL,
+  DEVELOPMENT_BUILD_FLAVOR,
+  DEVELOPMENT_LICENSE_PROVIDER_ID,
+  isPathInside,
+  readAcceptanceMarker,
+  resolveAcceptanceRoot,
+  configureUiEditorAcceptanceProfile,
+});


### PR DESCRIPTION
## Ziel

M82.7.3 macht den realen Schriftgrößen-Istwert im BBM-Editor wirksam und führt einen vollständig isolierten UI-Editor-Abnahmeweg ein.

## Enthalten

- aktueller Host-Istwert wird im Editor angezeigt
- `Kleiner`, `Größer` und direkte Eingabe verwenden den realen Fontwert
- kein Fallbackwert `16`
- fehlender Istwert deaktiviert die Schriftsteuerung
- `npm start` baut vorab den aktuellen lokalen UI-Editor-Manager
- neuer isolierter Abnahmebefehl `npm run start:ui-editor:acceptance`
- isoliertes `userData` und `sessionData`
- interne DevelopmentLicense nur im Acceptance-Weg
- zwei Starts mit Restore-Nachweis
- echte Benutzer-DB, Sicherung und Lizenz bleiben unangetastet
- keine Fachlogik-, Topologie- oder Scrolländerung
- M82.7.3 `[A]`

## Prüfungen

- M82.7.3-Einzeltests 13/13
- Isolations-/Sentineltests 8/8
- `npm test` – 8/8 Gruppen
- `npm run test:node` – 8/8 Gruppen
- gezieltes ESLint ohne Fehler
- sichtbare Zwei-Start-Abnahme erfolgreich
- `git diff --check`

`docs/licensing.md` ist nicht Bestandteil des Commits.

## Commit

`15814ec61f811168efe79d9640502523bccdb8b8`