### PR TITLE
M82.7.5 Layoutpersistenz und Meta-Einzelziele absichern

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,15 @@
 # STATUS.md — BBM-Produktiv
 
+### M82.7.5 – Gespeichertes Layout und Meta-Elemente
+
+- Status: `[A] abgenommen`; Lebenszykluskorrektur, explizite Meta-Registrierung, automatisierte Regression und sichtbare isolierte Zwei-Start-Abnahme sind abgeschlossen.
+- Der bestehende atomare Profilstore bleibt die einzige Persistenzquelle. Gespeicherte und saubere Sitzungen behalten den angewandten Zustand; „Ohne Speichern“ stellt exakt die beim Öffnen erfasste Sitzungsgrenze wieder her. Rerender, Datensatzwechsel, Modulwechsel und Neustart verwenden denselben Arbeitszustands-/Startup-Restore-Weg.
+- Drei vorhandene Meta-Headertexte und vier vorhandene logische Zeilenbestandteile sind mit stabilen IDs einzeln registriert. Die Zeilenziele verwenden statische Multi-Refs über alle sichtbaren Karten; es wurden keine Wrapper, DOM-Knoten oder Fachwert-IDs ergänzt.
+- Sichtbar bestätigt sind „Fertig bis · Überschrift“ mit 9,667 DIP, „Status · Listeneinträge“ mit X=-5 und „Ampel · Listeneinträge“ mit 17×12 DIP nach Save, Editor-Close, Datensatz-Rerender, Modulwechsel und zweitem isoliertem Start.
+- Der Editor-Close wird nur einmal weitergereicht; zerstörte Electron-Fenster werden vor dem Zugriff auf `webContents` erkannt. Der Acceptance-Runner entfernte sein isoliertes Profil vollständig.
+- Topologie, Scrollstruktur, Fachlogik, Benutzerdateien und `docs/licensing.md` bleiben unverändert.
+- Detaildokument: `docs/M82_7_5_BBM_PERSISTENZ_UND_META_ELEMENTE.md`.
+
 ### M82.7.4.1 – Ampelsymbol verschiebbar
 
 - Status: `[A] abgenommen`; generischer Move-Weg, automatisierte Regression und sichtbare isolierte Zwei-Start-Abnahme sind abgeschlossen.

--- a/docs/M82_7_5_BBM_PERSISTENZ_UND_META_ELEMENTE.md
+++ b/docs/M82_7_5_BBM_PERSISTENZ_UND_META_ELEMENTE.md
@@ -1,0 +1,69 @@
+# M82.7.5 – Gespeichertes Layout und Meta-Elemente
+
+## Status
+
+`[A]` – Implementierung, automatisierte Regression und sichtbare isolierte Zwei-Start-Abnahme sind abgeschlossen.
+
+## Ursache und Lebenszyklus
+
+Der vorhandene atomare UI-Profilstore und der Startup-Restore waren bereits die richtige Persistenzquelle. Die Layoutstyles wurden beim Schließen des Editors ebenfalls nicht entfernt. Es fehlte aber eine eindeutige Abschlusssemantik zwischen nativem Editor und Electron-Ziel-App: `editorClosed` unterschied nicht zwischen gespeichert, sauber und „ohne Speichern“. Zusätzlich wurde das Ereignis vor und während der Session-Entsorgung doppelt weitergereicht. Beim späteren App-Shutdown konnte dadurch noch auf `webContents` eines bereits zerstörten Fensters zugegriffen werden.
+
+Der verbindliche Lebenszyklus ist jetzt:
+
+1. `getRegistry` erfasst einmalig den tatsächlichen Arbeitszustand als Sitzungsgrenze.
+2. Änderungen laufen ausschließlich über den vorhandenen generischen HostAdapter-/Ref-Weg.
+3. Speichern schreibt weiterhin über den bestehenden atomaren Profilstore.
+4. Der native Editor meldet beim Schließen genau eine Disposition: `saved`, `clean`, `discarded` oder `unknown`.
+5. `saved` und `clean` behalten den aktuellen Zustand; `discarded` stellt exakt die Sitzungsgrenze wieder her. Ein unerwartetes `unknown` verwirft keine Änderung eigenmächtig.
+6. Rerender und Datensatzwechsel binden neue DOM-Knoten an den vorhandenen Arbeitszustand.
+7. Beim BBM-Neustart lädt der vorhandene Startup-Restore das gespeicherte Profil genau einmal.
+8. Die Entsorgung prüft das Fenster vor dem Zugriff auf `webContents`; zerstörte Fenster erhalten kein spätes Ereignis.
+
+Damit sind gespeicherter Zustand und ungespeicherte Sitzung technisch getrennt. Nur „Ohne Speichern“, ein expliziter Reset/Originalzustand mit anschließendem Speichern oder eine Profiländerung entfernt eine gespeicherte Layoutwirkung.
+
+## Inventar der bestätigten Meta-Elemente
+
+Alle Ziele zeigen auf bereits vorhandene DOM-Knoten. Es wurden keine Wrapper, Zeilen-IDs, Fachwert-IDs oder neuen Ansichten erzeugt.
+
+| ID / Ref-Key | Parent | vorhandener DOM-Ref | Baseline und Grenzen | erlaubte Operationen | Auswahl / Scope |
+| --- | --- | --- | --- | --- | --- |
+| `restarbeiten.main.tableHeader.dueDate` | `restarbeiten.list.table.meta.header` | vorhandener Textknoten „Fertig bis“ im Meta-Header | X/Y 0; Schrift 8,667 DIP, 6–24 | move, textResize, setVisibility | einzelnes Element / Restarbeiten-Liste |
+| `restarbeiten.main.tableHeader.status` | `restarbeiten.list.table.meta.header` | vorhandener Textknoten „Status“ im Meta-Header | X/Y 0; Schrift 8,667 DIP, 6–24 | move, textResize, setVisibility | einzelnes Element / Restarbeiten-Liste |
+| `restarbeiten.main.tableHeader.responsible` | `restarbeiten.list.table.meta.header` | vorhandener Textknoten „Verantw.“ im Meta-Header | X/Y 0; Schrift 8,667 DIP, 6–24 | move, textResize, setVisibility | einzelnes Element / Restarbeiten-Liste |
+| `restarbeiten.record.dueDate` | `restarbeiten.list.table.meta.cells` | vorhandene Fälligkeitszeilen aller sichtbaren Karten | X/Y 0; Schrift 10,667 DIP, 7–32 | move, textResize, setVisibility | statischer logischer Multi-Ref / Restarbeiten-Liste |
+| `restarbeiten.record.ampel` | `restarbeiten.list.table.meta.cells` | vorhandene innere `span.bbm-restarbeiten-ampel` aller sichtbaren Karten | X/Y 0; 12×12 DIP, Breite/Höhe 7–48 | move, resizeWidth, resizeHeight, setVisibility | statischer logischer Multi-Ref / Restarbeiten-Liste |
+| `restarbeiten.record.status` | `restarbeiten.list.table.meta.cells` | vorhandene Statuszeilen aller sichtbaren Karten | X/Y 0; Schrift 10,667 DIP, 7–32 | move, textResize, setVisibility | statischer logischer Multi-Ref / Restarbeiten-Liste |
+| `restarbeiten.record.responsible` | `restarbeiten.list.table.meta.cells` | vorhandene Verantwortlichenzeilen aller sichtbaren Karten | X/Y 0; Schrift 10,667 DIP, 7–32 | move, textResize, setVisibility | statischer logischer Multi-Ref / Restarbeiten-Liste |
+
+Die vier Zeilenziele sind bewusst logische Multi-Refs: Eine Layoutänderung gilt für denselben sichtbaren Bestandteil aller Listeneinträge. Fachwerte und fachliche Zuordnungen bleiben davon unberührt. Bei leerer Liste bleibt der Vertrag logisch auflösbar; der Datenbereich wird dabei nicht fälschlich als Kind auswählbar.
+
+## Sichtbare Abnahme
+
+Die Abnahme lief ausschließlich mit `npm run start:ui-editor:acceptance` in dessen isoliertem Development-/Diagnostic-Profil:
+
+- Headerziel „Fertig bis · Überschrift“ direkt ausgewählt und von 8,667 auf 9,667 DIP vergrößert.
+- Zeilenziel „Status · Listeneinträge“ direkt ausgewählt und mit Schrittweite 5 von X=0 auf X=-5 verschoben.
+- Ziel „Ampel · Listeneinträge“ direkt ausgewählt und von 12×12 auf 17×12 DIP verbreitert.
+- gespeichert, Editor geschlossen und die drei Wirkungen in der laufenden Ziel-App beibehalten.
+- einen anderen Datensatz gewählt; der vollständige Listen-/Editbox-Rerender behielt alle Wirkungen.
+- zum Modul „Firmen“ gewechselt; beim zweiten isolierten App-Start kehrte der Diagnostic-Lauf in die Restarbeitenansicht zurück.
+- der zweite Start meldete `layout_profile_loaded` und `startup_layout_applied`; der Header zeigte erneut 9,667 DIP, Status und Ampel blieben sichtbar verändert und als getrennte Ziele auswählbar.
+- beide App-Läufe verwendeten denselben isolierten Datenbankhash und der temporäre Acceptance-Root wurde anschließend entfernt.
+
+## Automatisierte Prüfung
+
+- M82.7.5-Einzeltest: 34/34 grün.
+- `npm test`: 8/8 Testgruppen, kein OOM.
+- `npm run test:node`: Node 22 / ABI 127 vor dem Lauf, 8/8 Gruppen und Wiederherstellung auf Electron ABI 123 im `finally`.
+- gezieltes ESLint aller geänderten JavaScript-/Testharnessdateien: ohne Befund.
+- `npm run pack`: grün, Electron-ABI aktiv und `npmRebuild: false` wirksam.
+- globales `npm run lint`: bekannter Altstand mit 16 Fehlern und 371 Warnungen; keine geänderte M82.7.5-Datei erzeugt einen Fehler.
+- `git diff --check`: grün.
+
+## Grenzen
+
+- Keine neue UI, kein neuer DOM-Knoten und keine zweite Profilablage.
+- Keine Änderung an Tabellenbreitenquelle, Topologie, Scrollbesitzern oder Fachlogik.
+- Keine Benutzerlizenz, echte Benutzerdatenbank oder Sicherungsdatenbank wurde gelesen oder verwendet.
+- `docs/licensing.md` bleibt Fremdänderung und unangetastet.
+- Commit, Push, Pull Request und Merge sind nicht erfolgt.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -156,6 +156,7 @@ const TEST_GROUPS = Object.freeze([
       ["m82-7-2GenericTextResize.test.cjs", "runM8272GenericTextResizeTests"],
       ["m82-7-3TextResizeCurrentValue.test.cjs", "runM8273TextResizeCurrentValueTests"],
       ["m82-7-4AmpelEditing.test.cjs", "runM8274AmpelEditingTests"],
+      ["m82-7-5LayoutPersistenceMetaElements.test.cjs", "runM8275LayoutPersistenceMetaElementsTests"],
       ["uiEditorAcceptanceIsolation.test.cjs", "runUiEditorAcceptanceIsolationTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),

--- a/scripts/tests/m80-1RegistrationRefresh.test.cjs
+++ b/scripts/tests/m80-1RegistrationRefresh.test.cjs
@@ -83,7 +83,7 @@ async function runM801RegistrationRefreshTests(run) {
       document.body.appendChild(rendered.root);
       const registration = rendered.registration;
       runtimeRegistration = structuredClone(registration);
-      assert.equal(registration.registryVersion, 11);
+      assert.equal(registration.registryVersion, 12);
       assert.equal(registration.registryStatus, "incomplete");
       assert.deepEqual(registration.activeScopes, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]);
       const complete = registration.registryScopes.filter((scope) => scope.status === "complete");

--- a/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
+++ b/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
@@ -15,7 +15,7 @@ async function runM802HeaderEditboxLayoutTests(run) {
   const elements = complete.flatMap((scope) => scope.elements);
 
   await run("M80.2 Registry: Header, Liste und Editbox sind direkt aktiv; Split ist gesperrt", () => {
-    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 11);
+    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 12);
     assert.deepEqual(registryModule.BBM_M80_ACTIVE_SCOPES, [
       "restarbeiten.header.root",
       "restarbeiten.list.root",

--- a/scripts/tests/m82-1BbmFeintuning.test.cjs
+++ b/scripts/tests/m82-1BbmFeintuning.test.cjs
@@ -24,7 +24,7 @@ async function runM821BbmFeintuningTests(run) {
   const editbox = read("src/renderer/modules/restarbeiten/RestarbeitenEditbox.js");
   const css = read("src/renderer/modules/restarbeiten/styles/restarbeiten.css");
 
-  await run("M82.1 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 11));
+  await run("M82.1 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 12));
   await run("M82.1 BBM 02: Manifestversion folgt der Registry", () => assert.equal(manifest.registryVersion, registry.BBM_M80_REGISTRY_VERSION));
   await run("M82.1 BBM 03: Manifestfingerprint ist aktuell", () => assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)));
   await run("M82.1/M82.6 BBM 04: beide Referenzmodule besitzen je drei aktive Scopes", () => assert.deepEqual(registry.BBM_M80_ACTIVE_SCOPES, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root", "protokoll.screen.root", "protokoll.list.root", "protokoll.edit.root"]));

--- a/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
+++ b/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
@@ -47,7 +47,7 @@ async function runM823BbmSpacerCompactUiTests(run) {
     groupWidthEditable,
   });
 
-  await run("M82.3 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 11));
+  await run("M82.3 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 12));
   await run("M82.3 BBM 02: Manifest folgt Registry und Fingerprint", () => { assert.equal(manifest.registryVersion, registry.BBM_M80_REGISTRY_VERSION); assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)); });
   await run("M82.3 BBM 03: Kurztextbezeichnung besitzt reservierte Breite", () => assert.deepEqual(label.baseline.spacing, { reservedWidth: 40 }));
   await run("M82.3 BBM 04: Kurztextbezeichnung erlaubt Spacer davor und danach", () => assert.deepEqual(label.spacingTargets, ["beforeElement", "afterElement", "reservedWidth"]));

--- a/scripts/tests/m82-7-2GenericTextResize.test.cjs
+++ b/scripts/tests/m82-7-2GenericTextResize.test.cjs
@@ -125,11 +125,11 @@ async function runM8272GenericTextResizeTests(run) {
       return { lower, higher, direct };
     };
 
-    await run("M82.7.2 BBM: Inventar umfasst exakt alle 59 textResize-Ziele in fuenf produktiven Scopes", () => {
-      assert.equal(textEntries.length, 59);
+    await run("M82.7.2/M82.7.5 BBM: Inventar umfasst exakt alle 65 textResize-Ziele in fuenf produktiven Scopes", () => {
+      assert.equal(textEntries.length, 65);
       assert.deepEqual(Object.fromEntries(scopes.map((scope) => [scope.scopeId, scope.elements.filter((entry) => entry.allowedOps.includes("textResize")).length]).filter(([, count]) => count)), {
         "restarbeiten.header.root": 14,
-        "restarbeiten.list.root": 6,
+        "restarbeiten.list.root": 12,
         "restarbeiten.edit.root": 22,
         "protokoll.screen.root": 6,
         "protokoll.edit.root": 11,
@@ -142,7 +142,7 @@ async function runM8272GenericTextResizeTests(run) {
         assert.ok(Number.isFinite(initialStates.get(entry.id).fontSize), entry.id);
       }
     });
-    await run("M82.7.2 BBM: kleiner, groesser und direkter DIP-Wert wirken generisch auf alle 59 realen Refs", () => {
+    await run("M82.7.2/M82.7.5 BBM: kleiner, groesser und direkter DIP-Wert wirken generisch auf alle 65 realen Refs", () => {
       for (const entry of textEntries) {
         const candidates = changeValues(entry);
         const smaller = submit(entry, candidates.lower, "smaller");

--- a/scripts/tests/m82-7-5LayoutPersistenceMetaElements.test.cjs
+++ b/scripts/tests/m82-7-5LayoutPersistenceMetaElements.test.cjs
@@ -1,0 +1,134 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const ROOT = path.resolve(__dirname, "../..");
+const read = (relativePath) => fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+
+class FakeElement {
+  constructor(tagName = "DIV", width = 100, height = 24) {
+    this.tagName = tagName.toUpperCase(); this.attributes = {}; this.dataset = {}; this.className = "";
+    this.parentElement = null; this.children = []; this.isConnected = true; this.hidden = false;
+    this._rect = { left: 0, top: 0, width, height };
+    this.style = { setProperty(name, value) { this[name] = value; }, getPropertyValue(name) { return this[name] || ""; } };
+    this.classList = {
+      contains: (name) => this.className.split(/\s+/).includes(name),
+      toggle: (name, active) => { const names = new Set(this.className.split(/\s+/).filter(Boolean)); if (active) names.add(name); else names.delete(name); this.className = [...names].join(" "); },
+    };
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); if (name === "data-ui-editor-id") this.dataset.uiEditorId = String(value); }
+  getAttribute(name) { return this.attributes[name] || null; }
+  addEventListener() {}
+  append(...children) { children.forEach((child) => { child.parentElement = this; this.children.push(child); }); }
+  appendChild(child) { this.append(child); return child; }
+  replaceChildren(...children) { this.children = []; this.append(...children); }
+  getBoundingClientRect() {
+    const width = Number.parseFloat(this.style.width) || this._rect.width;
+    const height = Number.parseFloat(this.style.height) || this._rect.height;
+    return { left: this._rect.left, top: this._rect.top, width, height, right: this._rect.left + width, bottom: this._rect.top + height };
+  }
+}
+
+function computedStyle(element) {
+  const rect = element.getBoundingClientRect();
+  return { ...element.style, display: element.style.display || "", width: `${rect.width}px`, height: `${rect.height}px`, paddingLeft: element.style.paddingLeft || "0px", paddingTop: element.style.paddingTop || "0px", fontSize: element.style.fontSize || "10.667px", boxSizing: "border-box" };
+}
+
+async function runM8275LayoutPersistenceMetaElementsTests(run) {
+  const registry = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Registry.js"));
+  const refs = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Refs.js"));
+  const host = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80HostAdapter.js"));
+  const listModule = await importEsmFromFile(path.join(ROOT, "src/renderer/modules/restarbeiten/RestarbeitenList.js"));
+  const scope = registry.listM80RegistryScopes().find((item) => item.scopeId === "restarbeiten.list.root");
+  const byId = new Map(scope.elements.map((entry) => [entry.id, entry]));
+  const headerIds = ["restarbeiten.main.tableHeader.dueDate", "restarbeiten.main.tableHeader.status", "restarbeiten.main.tableHeader.responsible"];
+  const rowIds = ["restarbeiten.record.dueDate", "restarbeiten.record.ampel", "restarbeiten.record.status", "restarbeiten.record.responsible"];
+  const previous = { document: global.document, window: global.window, Element: global.Element, CustomEvent: global.CustomEvent };
+  const body = new FakeElement("BODY", 1600, 900);
+  global.Element = FakeElement;
+  global.CustomEvent = class { constructor(type) { this.type = type; } };
+  global.document = { body, createElement: (tag) => new FakeElement(tag), querySelector: () => null, addEventListener() {}, removeEventListener() {} };
+  global.window = { getComputedStyle: computedStyle, dispatchEvent() {}, uiEditor: {} };
+
+  try {
+    await run("M82.7.5 BBM 01: Registryversion kennzeichnet den erweiterten Vertrag", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 12));
+    await run("M82.7.5 BBM 02: Listenscope enthaelt die sieben neuen logischen Ziele", () => assert.equal(scope.elements.length, 23));
+    await run("M82.7.5 BBM 03: alle bestaetigten stabilen IDs sind exakt registriert", () => [...headerIds, ...rowIds].forEach((id) => assert.ok(byId.has(id), id)));
+    await run("M82.7.5 BBM 04: Header-Kinder besitzen den existierenden Meta-Header als Parent", () => headerIds.forEach((id) => assert.equal(byId.get(id).parentId, "restarbeiten.list.table.meta.header")));
+    await run("M82.7.5 BBM 05: Zeilenkinder besitzen den existierenden Meta-Datenbereich als Parent", () => rowIds.forEach((id) => assert.equal(byId.get(id).parentId, "restarbeiten.list.table.meta.cells")));
+    await run("M82.7.5 BBM 06: Headertexte erlauben nur Move, Textgroesse und Sichtbarkeit", () => headerIds.forEach((id) => assert.deepEqual(byId.get(id).allowedOps, ["move", "textResize", "setVisibility"])));
+    await run("M82.7.5 BBM 07: Zeilentexte verwenden denselben generischen Textvertrag", () => [rowIds[0], rowIds[2], rowIds[3]].forEach((id) => assert.deepEqual(byId.get(id).allowedOps, ["move", "textResize", "setVisibility"])));
+    await run("M82.7.5 BBM 08: Listenampel bleibt generisch beweglich, skalierbar und sichtbar", () => assert.deepEqual(byId.get(rowIds[1]).allowedOps, ["move", "resizeWidth", "resizeHeight", "setVisibility"]));
+    await run("M82.7.5 BBM 09: Baselines und Grenzen sind explizit", () => { assert.deepEqual([byId.get(headerIds[0]).baseline.fontSize, byId.get(headerIds[0]).baseline.minFontSize, byId.get(headerIds[0]).baseline.maxFontSize], [8.667, 6, 24]); assert.deepEqual([byId.get(rowIds[1]).baseline.width, byId.get(rowIds[1]).baseline.height], [12, 12]); });
+
+    const header = listModule.buildRestarbeitenTableHeader();
+    const records = listModule.buildRestarbeitenList({ items: [{ id: 1, numberLine: "1", dateLine: "01.01.26", itemClassLabel: "Rest", locationLine: "A", shortTextLine: "Kurz", longTextLine: "Lang", dueDateLabel: "02.01.26", ampelState: "green", statusLabel: "offen", responsibleLabel: "B" }, { id: 2, numberLine: "2", dateLine: "01.01.26", itemClassLabel: "Mangel", locationLine: "C", shortTextLine: "Kurz", longTextLine: "Lang", dueDateLabel: "03.01.26", ampelState: "red", statusLabel: "offen", responsibleLabel: "D" }] });
+    await run("M82.7.5 BBM 10: vorhandene Header-DOM-Knoten werden inventarisiert", () => assert.deepEqual(Object.keys(header._m80MetaHeaderParts), ["dueDate", "status", "responsible"]));
+    await run("M82.7.5 BBM 11: vorhandene Zeilen-DOM-Knoten werden ohne Wrapper inventarisiert", () => assert.deepEqual(Object.fromEntries(Object.entries(records._m80MetaParts).map(([key, values]) => [key, values.length])), { dueDate: 2, ampel: 2, status: 2, responsible: 2 }));
+    await run("M82.7.5 BBM 12: Renderer erzeugt keine neue Tabellenansicht", () => { const source = read("src/renderer/modules/restarbeiten/RestarbeitenList.js"); assert.doesNotMatch(source, /m82-7-5|meta-wrapper|editor-wrapper/i); });
+    await run("M82.7.5 BBM 13: Header- und Zeileninventar enthalten keine Fachwert-IDs", () => [...Object.values(header._m80MetaHeaderParts), ...Object.values(records._m80MetaParts).flat()].forEach((element) => assert.doesNotMatch(element.getAttribute("data-ui-editor-id") || "", /\b\d+\b|green|red|offen/)));
+
+    refs.resetM80PilotWorkingStatesForDiagnostic(); refs.beginM80PilotRender();
+    const fallback = new FakeElement("DIV", 172, 100);
+    const due = [new FakeElement("DIV", 80, 16), new FakeElement("DIV", 80, 16)];
+    const ampel = [new FakeElement("SPAN", 12, 12), new FakeElement("SPAN", 12, 12)];
+    const status = [new FakeElement("DIV", 60, 16), new FakeElement("DIV", 60, 16)];
+    const responsible = [new FakeElement("DIV", 90, 16), new FakeElement("DIV", 90, 16)];
+    refs.registerM80MultiRef(rowIds[0], due, fallback);
+    refs.registerM80MultiRef(rowIds[1], ampel, fallback);
+    refs.registerM80MultiRef(rowIds[2], status, fallback);
+    refs.registerM80MultiRef(rowIds[3], responsible, fallback);
+    refs.completeM80PilotRender();
+    await run("M82.7.5 BBM 14: Fertig-bis-Multiref bindet alle vorhandenen Ziele", () => assert.deepEqual(refs.getM80Ref(rowIds[0]).targets, due));
+    await run("M82.7.5 BBM 15: Ampel-Multiref bindet alle vorhandenen Ziele", () => assert.deepEqual(refs.getM80Ref(rowIds[1]).targets, ampel));
+    await run("M82.7.5 BBM 16: Status-Multiref bindet alle vorhandenen Ziele", () => assert.deepEqual(refs.getM80Ref(rowIds[2]).targets, status));
+    await run("M82.7.5 BBM 17: Verantwortlich-Multiref bindet alle vorhandenen Ziele", () => assert.deepEqual(refs.getM80Ref(rowIds[3]).targets, responsible));
+    await run("M82.7.5 BBM 18: direkte Auswahl liefert zuerst das exakte logische Kind", () => assert.equal(refs.getM80IdFromTarget(due[1]), rowIds[0]));
+    await run("M82.7.5 BBM 19: allgemeiner Move-Weg wirkt auf alle Wiederholungen", () => { refs.applyM80State(rowIds[0], { ...refs.snapshotM80State(rowIds[0]), x: 5 }, "move"); due.forEach((element) => assert.equal(element.style.translate, "5px 0px")); });
+    await run("M82.7.5 BBM 20: allgemeiner textResize-Weg wirkt auf alle Wiederholungen", () => { refs.applyM80State(rowIds[2], { ...refs.snapshotM80State(rowIds[2]), fontSize: 14 }, "textResize"); status.forEach((element) => assert.equal(element.style.fontSize, "14px")); });
+    await run("M82.7.5 BBM 21: allgemeiner Sichtbarkeitsweg wirkt auf alle Wiederholungen", () => { refs.applyM80State(rowIds[3], { ...refs.snapshotM80State(rowIds[3]), visible: false }, "setVisibility"); responsible.forEach((element) => assert.equal(element.classList.contains("bbm-ui-editor-hidden"), true)); });
+    await run("M82.7.5 BBM 22: Multiref bleibt bei leerer Liste logisch aufgeloest", () => { refs.beginM80PilotRender(); refs.registerM80MultiRef(rowIds[0], [], fallback); refs.completeM80PilotRender(); assert.equal(refs.getM80ReferenceStatus(rowIds[0]).referenceResolved, true); });
+    await run("M82.7.5 BBM 23: Fallback-Container wird nicht faelschlich als Kind auswaehlbar", () => assert.equal(refs.getM80IdFromTarget(fallback), null));
+
+    refs.beginM80PilotRender(); refs.registerM80MultiRef(rowIds[0], due, fallback); refs.completeM80PilotRender();
+    host.handleM80EditorRequest({ action: "getRegistry" });
+    refs.applyM80State(rowIds[0], { ...refs.snapshotM80State(rowIds[0]), x: 10 }, "move");
+    await run("M82.7.5 BBM 24: gespeichertes Sitzungsende behaelt die angewendete Aenderung", () => { const result = host.handleM80EditorEvent({ action: "editorClosed", disposition: "saved" }); assert.equal(result.restoredElementCount, 0); assert.equal(refs.snapshotM80State(rowIds[0]).x, 10); });
+    host.handleM80EditorRequest({ action: "getRegistry" }); refs.applyM80State(rowIds[0], { ...refs.snapshotM80State(rowIds[0]), x: 15 }, "move");
+    await run("M82.7.5 BBM 25: sauberes Sitzungsende behaelt den aktuellen gespeicherten Zustand", () => { host.handleM80EditorEvent({ action: "editorClosed", disposition: "clean" }); assert.equal(refs.snapshotM80State(rowIds[0]).x, 15); });
+    host.handleM80EditorRequest({ action: "getRegistry" }); refs.applyM80State(rowIds[0], { ...refs.snapshotM80State(rowIds[0]), x: 20 }, "move");
+    await run("M82.7.5 BBM 26: Ohne Speichern stellt exakt die Oeffnungsgrenze wieder her", () => { const result = host.handleM80EditorEvent({ action: "editorClosed", disposition: "discarded" }); assert.ok(result.restoredElementCount > 0); assert.equal(refs.snapshotM80State(rowIds[0]).x, 15); });
+    host.handleM80EditorRequest({ action: "getRegistry" }); refs.applyM80State(rowIds[0], { ...refs.snapshotM80State(rowIds[0]), x: 25 }, "move");
+    await run("M82.7.5 BBM 27: unbekannter Prozessabbruch verwirft nicht eigenmaechtig", () => { host.handleM80EditorEvent({ action: "editorClosed", disposition: "invalid" }); assert.equal(refs.snapshotM80State(rowIds[0]).x, 25); });
+    await run("M82.7.5 BBM 28: Sitzungsgrenze wird nach Close immer geloescht", () => assert.equal(host.getM80InteractionStatus().editorSessionBoundaryElementCount, 0));
+    await run("M82.7.5 BBM 29: Rerender wendet den gespeicherten Arbeitszustand auf neue Knoten an", () => { const rerendered = [new FakeElement("DIV", 80, 16), new FakeElement("DIV", 80, 16)]; refs.beginM80PilotRender(); refs.registerM80MultiRef(rowIds[0], rerendered, fallback); refs.completeM80PilotRender(); assert.equal(rerendered[0].style.translate, "25px 0px"); assert.equal(rerendered[1].style.translate, "25px 0px"); });
+    await run("M82.7.5 BBM 30: Startup-Restore erzeugt den generischen Delta-Request", () => { const requests = host.createM80StartupRequests("restarbeiten.list.root", { ...refs.snapshotM80State(rowIds[0]), x: 30 }); assert.deepEqual(requests.map((item) => item.request.operation), ["move"]); });
+    const sessionSource = read("src/main/ui-editor/electronUiEditorSession.js");
+    await run("M82.7.5 BBM 31: natives editorClosed wird nicht vor der Disposal-Kette doppelt weitergereicht", () => assert.match(sessionSource, /if \(action === "editorClosed"\) \{[\s\S]*#disposeSession\("editor_closed", false, message\.payload\);[\s\S]*return;/));
+    await run("M82.7.5 BBM 32: zerstoertes Fenster oder WebContents wird beim Close nicht beschrieben", () => {
+      const windowGuard = sessionSource.indexOf("if (window && !window.isDestroyed?.())");
+      const webContentsAccess = sessionSource.indexOf("const webContents = window.webContents;", windowGuard);
+      const webContentsGuard = sessionSource.indexOf("if (webContents && !webContents.isDestroyed?.())", webContentsAccess);
+      assert.ok(windowGuard >= 0);
+      assert.ok(webContentsAccess > windowGuard);
+      assert.ok(webContentsGuard > webContentsAccess);
+    });
+    await run("M82.7.5 BBM 33: Registry und Multi-Ref-Weg enthalten keine Fachwerte", () => { const source = read("src/renderer/ui-editor/m80Registry.js") + read("src/renderer/ui-editor/m80Refs.js"); assert.doesNotMatch(source, /data-bbm-restarbeiten-record-id|item\.dueDate|item\.responsible|app\.db/); });
+    await run("M82.7.5 BBM 34: licensing-Dokumentation behaelt den Schutz-Hash", () => { const hash = crypto.createHash("sha256").update(fs.readFileSync(path.join(ROOT, "docs/licensing.md"))).digest("hex").toUpperCase(); assert.equal(hash, "02AE66A8873C74869539F13F734B7CE43BC63B6EF37DA553A40C27A4F514D784"); });
+  } finally {
+    refs.resetM80PilotWorkingStatesForDiagnostic();
+    global.document = previous.document; global.window = previous.window; global.Element = previous.Element; global.CustomEvent = previous.CustomEvent;
+  }
+}
+
+module.exports = { runM8275LayoutPersistenceMetaElementsTests };
+
+if (require.main === module) {
+  let failed = false;
+  const run = async (name, test) => { try { await test(); console.log(`ok - ${name}`); } catch (error) { failed = true; console.error(`not ok - ${name}`); console.error(error?.stack || error); } };
+  runM8275LayoutPersistenceMetaElementsTests(run).then(() => { if (failed) process.exitCode = 1; }).catch((error) => { process.exitCode = 1; console.error(error?.stack || error); });
+}

--- a/scripts/tests/m82AppStarterPackage.test.cjs
+++ b/scripts/tests/m82AppStarterPackage.test.cjs
@@ -46,7 +46,7 @@ async function runM82AppStarterPackageTests(run) {
     assert.equal(byId.get("restarbeiten.header.root").status, "complete");
     assert.equal(byId.get("restarbeiten.header.root").elementCount, 31);
     assert.equal(byId.get("restarbeiten.list.root").status, "complete");
-    assert.equal(byId.get("restarbeiten.list.root").elementCount, 16);
+    assert.equal(byId.get("restarbeiten.list.root").elementCount, 23);
     assert.equal(byId.get("restarbeiten.edit.root").status, "complete");
     assert.equal(byId.get("restarbeiten.edit.root").elementCount, 53);
     assert.equal(byId.get("bbm.remaining").status, "blocked");

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 112, "112 Suite-Einstiege einschließlich Entwicklungs-Lizenz sowie M82.4 bis M82.7.4-Isolation");
+    assert.equal(suites.length, 113, "113 Suite-Einstiege einschließlich Entwicklungs-Lizenz sowie M82.4 bis M82.7.5-Isolation");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/src/main/ui-editor/electronUiEditorSession.js
+++ b/src/main/ui-editor/electronUiEditorSession.js
@@ -411,8 +411,11 @@ class ElectronUiEditorSessionController {
     }
     if (message.messageType === "event" && NATIVE_EVENT_ACTIONS.has(action)) {
       if (action === "activateTarget") this.getMainWindow?.()?.focus?.();
+      if (action === "editorClosed") {
+        void this.#disposeSession("editor_closed", false, message.payload);
+        return;
+      }
       this.getMainWindow?.()?.webContents?.send?.("uiEditor:event", message.payload);
-      if (action === "editorClosed") void this.#disposeSession("editor_closed", false);
     }
   }
 
@@ -520,7 +523,7 @@ class ElectronUiEditorSessionController {
     this.heartbeat.unref?.();
   }
 
-  async #disposeSession(reason, stopProcess) {
+  async #disposeSession(reason, stopProcess, closePayload = null) {
     if (this.stopping) return;
     this.stopping = true;
     clearInterval(this.heartbeat);
@@ -544,7 +547,16 @@ class ElectronUiEditorSessionController {
       ]);
       if (child.exitCode === null || child.exitCode === undefined) child.kill();
     }
-    this.getMainWindow?.()?.webContents?.send?.("uiEditor:event", { action: "editorClosed", reason });
+    const window = this.getMainWindow?.();
+    if (window && !window.isDestroyed?.()) {
+      const webContents = window.webContents;
+      if (webContents && !webContents.isDestroyed?.()) {
+        const disposition = ["clean", "saved", "discarded"].includes(closePayload?.disposition)
+          ? closePayload.disposition
+          : "unknown";
+        webContents.send("uiEditor:event", { action: "editorClosed", reason, disposition });
+      }
+    }
     this.stopping = false;
   }
 }

--- a/src/renderer/modules/restarbeiten/RestarbeitenList.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenList.js
@@ -28,9 +28,10 @@ export function buildRestarbeitenTableHeader() {
     uiId: "restarbeiten.main.tableHeader.subject",
   });
   const meta = createEl("div", { className: "bbm-restarbeiten-table-header__meta" });
-  appendText(meta, "", "Fertig bis", "restarbeiten.main.tableHeader.dueDate");
-  appendText(meta, "", "Status", "restarbeiten.main.tableHeader.status");
-  appendText(meta, "", "Verantw.", "restarbeiten.main.tableHeader.responsible");
+  const dueDate = appendText(meta, "", "Fertig bis", "restarbeiten.main.tableHeader.dueDate");
+  const status = appendText(meta, "", "Status", "restarbeiten.main.tableHeader.status");
+  const responsible = appendText(meta, "", "Verantw.", "restarbeiten.main.tableHeader.responsible");
+  header._m80MetaHeaderParts = { dueDate, status, responsible };
   header.append(number, subject, meta);
   return header;
 }
@@ -49,8 +50,10 @@ export function buildRestarbeitenList({
   });
   const rows = [];
   const columnCells = [[], [], []];
+  const metaParts = { dueDate: [], ampel: [], status: [], responsible: [] };
   records._m80Rows = rows;
   records._m80ColumnCells = columnCells;
+  records._m80MetaParts = metaParts;
 
   if (!items.length) {
     records.appendChild(
@@ -103,13 +106,15 @@ export function buildRestarbeitenList({
     dueLine.className = "bbm-restarbeiten-record__due";
     dueLine.textContent = item.dueDateLabel;
     metaColumn.appendChild(dueLine);
+    metaParts.dueDate.push(dueLine);
     if (showAmpel) {
       const ampel = createEl("span", { className: "bbm-restarbeiten-ampel", uiId: "restarbeiten.record.ampel" });
       ampel.dataset.state = item.ampelState || "neutral";
       metaColumn.appendChild(ampel);
+      metaParts.ampel.push(ampel);
     }
-    appendText(metaColumn, "", item.statusLabel, "restarbeiten.record.status");
-    appendText(metaColumn, "", item.responsibleLabel, "restarbeiten.record.responsible");
+    metaParts.status.push(appendText(metaColumn, "", item.statusLabel, "restarbeiten.record.status"));
+    metaParts.responsible.push(appendText(metaColumn, "", item.responsibleLabel, "restarbeiten.record.responsible"));
     if (item.requiredFieldSummary) {
       appendText(metaColumn, "bbm-restarbeiten-record__required", item.requiredFieldSummary);
     }

--- a/src/renderer/modules/restarbeiten/RestarbeitenMainBody.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenMainBody.js
@@ -1,5 +1,5 @@
 import { buildRestarbeitenList, buildRestarbeitenTableHeader } from "./RestarbeitenList.js";
-import { registerM80Ref, registerM80TableColumnRef, registerM80TableRef } from "../../ui-editor/m80Refs.js";
+import { registerM80MultiRef, registerM80Ref, registerM80TableColumnRef, registerM80TableRef } from "../../ui-editor/m80Refs.js";
 
 function createEl(tag, { className = "", uiId = "" } = {}) {
   const el = document.createElement(tag);
@@ -62,6 +62,15 @@ export function buildRestarbeitenMainBody(options = {}) {
     "--bbm-restarbeiten-meta-column",
     172
   );
+  const headerMeta = header._m80MetaHeaderParts;
+  const recordMeta = records._m80MetaParts;
+  registerM80Ref("restarbeiten.main.tableHeader.dueDate", headerMeta.dueDate);
+  registerM80Ref("restarbeiten.main.tableHeader.status", headerMeta.status);
+  registerM80Ref("restarbeiten.main.tableHeader.responsible", headerMeta.responsible);
+  registerM80MultiRef("restarbeiten.record.dueDate", recordMeta.dueDate, records);
+  registerM80MultiRef("restarbeiten.record.ampel", recordMeta.ampel, records);
+  registerM80MultiRef("restarbeiten.record.status", recordMeta.status, records);
+  registerM80MultiRef("restarbeiten.record.responsible", recordMeta.responsible, records);
 
   table.append(header, records);
   paper.appendChild(table);

--- a/src/renderer/ui-editor/m80HostAdapter.js
+++ b/src/renderer/ui-editor/m80HostAdapter.js
@@ -8,6 +8,7 @@ import {
 import {
   applyM80State,
   beginM80PilotRender,
+  captureM80WorkingStates,
   clearM80VisualState,
   completeM80PilotRender,
   getM80IdsFromTarget,
@@ -15,6 +16,8 @@ import {
   getM80Ref,
   listM80Refs,
   registerM80Ref,
+  registerM80MultiRef,
+  restoreM80WorkingStates,
   fitM80Table,
   resetM80Table,
   resetM80PilotWorkingStatesForDiagnostic,
@@ -53,6 +56,7 @@ let hoverCandidates = [];
 let hoverIndex = 0;
 let startupRestorePromise = null;
 let startupRestoreStatus = { state: "pending", applied: false, editorProcessRequired: false };
+let editorSessionBoundary = null;
 let diagnosticRegistryRevision = 0;
 const pendingGeometryRisks = new Map();
 const capturedRuntimeBaselines = new Map();
@@ -695,7 +699,15 @@ export function handleM80EditorEvent(event = {}) {
   if (action === "cancelTargetSelection") { stopSelection({ clearHover: true }); clearGeometryRiskPreview(); return { ok: true }; }
   if (action === "highlightElement") { clearGeometryRiskPreview(); highlightM80Element(event.elementId); return { ok: true }; }
   if (action === "clearGeometryPreview") { clearGeometryRiskPreview(); return { ok: true }; }
-  if (action === "editorClosed") { stopSelection(); selectedId = null; pendingGeometryRisks.clear(); clearGeometryRiskPreview(); clearM80VisualState(); return { ok: true }; }
+  if (action === "editorClosed") {
+    const disposition = ["clean", "saved", "discarded"].includes(event.disposition) ? event.disposition : "unknown";
+    const restoredElementCount = disposition === "discarded" && editorSessionBoundary
+      ? restoreM80WorkingStates(editorSessionBoundary)
+      : 0;
+    editorSessionBoundary = null;
+    stopSelection(); selectedId = null; pendingGeometryRisks.clear(); clearGeometryRiskPreview(); clearM80VisualState();
+    return { ok: true, disposition, restoredElementCount };
+  }
   return { ok: false, errorCode: "electron_editor_message_invalid" };
 }
 
@@ -703,6 +715,7 @@ export function handleM80EditorRequest(request = {}) {
   const action = String(request.action || "");
   if (!ALLOWED_ACTIONS.has(action)) throw Object.assign(new Error("Unbekannte Editoranfrage."), { code: "electron_editor_message_invalid" });
   if (action === "getRegistry") {
+    editorSessionBoundary ??= captureM80WorkingStates();
     const registration = createM80RegistrationDescriptor();
     return {
       registryVersion: registration.registryVersion,
@@ -828,5 +841,5 @@ export async function refreshM80StartupLayoutAfterRegistryMount() {
 }
 
 export function clearM80EditorInteraction() { stopSelection(); selectedId = null; pendingGeometryRisks.clear(); clearGeometryRiskPreview(); clearM80VisualState(); }
-export function getM80InteractionStatus() { return { selectionMode, selectedId, hoverElementIds: hoverCandidates.map((candidate) => candidate.entry.id), hoverIndex, startupRestoreStatus: { ...startupRestoreStatus }, scopeStates: layoutPayload() }; }
-export { beginM80PilotRender, completeM80PilotRender, registerM80Ref, resetM80PilotWorkingStatesForDiagnostic };
+export function getM80InteractionStatus() { return { selectionMode, selectedId, hoverElementIds: hoverCandidates.map((candidate) => candidate.entry.id), hoverIndex, startupRestoreStatus: { ...startupRestoreStatus }, editorSessionBoundaryElementCount: editorSessionBoundary?.size || 0, scopeStates: layoutPayload() }; }
+export { beginM80PilotRender, completeM80PilotRender, registerM80MultiRef, registerM80Ref, resetM80PilotWorkingStatesForDiagnostic };

--- a/src/renderer/ui-editor/m80Refs.js
+++ b/src/renderer/ui-editor/m80Refs.js
@@ -207,9 +207,40 @@ export function registerM80Ref(id, element, custom = {}) {
     apply: custom.apply || ((state, requestedOperation = null) => applyGeneric(element, state, entry, requestedOperation)),
   };
   refs.set(id, ref);
-  targets.forEach((target) => bindElementId(target, id));
+  const bindingTargets = Array.isArray(custom.bindingTargets) ? custom.bindingTargets : targets;
+  bindingTargets.filter(isElementRef).forEach((target) => bindElementId(target, id));
   if (persistentWorkingStateIds.has(id) && workingStates.has(id)) applyPersistentWorkingState(ref);
   return element;
+}
+
+export function registerM80MultiRef(id, elements, fallbackElement) {
+  const entry = getM80RegistryEntry(id);
+  const targets = [...new Set((Array.isArray(elements) ? elements : []).filter(isElementRef))];
+  const primary = targets[0] || fallbackElement;
+  if (!entry || !isElementRef(primary)) throw new Error(`UngÃ¼ltige explizite M80-Multireferenz: ${id}`);
+  targets.forEach((target) => applyAttributes(target, id));
+  let logicalState = {
+    elementId: id,
+    x: finite(entry.baseline?.x),
+    y: finite(entry.baseline?.y),
+    width: positive(entry.baseline?.width, 1),
+    height: positive(entry.baseline?.height, 1),
+    textOffsetX: finite(entry.baseline?.textOffsetX),
+    textOffsetY: finite(entry.baseline?.textOffsetY),
+    fontSize: positive(entry.baseline?.fontSize, 12),
+    visible: entry.baseline?.visible !== false,
+    spacing: { ...(entry.baseline?.spacing || {}) },
+  };
+  return registerM80Ref(id, primary, {
+    targets,
+    bindingTargets: targets,
+    applyPrimaryAttributes: false,
+    read: () => targets.length ? readGeneric(targets[0], id) : { ...logicalState, spacing: { ...logicalState.spacing } },
+    apply: (state, requestedOperation = null) => {
+      logicalState = { ...logicalState, ...state, elementId: id, spacing: { ...(state.spacing || logicalState.spacing || {}) } };
+      targets.forEach((target) => applyGeneric(target, logicalState, entry, requestedOperation));
+    },
+  });
 }
 
 export function completeM80PilotRender() {
@@ -476,6 +507,28 @@ export function applyM80State(id, state, requestedOperation = null) {
   return { ...readback };
 }
 export function snapshotM80State(id) { return readM80State(id); }
+export function captureM80WorkingStates() {
+  return new Map([...refs.values()].map((ref) => {
+    const state = ref.read();
+    return [ref.id, { ...state, spacing: { ...(state.spacing || {}) } }];
+  }));
+}
+export function restoreM80WorkingStates(states) {
+  if (!(states instanceof Map)) throw new TypeError("Gespeicherter Editor-Sitzungszustand fehlt.");
+  for (const [id, state] of states) {
+    const value = { ...state, spacing: { ...(state?.spacing || {}) } };
+    const ref = refs.get(id);
+    if (ref) {
+      ref.apply(value);
+      workingStates.set(id, { ...ref.read() });
+    } else {
+      workingStates.set(id, value);
+    }
+    persistentWorkingStateIds.add(id);
+    persistentWorkingStateOperations.set(id, new Set(["*"]));
+  }
+  return states.size;
+}
 export function listM80CurrentStates(scopeId) {
   return [...refs.values()].filter((ref) => {
       let entry = ref.entry;

--- a/src/renderer/ui-editor/m80Registry.js
+++ b/src/renderer/ui-editor/m80Registry.js
@@ -1,4 +1,4 @@
-export const BBM_M80_REGISTRY_VERSION = 11;
+export const BBM_M80_REGISTRY_VERSION = 12;
 export const BBM_M80_REGISTRY_STATUS = "incomplete";
 
 const GROUP_LAYOUT = Object.freeze(["move", "setVisibility"]);
@@ -159,6 +159,13 @@ const listElements = [
     element({ id: column.headerElementId, name: `${column.displayName} · Überschrift`, type: "tableHeaderCell", role: "tableHeaderCell", parentId: column.columnId, order: 60 + index * 2, allowedOps: ["textResize"], componentKind: "tableHeaderCell", tableBinding: tableBinding(column.columnId, "header"), baseline: { fontSize: 12, minFontSize: 8, maxFontSize: 32 } }),
     element({ id: column.dataCellTemplateId, name: `${column.displayName} · Datenbereich`, type: "tableDataCell", role: "tableDataCell", parentId: column.columnId, order: 61 + index * 2, allowedOps: [], componentKind: "dataCellTemplate", tableBinding: tableBinding(column.columnId, "data") }),
   ]),
+  element({ id: "restarbeiten.main.tableHeader.dueDate", name: "Fertig bis · Überschrift", type: "label", role: "fieldLabel", parentId: "restarbeiten.list.table.meta.header", order: 70, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "tableHeaderLabel", baseline: { x: 0, y: 0, fontSize: 8.667, minFontSize: 6, maxFontSize: 24 } }),
+  element({ id: "restarbeiten.main.tableHeader.status", name: "Status · Überschrift", type: "label", role: "fieldLabel", parentId: "restarbeiten.list.table.meta.header", order: 71, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "tableHeaderLabel", baseline: { x: 0, y: 0, fontSize: 8.667, minFontSize: 6, maxFontSize: 24 } }),
+  element({ id: "restarbeiten.main.tableHeader.responsible", name: "Verantwortlich · Überschrift", type: "label", role: "fieldLabel", parentId: "restarbeiten.list.table.meta.header", order: 72, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "tableHeaderLabel", baseline: { x: 0, y: 0, fontSize: 8.667, minFontSize: 6, maxFontSize: 24 } }),
+  element({ id: "restarbeiten.record.dueDate", name: "Fertig bis · Listeneinträge", type: "label", role: "date", parentId: "restarbeiten.list.table.meta.cells", order: 73, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "staticMultiRef", baseline: { x: 0, y: 0, fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
+  element({ id: "restarbeiten.record.ampel", name: "Ampel · Listeneinträge", type: "statusIndicator", role: "status", parentId: "restarbeiten.list.table.meta.cells", order: 74, allowedOps: ["move", ...ICON_LAYOUT], componentKind: "staticMultiRef", baseline: { x: 0, y: 0, width: 12, height: 12, minWidth: 7, maxWidth: 48, minHeight: 7, maxHeight: 48 } }),
+  element({ id: "restarbeiten.record.status", name: "Status · Listeneinträge", type: "label", role: "status", parentId: "restarbeiten.list.table.meta.cells", order: 75, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "staticMultiRef", baseline: { x: 0, y: 0, fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
+  element({ id: "restarbeiten.record.responsible", name: "Verantwortlich · Listeneinträge", type: "label", role: "responsible", parentId: "restarbeiten.list.table.meta.cells", order: 76, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "staticMultiRef", baseline: { x: 0, y: 0, fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
 ];
 
 const editElements = [

--- a/ui-editor-target.json
+++ b/ui-editor-target.json
@@ -7,8 +7,8 @@
   "integrationMode": "existing-app",
   "contractVersion": "1.2",
   "adapterVersion": "1.2",
-  "registryVersion": 11,
-  "registryFingerprint": "sha256:82f2f558cf253b63115f6e46bcbf05dd94c9ce4e9ed970a2915161ab9e9ebf7f",
+  "registryVersion": 12,
+  "registryFingerprint": "sha256:4d0a4c27786d64e6c80cfe5d6e57c1c32da1193cda307553334e588e0606241e",
   "registryStatus": "incomplete",
   "activeScopes": [
     "restarbeiten.header.root",
@@ -48,7 +48,7 @@
   "transportProtocolVersion": "1.0",
   "scopes": [
     { "scopeId": "restarbeiten.header.root", "status": "complete", "reason": null, "elementCount": 31, "missingReferenceCount": 0 },
-    { "scopeId": "restarbeiten.list.root", "status": "complete", "reason": null, "elementCount": 16, "missingReferenceCount": 0 },
+    { "scopeId": "restarbeiten.list.root", "status": "complete", "reason": null, "elementCount": 23, "missingReferenceCount": 0 },
     { "scopeId": "restarbeiten.edit.root", "status": "complete", "reason": null, "elementCount": 53, "missingReferenceCount": 0 },
     { "scopeId": "protokoll.screen.root", "status": "complete", "reason": null, "elementCount": 25, "missingReferenceCount": 0 },
     { "scopeId": "protokoll.list.root", "status": "complete", "reason": null, "elementCount": 7, "missingReferenceCount": 0 },


### PR DESCRIPTION
## Ziel

M82.7.5 hält gespeicherte Layoutwerte nach Editor-Close, Rerender, Modulwechsel und Neustart aktiv und registriert vorhandene Meta-Elemente einzeln.

## Enthalten

- gespeicherte Layoutwerte bleiben nach Editor-Close sichtbar
- `saved` und `clean` behalten den Hostzustand
- `discarded` stellt nur die Sitzungsgrenze wieder her
- kein doppeltes `editorClosed`
- kein Zugriff auf zerstörte `webContents`
- Meta-Header einzeln registriert
- Meta-Zeilenbestandteile als stabile Multi-Refs registriert
- keine IDs aus Fachwerten oder Datenbankinhalten
- keine neuen DOM-Knoten, Topologie- oder Scrolländerungen
- False-Dirty ausdrücklich nicht verändert
- M82.7.5 `[A]`

## Prüfungen

- M82.7.5-Einzeltests 34/34
- `npm test` – 8/8 Gruppen
- `npm run test:node` – 8/8 Gruppen
- gezieltes ESLint ohne Befund
- `npm run pack` erfolgreich
- sichtbare isolierte Zwei-Start-Abnahme erfolgreich
- `git diff --check`

`docs/licensing.md` ist nicht Bestandteil des Commits.

## Commit

`16a2b6bee098e97d3393da5ee6ee9c36be9ee248`