### PR TITLE
M83.0 komponentenbasierte Vollregistrierung einführen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -873,3 +873,7 @@ Wenn Tabellen, Metaspalten, Buttons oder Fachaktionen nicht sauber klassifiziert
 
 In diesem Fall darf keine UI- oder PDF-Struktur als fertig gemeldet werden.
 <!-- UI-EDITOR-KIT:END -->
+
+## Pflichtregel: komponentenbasierte Vollregistrierung
+
+Eine neue oder strukturell geänderte editorfähige BBM-Komponente ist nur zusammen mit ihrem vollständigen, komponentennahen Editorvertrag fertig. Der Vertrag deklariert stabile `componentId`, Scope, alle tatsächlich vorhandenen verpflichtenden Slots, stabile Element-IDs, Parents, Ref-Keys, Single-/Multi-Ref-Semantik, Typ/Rolle/Auswahlart, Baselines, Grenzen, erlaubte und gesperrte Operationen sowie Operationseffekte. Die produktive Komponente stellt gleichzeitig die explizite Ref-Auflösung bereit. `m80Registry.js` aggregiert Komponentenverträge und darf Unterziele weder zentral als zweite Handliste pflegen noch aus DOM oder Fachwerten ableiten. Komponenten- und gemountete Ref-Guardrails müssen grün sein; eine spätere manuelle Einzelregistrierung ist kein regulärer Meilenstein.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,15 @@
 # STATUS.md — BBM-Produktiv
 
+### M83.0 – Komponentenbasierte Vollregistrierung
+
+- Status: `[A]` abgenommen; Komponentenmechanismus, Vollständigkeits-Guardrails, automatisierte Runtime-Nachweise und die sichtbare isolierte Electron-Acceptance sind grün.
+- Acht komponentennahe Verträge ersetzen die zentrale Unterelement-Handliste für alle sechs offiziell editorfähigen Restarbeiten- und Protokoll-Scopes.
+- Die Restarbeiten-Liste registriert 32 Ziele, darunter Nr., Datum, Klasse, Nachpflege, Fotos, Verortung, Kurz-/Langtext und die vorhandenen End-Metaziele als getrennte Single-/Multi-Ref-Ziele.
+- Der reale Runtime-Harness belegt getrennte Auswahl, Kindwirkung, Rerender-Persistenz, vollständige gemountete Ref-Auflösung und benannte Fehler bei fehlenden oder doppelten Refs.
+- Zeilentopologie, drei vorhandene Spalten und Scrollstruktur bleiben unverändert; es wurden keine Wrapper oder Fachlogik ergänzt.
+- `docs/licensing.md` bleibt Fremdänderung und unangetastet.
+- Sichtbar bestätigt sind Meta-Spalte, Nr., Datum und Klasse als getrennte stabile Ziele, Kind-Isolation, Ampel-Multi-Ref über alle sichtbaren Zeilen, Rerender-Übernahme, Speichern und automatischer Zweitstart mit Restore ohne neue Scrollleiste oder Topologieänderung.
+
 ### M82.7.5 – Gespeichertes Layout und Meta-Elemente
 
 - Status: `[A] abgenommen`; Lebenszykluskorrektur, explizite Meta-Registrierung, automatisierte Regression und sichtbare isolierte Zwei-Start-Abnahme sind abgeschlossen.

--- a/docs/M83_0_KOMPONENTENBASIERTE_VOLLREGISTRIERUNG.md
+++ b/docs/M83_0_KOMPONENTENBASIERTE_VOLLREGISTRIERUNG.md
@@ -1,0 +1,55 @@
+# M83.0 – Komponentenbasierte Vollregistrierung
+
+## Ursache des Altproblems
+
+Bis M82.7.5 wurden alle offiziellen Ziele in `m80Registry.js` zentral aufgezählt. Produktive DOM-Marker und Ref-Aufrufe lagen dagegen in den jeweiligen Komponenten. Manifestzählungen, Fingerprinttests und bekannte-ID-Tests prüften nur die zentrale Liste. Deshalb konnte ein Container als vollständig gelten, obwohl vorhandene Kinder wie Nr., Datum oder Klasse nie Bestandteil der Registry und damit auch nie Bestandteil der Ref-Prüfung waren.
+
+## Neuer BBM-Komponentenvertrag
+
+Die sechs offiziellen Scopes werden aus acht UI-Komponentenverträgen aggregiert, die direkt als Begleitdateien bei ihren produktiven Komponenten liegen:
+
+- Restarbeiten-Filterbar: 31 Ziele,
+- Restarbeiten-Liste: 32 Ziele,
+- Restarbeiten-Editbox: 53 Ziele,
+- Protokoll-Screen: 10 Ziele und Quicklane: 15 Ziele,
+- Protokoll-Listen-Shell: 4 Ziele und logische Spalten: 3 Ziele,
+- Protokoll-Editbox: 24 Ziele.
+
+Jedes Bündel deklariert `componentId`, Scope, Pflichtslots, Single-/Multi-Ref-Semantik und vollständige Elementverträge. `m80Registry.js` importiert und aggregiert nur noch diese Komponenten. Es enthält keine zentrale Unterelement-Handliste mehr.
+
+## Ref- und Laufzeitmodell
+
+Die bestehenden produktiven Ref-Aufrufe bleiben explizit. `m80Refs.js` gleicht den gemounteten Zustand gegen die Komponentenverträge ab:
+
+- Single-Refs müssen genau ein Ziel besitzen und dürfen nicht durch einen anderen Knoten überschrieben werden.
+- Multi-Refs binden alle sichtbaren Instanzen eines logischen Templateziels.
+- Leere Listen bleiben mit null gemounteten Instanzen gültig.
+- Direkte Auswahl ordnet das Kind vor einem gemeinsam gebundenen Parent.
+- Unvollständige Bindings blockieren den Scope mit dem konkreten Guardrail-Code.
+
+## Vollnachweis Restarbeiten-Liste
+
+Die bestehende erste zusammengefasste Spalte bleibt unverändert aufgebaut und registriert nun getrennt:
+
+- Spaltencontainer, Spaltenkopf und Datenbereich,
+- Nr., Datum, Klasse, optionalen Nachpflegehinweis und Fotos,
+- die vorhandenen Gegenstandsbestandteile Verortung, Kurztext und optionalen Langtext,
+- die vorhandenen End-Metaziele Fertig bis, Ampel, Status, Verantwortlich und optionalen Pflichtfeldhinweis.
+
+Die IDs sind statische Template-IDs. Es werden keine Datensatz- oder Datenbank-IDs verwendet. Die produktive Zeile behält exakt ihre drei bestehenden Kinder `numberColumn`, `contentColumn` und `metaColumn`; es wurden keine Wrapper, Viewports oder Scrollbesitzer ergänzt.
+
+## Guardrails
+
+Statische Validierung prüft Pflichtslots, Registrydeckung, Parents, ID-Quelle, Capabilities, Baselines und Grenzen. Die gemountete Validierung prüft Ref-Auflösung, Zielanzahl und direkte Auswahl. Fehler wie `component_required_slot_missing`, `component_slot_reference_missing`, `component_single_ref_duplicate`, `component_parent_missing`, `component_capability_unsupported`, `component_resize_bounds_missing` und `component_child_selection_swallowed` benennen Komponente und Slot.
+
+## Vorgehen für neue BBM-UIs
+
+Eine neue oder strukturell geänderte editorfähige Komponente muss gleichzeitig ihren vollständigen Begleitvertrag und ihre explizite Ref-Auflösung liefern. Die zentrale Registry darf nur das Bündel aggregieren. Eine UI-Aufgabe ist ohne grünen Komponenten- und Laufzeitvertrag nicht abgeschlossen.
+
+## PDF-Vorbereitung
+
+Für spätere PDF-Komponenten gilt dasselbe Architekturprinzip: Renderer und expliziter Layoutvertrag gehören zusammen; keine automatische PDF-Erkennung; stabile IDs und vollständige Slots; Operationen über den vorhandenen PDF-HostAdapter. M83.0 ändert weder PDF-Code noch PDF-Ausgabe.
+
+## Sichtbare Abnahme
+
+Die isolierte Acceptance mit `npm run start:ui-editor:acceptance` ist erfolgreich nachgetragen. Meta-Spalte, Nr., Datum und Klasse sind als unterschiedliche stabile Ziele auswählbar; eine Kindänderung bleibt auf das Kind begrenzt. Die Listenampel wendet ihren Multi-Ref-Layoutwert auf alle sichtbaren Zeilen an, neu gerenderte Zeilen übernehmen ihn. Speichern und automatischer zweiter Acceptance-Start stellen den Wert wieder her. Es entstanden keine neue Scrollleiste und keine Topologieänderung.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -157,6 +157,7 @@ const TEST_GROUPS = Object.freeze([
       ["m82-7-3TextResizeCurrentValue.test.cjs", "runM8273TextResizeCurrentValueTests"],
       ["m82-7-4AmpelEditing.test.cjs", "runM8274AmpelEditingTests"],
       ["m82-7-5LayoutPersistenceMetaElements.test.cjs", "runM8275LayoutPersistenceMetaElementsTests"],
+      ["m83-0ComponentContracts.test.cjs", "runM830ComponentContractTests"],
       ["uiEditorAcceptanceIsolation.test.cjs", "runUiEditorAcceptanceIsolationTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),

--- a/scripts/tests/_esmLoader.cjs
+++ b/scripts/tests/_esmLoader.cjs
@@ -1,50 +1,77 @@
-const fs = require("node:fs/promises");
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
 const path = require("node:path");
 const { pathToFileURL } = require("node:url");
 
-const dataUrlCache = new Map();
 const modulePromiseCache = new Map();
+const materializationCache = new Map();
+const mirrorRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-esm-loader-"));
+fs.writeFileSync(path.join(mirrorRoot, "package.json"), '{"type":"module"}\n', "utf8");
 
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function mirrorPath(absPath) {
+  const parsed = path.parse(absPath);
+  const rootName = parsed.root.replace(/[:\\/]+/g, "_") || "root";
+  return path.join(mirrorRoot, rootName, path.relative(parsed.root, absPath));
 }
 
-async function toDataUrl(absPath, cache) {
-  const key = path.resolve(absPath);
-  if (cache.has(key)) return cache.get(key);
+function collectRelativeSpecifiers(code) {
+  const patterns = [
+    /from\s+["'](\.{1,2}\/[^"']+)["']/g,
+    /import\s+["'](\.{1,2}\/[^"']+)["']/g,
+  ];
+  return patterns.flatMap((pattern) => Array.from(code.matchAll(pattern), (match) => match[1]));
+}
 
-  let code = await fs.readFile(key, "utf8");
-  const baseDir = path.dirname(key);
-
-  const specifiers = Array.from(code.matchAll(/from\s+["'](\.{1,2}\/[^"']+)["']/g)).map((m) => m[1]);
-  const uniqueSpecs = [...new Set(specifiers)];
-
-  for (const spec of uniqueSpecs) {
-    const childPath = path.resolve(baseDir, spec);
-    const childUrl = await toDataUrl(childPath, cache);
-    const rx = new RegExp(`(from\\s+["'])${escapeRegExp(spec)}(["'])`, "g");
-    code = code.replace(rx, `$1${childUrl}$2`);
+function materializeFile(absPath) {
+  const sourcePath = path.resolve(absPath);
+  let materialization = materializationCache.get(sourcePath);
+  if (!materialization) {
+    materialization = (async () => {
+      const targetPath = mirrorPath(sourcePath);
+      const code = await fsp.readFile(sourcePath, "utf8");
+      await fsp.mkdir(path.dirname(targetPath), { recursive: true });
+      await fsp.writeFile(targetPath, `${code}\n//# sourceURL=${pathToFileURL(sourcePath).href}\n`, "utf8");
+      return { sourcePath, targetPath, code };
+    })();
+    materializationCache.set(sourcePath, materialization);
   }
+  return materialization;
+}
 
-  const sourceUrl = pathToFileURL(key).href;
-  const withSourceUrl = `${code}\n//# sourceURL=${sourceUrl}`;
-  const dataUrl = `data:text/javascript;base64,${Buffer.from(withSourceUrl, "utf8").toString("base64")}`;
-  cache.set(key, dataUrl);
-  return dataUrl;
+async function materializeGraph(absPath) {
+  const rootPath = path.resolve(absPath);
+  const pending = [rootPath];
+  const visited = new Set();
+  while (pending.length > 0) {
+    const sourcePath = pending.shift();
+    if (visited.has(sourcePath)) continue;
+    visited.add(sourcePath);
+    const materialized = await materializeFile(sourcePath);
+    const baseDir = path.dirname(sourcePath);
+    for (const specifier of collectRelativeSpecifiers(materialized.code)) {
+      pending.push(path.resolve(baseDir, specifier));
+    }
+  }
+  return mirrorPath(rootPath);
 }
 
 async function importEsmFromFile(filePath) {
   const resolvedPath = path.resolve(filePath);
   let modulePromise = modulePromiseCache.get(resolvedPath);
-
   if (!modulePromise) {
-    modulePromise = toDataUrl(resolvedPath, dataUrlCache).then((dataUrl) => import(dataUrl));
+    modulePromise = materializeGraph(resolvedPath).then((targetPath) => import(pathToFileURL(targetPath).href));
     modulePromiseCache.set(resolvedPath, modulePromise);
   }
-
   return modulePromise;
 }
 
-module.exports = {
-  importEsmFromFile,
-};
+process.once("exit", () => {
+  try {
+    fs.rmSync(mirrorRoot, { recursive: true, force: true });
+  } catch {
+    // Best-effort cleanup during process shutdown.
+  }
+});
+
+module.exports = { importEsmFromFile };

--- a/scripts/tests/m80-1RegistrationRefresh.test.cjs
+++ b/scripts/tests/m80-1RegistrationRefresh.test.cjs
@@ -83,7 +83,7 @@ async function runM801RegistrationRefreshTests(run) {
       document.body.appendChild(rendered.root);
       const registration = rendered.registration;
       runtimeRegistration = structuredClone(registration);
-      assert.equal(registration.registryVersion, 12);
+      assert.equal(registration.registryVersion, 13);
       assert.equal(registration.registryStatus, "incomplete");
       assert.deepEqual(registration.activeScopes, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]);
       const complete = registration.registryScopes.filter((scope) => scope.status === "complete");

--- a/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
+++ b/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
@@ -15,7 +15,7 @@ async function runM802HeaderEditboxLayoutTests(run) {
   const elements = complete.flatMap((scope) => scope.elements);
 
   await run("M80.2 Registry: Header, Liste und Editbox sind direkt aktiv; Split ist gesperrt", () => {
-    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 12);
+    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 13);
     assert.deepEqual(registryModule.BBM_M80_ACTIVE_SCOPES, [
       "restarbeiten.header.root",
       "restarbeiten.list.root",

--- a/scripts/tests/m82-1BbmFeintuning.test.cjs
+++ b/scripts/tests/m82-1BbmFeintuning.test.cjs
@@ -24,7 +24,7 @@ async function runM821BbmFeintuningTests(run) {
   const editbox = read("src/renderer/modules/restarbeiten/RestarbeitenEditbox.js");
   const css = read("src/renderer/modules/restarbeiten/styles/restarbeiten.css");
 
-  await run("M82.1 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 12));
+  await run("M82.1 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 13));
   await run("M82.1 BBM 02: Manifestversion folgt der Registry", () => assert.equal(manifest.registryVersion, registry.BBM_M80_REGISTRY_VERSION));
   await run("M82.1 BBM 03: Manifestfingerprint ist aktuell", () => assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)));
   await run("M82.1/M82.6 BBM 04: beide Referenzmodule besitzen je drei aktive Scopes", () => assert.deepEqual(registry.BBM_M80_ACTIVE_SCOPES, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root", "protokoll.screen.root", "protokoll.list.root", "protokoll.edit.root"]));

--- a/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
+++ b/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
@@ -47,7 +47,7 @@ async function runM823BbmSpacerCompactUiTests(run) {
     groupWidthEditable,
   });
 
-  await run("M82.3 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 12));
+  await run("M82.3 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 13));
   await run("M82.3 BBM 02: Manifest folgt Registry und Fingerprint", () => { assert.equal(manifest.registryVersion, registry.BBM_M80_REGISTRY_VERSION); assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)); });
   await run("M82.3 BBM 03: Kurztextbezeichnung besitzt reservierte Breite", () => assert.deepEqual(label.baseline.spacing, { reservedWidth: 40 }));
   await run("M82.3 BBM 04: Kurztextbezeichnung erlaubt Spacer davor und danach", () => assert.deepEqual(label.spacingTargets, ["beforeElement", "afterElement", "reservedWidth"]));

--- a/scripts/tests/m82-5BbmSimpleEditorMode.test.cjs
+++ b/scripts/tests/m82-5BbmSimpleEditorMode.test.cjs
@@ -60,8 +60,7 @@ async function runM825BbmSimpleEditorModeTests(run) {
   refs.registerM80TableRef("restarbeiten.list.table", table, table);
   ["number", "subject", "meta"].forEach((key, index) => refs.registerM80TableColumnRef(
     `restarbeiten.list.table.${key}`, tableHeaders[index], [cells[index]], table, table, variables[index], tableHeaders[index]._rect.width));
-  const header = new FakeElement(560, 28);
-  refs.registerM80Ref("restarbeiten.list.table.subject.header", header);
+  const header = tableHeaders[1];
   refs.completeM80PilotRender();
   try {
     await run("M82.5 BBM 06: Direktauswahl markiert die verständliche Überschrift", () => assert.equal(header.attributes["data-ui-inspector-id"], "restarbeiten.list.table.subject.header"));
@@ -70,7 +69,7 @@ async function runM825BbmSimpleEditorModeTests(run) {
       changeRequest: { changeId: "m82-5-header-font", elementId: "restarbeiten.list.table.subject.header", operation: "textResize", payload: { text: { fontSize: 18 } }, source: "target-app-start" },
     }).changeResult;
     await run("M82.5 BBM 07: Überschrift nimmt direkte Schriftgröße an", () => { assert.equal(result.success, true); assert.equal(header.style.fontSize, "18px"); });
-    await run("M82.5 BBM 08: Schriftänderung verändert keine Spaltenbreite", () => assert.equal(header.getBoundingClientRect().width, 560));
+    await run("M82.5 BBM 08: Schriftänderung verändert keine Spaltenbreite", () => assert.equal(header.getBoundingClientRect().width, 464));
     await run("M82.5 BBM 09: Rücklesung liefert die neue Schriftgröße", () => assert.equal(refs.snapshotM80State("restarbeiten.list.table.subject.header").fontSize, 18));
     await run("M82.5 BBM 10: Änderung enthält keine Fachwerte", () => assert.equal(["recordId", "dueDate", "responsible", "status"].some((key) => key in result.newState), false));
     const request = { changeId: "m82-5-confirmed-width", elementId: "restarbeiten.list.table.subject", operation: "resizeWidth", payload: { width: 369 }, source: "ui-editor-panel" };

--- a/scripts/tests/m82-7-2GenericTextResize.test.cjs
+++ b/scripts/tests/m82-7-2GenericTextResize.test.cjs
@@ -125,11 +125,11 @@ async function runM8272GenericTextResizeTests(run) {
       return { lower, higher, direct };
     };
 
-    await run("M82.7.2/M82.7.5 BBM: Inventar umfasst exakt alle 65 textResize-Ziele in fuenf produktiven Scopes", () => {
-      assert.equal(textEntries.length, 65);
+    await run("M82.7.2/M83.0 BBM: Inventar umfasst exakt alle 74 textResize-Ziele in fuenf produktiven Scopes", () => {
+      assert.equal(textEntries.length, 74);
       assert.deepEqual(Object.fromEntries(scopes.map((scope) => [scope.scopeId, scope.elements.filter((entry) => entry.allowedOps.includes("textResize")).length]).filter(([, count]) => count)), {
         "restarbeiten.header.root": 14,
-        "restarbeiten.list.root": 12,
+        "restarbeiten.list.root": 21,
         "restarbeiten.edit.root": 22,
         "protokoll.screen.root": 6,
         "protokoll.edit.root": 11,

--- a/scripts/tests/m82-7-4AmpelEditing.test.cjs
+++ b/scripts/tests/m82-7-4AmpelEditing.test.cjs
@@ -115,7 +115,7 @@ async function runM8274AmpelEditingTests(run) {
     const topology = refs.snapshotM80Topology();
     await run("M82.7.4 BBM 08: Ref zeigt direkt auf das innere sichtbare Symbol", () => assert.strictEqual(refs.getM80Ref(AMPEL_ID).element, symbol));
     await run("M82.7.4 BBM 09: Ref wird genau einmal aufgeloest", () => assert.equal(refs.listM80Refs().filter((ref) => ref.id === AMPEL_ID).length, 1));
-    await run("M82.7.4 BBM 10: refKey und referenceResolved werden korrekt gemeldet", () => assert.deepEqual(refs.getM80ReferenceStatus(AMPEL_ID), { refKey: entry.refKey, referenceResolved: true }));
+    await run("M82.7.4 BBM 10: Ref-Status meldet Schluessel, Aufloesung und Zielanzahl", () => assert.deepEqual(refs.getM80ReferenceStatus(AMPEL_ID), { refKey: entry.refKey, referenceResolved: true, targetCount: 1, mountedInstanceCount: 1 }));
     await run("M82.7.4 BBM 11: reale Ausgangsbounds sind 12 mal 12 px", () => assert.deepEqual([baseline.width, baseline.height], [12, 12]));
     await run("M82.7.4.1 BBM 11a: links bewegt nur das innere Symbol auf X minus 5", () => { const result = submit(host, "move", { x: -5 }, "move-left"); assert.equal(result.success, true, result.message); assert.deepEqual([refs.snapshotM80State(AMPEL_ID).x, refs.snapshotM80State(AMPEL_ID).y], [-5, 0]); assert.equal(symbol.style.translate, "-5px 0px"); });
     await run("M82.7.4.1 BBM 11b: rechts stellt X 0 wieder her", () => { assert.equal(submit(host, "move", { x: 0 }, "move-right").success, true); assert.deepEqual([refs.snapshotM80State(AMPEL_ID).x, refs.snapshotM80State(AMPEL_ID).y], [0, 0]); });

--- a/scripts/tests/m82-7-5LayoutPersistenceMetaElements.test.cjs
+++ b/scripts/tests/m82-7-5LayoutPersistenceMetaElements.test.cjs
@@ -55,8 +55,8 @@ async function runM8275LayoutPersistenceMetaElementsTests(run) {
   global.window = { getComputedStyle: computedStyle, dispatchEvent() {}, uiEditor: {} };
 
   try {
-    await run("M82.7.5 BBM 01: Registryversion kennzeichnet den erweiterten Vertrag", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 12));
-    await run("M82.7.5 BBM 02: Listenscope enthaelt die sieben neuen logischen Ziele", () => assert.equal(scope.elements.length, 23));
+    await run("M82.7.5 BBM 01: Registryversion kennzeichnet den erweiterten Vertrag", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 13));
+    await run("M82.7.5 BBM 02: Listenscope enthaelt den vollstaendigen Komponentenvertrag", () => assert.equal(scope.elements.length, 32));
     await run("M82.7.5 BBM 03: alle bestaetigten stabilen IDs sind exakt registriert", () => [...headerIds, ...rowIds].forEach((id) => assert.ok(byId.has(id), id)));
     await run("M82.7.5 BBM 04: Header-Kinder besitzen den existierenden Meta-Header als Parent", () => headerIds.forEach((id) => assert.equal(byId.get(id).parentId, "restarbeiten.list.table.meta.header")));
     await run("M82.7.5 BBM 05: Zeilenkinder besitzen den existierenden Meta-Datenbereich als Parent", () => rowIds.forEach((id) => assert.equal(byId.get(id).parentId, "restarbeiten.list.table.meta.cells")));
@@ -68,9 +68,9 @@ async function runM8275LayoutPersistenceMetaElementsTests(run) {
     const header = listModule.buildRestarbeitenTableHeader();
     const records = listModule.buildRestarbeitenList({ items: [{ id: 1, numberLine: "1", dateLine: "01.01.26", itemClassLabel: "Rest", locationLine: "A", shortTextLine: "Kurz", longTextLine: "Lang", dueDateLabel: "02.01.26", ampelState: "green", statusLabel: "offen", responsibleLabel: "B" }, { id: 2, numberLine: "2", dateLine: "01.01.26", itemClassLabel: "Mangel", locationLine: "C", shortTextLine: "Kurz", longTextLine: "Lang", dueDateLabel: "03.01.26", ampelState: "red", statusLabel: "offen", responsibleLabel: "D" }] });
     await run("M82.7.5 BBM 10: vorhandene Header-DOM-Knoten werden inventarisiert", () => assert.deepEqual(Object.keys(header._m80MetaHeaderParts), ["dueDate", "status", "responsible"]));
-    await run("M82.7.5 BBM 11: vorhandene Zeilen-DOM-Knoten werden ohne Wrapper inventarisiert", () => assert.deepEqual(Object.fromEntries(Object.entries(records._m80MetaParts).map(([key, values]) => [key, values.length])), { dueDate: 2, ampel: 2, status: 2, responsible: 2 }));
+    await run("M82.7.5 BBM 11: vorhandene Zeilen-DOM-Knoten werden ohne Wrapper inventarisiert", () => assert.deepEqual(Object.fromEntries(["dueDate", "ampel", "status", "responsible"].map((key) => [key, records._m83ComponentParts[key].length])), { dueDate: 2, ampel: 2, status: 2, responsible: 2 }));
     await run("M82.7.5 BBM 12: Renderer erzeugt keine neue Tabellenansicht", () => { const source = read("src/renderer/modules/restarbeiten/RestarbeitenList.js"); assert.doesNotMatch(source, /m82-7-5|meta-wrapper|editor-wrapper/i); });
-    await run("M82.7.5 BBM 13: Header- und Zeileninventar enthalten keine Fachwert-IDs", () => [...Object.values(header._m80MetaHeaderParts), ...Object.values(records._m80MetaParts).flat()].forEach((element) => assert.doesNotMatch(element.getAttribute("data-ui-editor-id") || "", /\b\d+\b|green|red|offen/)));
+    await run("M82.7.5 BBM 13: Header- und Zeileninventar enthalten keine Fachwert-IDs", () => [...Object.values(header._m80MetaHeaderParts), ...Object.values(records._m83ComponentParts).flat()].forEach((element) => assert.doesNotMatch(element.getAttribute("data-ui-editor-id") || "", /\b\d+\b|green|red|offen/)));
 
     refs.resetM80PilotWorkingStatesForDiagnostic(); refs.beginM80PilotRender();
     const fallback = new FakeElement("DIV", 172, 100);

--- a/scripts/tests/m82AppStarterPackage.test.cjs
+++ b/scripts/tests/m82AppStarterPackage.test.cjs
@@ -46,7 +46,7 @@ async function runM82AppStarterPackageTests(run) {
     assert.equal(byId.get("restarbeiten.header.root").status, "complete");
     assert.equal(byId.get("restarbeiten.header.root").elementCount, 31);
     assert.equal(byId.get("restarbeiten.list.root").status, "complete");
-    assert.equal(byId.get("restarbeiten.list.root").elementCount, 23);
+    assert.equal(byId.get("restarbeiten.list.root").elementCount, 32);
     assert.equal(byId.get("restarbeiten.edit.root").status, "complete");
     assert.equal(byId.get("restarbeiten.edit.root").elementCount, 53);
     assert.equal(byId.get("bbm.remaining").status, "blocked");

--- a/scripts/tests/m83-0ComponentContracts.test.cjs
+++ b/scripts/tests/m83-0ComponentContracts.test.cjs
@@ -1,0 +1,118 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const ROOT = path.resolve(__dirname, "../..");
+const read = (relativePath) => fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+
+class FakeElement {
+  constructor(tagName = "DIV", width = 100, height = 24) {
+    this.tagName = tagName.toUpperCase(); this.nodeName = this.tagName; this.attributes = {}; this.dataset = {}; this.className = "";
+    this.parentElement = null; this.children = []; this.isConnected = true; this._rect = { left: 0, top: 0, width, height };
+    this.style = { setProperty(name, value) { this[name] = value; }, getPropertyValue(name) { return this[name] || ""; } };
+    this.classList = { contains: (name) => this.className.split(/\s+/).includes(name), toggle: (name, active) => { const names = new Set(this.className.split(/\s+/).filter(Boolean)); if (active) names.add(name); else names.delete(name); this.className = [...names].join(" "); } };
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); if (name.startsWith("data-")) this.dataset[name.slice(5).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())] = String(value); }
+  getAttribute(name) { return this.attributes[name] || null; }
+  addEventListener() {}
+  append(...children) { children.forEach((child) => { child.parentElement = this; this.children.push(child); }); }
+  appendChild(child) { this.append(child); return child; }
+  getBoundingClientRect() { const width = Number.parseFloat(this.style.width) || this._rect.width; const height = Number.parseFloat(this.style.height) || this._rect.height; return { left: 0, top: 0, width, height, right: width, bottom: height }; }
+}
+
+function computedStyle(element) {
+  const rect = element.getBoundingClientRect();
+  return { ...element.style, width: `${rect.width}px`, height: `${rect.height}px`, paddingLeft: element.style.paddingLeft || "0px", paddingTop: element.style.paddingTop || "0px", fontSize: element.style.fontSize || "10.667px", boxSizing: "border-box" };
+}
+
+async function runM830ComponentContractTests(run) {
+  const registry = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Registry.js"));
+  const refs = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Refs.js"));
+  const mainBody = await importEsmFromFile(path.join(ROOT, "src/renderer/modules/restarbeiten/RestarbeitenMainBody.js"));
+  const contracts = registry.listM83ComponentContracts();
+  const scopes = registry.listM80RegistryScopes().filter((scope) => scope.status === "complete");
+  const registryIds = scopes.flatMap((scope) => scope.elements.map((entry) => entry.id));
+  const contractIds = contracts.flatMap((component) => component.slots.map((slot) => slot.element.id));
+  const listContract = contracts.find((component) => component.componentId === "bbm.restarbeiten.list");
+
+  await run("M83.0 BBM 01: alle offiziellen Scopes stammen aus acht komponentennahen Vertraegen", () => {
+    assert.equal(contracts.length, 8); assert.deepEqual([...contractIds].sort(), [...registryIds].sort()); assert.equal(new Set(contractIds).size, contractIds.length);
+    for (const component of contracts) assert.deepEqual([...component.requiredSlots].sort(), component.slots.map((slot) => slot.slotId).sort(), component.componentId);
+  });
+  await run("M83.0 BBM 02: Meta-Startspalte deklariert Spalte, Kopf, Nr., Datum, Klasse und reale Zusatzinhalte", () => {
+    const ids = new Set(listContract.slots.map((slot) => slot.element.id));
+    for (const id of ["restarbeiten.list.table.number", "restarbeiten.list.table.number.header", "restarbeiten.list.table.number.cells", "restarbeiten.record.number", "restarbeiten.record.createdAt", "restarbeiten.record.itemClass", "restarbeiten.record.aftercare", "restarbeiten.record.photos"]) assert.equal(ids.has(id), true, id);
+  });
+  await run("M83.0 BBM 03: zentrale Registry aggregiert nur Komponenten und fuehrt keine Unterelement-Handliste", () => {
+    const source = read("src/renderer/ui-editor/m80Registry.js"); assert.doesNotMatch(source, /m83Element\(|restarbeiten\.record\.number|protokoll\.edit\.short/); assert.match(source, /aggregateBbmM83Components\(BBM_M83_COMPONENT_CONTRACTS\)/);
+  });
+  await run("M83.0 BBM 04: Komponenten-IDs und Ref-Quellen enthalten keine Fachwerte oder Datenbank-IDs", () => {
+    const source = contracts.map((component) => JSON.stringify(component)).join("\n") + read("src/renderer/ui-editor/m80Refs.js");
+    assert.doesNotMatch(source, /data-bbm-restarbeiten-record-id|app\.db|item\.id|databaseId|recordId/); assert.ok(contractIds.every((id) => !/(?:^|\.)\d{4,}(?:\.|$)|[0-9a-f]{8}-[0-9a-f-]{27,}/i.test(id)));
+  });
+  await run("M83.0 BBM 05: Restarbeiten-Liste, Editbox und Protokoll sind vollstaendig gebuendelt", () => {
+    assert.deepEqual(Object.fromEntries(contracts.map((component) => [component.componentId, component.slots.length])), { "bbm.restarbeiten.filterbar": 31, "bbm.restarbeiten.list": 32, "bbm.restarbeiten.editbox": 53, "bbm.protokoll.screen": 10, "bbm.protokoll.quicklane": 15, "bbm.protokoll.list.shell": 4, "bbm.protokoll.list.columns": 3, "bbm.protokoll.editbox": 24 });
+  });
+
+  const previous = { document: global.document, window: global.window, Element: global.Element, CustomEvent: global.CustomEvent };
+  const body = new FakeElement("BODY", 1600, 900);
+  global.Element = FakeElement; global.CustomEvent = class { constructor(type) { this.type = type; } };
+  global.document = { body, createElement: (tag) => new FakeElement(tag), querySelector: () => null };
+  global.window = { getComputedStyle: computedStyle, dispatchEvent() {} };
+  const items = [
+    { id: 7, numberLine: "17", dateLine: "01.08.26", itemClassLabel: "Rest", nachpflegeLabel: "Nachpflege", locationLine: "Bauteil A", shortTextLine: "Kurz A", longTextLine: "Lang A", dueDateLabel: "08.08.26", ampelState: "green", statusLabel: "offen", responsibleLabel: "Firma A", requiredFieldSummary: "Pflichtangabe" },
+    { id: 8, numberLine: "18", dateLine: "02.08.26", itemClassLabel: "Mangel", locationLine: "Bauteil B", shortTextLine: "Kurz B", longTextLine: "Lang B", dueDateLabel: "09.08.26", ampelState: "red", statusLabel: "offen", responsibleLabel: "Firma B" },
+  ];
+  try {
+    refs.resetM80PilotWorkingStatesForDiagnostic(); refs.beginM80PilotRender();
+    body.appendChild(mainBody.buildRestarbeitenMainBody({ items, showAmpel: true, showLongtext: true }));
+    await run("M83.0 BBM 06: reale gemountete Listenkomponente erfuellt alle Einzel- und Multi-Refs", () => assert.equal(refs.validateM83ComponentReferences(["bbm.restarbeiten.list"]).ok, true));
+    await run("M83.0 BBM 07: Nr., Datum und Klasse sind getrennte Multi-Refs und getrennt direkt auswaehlbar", () => {
+      const ids = ["restarbeiten.record.number", "restarbeiten.record.createdAt", "restarbeiten.record.itemClass"];
+      ids.forEach((id) => { const ref = refs.getM80Ref(id); assert.equal(ref.contractTargets.length, 2); assert.equal(refs.getM80IdFromTarget(ref.contractTargets[0]), id); }); assert.equal(new Set(ids.map((id) => refs.getM80Ref(id).element)).size, 3);
+    });
+    await run("M83.0 BBM 08: Kind-Aenderung wirkt nur auf Nr. und nicht auf Datum, Klasse oder Spaltencontainer", () => {
+      const number = refs.getM80Ref("restarbeiten.record.number"); const date = refs.getM80Ref("restarbeiten.record.createdAt"); const itemClass = refs.getM80Ref("restarbeiten.record.itemClass"); const column = refs.getM80Ref("restarbeiten.list.table.number");
+      refs.applyM80State(number.id, { ...refs.snapshotM80State(number.id), x: 5 }, "move"); refs.applyM80State(number.id, { ...refs.snapshotM80State(number.id), fontSize: 14 }, "textResize");
+      number.contractTargets.forEach((target) => { assert.equal(target.style.translate, "5px 0px"); assert.equal(target.style.fontSize, "14px"); }); assert.equal(date.contractTargets[0].style.translate, undefined); assert.equal(itemClass.contractTargets[0].style.fontSize, undefined); assert.equal(column.element.style.translate, undefined);
+    });
+    await run("M83.0 BBM 09: Header und Zeileninhalt bleiben getrennte Ziele", () => {
+      assert.notStrictEqual(refs.getM80Ref("restarbeiten.list.table.number.header").element, refs.getM80Ref("restarbeiten.record.number").element); assert.equal(refs.getM80IdFromTarget(refs.getM80Ref("restarbeiten.list.table.number.header").element), "restarbeiten.list.table.number.header");
+    });
+    await run("M83.0 BBM 10: weitere vorhandene Start-, Gegenstands- und End-Metaziele sind gemountet", () => {
+      for (const id of ["restarbeiten.record.aftercare", "restarbeiten.record.photos", "restarbeiten.record.location", "restarbeiten.record.shortText", "restarbeiten.record.longText", "restarbeiten.record.dueDate", "restarbeiten.record.ampel", "restarbeiten.record.status", "restarbeiten.record.responsible", "restarbeiten.record.requiredSummary"]) assert.ok(refs.getM80Ref(id), id);
+    });
+    await run("M83.0 BBM 11: Rerender erhaelt gespeicherten Kindzustand und erneuert Multi-Refs", () => {
+      refs.completeM80PilotRender(); refs.beginM80PilotRender(); body.appendChild(mainBody.buildRestarbeitenMainBody({ items: [items[1]], showAmpel: true, showLongtext: true }));
+      assert.equal(refs.validateM83ComponentReferences(["bbm.restarbeiten.list"]).ok, true); const number = refs.getM80Ref("restarbeiten.record.number"); assert.equal(number.contractTargets.length, 1); assert.equal(number.contractTargets[0].style.translate, "5px 0px"); assert.equal(number.contractTargets[0].style.fontSize, "14px");
+    });
+    await run("M83.0 BBM 12: Renderer behaelt drei vorhandene Spalten und erzeugt keine Wrapper oder neue Scrollstruktur", () => {
+      const source = read("src/renderer/modules/restarbeiten/RestarbeitenList.js"); assert.match(source, /row\.append\(numberColumn, contentColumn, metaColumn\)/); assert.doesNotMatch(source, /editorWrapper|componentContractWrapper|createElement\(["'](?:viewport|scroll)/i);
+    });
+    await run("M83.0 BBM 13: fehlende reale Ref-Bindung benennt Komponente und Slot", () => {
+      refs.beginM80PilotRender(); assert.throws(() => refs.validateM83ComponentReferences(["bbm.restarbeiten.list"]), (error) => error.code === "component_reference_contract_invalid" && error.details.some((entry) => entry.code === "component_slot_reference_missing" && entry.slotId === "restarbeiten.record.number"));
+    });
+    await run("M83.0 BBM 14: doppelter Einzel-Ref wird sofort benannt und abgelehnt", () => {
+      refs.beginM80PilotRender(); refs.registerM80Ref("restarbeiten.list.root", new FakeElement("MAIN")); assert.throws(() => refs.registerM80Ref("restarbeiten.list.root", new FakeElement("MAIN")), (error) => error.code === "component_single_ref_duplicate");
+    });
+  } finally {
+    refs.resetM80PilotWorkingStatesForDiagnostic(); global.document = previous.document; global.window = previous.window; global.Element = previous.Element; global.CustomEvent = previous.CustomEvent;
+  }
+
+  await run("M83.0 BBM 15: keine DOM-Erkennung erzeugt Registryziele und keine PDF-Funktion wurde veraendert", () => {
+    const source = read("src/renderer/ui-editor/m80Registry.js") + read("src/renderer/ui-editor/m83ComponentContract.js"); assert.doesNotMatch(source, /querySelector|querySelectorAll|MutationObserver|createElement/); assert.doesNotMatch(source, /PdfAdapter|pdfRegistry|pdfLayoutSession/);
+  });
+  await run("M83.0 BBM 16: Schutzdatei licensing bleibt bytegenau unveraendert", () => {
+    const hash = crypto.createHash("sha256").update(fs.readFileSync(path.join(ROOT, "docs/licensing.md"))).digest("hex").toUpperCase(); assert.equal(hash, "02AE66A8873C74869539F13F734B7CE43BC63B6EF37DA553A40C27A4F514D784");
+  });
+}
+
+module.exports = { runM830ComponentContractTests };
+if (require.main === module) {
+  let failed = false; const run = async (name, test) => { try { await test(); console.log(`ok - ${name}`); } catch (error) { failed = true; console.error(`not ok - ${name}`); console.error(error?.stack || error); } };
+  runM830ComponentContractTests(run).then(() => { if (failed) process.exitCode = 1; }).catch((error) => { process.exitCode = 1; console.error(error?.stack || error); });
+}

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 113, "113 Suite-Einstiege einschließlich Entwicklungs-Lizenz sowie M82.4 bis M82.7.5-Isolation");
+    assert.equal(suites.length, 114, "114 Suite-Einstiege einschließlich M83.0-Komponentenvertrag");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/src/renderer/modules/protokoll/TopsList.js
+++ b/src/renderer/modules/protokoll/TopsList.js
@@ -3,7 +3,7 @@ import {
   normalizeTopShortText,
 } from "../../shared/text/topTextPresentation.js";
 import { applyProtokollTopsUiLayout } from "../../../shared/tableLayouts/protokollTopsLayout.js";
-import { completeM80PilotRender, registerM80Ref } from "../../ui-editor/m80Refs.js";
+import { beginM83ComponentBinding, completeM80PilotRender, registerM80Ref } from "../../ui-editor/m80Refs.js";
 
 const PROTOKOLL_LIST_COLUMN_REFS = Object.freeze([
   Object.freeze({ id: "protokoll.list.column.number", key: "number", widthVariable: "--bbm-tops-list-number-col", minimumWidth: 40, maximumWidth: 220 }),
@@ -145,6 +145,7 @@ export class TopsList {
   }
 
   _registerUiEditorColumnRefs() {
+    beginM83ComponentBinding("bbm.protokoll.list.columns");
     for (const column of PROTOKOLL_LIST_COLUMN_REFS) {
       const targets = this._uiEditorColumnRefs[column.key] || [];
       const primary = targets[0];

--- a/src/renderer/modules/protokoll/TopsList.uiEditorContract.js
+++ b/src/renderer/modules/protokoll/TopsList.uiEditorContract.js
@@ -1,0 +1,30 @@
+import { m83Component, m83Element, m83Slot } from "../../ui-editor/m83ComponentContract.js";
+
+const scopeId = "protokoll.list.root";
+const columns = Object.freeze([
+  Object.freeze({ id: "protokoll.list.column.number", name: "TOP / Nummer", currentWidth: 64, minimumWidth: 40, maximumWidth: 220, widthSourceId: "--bbm-tops-list-number-col", order: 31, role: "metaColumn" }),
+  Object.freeze({ id: "protokoll.list.column.text", name: "Gegenstand / Kurztext / Langtext", currentWidth: 650, minimumWidth: 180, maximumWidth: 1400, widthSourceId: "--bbm-tops-list-text-col", order: 32, role: "contentColumn" }),
+  Object.freeze({ id: "protokoll.list.column.meta", name: "Status / Fertig bis / Verantwortlich", currentWidth: 74, minimumWidth: 50, maximumWidth: 420, widthSourceId: "--bbm-tops-list-meta-col", order: 33, role: "metaColumn" }),
+]);
+const elements = [
+  m83Element({ id: scopeId, name: "Protokoll-Listenbereich", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: [], componentKind: "sheetScrollOwner" }),
+  m83Element({ id: "protokoll.list.canvas", name: "Protokoll-Dokumentfläche", type: "area", role: "contentArea", parentId: scopeId, order: 10, allowedOps: [], componentKind: "documentCanvas" }),
+  m83Element({ id: "protokoll.list.paper", name: "Protokoll-Dokumentblatt", type: "group", role: "layoutGroup", parentId: "protokoll.list.canvas", order: 20, allowedOps: [], componentKind: "documentPaper" }),
+  m83Element({ id: "protokoll.list.table", name: "Protokoll-TOP-Liste", type: "group", role: "contentTable", parentId: "protokoll.list.paper", order: 30, allowedOps: [], componentKind: "existingContentTable" }),
+  ...columns.map((column) => m83Element({ id: column.id, name: column.name, type: "group", role: column.role, parentId: "protokoll.list.table", order: column.order, allowedOps: ["resizeWidth"], columnRole: column.role, componentKind: "logicalColumn", baseline: { width: column.currentWidth, minWidth: column.minimumWidth, maxWidth: column.maximumWidth } })),
+];
+
+export const PROTOKOLL_LIST_REQUIRED_SLOTS = Object.freeze([scopeId, "protokoll.list.canvas", "protokoll.list.paper", "protokoll.list.table"]);
+export const PROTOKOLL_LIST_COLUMNS_REQUIRED_SLOTS = Object.freeze(columns.map((column) => column.id));
+export const protokollListUiEditorContract = m83Component({
+  componentId: "bbm.protokoll.list.shell",
+  scopeId,
+  requiredSlots: PROTOKOLL_LIST_REQUIRED_SLOTS,
+  slots: elements.slice(0, 4).map((entry) => m83Slot(entry.id, entry)),
+});
+export const protokollListColumnsUiEditorContract = m83Component({
+  componentId: "bbm.protokoll.list.columns",
+  scopeId,
+  requiredSlots: PROTOKOLL_LIST_COLUMNS_REQUIRED_SLOTS,
+  slots: elements.slice(4).map((entry) => m83Slot(entry.id, entry, { referenceKind: "multi" })),
+});

--- a/src/renderer/modules/protokoll/TopsScreenQuicklane.js
+++ b/src/renderer/modules/protokoll/TopsScreenQuicklane.js
@@ -1,5 +1,5 @@
 import { getTopFilterBadge, getTopFilterLabel, normalizeTopFilterMode } from "./topFilterMode.js";
-import { completeM80PilotRender, registerM80Ref } from "../../ui-editor/m80Refs.js";
+import { beginM83ComponentBinding, completeM80PilotRender, registerM80Ref } from "../../ui-editor/m80Refs.js";
 
 const ICON_CLASS = "bbm-tops-screen-quicklane-icon";
 const AMPEL_STATUS_ICON_URL = "./assets/icons/ampel-status.svg";
@@ -218,6 +218,7 @@ export class TopsScreenQuicklane {
   }
 
   _registerUiEditorRefs({ navigation, visibility, filter, output }) {
+    beginM83ComponentBinding("bbm.protokoll.quicklane");
     registerM80Ref("protokoll.topsScreen.quicklane", this.root);
     const groups = [
       ["protokoll.topsScreen.quicklane.group.navigation", navigation, [

--- a/src/renderer/modules/protokoll/TopsWorkbench.uiEditorContract.js
+++ b/src/renderer/modules/protokoll/TopsWorkbench.uiEditorContract.js
@@ -1,0 +1,52 @@
+import {
+  FIELD_LAYOUT,
+  GROUP_LAYOUT,
+  ICON_LAYOUT,
+  TEXT_LAYOUT,
+  ZONE_HEIGHT_LAYOUT,
+  m83Component,
+  m83Element,
+  m83Slot,
+} from "../../ui-editor/m83ComponentContract.js";
+
+const scopeId = "protokoll.edit.root";
+const groupLayout = Object.freeze(["move", "resizeWidth", "resizeHeight"]);
+const elements = [
+  m83Element({ id: scopeId, name: "Protokoll-Eingabebereich", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: ZONE_HEIGHT_LAYOUT, componentKind: "fixedEditArea", baseline: { width: 940, height: 300, minWidth: 320, maxWidth: 1880, minHeight: 160, maxHeight: 720 } }),
+  m83Element({ id: "protokoll.edit.canvas", name: "Protokoll-Eingabefläche", type: "area", role: "formArea", parentId: scopeId, order: 10, allowedOps: [], componentKind: "editCanvas" }),
+  m83Element({ id: "protokoll.edit.workbench", name: "Gruppe TOP-Bearbeitung", type: "group", role: "layoutGroup", parentId: "protokoll.edit.canvas", order: 20, allowedOps: groupLayout, componentKind: "workbench" }),
+  m83Element({ id: "protokoll.edit.header", name: "Gruppe TOP-Bearbeitungskopf", type: "group", role: "layoutGroup", parentId: "protokoll.edit.workbench", order: 30, allowedOps: GROUP_LAYOUT, componentKind: "header" }),
+  m83Element({ id: "protokoll.edit.header.label", name: "Bezeichnung TOP bearbeiten", type: "label", role: "fieldLabel", parentId: "protokoll.edit.header", order: 31, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  m83Element({ id: "protokoll.edit.text", name: "Gruppe Textbearbeitung", type: "group", role: "fieldCollection", parentId: "protokoll.edit.workbench", order: 40, allowedOps: groupLayout, componentKind: "editbox" }),
+  ...[["short", "Kurztext", "text", 41], ["long", "Langtext", "multilineText", 50]].flatMap(([key, name, fieldKind, order]) => [
+    m83Element({ id: `protokoll.edit.${key}`, name: `Gruppe ${name}`, type: "fieldGroup", role: "formFieldGroup", parentId: "protokoll.edit.text", order, allowedOps: groupLayout, componentKind: "fieldGroup" }),
+    m83Element({ id: `protokoll.edit.${key}.label`, name: `Bezeichnung ${name}`, type: "label", role: "fieldLabel", parentId: `protokoll.edit.${key}`, order: order + 1, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+    m83Element({ id: `protokoll.edit.${key}.field`, name: `Eingabefeld ${name}`, type: "field", role: "dataFieldLayout", parentId: `protokoll.edit.${key}`, order: order + 2, allowedOps: FIELD_LAYOUT, fieldKind, componentKind: fieldKind === "text" ? "input" : "textarea" }),
+  ]),
+  m83Element({ id: "protokoll.edit.meta", name: "Gruppe Status und Zuordnung", type: "group", role: "fieldCollection", parentId: "protokoll.edit.workbench", order: 60, allowedOps: groupLayout, componentKind: "metaPanel" }),
+  m83Element({ id: "protokoll.edit.flags", name: "Gruppe Kennzeichnungen", type: "group", role: "layoutGroup", parentId: "protokoll.edit.meta", order: 61, allowedOps: groupLayout, componentKind: "flagGroup" }),
+  ...[["status", "Status", "select", 70], ["due", "Fertig bis", "date", 80], ["responsible", "Verantwortlich", "select", 90]].flatMap(([key, name, fieldKind, order]) => [
+    m83Element({ id: `protokoll.edit.${key}`, name: `Gruppe ${name}`, type: "fieldGroup", role: "formFieldGroup", parentId: "protokoll.edit.meta", order, allowedOps: groupLayout, componentKind: "fieldGroup" }),
+    m83Element({ id: `protokoll.edit.${key}.label`, name: `Bezeichnung ${name}`, type: "label", role: "fieldLabel", parentId: `protokoll.edit.${key}`, order: order + 1, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+    m83Element({ id: `protokoll.edit.${key}.field`, name: `Eingabefeld ${name}`, type: "field", role: "dataFieldLayout", parentId: `protokoll.edit.${key}`, order: order + 2, allowedOps: FIELD_LAYOUT, fieldKind, componentKind: fieldKind === "date" ? "dateInput" : "select" }),
+  ]),
+  m83Element({ id: "protokoll.edit.ampel", name: "Statussymbol Ampel", type: "statusIndicator", role: "status", parentId: "protokoll.edit.meta", order: 100, allowedOps: ICON_LAYOUT, componentKind: "statusIndicator" }),
+];
+
+export const PROTOKOLL_EDIT_REQUIRED_SLOTS = Object.freeze([
+  scopeId, "protokoll.edit.canvas", "protokoll.edit.workbench", "protokoll.edit.header", "protokoll.edit.header.label", "protokoll.edit.text",
+  "protokoll.edit.short", "protokoll.edit.short.label", "protokoll.edit.short.field",
+  "protokoll.edit.long", "protokoll.edit.long.label", "protokoll.edit.long.field",
+  "protokoll.edit.meta", "protokoll.edit.flags",
+  ...["status", "due", "responsible"].flatMap((key) => [`protokoll.edit.${key}`, `protokoll.edit.${key}.label`, `protokoll.edit.${key}.field`]),
+  "protokoll.edit.ampel",
+]);
+
+export const protokollEditUiEditorContract = m83Component({
+  componentId: "bbm.protokoll.editbox",
+  scopeId,
+  requiredSlots: PROTOKOLL_EDIT_REQUIRED_SLOTS,
+  slots: elements.map((entry) => m83Slot(entry.id, entry, {
+    requirements: { textResize: entry.type === "label", move: entry.allowedOps.includes("move") },
+  })),
+});

--- a/src/renderer/modules/protokoll/screens/TopsScreen.js
+++ b/src/renderer/modules/protokoll/screens/TopsScreen.js
@@ -40,6 +40,7 @@ import {
 import { OVERLAY_TOP } from "../../../ui/zIndex.js";
 import {
   beginM80PilotRender,
+  beginM83ComponentBinding,
   completeM80PilotRender,
   registerM80Ref,
 } from "../../../ui-editor/m80Refs.js";
@@ -203,6 +204,9 @@ export default class TopsScreen {
   }
 
   _registerUiEditorRefs() {
+    beginM83ComponentBinding("bbm.protokoll.screen");
+    beginM83ComponentBinding("bbm.protokoll.list.shell");
+    beginM83ComponentBinding("bbm.protokoll.editbox");
     const header = this.header;
     const workbench = this.workbench;
     const editbox = workbench?.sharedEditboxCore?.editbox;
@@ -220,8 +224,6 @@ export default class TopsScreen {
     registerM80Ref("protokoll.header.meta.due", header.metaLegendDue);
     registerM80Ref("protokoll.header.meta.status", header.metaLegendStatus);
     registerM80Ref("protokoll.header.meta.responsible", header.metaLegendResponsible);
-    registerM80Ref("protokoll.topsScreen.quicklane", this.quicklane.root);
-
     registerM80Ref("protokoll.list.root", this.sheetArea);
     registerM80Ref("protokoll.list.canvas", this.sheetCanvas);
     registerM80Ref("protokoll.list.paper", this.sheetPaper);

--- a/src/renderer/modules/protokoll/screens/TopsScreen.uiEditorContract.js
+++ b/src/renderer/modules/protokoll/screens/TopsScreen.uiEditorContract.js
@@ -1,0 +1,62 @@
+import {
+  DOMAIN_LOCKS,
+  GROUP_LAYOUT,
+  TEXT_LAYOUT,
+  m83Component,
+  m83DomainButton,
+  m83Element,
+  m83Slot,
+} from "../../../ui-editor/m83ComponentContract.js";
+
+const scopeId = "protokoll.screen.root";
+const protokollGroupLayout = Object.freeze(["move", "resizeWidth", "resizeHeight"]);
+
+const elements = [
+  m83Element({ id: scopeId, name: "Protokoll-TopScreen", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: [], componentKind: "screen" }),
+  m83Element({ id: "protokoll.header", name: "Protokoll-Kopfbereich", type: "area", role: "contentArea", parentId: scopeId, order: 10, allowedOps: GROUP_LAYOUT, componentKind: "header" }),
+  m83Element({ id: "protokoll.header.titleGroup", name: "Gruppe Protokollbezeichnung", type: "group", role: "layoutGroup", parentId: "protokoll.header", order: 20, allowedOps: protokollGroupLayout, componentKind: "titleGroup" }),
+  m83Element({ id: "protokoll.header.title", name: "Bezeichnung Protokoll", type: "label", role: "fieldLabel", parentId: "protokoll.header.titleGroup", order: 21, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  m83Element({ id: "protokoll.header.keyword", name: "Schlagwort", type: "label", role: "dataFieldLayout", parentId: "protokoll.header.titleGroup", order: 22, allowedOps: TEXT_LAYOUT, componentKind: "interactiveLabel", lockedOps: DOMAIN_LOCKS }),
+  m83Element({ id: "protokoll.header.context", name: "Protokollkontext", type: "label", role: "status", parentId: "protokoll.header.titleGroup", order: 23, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  m83Element({ id: "protokoll.header.meta", name: "Gruppe Listenbezeichnungen", type: "group", role: "layoutGroup", parentId: "protokoll.header", order: 30, allowedOps: GROUP_LAYOUT, componentKind: "tableLegend" }),
+  m83Element({ id: "protokoll.header.meta.due", name: "Bezeichnung Fertig bis", type: "label", role: "fieldLabel", parentId: "protokoll.header.meta", order: 31, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  m83Element({ id: "protokoll.header.meta.status", name: "Bezeichnung Status", type: "label", role: "fieldLabel", parentId: "protokoll.header.meta", order: 32, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  m83Element({ id: "protokoll.header.meta.responsible", name: "Bezeichnung Verantwortlich", type: "label", role: "fieldLabel", parentId: "protokoll.header.meta", order: 33, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  m83Element({ id: "protokoll.topsScreen.quicklane", name: "Protokoll-Quicklane", type: "area", role: "layout", parentId: scopeId, order: 40, allowedOps: protokollGroupLayout, componentKind: "toolbar" }),
+  ...[["navigation", "Navigation", 41], ["visibility", "Sichtbarkeit", 42], ["filter", "TOP-Filter", 43], ["output", "Ausgabe", 44]].map(([key, name, order]) => m83Element({ id: `protokoll.topsScreen.quicklane.group.${key}`, name: `Gruppe ${name}`, type: "group", role: "layoutGroup", parentId: "protokoll.topsScreen.quicklane", order, allowedOps: GROUP_LAYOUT, componentKind: "toolbarGroup" })),
+  ...[
+    ["pin", "Fixieren", "navigation", 50], ["action.project", "Projekt", "navigation", 51], ["action.firms", "Firmen", "navigation", 52], ["action.participants", "Teilnehmer", "navigation", 53],
+    ["action.ampel", "Ampel", "visibility", 54], ["action.longtext", "Langtext", "visibility", 55], ["action.topFilter", "TOP-Filter", "filter", 56],
+    ["action.preview", "PDF-Vorschau", "output", 57], ["action.print", "Drucken", "output", 58], ["action.mail", "E-Mail", "output", 59],
+  ].map(([key, name, group, order]) => m83DomainButton({ id: `protokoll.topsScreen.quicklane.${key}`, name, parentId: `protokoll.topsScreen.quicklane.group.${group}`, order, actionKind: "domainAction" })),
+];
+
+export const PROTOKOLL_SCREEN_REQUIRED_SLOTS = Object.freeze([
+  scopeId, "protokoll.header", "protokoll.header.titleGroup", "protokoll.header.title", "protokoll.header.keyword", "protokoll.header.context",
+  "protokoll.header.meta", "protokoll.header.meta.due", "protokoll.header.meta.status", "protokoll.header.meta.responsible",
+]);
+export const PROTOKOLL_QUICKLANE_REQUIRED_SLOTS = Object.freeze([
+  "protokoll.topsScreen.quicklane",
+  ...["navigation", "visibility", "filter", "output"].map((key) => `protokoll.topsScreen.quicklane.group.${key}`),
+  "protokoll.topsScreen.quicklane.pin", "protokoll.topsScreen.quicklane.action.project", "protokoll.topsScreen.quicklane.action.firms", "protokoll.topsScreen.quicklane.action.participants",
+  "protokoll.topsScreen.quicklane.action.ampel", "protokoll.topsScreen.quicklane.action.longtext", "protokoll.topsScreen.quicklane.action.topFilter",
+  "protokoll.topsScreen.quicklane.action.preview", "protokoll.topsScreen.quicklane.action.print", "protokoll.topsScreen.quicklane.action.mail",
+]);
+
+export const protokollScreenUiEditorContract = m83Component({
+  componentId: "bbm.protokoll.screen",
+  scopeId,
+  requiredSlots: PROTOKOLL_SCREEN_REQUIRED_SLOTS,
+  slots: elements.slice(0, 10).map((entry) => m83Slot(entry.id, entry, {
+    requirements: { textResize: entry.type === "label", move: entry.allowedOps.includes("move") },
+  })),
+});
+
+export const protokollQuicklaneUiEditorContract = m83Component({
+  componentId: "bbm.protokoll.quicklane",
+  scopeId,
+  requiredSlots: PROTOKOLL_QUICKLANE_REQUIRED_SLOTS,
+  slots: elements.slice(10).map((entry) => m83Slot(entry.id, entry, {
+    requirements: { move: entry.allowedOps.includes("move") },
+  })),
+});

--- a/src/renderer/modules/restarbeiten/RestarbeitenEditbox.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenEditbox.js
@@ -5,7 +5,7 @@ import {
   getRestarbeitRequiredFieldSummary,
   normalizeRestarbeitStatus,
 } from "./domain/restarbeitenRules.js";
-import { registerM80FlowLabelRef, registerM80Ref } from "../../ui-editor/m80Refs.js";
+import { beginM83ComponentBinding, registerM80FlowLabelRef, registerM80Ref } from "../../ui-editor/m80Refs.js";
 
 function createEl(tag, { className = "", text = "", uiId = "" } = {}) {
   const el = document.createElement(tag);
@@ -247,6 +247,7 @@ export function buildRestarbeitenEditbox({
   onNote,
   onAutoSave,
 } = {}) {
+  beginM83ComponentBinding("bbm.restarbeiten.editbox");
   const labels = resolveLocationLabels(settings);
   const missingRequiredFields = getMissingRestarbeitRequiredFields(draft);
   const validationText = getValidationText(draft);

--- a/src/renderer/modules/restarbeiten/RestarbeitenEditbox.uiEditorContract.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenEditbox.uiEditorContract.js
@@ -1,0 +1,86 @@
+import {
+  FIELD_LAYOUT,
+  GROUP_LAYOUT,
+  ICON_LAYOUT,
+  SPACING_LAYOUT,
+  TEXT_LAYOUT,
+  ZONE_HEIGHT_LAYOUT,
+  m83Component,
+  m83DomainButton,
+  m83Element,
+  m83Slot,
+} from "../../ui-editor/m83ComponentContract.js";
+
+const scopeId = "restarbeiten.edit.root";
+const textGroupLayout = Object.freeze([...GROUP_LAYOUT, "resizeWidth", "resizeHeight", ...SPACING_LAYOUT]);
+
+const elements = [
+  m83Element({ id: scopeId, name: "Eingabebereich Restarbeiten", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: ZONE_HEIGHT_LAYOUT, componentKind: "fixedEditArea", baseline: { width: 900, height: 276, minWidth: 320, maxWidth: 1800, minHeight: 190, maxHeight: 520 }, operationEffects: { resizeHeight: "parentReflowRequired" }, operationAffectedIds: { resizeHeight: ["restarbeiten.edit.area", "restarbeiten.list.root"] } }),
+  m83Element({ id: "restarbeiten.edit.area", name: "Layoutzone Eingabebereich", type: "area", role: "formArea", parentId: scopeId, order: 10, allowedOps: [], componentKind: "formArea", baseline: { width: 878, height: 252, minWidth: 300, minHeight: 160 } }),
+  m83Element({ id: "restarbeiten.edit.header", name: "Gruppe Editbox-Kopf", type: "group", role: "layoutGroup", parentId: "restarbeiten.edit.area", order: 20, allowedOps: GROUP_LAYOUT, componentKind: "header" }),
+  m83Element({ id: "restarbeiten.edit.header.current", name: "Status aktueller Datensatz", type: "label", role: "status", parentId: "restarbeiten.edit.header", order: 21, allowedOps: ["setVisibility"], componentKind: "label" }),
+  m83Element({ id: "restarbeiten.edit.fields", name: "Layoutzone Textfelder", type: "group", role: "fieldCollection", parentId: "restarbeiten.edit.area", order: 30, allowedOps: [], componentKind: "fieldCollection", selectionKind: "layoutZone" }),
+
+  m83Element({ id: "restarbeiten.edit.short", name: "Gruppe Kurztext/Gegenstand", type: "group", role: "formFieldGroup", parentId: "restarbeiten.edit.fields", order: 40, allowedOps: textGroupLayout, spacingTargets: ["groupPaddingLeft", "groupPaddingRight", "groupPaddingTop", "groupPaddingBottom", "childGapHorizontal", "childGapVertical"], componentKind: "fieldGroup", baseline: { width: null, height: null, minWidth: 320, maxWidth: 1400, minHeight: 42, maxHeight: 96 } }),
+  m83Element({ id: "restarbeiten.edit.short.headerZone", name: "Kopfzeile Kurztext/Gegenstand", type: "group", role: "layoutGroup", parentId: "restarbeiten.edit.short", order: 41, allowedOps: SPACING_LAYOUT, spacingTargets: ["groupPaddingLeft", "groupPaddingRight", "groupPaddingTop", "groupPaddingBottom", "childGapHorizontal"], componentKind: "layoutZone", selectionKind: "layoutZone" }),
+  m83Element({ id: "restarbeiten.edit.short.label", name: "Bezeichnung Kurztext/Gegenstand", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.short", order: 42, allowedOps: [...TEXT_LAYOUT, ...SPACING_LAYOUT], spacingTargets: ["beforeElement", "afterElement", "reservedWidth"], componentKind: "label", baseline: { width: 150, height: 22, spacing: { reservedWidth: 40 }, minWidth: 74, maxWidth: 190, minHeight: 18, maxHeight: 48 }, operationEffects: { resizeWidth: "parentReflowRequired", resizeHeight: "parentReflowRequired" }, operationAffectedIds: { resizeWidth: ["restarbeiten.edit.short.headerZone", "restarbeiten.edit.short.field"], resizeHeight: ["restarbeiten.edit.short.headerZone", "restarbeiten.edit.short.field"] } }),
+  m83Element({ id: "restarbeiten.edit.short.remaining", name: "Restzeichenanzeige Kurztext", type: "label", role: "status", parentId: "restarbeiten.edit.short.headerZone", order: 43, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "counter", baseline: { fontSize: 8.667, minFontSize: 6, maxFontSize: 10 } }),
+  m83DomainButton({ id: "restarbeiten.edit.short.dictation", name: "Diktatbutton Kurztext", parentId: "restarbeiten.edit.short.headerZone", order: 44, actionKind: "domainDictation", baseline: { width: 22, height: 22, minWidth: 20, maxWidth: 32, minHeight: 20, maxHeight: 32 }, operationEffects: { move: "groupWithChildren" }, operationAffectedIds: { move: ["restarbeiten.edit.short.dictation.icon"] } }),
+  m83Element({ id: "restarbeiten.edit.short.dictation.icon", name: "Mikrofonsymbol Kurztext", type: "componentPart", role: "layout", parentId: "restarbeiten.edit.short.dictation", order: 45, allowedOps: ICON_LAYOUT, componentKind: "icon", baseline: { width: 17, height: 17, minWidth: 12, maxWidth: 22, minHeight: 12, maxHeight: 22 } }),
+  m83Element({ id: "restarbeiten.edit.class", name: "Gruppe Klasse", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.short.headerZone", order: 46, allowedOps: GROUP_LAYOUT, componentKind: "choiceField" }),
+  m83Element({ id: "restarbeiten.edit.class.label", name: "Bezeichnung Klasse", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.class", order: 47, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  m83Element({ id: "restarbeiten.edit.class.control", name: "Eingabefeld Klasse", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.class", order: 48, allowedOps: FIELD_LAYOUT, fieldKind: "buttonChoice", componentKind: "choice" }),
+  m83DomainButton({ id: "restarbeiten.edit.class.rest", name: "Klasse Rest", parentId: "restarbeiten.edit.class.control", order: 49, actionKind: "domainSelection" }),
+  m83DomainButton({ id: "restarbeiten.edit.class.defect", name: "Klasse Mangel", parentId: "restarbeiten.edit.class.control", order: 50, actionKind: "domainSelection" }),
+  m83Element({ id: "restarbeiten.edit.short.actions", name: "Weitere Kurztextaktionen", type: "group", role: "layoutGroup", parentId: "restarbeiten.edit.short.headerZone", order: 51, allowedOps: GROUP_LAYOUT, componentKind: "actionGroup" }),
+  m83DomainButton({ id: "restarbeiten.edit.action.new", name: "Neu", parentId: "restarbeiten.edit.short.actions", order: 52, actionKind: "domainCreate" }),
+  m83DomainButton({ id: "restarbeiten.edit.action.delete", name: "Löschen", parentId: "restarbeiten.edit.short.actions", order: 53, actionKind: "domainDelete" }),
+  m83Element({ id: "restarbeiten.edit.short.field", name: "Texteingabe Kurztext/Gegenstand", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.short", order: 54, allowedOps: FIELD_LAYOUT, fieldKind: "text", componentKind: "input" }),
+
+  m83Element({ id: "restarbeiten.edit.long", name: "Gruppe Langtext/Beschreibung", type: "group", role: "formFieldGroup", parentId: "restarbeiten.edit.fields", order: 60, allowedOps: GROUP_LAYOUT, componentKind: "fieldGroup" }),
+  m83Element({ id: "restarbeiten.edit.long.headerZone", name: "Kopfzeile Langtext/Beschreibung", type: "group", role: "layoutGroup", parentId: "restarbeiten.edit.long", order: 61, allowedOps: [], componentKind: "layoutZone", selectionKind: "layoutZone" }),
+  m83Element({ id: "restarbeiten.edit.long.label", name: "Bezeichnung Langtext/Beschreibung", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.long", order: 62, allowedOps: TEXT_LAYOUT, componentKind: "label", baseline: { width: 150, height: 22, minWidth: 90, maxWidth: 220, minHeight: 18, maxHeight: 48 }, operationEffects: { resizeWidth: "parentReflowRequired", resizeHeight: "parentReflowRequired" }, operationAffectedIds: { resizeWidth: ["restarbeiten.edit.long.headerZone", "restarbeiten.edit.long.field"], resizeHeight: ["restarbeiten.edit.long.headerZone", "restarbeiten.edit.long.field"] } }),
+  m83Element({ id: "restarbeiten.edit.long.remaining", name: "Restzeichenanzeige Langtext", type: "label", role: "status", parentId: "restarbeiten.edit.long.headerZone", order: 63, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "counter", baseline: { fontSize: 8.667, minFontSize: 6, maxFontSize: 10 } }),
+  m83DomainButton({ id: "restarbeiten.edit.long.dictation", name: "Diktatbutton Langtext", parentId: "restarbeiten.edit.long.headerZone", order: 64, actionKind: "domainDictation", baseline: { width: 22, height: 22, minWidth: 20, maxWidth: 32, minHeight: 20, maxHeight: 32 }, operationEffects: { move: "groupWithChildren" }, operationAffectedIds: { move: ["restarbeiten.edit.long.dictation.icon"] } }),
+  m83Element({ id: "restarbeiten.edit.long.dictation.icon", name: "Mikrofonsymbol Langtext", type: "componentPart", role: "layout", parentId: "restarbeiten.edit.long.dictation", order: 65, allowedOps: ICON_LAYOUT, componentKind: "icon", baseline: { width: 17, height: 17, minWidth: 12, maxWidth: 22, minHeight: 12, maxHeight: 22 } }),
+  m83Element({ id: "restarbeiten.edit.long.field", name: "Texteingabe Langtext/Beschreibung", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.long", order: 66, allowedOps: FIELD_LAYOUT, fieldKind: "multilineText", componentKind: "textarea" }),
+
+  m83Element({ id: "restarbeiten.edit.location", name: "Gruppe Verortung", type: "group", role: "fieldCollection", parentId: "restarbeiten.edit.area", order: 70, allowedOps: GROUP_LAYOUT, componentKind: "locationGroup" }),
+  ...[1, 2, 3, 4].flatMap((level, index) => [
+    m83Element({ id: `restarbeiten.edit.location.${level}`, name: `Gruppe Verortung L${level}`, type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.location", order: 71 + index * 3, allowedOps: GROUP_LAYOUT, componentKind: "fieldGroup" }),
+    m83Element({ id: `restarbeiten.edit.location.${level}.label`, name: `Bezeichnung Verortung L${level}`, type: "label", role: "fieldLabel", parentId: `restarbeiten.edit.location.${level}`, order: 72 + index * 3, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+    m83Element({ id: `restarbeiten.edit.location.${level}.field`, name: `Eingabefeld Verortung L${level}`, type: "field", role: "dataFieldLayout", parentId: `restarbeiten.edit.location.${level}`, order: 73 + index * 3, allowedOps: FIELD_LAYOUT, fieldKind: "text", componentKind: "input" }),
+  ]),
+
+  m83Element({ id: "restarbeiten.edit.meta", name: "Gruppe Status und Zuordnung", type: "group", role: "fieldCollection", parentId: "restarbeiten.edit.area", order: 90, allowedOps: GROUP_LAYOUT, componentKind: "metaGroup" }),
+  ...[["status", "Status", "select", 91], ["due", "Fertig bis", "date", 94], ["responsible", "Verantwortlich", "select", 98]].flatMap(([key, name, fieldKind, order]) => [
+    m83Element({ id: `restarbeiten.edit.meta.${key}`, name: `Gruppe ${name}`, type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.meta", order, allowedOps: GROUP_LAYOUT, componentKind: "fieldGroup" }),
+    m83Element({ id: `restarbeiten.edit.meta.${key}.label`, name: `Bezeichnung ${name}`, type: "label", role: "fieldLabel", parentId: `restarbeiten.edit.meta.${key}`, order: order + 1, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+    m83Element({ id: `restarbeiten.edit.meta.${key}.field`, name: `Eingabefeld ${name}`, type: "field", role: "dataFieldLayout", parentId: `restarbeiten.edit.meta.${key}`, order: order + 2, allowedOps: FIELD_LAYOUT, fieldKind, componentKind: fieldKind === "date" ? "dateInput" : "select" }),
+  ]),
+  m83Element({ id: "restarbeiten.edit.meta.ampel", name: "Statussymbol Ampel", type: "statusIndicator", role: "status", parentId: "restarbeiten.edit.meta", order: 97, allowedOps: ["move", ...ICON_LAYOUT], componentKind: "statusIndicator", baseline: { width: 12, height: 12, minWidth: 7, maxWidth: 48, minHeight: 7, maxHeight: 48 } }),
+  m83Element({ id: "restarbeiten.edit.validation", name: "Status Pflichtfeldhinweis", type: "label", role: "status", parentId: "restarbeiten.edit.meta", order: 101, allowedOps: ["setVisibility"], componentKind: "validation" }),
+  m83DomainButton({ id: "restarbeiten.edit.action.note", name: "Notizbutton", parentId: "restarbeiten.edit.meta", order: 102, actionKind: "domainNote" }),
+];
+
+export const RESTARBEITEN_EDITBOX_REQUIRED_SLOTS = Object.freeze([
+  scopeId, "restarbeiten.edit.area", "restarbeiten.edit.header", "restarbeiten.edit.header.current", "restarbeiten.edit.fields",
+  "restarbeiten.edit.short", "restarbeiten.edit.short.headerZone", "restarbeiten.edit.short.label", "restarbeiten.edit.short.remaining", "restarbeiten.edit.short.dictation", "restarbeiten.edit.short.dictation.icon",
+  "restarbeiten.edit.class", "restarbeiten.edit.class.label", "restarbeiten.edit.class.control", "restarbeiten.edit.class.rest", "restarbeiten.edit.class.defect",
+  "restarbeiten.edit.short.actions", "restarbeiten.edit.action.new", "restarbeiten.edit.action.delete", "restarbeiten.edit.short.field",
+  "restarbeiten.edit.long", "restarbeiten.edit.long.headerZone", "restarbeiten.edit.long.label", "restarbeiten.edit.long.remaining", "restarbeiten.edit.long.dictation", "restarbeiten.edit.long.dictation.icon", "restarbeiten.edit.long.field",
+  "restarbeiten.edit.location",
+  ...[1, 2, 3, 4].flatMap((level) => [`restarbeiten.edit.location.${level}`, `restarbeiten.edit.location.${level}.label`, `restarbeiten.edit.location.${level}.field`]),
+  "restarbeiten.edit.meta",
+  ...["status", "due", "responsible"].flatMap((key) => [`restarbeiten.edit.meta.${key}`, `restarbeiten.edit.meta.${key}.label`, `restarbeiten.edit.meta.${key}.field`]),
+  "restarbeiten.edit.meta.ampel", "restarbeiten.edit.validation", "restarbeiten.edit.action.note",
+]);
+
+export const restarbeitenEditboxUiEditorContract = m83Component({
+  componentId: "bbm.restarbeiten.editbox",
+  scopeId,
+  requiredSlots: RESTARBEITEN_EDITBOX_REQUIRED_SLOTS,
+  slots: elements.map((entry) => m83Slot(entry.id, entry, {
+    requirements: { textResize: entry.type === "label" && entry.allowedOps.includes("textResize"), move: entry.allowedOps.includes("move") },
+  })),
+});

--- a/src/renderer/modules/restarbeiten/RestarbeitenFilterbar.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenFilterbar.js
@@ -1,5 +1,5 @@
 import { RESTARBEITEN_STATUS_OPTIONS } from "./domain/restarbeitenRules.js";
-import { registerM80Ref } from "../../ui-editor/m80Refs.js";
+import { beginM83ComponentBinding, registerM80Ref } from "../../ui-editor/m80Refs.js";
 
 const DEFAULT_LOCATION_LABELS = ["Haus", "Geschoss", "Einheit", "Raum"];
 
@@ -63,6 +63,7 @@ export function buildRestarbeitenFilterbar({
   onFilterChange,
   onClose,
 } = {}) {
+  beginM83ComponentBinding("bbm.restarbeiten.filterbar");
   const labels = resolveLocationLabels(settings);
   const root = createEl("section", {
     className: "bbm-restarbeiten-filterbar",

--- a/src/renderer/modules/restarbeiten/RestarbeitenFilterbar.uiEditorContract.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenFilterbar.uiEditorContract.js
@@ -1,0 +1,44 @@
+import {
+  FIELD_LAYOUT,
+  GROUP_LAYOUT,
+  TEXT_LAYOUT,
+  ZONE_HEIGHT_LAYOUT,
+  m83Component,
+  m83DomainButton,
+  m83Element,
+  m83Slot,
+} from "../../ui-editor/m83ComponentContract.js";
+
+const scopeId = "restarbeiten.header.root";
+const elements = [
+  m83Element({ id: scopeId, name: "Kopf- und Filterbereich Restarbeiten", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: ZONE_HEIGHT_LAYOUT, componentKind: "fixedHeader", baseline: { width: 1180, height: 102, minWidth: 640, maxWidth: 2400, minHeight: 56, maxHeight: 220 } }),
+  m83Element({ id: "restarbeiten.filterbar", name: "Filterkopf Restarbeiten", type: "area", role: "layout", parentId: scopeId, order: 10, allowedOps: GROUP_LAYOUT, componentKind: "filterbar", baseline: { width: 1092, height: 72, minWidth: 560, maxWidth: 2200, minHeight: 48, maxHeight: 220 } }),
+  m83Element({ id: "restarbeiten.filterbar.group.location", name: "Gruppe Verortungsfilter", type: "group", role: "layoutGroup", parentId: "restarbeiten.filterbar", order: 20, allowedOps: GROUP_LAYOUT, componentKind: "filterGroup" }),
+  ...[1, 2, 3, 4].flatMap((level, index) => [
+    m83Element({ id: `restarbeiten.filterbar.location.level${level}`, name: `Gruppe Verortung L${level}`, type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.filterbar.group.location", order: 21 + index * 3, allowedOps: GROUP_LAYOUT, componentKind: "fieldGroup" }),
+    m83Element({ id: `restarbeiten.filterbar.location.level${level}.label`, name: `Verortung L${level} · Bezeichnung`, type: "label", role: "fieldLabel", parentId: `restarbeiten.filterbar.location.level${level}`, order: 22 + index * 3, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+    m83Element({ id: `restarbeiten.filterbar.location.level${level}.field`, name: `Eingabefeld Verortung L${level}`, type: "field", role: "dataFieldLayout", parentId: `restarbeiten.filterbar.location.level${level}`, order: 23 + index * 3, allowedOps: FIELD_LAYOUT, fieldKind: "select", componentKind: "select" }),
+  ]),
+  m83Element({ id: "restarbeiten.filterbar.group.class", name: "Gruppe Klassenfilter", type: "group", role: "layoutGroup", parentId: "restarbeiten.filterbar", order: 40, allowedOps: GROUP_LAYOUT, componentKind: "buttonGroup" }),
+  m83DomainButton({ id: "restarbeiten.filterbar.class.all", name: "Klasse · Alle", parentId: "restarbeiten.filterbar.group.class", order: 41, actionKind: "domainFilter" }),
+  m83DomainButton({ id: "restarbeiten.filterbar.class.rest", name: "Klasse · Rest", parentId: "restarbeiten.filterbar.group.class", order: 42, actionKind: "domainFilter" }),
+  m83DomainButton({ id: "restarbeiten.filterbar.class.defect", name: "Klasse · Mangel", parentId: "restarbeiten.filterbar.group.class", order: 43, actionKind: "domainFilter" }),
+  m83Element({ id: "restarbeiten.filterbar.group.meta", name: "Gruppe Status- und Zuordnungsfilter", type: "group", role: "layoutGroup", parentId: "restarbeiten.filterbar", order: 50, allowedOps: GROUP_LAYOUT, componentKind: "filterGroup" }),
+  ...[["status", "Status", "select"], ["dueDate", "Fertig bis", "date"], ["responsible", "Verantwortlich", "select"]].flatMap(([key, name, fieldKind], index) => [
+    m83Element({ id: `restarbeiten.filterbar.meta.${key}`, name: `Gruppe ${name}`, type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.filterbar.group.meta", order: 51 + index * 3, allowedOps: GROUP_LAYOUT, componentKind: "fieldGroup" }),
+    m83Element({ id: `restarbeiten.filterbar.meta.${key}.label`, name: `${name} · Bezeichnung`, type: "label", role: "fieldLabel", parentId: `restarbeiten.filterbar.meta.${key}`, order: 52 + index * 3, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+    m83Element({ id: `restarbeiten.filterbar.meta.${key}.field`, name: `Eingabefeld ${name}`, type: "field", role: "dataFieldLayout", parentId: `restarbeiten.filterbar.meta.${key}`, order: 53 + index * 3, allowedOps: FIELD_LAYOUT, fieldKind, componentKind: fieldKind === "date" ? "dateInput" : "select" }),
+  ]),
+  m83Element({ id: "restarbeiten.filterbar.actions", name: "Gruppe Header-Aktionen", type: "group", role: "layoutGroup", parentId: "restarbeiten.filterbar", order: 70, allowedOps: GROUP_LAYOUT, componentKind: "actionGroup" }),
+  m83DomainButton({ id: "restarbeiten.filterbar.action.close", name: "Schließen", parentId: "restarbeiten.filterbar.actions", order: 71, actionKind: "domainNavigation" }),
+];
+
+export const RESTARBEITEN_FILTERBAR_REQUIRED_SLOTS = Object.freeze(elements.map((entry) => entry.id));
+export const restarbeitenFilterbarUiEditorContract = m83Component({
+  componentId: "bbm.restarbeiten.filterbar",
+  scopeId,
+  requiredSlots: RESTARBEITEN_FILTERBAR_REQUIRED_SLOTS,
+  slots: elements.map((entry) => m83Slot(entry.id, entry, {
+    requirements: { textResize: entry.type === "label", move: entry.allowedOps.includes("move") },
+  })),
+});

--- a/src/renderer/modules/restarbeiten/RestarbeitenList.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenList.js
@@ -50,10 +50,14 @@ export function buildRestarbeitenList({
   });
   const rows = [];
   const columnCells = [[], [], []];
-  const metaParts = { dueDate: [], ampel: [], status: [], responsible: [] };
+  const componentParts = {
+    number: [], createdAt: [], itemClass: [], aftercare: [], photos: [],
+    location: [], shortText: [], longText: [], dueDate: [], ampel: [], status: [],
+    responsible: [], requiredSummary: [],
+  };
   records._m80Rows = rows;
   records._m80ColumnCells = columnCells;
-  records._m80MetaParts = metaParts;
+  records._m83ComponentParts = componentParts;
 
   if (!items.length) {
     records.appendChild(
@@ -75,16 +79,16 @@ export function buildRestarbeitenList({
     row.addEventListener("click", () => onSelect?.(item.id));
 
     const numberColumn = createEl("div", { uiId: "restarbeiten.record.numberColumn" });
-    appendText(
+    componentParts.number.push(appendText(
       numberColumn,
       "bbm-restarbeiten-record__number",
       item.numberLine === "\u2014" ? item.numberLine : `#${item.numberLine}`,
       "restarbeiten.record.number"
-    );
-    appendText(numberColumn, "bbm-restarbeiten-record__date", item.dateLine, "restarbeiten.record.createdAt");
-    appendText(numberColumn, "bbm-restarbeiten-record__class", item.itemClassLabel, "restarbeiten.record.itemClass");
+    ));
+    componentParts.createdAt.push(appendText(numberColumn, "bbm-restarbeiten-record__date", item.dateLine, "restarbeiten.record.createdAt"));
+    componentParts.itemClass.push(appendText(numberColumn, "bbm-restarbeiten-record__class", item.itemClassLabel, "restarbeiten.record.itemClass"));
     if (item.nachpflegeLabel) {
-      appendText(numberColumn, "bbm-restarbeiten-record__nachpflege", item.nachpflegeLabel);
+      componentParts.aftercare.push(appendText(numberColumn, "bbm-restarbeiten-record__nachpflege", item.nachpflegeLabel, "restarbeiten.record.aftercare"));
     }
     const photos = appendText(numberColumn, "bbm-restarbeiten-record__photos", "Fotos", "restarbeiten.record.photos");
     photos.setAttribute("role", "button");
@@ -93,12 +97,13 @@ export function buildRestarbeitenList({
       event?.stopPropagation?.();
       onPhotos?.(item.id);
     });
+    componentParts.photos.push(photos);
 
     const contentColumn = createEl("div", { uiId: "restarbeiten.record.contentColumn" });
-    appendText(contentColumn, "bbm-restarbeiten-record__location", item.locationLine, "restarbeiten.record.location");
-    appendText(contentColumn, "bbm-restarbeiten-record__short", item.shortTextLine || item.workLine1, "restarbeiten.record.shortText");
+    componentParts.location.push(appendText(contentColumn, "bbm-restarbeiten-record__location", item.locationLine, "restarbeiten.record.location"));
+    componentParts.shortText.push(appendText(contentColumn, "bbm-restarbeiten-record__short", item.shortTextLine || item.workLine1, "restarbeiten.record.shortText"));
     if (showLongtext) {
-      appendText(contentColumn, "bbm-restarbeiten-record__long", item.longTextLine || item.workLine2, "restarbeiten.record.longText");
+      componentParts.longText.push(appendText(contentColumn, "bbm-restarbeiten-record__long", item.longTextLine || item.workLine2, "restarbeiten.record.longText"));
     }
 
     const metaColumn = createEl("div", { className: "bbm-restarbeiten-record__meta", uiId: "restarbeiten.record.metaColumn" });
@@ -106,17 +111,17 @@ export function buildRestarbeitenList({
     dueLine.className = "bbm-restarbeiten-record__due";
     dueLine.textContent = item.dueDateLabel;
     metaColumn.appendChild(dueLine);
-    metaParts.dueDate.push(dueLine);
+    componentParts.dueDate.push(dueLine);
     if (showAmpel) {
       const ampel = createEl("span", { className: "bbm-restarbeiten-ampel", uiId: "restarbeiten.record.ampel" });
       ampel.dataset.state = item.ampelState || "neutral";
       metaColumn.appendChild(ampel);
-      metaParts.ampel.push(ampel);
+      componentParts.ampel.push(ampel);
     }
-    metaParts.status.push(appendText(metaColumn, "", item.statusLabel, "restarbeiten.record.status"));
-    metaParts.responsible.push(appendText(metaColumn, "", item.responsibleLabel, "restarbeiten.record.responsible"));
+    componentParts.status.push(appendText(metaColumn, "", item.statusLabel, "restarbeiten.record.status"));
+    componentParts.responsible.push(appendText(metaColumn, "", item.responsibleLabel, "restarbeiten.record.responsible"));
     if (item.requiredFieldSummary) {
-      appendText(metaColumn, "bbm-restarbeiten-record__required", item.requiredFieldSummary);
+      componentParts.requiredSummary.push(appendText(metaColumn, "bbm-restarbeiten-record__required", item.requiredFieldSummary, "restarbeiten.record.requiredSummary"));
     }
 
     row.append(numberColumn, contentColumn, metaColumn);

--- a/src/renderer/modules/restarbeiten/RestarbeitenList.uiEditorContract.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenList.uiEditorContract.js
@@ -1,0 +1,103 @@
+import {
+  COLUMN_LAYOUT,
+  COMPACT_TEXT_LAYOUT,
+  DOMAIN_LOCKS,
+  GROUP_LAYOUT,
+  ICON_LAYOUT,
+  TABLE_LAYOUT,
+  m83Component,
+  m83Element,
+  m83Slot,
+} from "../../ui-editor/m83ComponentContract.js";
+
+const scopeId = "restarbeiten.list.root";
+
+export const RESTARBEITEN_LIST_TABLE_COLUMNS = Object.freeze([
+  Object.freeze({ columnId: "restarbeiten.list.table.number", displayName: "Nr. / Datum / Klasse / Fotos", headerElementId: "restarbeiten.list.table.number.header", dataCellTemplateId: "restarbeiten.list.table.number.cells", cellElementIds: Object.freeze([]), currentWidth: 82, minimumWidth: 50, maximumWidth: 240, widthMode: "fixed", resizable: true, wrapMode: "noWrap", overflowMode: "clip", alignment: "stretch", visibility: true, order: 1, lockedOps: DOMAIN_LOCKS, widthSourceId: "restarbeiten.list.table.number", flexible: false, priority: 10 }),
+  Object.freeze({ columnId: "restarbeiten.list.table.subject", displayName: "Gegenstand – Verortung / Kurztext / Langtext", headerElementId: "restarbeiten.list.table.subject.header", dataCellTemplateId: "restarbeiten.list.table.subject.cells", cellElementIds: Object.freeze([]), currentWidth: 560, minimumWidth: 160, maximumWidth: 1200, widthMode: "proportional", resizable: true, wrapMode: "wordWrap", overflowMode: "clip", alignment: "stretch", visibility: true, order: 2, lockedOps: DOMAIN_LOCKS, widthSourceId: "restarbeiten.list.table.subject", flexible: true, priority: 100 }),
+  Object.freeze({ columnId: "restarbeiten.list.table.meta", displayName: "Fertig bis / Ampel / Status / Verantwortlich", headerElementId: "restarbeiten.list.table.meta.header", dataCellTemplateId: "restarbeiten.list.table.meta.cells", cellElementIds: Object.freeze([]), currentWidth: 172, minimumWidth: 110, maximumWidth: 420, widthMode: "fixed", resizable: true, wrapMode: "wordWrap", overflowMode: "clip", alignment: "stretch", visibility: true, order: 3, lockedOps: DOMAIN_LOCKS, widthSourceId: "restarbeiten.list.table.meta", flexible: false, priority: 20 }),
+]);
+
+const listTableLayout = Object.freeze({
+  tableId: "restarbeiten.list.table", displayName: "Restarbeiten-Hauptliste",
+  bounds: Object.freeze({ left: 0, top: 0, width: 858, height: 680 }), viewportBounds: Object.freeze({ left: 0, top: 0, width: 858, height: 680 }), contentBounds: Object.freeze({ left: 0, top: 0, width: 858, height: 680 }),
+  parentId: "restarbeiten.list.paper", columnIds: Object.freeze(RESTARBEITEN_LIST_TABLE_COLUMNS.map((column) => column.columnId)), rowTemplateId: "restarbeiten.list.table.row",
+  horizontalOverflowMode: "fitViewport", verticalOverflowMode: "none", widthPolicy: "bounded", minimumWidth: 320, maximumWidth: 1600, reservedWidth: 44, scrollbarWidth: 0,
+  rowHeightMode: "bounded", minimumRowHeight: 54, maximumRowHeight: 180, columns: RESTARBEITEN_LIST_TABLE_COLUMNS,
+});
+
+function tableBinding(columnId, part) {
+  return Object.freeze({ tableId: "restarbeiten.list.table", columnId, widthSourceId: columnId, part });
+}
+
+const compactListText = Object.freeze(["move", "textResize", "setVisibility"]);
+const elements = [
+  m83Element({ id: scopeId, name: "Restarbeiten · Liste", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: [], componentKind: "scope" }),
+  m83Element({ id: "restarbeiten.list.area", name: "Restarbeiten-Liste", type: "area", role: "contentArea", parentId: scopeId, order: 10, allowedOps: GROUP_LAYOUT, componentKind: "contentArea", baseline: { width: 900, height: 420, minWidth: 320, minHeight: 180 } }),
+  m83Element({ id: "restarbeiten.list.paper", name: "Gruppe Listenblatt", type: "group", role: "layoutGroup", parentId: "restarbeiten.list.area", order: 20, allowedOps: GROUP_LAYOUT, componentKind: "paper", baseline: { width: 900, height: 720, minWidth: 320, minHeight: 240 } }),
+  m83Element({ id: "restarbeiten.list.table", name: "Restarbeiten-Hauptliste", type: "table", role: "contentTable", parentId: "restarbeiten.list.paper", order: 30, allowedOps: TABLE_LAYOUT, componentKind: "contentTable", tableLayout: listTableLayout, baseline: { width: 858, height: 680, minWidth: 320, maxWidth: 1600, minHeight: 160, maxHeight: 12000 } }),
+  ...RESTARBEITEN_LIST_TABLE_COLUMNS.map((column, index) => m83Element({ id: column.columnId, name: column.displayName, type: "tableColumn", role: index === 2 ? "metaColumn" : "contentColumn", parentId: "restarbeiten.list.table", order: 31 + index, allowedOps: COLUMN_LAYOUT, columnRole: index === 2 ? "metaColumn" : "contentColumn", componentKind: "contentColumn", tableColumnLayout: column, tableBinding: tableBinding(column.columnId, "column"), baseline: { width: column.currentWidth, height: 28, minWidth: column.minimumWidth, maxWidth: column.maximumWidth } })),
+  m83Element({ id: "restarbeiten.list.table.header", name: "Tabellenkopf der Restarbeiten-Liste", type: "tableHeader", role: "tableHeader", parentId: "restarbeiten.list.table", order: 40, allowedOps: [], componentKind: "tableHeader" }),
+  m83Element({ id: "restarbeiten.list.table.body", name: "Datenbereich der Restarbeiten-Liste", type: "tableBody", role: "tableBody", parentId: "restarbeiten.list.table", order: 50, allowedOps: [], componentKind: "tableBody" }),
+  m83Element({ id: "restarbeiten.list.table.row", refKey: "restarbeiten.record", name: "Restarbeiten-Zeile", type: "tableRow", role: "tableRow", parentId: "restarbeiten.list.table.body", order: 51, allowedOps: [], componentKind: "rowTemplate", rowLayout: { heightMode: "bounded", minimumHeight: 54, maximumHeight: 180 } }),
+  ...RESTARBEITEN_LIST_TABLE_COLUMNS.flatMap((column, index) => [
+    m83Element({ id: column.headerElementId, refKey: `restarbeiten.main.tableHeader.${["number", "subject", "meta"][index]}`, name: `${column.displayName} · Überschrift`, type: "tableHeaderCell", role: "tableHeaderCell", parentId: column.columnId, order: 60 + index * 2, allowedOps: ["textResize"], componentKind: "tableHeaderCell", tableBinding: tableBinding(column.columnId, "header"), baseline: { fontSize: 12, minFontSize: 8, maxFontSize: 32 } }),
+    m83Element({ id: column.dataCellTemplateId, refKey: `restarbeiten.record.${["numberColumn", "contentColumn", "metaColumn"][index]}`, name: `${column.displayName} · Datenbereich`, type: "tableDataCell", role: "tableDataCell", parentId: column.columnId, order: 61 + index * 2, allowedOps: [], componentKind: "dataCellTemplate", tableBinding: tableBinding(column.columnId, "data") }),
+  ]),
+  m83Element({ id: "restarbeiten.record.number", name: "Nr. · Listeneinträge", type: "label", role: "structure", parentId: "restarbeiten.list.table.number.cells", order: 70, allowedOps: compactListText, componentKind: "staticMultiRef", baseline: { fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
+  m83Element({ id: "restarbeiten.record.createdAt", name: "Datum · Listeneinträge", type: "label", role: "date", parentId: "restarbeiten.list.table.number.cells", order: 71, allowedOps: compactListText, componentKind: "staticMultiRef", baseline: { fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
+  m83Element({ id: "restarbeiten.record.itemClass", name: "Klasse · Listeneinträge", type: "label", role: "status", parentId: "restarbeiten.list.table.number.cells", order: 72, allowedOps: compactListText, componentKind: "staticMultiRef", baseline: { fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
+  m83Element({ id: "restarbeiten.record.aftercare", name: "Nachpflege · Listeneinträge", type: "label", role: "status", parentId: "restarbeiten.list.table.number.cells", order: 73, allowedOps: compactListText, componentKind: "conditionalMultiRef", baseline: { fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
+  m83Element({ id: "restarbeiten.record.photos", name: "Fotos · Listeneinträge", type: "button", role: "domainActionLayout", parentId: "restarbeiten.list.table.number.cells", order: 74, allowedOps: COMPACT_TEXT_LAYOUT, lockedOps: DOMAIN_LOCKS, actionKind: "domainPhotos", componentKind: "staticMultiRef", baseline: { fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
+  m83Element({ id: "restarbeiten.record.location", name: "Verortung · Listeneinträge", type: "label", role: "content", parentId: "restarbeiten.list.table.subject.cells", order: 75, allowedOps: compactListText, componentKind: "staticMultiRef", baseline: { fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
+  m83Element({ id: "restarbeiten.record.shortText", name: "Kurztext · Listeneinträge", type: "label", role: "fieldLabel", parentId: "restarbeiten.list.table.subject.cells", order: 76, allowedOps: compactListText, componentKind: "staticMultiRef", baseline: { fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
+  m83Element({ id: "restarbeiten.record.longText", name: "Langtext · Listeneinträge", type: "label", role: "fieldLabel", parentId: "restarbeiten.list.table.subject.cells", order: 77, allowedOps: compactListText, componentKind: "conditionalMultiRef", baseline: { fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
+  m83Element({ id: "restarbeiten.main.tableHeader.dueDate", name: "Fertig bis · Überschrift", type: "label", role: "fieldLabel", parentId: "restarbeiten.list.table.meta.header", order: 80, allowedOps: compactListText, componentKind: "tableHeaderLabel", baseline: { fontSize: 8.667, minFontSize: 6, maxFontSize: 24 } }),
+  m83Element({ id: "restarbeiten.main.tableHeader.status", name: "Status · Überschrift", type: "label", role: "fieldLabel", parentId: "restarbeiten.list.table.meta.header", order: 81, allowedOps: compactListText, componentKind: "tableHeaderLabel", baseline: { fontSize: 8.667, minFontSize: 6, maxFontSize: 24 } }),
+  m83Element({ id: "restarbeiten.main.tableHeader.responsible", name: "Verantwortlich · Überschrift", type: "label", role: "fieldLabel", parentId: "restarbeiten.list.table.meta.header", order: 82, allowedOps: compactListText, componentKind: "tableHeaderLabel", baseline: { fontSize: 8.667, minFontSize: 6, maxFontSize: 24 } }),
+  m83Element({ id: "restarbeiten.record.dueDate", name: "Fertig bis · Listeneinträge", type: "label", role: "date", parentId: "restarbeiten.list.table.meta.cells", order: 83, allowedOps: compactListText, componentKind: "staticMultiRef", baseline: { fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
+  m83Element({ id: "restarbeiten.record.ampel", name: "Ampel · Listeneinträge", type: "statusIndicator", role: "status", parentId: "restarbeiten.list.table.meta.cells", order: 84, allowedOps: ["move", ...ICON_LAYOUT], componentKind: "conditionalMultiRef", baseline: { width: 12, height: 12, minWidth: 7, maxWidth: 48, minHeight: 7, maxHeight: 48 } }),
+  m83Element({ id: "restarbeiten.record.status", name: "Status · Listeneinträge", type: "label", role: "status", parentId: "restarbeiten.list.table.meta.cells", order: 85, allowedOps: compactListText, componentKind: "staticMultiRef", baseline: { fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
+  m83Element({ id: "restarbeiten.record.responsible", name: "Verantwortlich · Listeneinträge", type: "label", role: "responsible", parentId: "restarbeiten.list.table.meta.cells", order: 86, allowedOps: compactListText, componentKind: "staticMultiRef", baseline: { fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
+  m83Element({ id: "restarbeiten.record.requiredSummary", name: "Pflichtfeldhinweis · Listeneinträge", type: "label", role: "status", parentId: "restarbeiten.list.table.meta.cells", order: 87, allowedOps: compactListText, componentKind: "conditionalMultiRef", baseline: { fontSize: 9, minFontSize: 7, maxFontSize: 24 } }),
+];
+
+export const RESTARBEITEN_LIST_REQUIRED_SLOTS = Object.freeze([
+  scopeId, "restarbeiten.list.area", "restarbeiten.list.paper", "restarbeiten.list.table",
+  "restarbeiten.list.table.number", "restarbeiten.list.table.subject", "restarbeiten.list.table.meta",
+  "restarbeiten.list.table.header", "restarbeiten.list.table.body", "restarbeiten.list.table.row",
+  "restarbeiten.list.table.number.header", "restarbeiten.list.table.number.cells",
+  "restarbeiten.list.table.subject.header", "restarbeiten.list.table.subject.cells",
+  "restarbeiten.list.table.meta.header", "restarbeiten.list.table.meta.cells",
+  "restarbeiten.record.number", "restarbeiten.record.createdAt", "restarbeiten.record.itemClass",
+  "restarbeiten.record.aftercare", "restarbeiten.record.photos", "restarbeiten.record.location",
+  "restarbeiten.record.shortText", "restarbeiten.record.longText",
+  "restarbeiten.main.tableHeader.dueDate", "restarbeiten.main.tableHeader.status", "restarbeiten.main.tableHeader.responsible",
+  "restarbeiten.record.dueDate", "restarbeiten.record.ampel", "restarbeiten.record.status",
+  "restarbeiten.record.responsible", "restarbeiten.record.requiredSummary",
+]);
+
+const multiIds = new Set([
+  "restarbeiten.list.table.row",
+  ...RESTARBEITEN_LIST_TABLE_COLUMNS.map((column) => column.columnId),
+  ...RESTARBEITEN_LIST_TABLE_COLUMNS.map((column) => column.dataCellTemplateId),
+  "restarbeiten.record.number", "restarbeiten.record.createdAt", "restarbeiten.record.itemClass", "restarbeiten.record.aftercare", "restarbeiten.record.photos",
+  "restarbeiten.record.location", "restarbeiten.record.shortText", "restarbeiten.record.longText", "restarbeiten.record.dueDate", "restarbeiten.record.ampel",
+  "restarbeiten.record.status", "restarbeiten.record.responsible", "restarbeiten.record.requiredSummary",
+]);
+const conditionalIds = new Set(["restarbeiten.record.aftercare", "restarbeiten.record.longText", "restarbeiten.record.ampel", "restarbeiten.record.requiredSummary"]);
+
+export const restarbeitenListUiEditorContract = m83Component({
+  componentId: "bbm.restarbeiten.list",
+  scopeId,
+  requiredSlots: RESTARBEITEN_LIST_REQUIRED_SLOTS,
+  slots: elements.map((entry) => m83Slot(entry.id, entry, {
+    referenceKind: multiIds.has(entry.id) ? "multi" : "single",
+    presence: conditionalIds.has(entry.id) ? "whenVisibleInstances" : "always",
+    requirements: {
+      textResize: entry.type === "label" || entry.type === "tableHeaderCell" || entry.id === "restarbeiten.record.photos",
+      move: entry.allowedOps.includes("move"),
+      sizeBounds: entry.allowedOps.some((operation) => operation.startsWith("resize")),
+    },
+  })),
+});

--- a/src/renderer/modules/restarbeiten/RestarbeitenMainBody.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenMainBody.js
@@ -1,5 +1,5 @@
 import { buildRestarbeitenList, buildRestarbeitenTableHeader } from "./RestarbeitenList.js";
-import { registerM80MultiRef, registerM80Ref, registerM80TableColumnRef, registerM80TableRef } from "../../ui-editor/m80Refs.js";
+import { beginM83ComponentBinding, registerM80MultiRef, registerM80Ref, registerM80TableColumnRef, registerM80TableRef } from "../../ui-editor/m80Refs.js";
 
 function createEl(tag, { className = "", uiId = "" } = {}) {
   const el = document.createElement(tag);
@@ -9,6 +9,7 @@ function createEl(tag, { className = "", uiId = "" } = {}) {
 }
 
 export function buildRestarbeitenMainBody(options = {}) {
+  beginM83ComponentBinding("bbm.restarbeiten.list");
   const main = createEl("main", {
     className: "bbm-restarbeiten-main",
     uiId: "restarbeiten.main",
@@ -34,7 +35,7 @@ export function buildRestarbeitenMainBody(options = {}) {
   registerM80TableRef("restarbeiten.list.table", table, table);
   registerM80Ref("restarbeiten.list.table.header", header);
   registerM80Ref("restarbeiten.list.table.body", records);
-  registerM80Ref("restarbeiten.list.table.row", records._m80Rows[0] || records, { targets: records._m80Rows });
+  registerM80MultiRef("restarbeiten.list.table.row", records._m80Rows, records, { mountedInstanceCount: records._m80Rows.length });
   registerM80TableColumnRef(
     "restarbeiten.list.table.number",
     header.children[0],
@@ -63,14 +64,25 @@ export function buildRestarbeitenMainBody(options = {}) {
     172
   );
   const headerMeta = header._m80MetaHeaderParts;
-  const recordMeta = records._m80MetaParts;
+  const componentParts = records._m83ComponentParts;
   registerM80Ref("restarbeiten.main.tableHeader.dueDate", headerMeta.dueDate);
   registerM80Ref("restarbeiten.main.tableHeader.status", headerMeta.status);
   registerM80Ref("restarbeiten.main.tableHeader.responsible", headerMeta.responsible);
-  registerM80MultiRef("restarbeiten.record.dueDate", recordMeta.dueDate, records);
-  registerM80MultiRef("restarbeiten.record.ampel", recordMeta.ampel, records);
-  registerM80MultiRef("restarbeiten.record.status", recordMeta.status, records);
-  registerM80MultiRef("restarbeiten.record.responsible", recordMeta.responsible, records);
+  for (const [id, key] of [
+    ["restarbeiten.record.number", "number"],
+    ["restarbeiten.record.createdAt", "createdAt"],
+    ["restarbeiten.record.itemClass", "itemClass"],
+    ["restarbeiten.record.aftercare", "aftercare"],
+    ["restarbeiten.record.photos", "photos"],
+    ["restarbeiten.record.location", "location"],
+    ["restarbeiten.record.shortText", "shortText"],
+    ["restarbeiten.record.longText", "longText"],
+    ["restarbeiten.record.dueDate", "dueDate"],
+    ["restarbeiten.record.ampel", "ampel"],
+    ["restarbeiten.record.status", "status"],
+    ["restarbeiten.record.responsible", "responsible"],
+    ["restarbeiten.record.requiredSummary", "requiredSummary"],
+  ]) registerM80MultiRef(id, componentParts[key], records, { mountedInstanceCount: componentParts[key].length });
 
   table.append(header, records);
   paper.appendChild(table);

--- a/src/renderer/ui-editor/m80HostAdapter.js
+++ b/src/renderer/ui-editor/m80HostAdapter.js
@@ -25,6 +25,7 @@ import {
   compareM80Topology,
   snapshotM80State,
   snapshotM80Geometry,
+  validateM83ComponentReferences,
 } from "./m80Refs.js";
 import {
   TABLE_LAYOUT_OPERATIONS,
@@ -490,6 +491,15 @@ function mountedActiveScopeGroup() {
 
 export function createM80RegistrationDescriptor() {
   const mountedScopes = mountedActiveScopeGroup();
+  const mountedComponentIds = listM80RegistryScopes()
+    .filter((scope) => mountedScopes.includes(scope.scopeId))
+    .flatMap((scope) => scope.componentIds || []);
+  let componentReferenceErrors = [];
+  try {
+    if (mountedComponentIds.length) validateM83ComponentReferences(mountedComponentIds);
+  } catch (error) {
+    componentReferenceErrors = Array.isArray(error?.details) ? error.details : [{ code: error?.code || "component_reference_contract_invalid", message: error?.message || String(error) }];
+  }
   const registryScopes = listM80RegistryScopes().map((scope) => {
     if (scope.status !== "complete") return scope;
     if (!mountedScopes.includes(scope.scopeId)) {
@@ -514,11 +524,14 @@ export function createM80RegistrationDescriptor() {
       }
       return resolved;
     });
-    const referenceComplete = elements.every((entry) => entry.referenceResolved === true);
+    const scopeComponentIds = new Set(scope.componentIds || []);
+    const scopeReferenceErrors = componentReferenceErrors.filter((entry) => !entry.componentId || scopeComponentIds.has(entry.componentId));
+    const referenceComplete = elements.every((entry) => entry.referenceResolved === true) && scopeReferenceErrors.length === 0;
     return {
       ...scope,
       status: referenceComplete ? "complete" : "blocked",
-      reason: referenceComplete ? null : "registry_reference_missing",
+      reason: referenceComplete ? null : scopeReferenceErrors[0]?.code || "registry_reference_missing",
+      componentReferenceErrors: scopeReferenceErrors,
       elements,
     };
   });

--- a/src/renderer/ui-editor/m80Refs.js
+++ b/src/renderer/ui-editor/m80Refs.js
@@ -1,4 +1,8 @@
-import { getM80RegistryEntry, m80EditorAttributes } from "./m80Registry.js";
+import { getM80RegistryEntry, getM83ComponentContract, listM80RegistryScopes, listM83ComponentContracts, m80EditorAttributes } from "./m80Registry.js";
+import {
+  orderUiComponentSelectionTargetIds,
+  validateUiComponentReferenceBindings,
+} from "../../../node_modules/ui-editor-kit/dist/ui-component-contract.mjs";
 import {
   fitTableToViewport,
   measureTableLayout,
@@ -177,6 +181,17 @@ export function beginM80PilotRender() {
   tableRuntimeBindings.clear();
 }
 
+export function beginM83ComponentBinding(componentId) {
+  const contract = getM83ComponentContract(componentId);
+  if (!contract) throw Object.assign(new Error(`Unbekannter Komponentenvertrag: ${componentId}`), { code: "component_contract_missing", componentId });
+  for (const slot of contract.slots) {
+    refs.delete(slot.element.id);
+    tableColumnRuntimeBindings.delete(slot.element.id);
+    tableRuntimeBindings.delete(slot.element.id);
+  }
+  return contract;
+}
+
 export function resetM80PilotWorkingStatesForDiagnostic() {
   refs.clear();
   tableColumnRuntimeBindings.clear();
@@ -198,11 +213,24 @@ export function registerM80Ref(id, element, custom = {}) {
   if (!entry || !isElementRef(element)) throw new Error(`Ungültige explizite M80-Referenz: ${id}`);
   if (custom.applyPrimaryAttributes !== false) applyAttributes(element, id);
   const targets = [...new Set([element, ...(Array.isArray(custom.targets) ? custom.targets : [])].filter(isElementRef))];
+  const contractTargets = [...new Set((Array.isArray(custom.contractTargets) ? custom.contractTargets : targets).filter(isElementRef))];
+  const existing = refs.get(id);
+  if (entry.referenceKind === "single" && (contractTargets.length !== 1 || (existing && existing.element !== element))) {
+    throw Object.assign(new Error(`Einzel-Ref loest nicht genau ein Ziel auf: ${id}`), {
+      code: "component_single_ref_duplicate",
+      elementId: id,
+      targetCount: existing && existing.element !== element ? contractTargets.length + 1 : contractTargets.length,
+    });
+  }
   const ref = {
     id,
     entry,
     element,
     targets,
+    contractTargets,
+    contractMountedInstanceCount: Number.isFinite(Number(custom.contractMountedInstanceCount))
+      ? Number(custom.contractMountedInstanceCount)
+      : contractTargets.length,
     read: custom.read || (() => readGeneric(element, id)),
     apply: custom.apply || ((state, requestedOperation = null) => applyGeneric(element, state, entry, requestedOperation)),
   };
@@ -213,7 +241,7 @@ export function registerM80Ref(id, element, custom = {}) {
   return element;
 }
 
-export function registerM80MultiRef(id, elements, fallbackElement) {
+export function registerM80MultiRef(id, elements, fallbackElement, options = {}) {
   const entry = getM80RegistryEntry(id);
   const targets = [...new Set((Array.isArray(elements) ? elements : []).filter(isElementRef))];
   const primary = targets[0] || fallbackElement;
@@ -233,6 +261,8 @@ export function registerM80MultiRef(id, elements, fallbackElement) {
   };
   return registerM80Ref(id, primary, {
     targets,
+    contractTargets: targets,
+    contractMountedInstanceCount: Number.isFinite(Number(options.mountedInstanceCount)) ? Number(options.mountedInstanceCount) : targets.length,
     bindingTargets: targets,
     applyPrimaryAttributes: false,
     read: () => targets.length ? readGeneric(targets[0], id) : { ...logicalState, spacing: { ...logicalState.spacing } },
@@ -295,6 +325,8 @@ export function registerM80TableColumnRef(id, headerCell, dataCells, tableElemen
   };
   registerM80Ref(id, headerCell, {
     targets,
+    contractTargets: targets,
+    contractMountedInstanceCount: targets.length,
     read: () => {
       const style = styleOf(headerCell);
       const rect = rectOf(headerCell);
@@ -328,9 +360,11 @@ export function registerM80TableColumnRef(id, headerCell, dataCells, tableElemen
       targets.forEach((target) => toggleClass(target, HIDDEN_CLASS, state.visible === false));
     },
   });
-  registerM80Ref(layout.headerElementId, headerCell, { targets: [headerCell] });
+  registerM80Ref(layout.headerElementId, headerCell, { targets: [headerCell], contractTargets: [headerCell], contractMountedInstanceCount: 1 });
   registerM80Ref(layout.dataCellTemplateId, dataCells?.[0] || tableElement, {
     targets: dataCells,
+    contractTargets: dataCells,
+    contractMountedInstanceCount: dataCells?.length || 0,
     applyPrimaryAttributes: Boolean(dataCells?.length),
   });
   return headerCell;
@@ -481,7 +515,10 @@ export function getM80IdsFromTarget(target) {
   let current = isElementRef(target) ? target : null;
   while (current) {
     const ids = elementIds.get(current);
-    if (ids?.size) return [...ids];
+    if (ids?.size) {
+      const elements = listM80RegistryScopes().flatMap((scope) => scope.elements);
+      return orderUiComponentSelectionTargetIds(elements, [...ids]);
+    }
     current = current.parentElement;
   }
   return [];
@@ -539,7 +576,40 @@ export function listM80CurrentStates(scopeId) {
 export function getM80ReferenceStatus(id) {
   const ref = getM80Ref(id);
   const entry = ref?.entry || getM80RegistryEntry(id);
-  return { refKey: String(entry?.refKey || id || ""), referenceResolved: Boolean(ref && (typeof ref.element.isConnected !== "boolean" || ref.element.isConnected)) };
+  const targets = (ref?.contractTargets || []).filter((target) => typeof target.isConnected !== "boolean" || target.isConnected);
+  return {
+    refKey: String(entry?.refKey || id || ""),
+    referenceResolved: Boolean(ref && (targets.length > 0 || (entry?.referenceKind === "multi" && (ref.contractMountedInstanceCount || 0) === 0))),
+    targetCount: targets.length,
+    mountedInstanceCount: ref?.contractMountedInstanceCount || 0,
+  };
+}
+
+export function validateM83ComponentReferences(componentIds = null) {
+  const contracts = listM83ComponentContracts();
+  const selectedIds = Array.isArray(componentIds) ? componentIds : contracts.map((component) => component.componentId);
+  const bindings = contracts
+    .filter((component) => selectedIds.includes(component.componentId))
+    .flatMap((component) => component.slots.flatMap((slot) => {
+      const ref = refs.get(slot.element.id);
+      if (!ref) return [];
+      const targets = (ref?.contractTargets || []).filter((target) => typeof target.isConnected !== "boolean" || target.isConnected);
+      return [{
+        componentId: component.componentId,
+        slotId: slot.slotId,
+        elementId: slot.element.id,
+        targetCount: targets.length,
+        mountedInstanceCount: ref?.contractMountedInstanceCount || 0,
+        referenceResolved: targets.length > 0,
+        selectionTargetIds: targets.length > 0 ? getM80IdsFromTarget(targets[0]) : [],
+      }];
+    }));
+  const result = validateUiComponentReferenceBindings({ components: contracts, bindings, componentIds: selectedIds });
+  if (!result.ok) {
+    const details = result.errors.map((entry) => `${entry.code}: ${entry.componentId || "?"}/${entry.slotId || entry.elementId || "?"}`).join("; ");
+    throw Object.assign(new Error(`BBM-Komponenten-Refs unvollstaendig: ${details}`), { code: "component_reference_contract_invalid", details: result.errors });
+  }
+  return result;
 }
 export function clearM80VisualState() {
   document.querySelector("[data-bbm-ui-editor-overlay]")?.remove();

--- a/src/renderer/ui-editor/m80Registry.js
+++ b/src/renderer/ui-editor/m80Registry.js
@@ -1,305 +1,47 @@
-export const BBM_M80_REGISTRY_VERSION = 12;
+import { restarbeitenFilterbarUiEditorContract } from "../modules/restarbeiten/RestarbeitenFilterbar.uiEditorContract.js";
+import { restarbeitenListUiEditorContract } from "../modules/restarbeiten/RestarbeitenList.uiEditorContract.js";
+import { restarbeitenEditboxUiEditorContract } from "../modules/restarbeiten/RestarbeitenEditbox.uiEditorContract.js";
+import { protokollQuicklaneUiEditorContract, protokollScreenUiEditorContract } from "../modules/protokoll/screens/TopsScreen.uiEditorContract.js";
+import { protokollListColumnsUiEditorContract, protokollListUiEditorContract } from "../modules/protokoll/TopsList.uiEditorContract.js";
+import { protokollEditUiEditorContract } from "../modules/protokoll/TopsWorkbench.uiEditorContract.js";
+import { aggregateBbmM83Components } from "./m83ComponentContract.js";
+
+export const BBM_M80_REGISTRY_VERSION = 13;
 export const BBM_M80_REGISTRY_STATUS = "incomplete";
 
-const GROUP_LAYOUT = Object.freeze(["move", "setVisibility"]);
-const ZONE_HEIGHT_LAYOUT = Object.freeze(["resizeHeight", "setVisibility"]);
-const TEXT_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "textResize", "setVisibility"]);
-const FIELD_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "textResize", "setVisibility"]);
-const BUTTON_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "setVisibility"]);
-const ICON_LAYOUT = Object.freeze(["resizeWidth", "resizeHeight", "setVisibility"]);
-const TABLE_LAYOUT = Object.freeze(["resizeHeight", "setVisibility", "fitTableToViewport", "resizeColumnsProportionally", "setRowHeightMode", "resetTable"]);
-const COLUMN_LAYOUT = Object.freeze(["resizeWidth", "textResize", "setVisibility", "setColumnWidthMode", "setColumnWrapMode", "setColumnOverflowMode", "resetTableColumn"]);
-const SPACING_LAYOUT = Object.freeze(["spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"]);
-const DOMAIN_LOCKS = Object.freeze(["executeTargetAction", "modifyDomainData", "createRecord", "deleteRecord"]);
+export const BBM_M83_COMPONENT_CONTRACTS = Object.freeze([
+  restarbeitenFilterbarUiEditorContract,
+  restarbeitenListUiEditorContract,
+  restarbeitenEditboxUiEditorContract,
+  protokollScreenUiEditorContract,
+  protokollQuicklaneUiEditorContract,
+  protokollListUiEditorContract,
+  protokollListColumnsUiEditorContract,
+  protokollEditUiEditorContract,
+]);
 
-function defaultBaseline(values = {}) {
-  return Object.freeze({
-    x: 0, y: 0, width: 100, height: 24, textOffsetX: 0, textOffsetY: 0,
-    fontSize: 12, visible: true, spacing: {}, minWidth: 8, maxWidth: 2400, minHeight: 8, maxHeight: 1600,
-    ...values,
-  });
-}
+const aggregate = aggregateBbmM83Components(BBM_M83_COMPONENT_CONTRACTS);
 
-function element(values) {
-  const allowedOps = Object.freeze([...(values.allowedOps || [])]);
-  const selectionKind = values.selectionKind || ({
-    root: "layoutZone", area: "layoutZone", group: "group", fieldGroup: "group",
-    label: values.role === "status" ? "statusText" : "label", field: "field", button: "button",
-    componentPart: "icon", statusIndicator: "icon", table: "table", tableHeader: "tableHeader",
-    tableBody: "tableBody", tableRow: "tableRow", tableColumn: "column", tableHeaderCell: "tableHeaderCell",
-    tableDataCell: "tableDataCell", tableFooter: "tableFooter", tableViewport: "tableViewport",
-    horizontalScrollArea: "horizontalScrollArea",
-  }[values.type] || "element");
-  return Object.freeze({
-    visible: true,
-    editable: allowedOps.length > 0,
-    ...values,
-    semanticKey: values.semanticKey || values.id,
-    registrationStatus: values.registrationStatus || (allowedOps.length > 0 ? "editorEnabled" : "editorContainer"),
-    refKey: values.refKey || values.id,
-    baseline: defaultBaseline(values.baseline),
-    selectionKind,
-    selectionLevels: Object.freeze([...(values.selectionLevels || [selectionKind])]),
-    spacingTargets: Object.freeze([...(values.spacingTargets || [])]),
-    operationEffects: Object.freeze({
-      ...Object.fromEntries(allowedOps.map((operation) => [operation,
-        selectionKind === "group" ? "groupWithChildren" : selectionKind === "layoutZone" ? "layoutZone" : "elementOnly"])),
-      ...(values.operationEffects || {}),
-    }),
-    operationAffectedIds: Object.freeze({ ...(values.operationAffectedIds || {}) }),
-    geometry: Object.freeze({ maximumStoredOffset: 2400, ...(values.geometry || {}) }),
-    allowedOps,
-    lockedOps: Object.freeze([...(values.lockedOps || [])]),
-  });
-}
-
-function domainButton(values) {
-  return element({ ...values, type: "button", role: "domainActionLayout", allowedOps: BUTTON_LAYOUT, lockedOps: DOMAIN_LOCKS, actionKind: values.actionKind || "domain" });
-}
-
-function completeScope(scopeId, elements) {
+function completeScope(scopeId) {
+  const components = aggregate.components.filter((component) => component.scopeId === scopeId);
+  const elements = aggregate.elements.filter((entry) => entry.scopeId === scopeId);
   return Object.freeze({
     scopeId,
     status: "complete",
-    inventoryStatus: "complete",
+    inventoryStatus: "componentContractComplete",
+    componentIds: Object.freeze(components.map((component) => component.componentId)),
     expectedElementIds: Object.freeze(elements.map((entry) => entry.id)),
     elements: Object.freeze(elements),
   });
 }
 
 function blockedScope(scopeId, name, reason = "registration_inventory_pending") {
-  return Object.freeze({
-    scopeId,
-    name,
-    status: "blocked",
-    inventoryStatus: "notInventoried",
-    expectedElementIds: Object.freeze([]),
-    elements: Object.freeze([]),
-    reason,
-  });
+  return Object.freeze({ scopeId, name, status: "blocked", inventoryStatus: "notInventoried", componentIds: Object.freeze([]), expectedElementIds: Object.freeze([]), elements: Object.freeze([]), reason });
 }
-
-const headerElements = [
-  element({ id: "restarbeiten.header.root", name: "Kopf- und Filterbereich Restarbeiten", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: ZONE_HEIGHT_LAYOUT, componentKind: "fixedHeader", baseline: { width: 1180, height: 102, minWidth: 640, maxWidth: 2400, minHeight: 56, maxHeight: 220 } }),
-  element({ id: "restarbeiten.filterbar", name: "Filterkopf Restarbeiten", type: "area", role: "layout", parentId: "restarbeiten.header.root", order: 10, allowedOps: GROUP_LAYOUT, componentKind: "filterbar", baseline: { width: 1092, height: 72, minWidth: 560, maxWidth: 2200, minHeight: 48, maxHeight: 220 } }),
-  element({ id: "restarbeiten.filterbar.group.location", name: "Gruppe Verortungsfilter", type: "group", role: "layoutGroup", parentId: "restarbeiten.filterbar", order: 20, allowedOps: GROUP_LAYOUT, componentKind: "filterGroup" }),
-  ...[1, 2, 3, 4].flatMap((level, index) => [
-    element({ id: `restarbeiten.filterbar.location.level${level}`, name: `Gruppe Verortung L${level}`, type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.filterbar.group.location", order: 21 + index * 3, allowedOps: GROUP_LAYOUT, componentKind: "fieldGroup" }),
-    element({ id: `restarbeiten.filterbar.location.level${level}.label`, name: `Verortung L${level} · Bezeichnung`, type: "label", role: "fieldLabel", parentId: `restarbeiten.filterbar.location.level${level}`, order: 22 + index * 3, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-    element({ id: `restarbeiten.filterbar.location.level${level}.field`, name: `Eingabefeld Verortung L${level}`, type: "field", role: "dataFieldLayout", parentId: `restarbeiten.filterbar.location.level${level}`, order: 23 + index * 3, allowedOps: FIELD_LAYOUT, fieldKind: "select", componentKind: "select" }),
-  ]),
-  element({ id: "restarbeiten.filterbar.group.class", name: "Gruppe Klassenfilter", type: "group", role: "layoutGroup", parentId: "restarbeiten.filterbar", order: 40, allowedOps: GROUP_LAYOUT, componentKind: "buttonGroup" }),
-  domainButton({ id: "restarbeiten.filterbar.class.all", name: "Klasse · Alle", parentId: "restarbeiten.filterbar.group.class", order: 41, actionKind: "domainFilter" }),
-  domainButton({ id: "restarbeiten.filterbar.class.rest", name: "Klasse · Rest", parentId: "restarbeiten.filterbar.group.class", order: 42, actionKind: "domainFilter" }),
-  domainButton({ id: "restarbeiten.filterbar.class.defect", name: "Klasse · Mangel", parentId: "restarbeiten.filterbar.group.class", order: 43, actionKind: "domainFilter" }),
-  element({ id: "restarbeiten.filterbar.group.meta", name: "Gruppe Status- und Zuordnungsfilter", type: "group", role: "layoutGroup", parentId: "restarbeiten.filterbar", order: 50, allowedOps: GROUP_LAYOUT, componentKind: "filterGroup" }),
-  ...[
-    ["status", "Status", "select"],
-    ["dueDate", "Fertig bis", "date"],
-    ["responsible", "Verantwortlich", "select"],
-  ].flatMap(([key, name, fieldKind], index) => [
-    element({ id: `restarbeiten.filterbar.meta.${key}`, name: `Gruppe ${name}`, type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.filterbar.group.meta", order: 51 + index * 3, allowedOps: GROUP_LAYOUT, componentKind: "fieldGroup" }),
-    element({ id: `restarbeiten.filterbar.meta.${key}.label`, name: `${name} · Bezeichnung`, type: "label", role: "fieldLabel", parentId: `restarbeiten.filterbar.meta.${key}`, order: 52 + index * 3, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-    element({ id: `restarbeiten.filterbar.meta.${key}.field`, name: `Eingabefeld ${name}`, type: "field", role: "dataFieldLayout", parentId: `restarbeiten.filterbar.meta.${key}`, order: 53 + index * 3, allowedOps: FIELD_LAYOUT, fieldKind, componentKind: fieldKind === "date" ? "dateInput" : "select" }),
-  ]),
-  element({ id: "restarbeiten.filterbar.actions", name: "Gruppe Header-Aktionen", type: "group", role: "layoutGroup", parentId: "restarbeiten.filterbar", order: 70, allowedOps: GROUP_LAYOUT, componentKind: "actionGroup" }),
-  domainButton({ id: "restarbeiten.filterbar.action.close", name: "Schließen", parentId: "restarbeiten.filterbar.actions", order: 71, actionKind: "domainNavigation" }),
-];
-
-const listTableColumns = Object.freeze([
-  Object.freeze({
-    columnId: "restarbeiten.list.table.number", displayName: "Nr. / Datum / Klasse / Fotos",
-    headerElementId: "restarbeiten.list.table.number.header", dataCellTemplateId: "restarbeiten.list.table.number.cells",
-    cellElementIds: Object.freeze([]), currentWidth: 82, minimumWidth: 50, maximumWidth: 240, widthMode: "fixed",
-    resizable: true, wrapMode: "noWrap", overflowMode: "clip", alignment: "stretch", visibility: true,
-    order: 1, lockedOps: Object.freeze([...DOMAIN_LOCKS]), widthSourceId: "restarbeiten.list.table.number", flexible: false, priority: 10,
-  }),
-  Object.freeze({
-    columnId: "restarbeiten.list.table.subject", displayName: "Gegenstand – Verortung / Kurztext / Langtext",
-    headerElementId: "restarbeiten.list.table.subject.header", dataCellTemplateId: "restarbeiten.list.table.subject.cells",
-    cellElementIds: Object.freeze([]), currentWidth: 560, minimumWidth: 160, maximumWidth: 1200, widthMode: "proportional",
-    resizable: true, wrapMode: "wordWrap", overflowMode: "clip", alignment: "stretch", visibility: true,
-    order: 2, lockedOps: Object.freeze([...DOMAIN_LOCKS]), widthSourceId: "restarbeiten.list.table.subject", flexible: true, priority: 100,
-  }),
-  Object.freeze({
-    columnId: "restarbeiten.list.table.meta", displayName: "Fertig bis / Ampel / Status / Verantwortlich",
-    headerElementId: "restarbeiten.list.table.meta.header", dataCellTemplateId: "restarbeiten.list.table.meta.cells",
-    cellElementIds: Object.freeze([]), currentWidth: 172, minimumWidth: 110, maximumWidth: 420, widthMode: "fixed",
-    resizable: true, wrapMode: "wordWrap", overflowMode: "clip", alignment: "stretch", visibility: true,
-    order: 3, lockedOps: Object.freeze([...DOMAIN_LOCKS]), widthSourceId: "restarbeiten.list.table.meta", flexible: false, priority: 20,
-  }),
-]);
-
-const listTableLayout = Object.freeze({
-  tableId: "restarbeiten.list.table", displayName: "Restarbeiten-Hauptliste",
-  bounds: Object.freeze({ left: 0, top: 0, width: 858, height: 680 }),
-  viewportBounds: Object.freeze({ left: 0, top: 0, width: 858, height: 680 }),
-  contentBounds: Object.freeze({ left: 0, top: 0, width: 858, height: 680 }),
-  parentId: "restarbeiten.list.paper",
-  columnIds: Object.freeze(listTableColumns.map((column) => column.columnId)),
-  rowTemplateId: "restarbeiten.list.table.row", horizontalOverflowMode: "fitViewport", verticalOverflowMode: "none",
-  widthPolicy: "bounded", minimumWidth: 320, maximumWidth: 1600, reservedWidth: 44, scrollbarWidth: 0,
-  rowHeightMode: "bounded", minimumRowHeight: 54, maximumRowHeight: 180, columns: listTableColumns,
-});
-
-function tableBinding(columnId, part) {
-  return Object.freeze({ tableId: "restarbeiten.list.table", columnId, widthSourceId: columnId, part });
-}
-
-const listElements = [
-  element({ id: "restarbeiten.list.root", name: "Restarbeiten · Liste", type: "root", role: "scopeRoot", parentId: null, order: 0, editable: false, allowedOps: [], componentKind: "scope" }),
-  element({ id: "restarbeiten.list.area", name: "Restarbeiten-Liste", type: "area", role: "contentArea", parentId: "restarbeiten.list.root", order: 10, allowedOps: GROUP_LAYOUT, componentKind: "contentArea", baseline: { width: 900, height: 420, minWidth: 320, minHeight: 180 } }),
-  element({ id: "restarbeiten.list.paper", name: "Gruppe Listenblatt", type: "group", role: "layoutGroup", parentId: "restarbeiten.list.area", order: 20, allowedOps: GROUP_LAYOUT, componentKind: "paper", baseline: { width: 900, height: 720, minWidth: 320, minHeight: 240 } }),
-  element({ id: "restarbeiten.list.table", name: "Restarbeiten-Hauptliste", type: "table", role: "contentTable", parentId: "restarbeiten.list.paper", order: 30, allowedOps: TABLE_LAYOUT, componentKind: "contentTable", tableLayout: listTableLayout, baseline: { width: 858, height: 680, minWidth: 320, maxWidth: 1600, minHeight: 160, maxHeight: 12000 } }),
-  ...listTableColumns.map((column, index) => element({ id: column.columnId, name: column.displayName, type: "tableColumn", role: index === 2 ? "metaColumn" : "contentColumn", parentId: "restarbeiten.list.table", order: 31 + index, allowedOps: COLUMN_LAYOUT, columnRole: index === 2 ? "metaColumn" : "contentColumn", tableColumnLayout: column, tableBinding: tableBinding(column.columnId, "column"), baseline: { width: column.currentWidth, height: 28, minWidth: column.minimumWidth, maxWidth: column.maximumWidth } })),
-  element({ id: "restarbeiten.list.table.header", name: "Tabellenkopf der Restarbeiten-Liste", type: "tableHeader", role: "tableHeader", parentId: "restarbeiten.list.table", order: 40, allowedOps: [], componentKind: "tableHeader" }),
-  element({ id: "restarbeiten.list.table.body", name: "Datenbereich der Restarbeiten-Liste", type: "tableBody", role: "tableBody", parentId: "restarbeiten.list.table", order: 50, allowedOps: [], componentKind: "tableBody" }),
-  element({ id: "restarbeiten.list.table.row", name: "Restarbeiten-Zeile", type: "tableRow", role: "tableRow", parentId: "restarbeiten.list.table.body", order: 51, allowedOps: [], componentKind: "rowTemplate", rowLayout: { heightMode: "bounded", minimumHeight: 54, maximumHeight: 180 } }),
-  ...listTableColumns.flatMap((column, index) => [
-    element({ id: column.headerElementId, name: `${column.displayName} · Überschrift`, type: "tableHeaderCell", role: "tableHeaderCell", parentId: column.columnId, order: 60 + index * 2, allowedOps: ["textResize"], componentKind: "tableHeaderCell", tableBinding: tableBinding(column.columnId, "header"), baseline: { fontSize: 12, minFontSize: 8, maxFontSize: 32 } }),
-    element({ id: column.dataCellTemplateId, name: `${column.displayName} · Datenbereich`, type: "tableDataCell", role: "tableDataCell", parentId: column.columnId, order: 61 + index * 2, allowedOps: [], componentKind: "dataCellTemplate", tableBinding: tableBinding(column.columnId, "data") }),
-  ]),
-  element({ id: "restarbeiten.main.tableHeader.dueDate", name: "Fertig bis · Überschrift", type: "label", role: "fieldLabel", parentId: "restarbeiten.list.table.meta.header", order: 70, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "tableHeaderLabel", baseline: { x: 0, y: 0, fontSize: 8.667, minFontSize: 6, maxFontSize: 24 } }),
-  element({ id: "restarbeiten.main.tableHeader.status", name: "Status · Überschrift", type: "label", role: "fieldLabel", parentId: "restarbeiten.list.table.meta.header", order: 71, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "tableHeaderLabel", baseline: { x: 0, y: 0, fontSize: 8.667, minFontSize: 6, maxFontSize: 24 } }),
-  element({ id: "restarbeiten.main.tableHeader.responsible", name: "Verantwortlich · Überschrift", type: "label", role: "fieldLabel", parentId: "restarbeiten.list.table.meta.header", order: 72, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "tableHeaderLabel", baseline: { x: 0, y: 0, fontSize: 8.667, minFontSize: 6, maxFontSize: 24 } }),
-  element({ id: "restarbeiten.record.dueDate", name: "Fertig bis · Listeneinträge", type: "label", role: "date", parentId: "restarbeiten.list.table.meta.cells", order: 73, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "staticMultiRef", baseline: { x: 0, y: 0, fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
-  element({ id: "restarbeiten.record.ampel", name: "Ampel · Listeneinträge", type: "statusIndicator", role: "status", parentId: "restarbeiten.list.table.meta.cells", order: 74, allowedOps: ["move", ...ICON_LAYOUT], componentKind: "staticMultiRef", baseline: { x: 0, y: 0, width: 12, height: 12, minWidth: 7, maxWidth: 48, minHeight: 7, maxHeight: 48 } }),
-  element({ id: "restarbeiten.record.status", name: "Status · Listeneinträge", type: "label", role: "status", parentId: "restarbeiten.list.table.meta.cells", order: 75, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "staticMultiRef", baseline: { x: 0, y: 0, fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
-  element({ id: "restarbeiten.record.responsible", name: "Verantwortlich · Listeneinträge", type: "label", role: "responsible", parentId: "restarbeiten.list.table.meta.cells", order: 76, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "staticMultiRef", baseline: { x: 0, y: 0, fontSize: 10.667, minFontSize: 7, maxFontSize: 32 } }),
-];
-
-const editElements = [
-  element({ id: "restarbeiten.edit.root", name: "Eingabebereich Restarbeiten", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: ZONE_HEIGHT_LAYOUT, componentKind: "fixedEditArea", baseline: { width: 900, height: 276, minWidth: 320, maxWidth: 1800, minHeight: 190, maxHeight: 520 }, operationEffects: { resizeHeight: "parentReflowRequired" }, operationAffectedIds: { resizeHeight: ["restarbeiten.edit.area", "restarbeiten.list.root"] } }),
-  element({ id: "restarbeiten.edit.area", name: "Layoutzone Eingabebereich", type: "area", role: "formArea", parentId: "restarbeiten.edit.root", order: 10, allowedOps: [], componentKind: "formArea", baseline: { width: 878, height: 252, minWidth: 300, minHeight: 160 } }),
-  element({ id: "restarbeiten.edit.header", name: "Gruppe Editbox-Kopf", type: "group", role: "layoutGroup", parentId: "restarbeiten.edit.area", order: 20, allowedOps: GROUP_LAYOUT, componentKind: "header" }),
-  element({ id: "restarbeiten.edit.header.current", name: "Status aktueller Datensatz", type: "label", role: "status", parentId: "restarbeiten.edit.header", order: 21, allowedOps: ["setVisibility"], componentKind: "label" }),
-  element({ id: "restarbeiten.edit.fields", name: "Layoutzone Textfelder", type: "group", role: "fieldCollection", parentId: "restarbeiten.edit.area", order: 30, allowedOps: [], componentKind: "fieldCollection", selectionKind: "layoutZone" }),
-  element({ id: "restarbeiten.edit.short", name: "Gruppe Kurztext/Gegenstand", type: "group", role: "formFieldGroup", parentId: "restarbeiten.edit.fields", order: 40, allowedOps: [...GROUP_LAYOUT, "resizeWidth", "resizeHeight", ...SPACING_LAYOUT], spacingTargets: ["groupPaddingLeft", "groupPaddingRight", "groupPaddingTop", "groupPaddingBottom", "childGapHorizontal", "childGapVertical"], componentKind: "fieldGroup", baseline: { width: null, height: null, minWidth: 320, maxWidth: 1400, minHeight: 42, maxHeight: 96 } }),
-  element({ id: "restarbeiten.edit.short.headerZone", name: "Kopfzeile Kurztext/Gegenstand", type: "group", role: "layoutGroup", parentId: "restarbeiten.edit.short", order: 41, allowedOps: SPACING_LAYOUT, spacingTargets: ["groupPaddingLeft", "groupPaddingRight", "groupPaddingTop", "groupPaddingBottom", "childGapHorizontal"], componentKind: "layoutZone", selectionKind: "layoutZone" }),
-  element({ id: "restarbeiten.edit.short.label", name: "Bezeichnung Kurztext/Gegenstand", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.short", order: 42, allowedOps: [...TEXT_LAYOUT, ...SPACING_LAYOUT], spacingTargets: ["beforeElement", "afterElement", "reservedWidth"], componentKind: "label", baseline: { width: 150, height: 22, spacing: { reservedWidth: 40 }, minWidth: 74, maxWidth: 190, minHeight: 18, maxHeight: 48 }, operationEffects: { resizeWidth: "parentReflowRequired", resizeHeight: "parentReflowRequired" }, operationAffectedIds: { resizeWidth: ["restarbeiten.edit.short.headerZone", "restarbeiten.edit.short.field"], resizeHeight: ["restarbeiten.edit.short.headerZone", "restarbeiten.edit.short.field"] } }),
-  element({ id: "restarbeiten.edit.short.remaining", name: "Restzeichenanzeige Kurztext", type: "label", role: "status", parentId: "restarbeiten.edit.short.headerZone", order: 43, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "counter", baseline: { x: 0, y: 0, fontSize: 8.667, minFontSize: 6, maxFontSize: 10 } }),
-  domainButton({ id: "restarbeiten.edit.short.dictation", name: "Diktatbutton Kurztext", parentId: "restarbeiten.edit.short.headerZone", order: 44, actionKind: "domainDictation", baseline: { width: 22, height: 22, minWidth: 20, maxWidth: 32, minHeight: 20, maxHeight: 32 }, operationEffects: { move: "groupWithChildren" }, operationAffectedIds: { move: ["restarbeiten.edit.short.dictation.icon"] } }),
-  element({ id: "restarbeiten.edit.short.dictation.icon", name: "Mikrofonsymbol Kurztext", type: "componentPart", role: "layout", parentId: "restarbeiten.edit.short.dictation", order: 45, allowedOps: ICON_LAYOUT, componentKind: "icon", baseline: { width: 17, height: 17, minWidth: 12, maxWidth: 22, minHeight: 12, maxHeight: 22 } }),
-  element({ id: "restarbeiten.edit.class", name: "Gruppe Klasse", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.short.headerZone", order: 46, allowedOps: GROUP_LAYOUT, componentKind: "choiceField" }),
-  element({ id: "restarbeiten.edit.class.label", name: "Bezeichnung Klasse", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.class", order: 47, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "restarbeiten.edit.class.control", name: "Eingabefeld Klasse", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.class", order: 48, allowedOps: FIELD_LAYOUT, fieldKind: "buttonChoice", componentKind: "choice" }),
-  domainButton({ id: "restarbeiten.edit.class.rest", name: "Klasse Rest", parentId: "restarbeiten.edit.class.control", order: 49, actionKind: "domainSelection" }),
-  domainButton({ id: "restarbeiten.edit.class.defect", name: "Klasse Mangel", parentId: "restarbeiten.edit.class.control", order: 50, actionKind: "domainSelection" }),
-  element({ id: "restarbeiten.edit.short.actions", name: "Weitere Kurztextaktionen", type: "group", role: "layoutGroup", parentId: "restarbeiten.edit.short.headerZone", order: 51, allowedOps: GROUP_LAYOUT, componentKind: "actionGroup" }),
-  domainButton({ id: "restarbeiten.edit.action.new", name: "Neu", parentId: "restarbeiten.edit.short.actions", order: 52, actionKind: "domainCreate" }),
-  domainButton({ id: "restarbeiten.edit.action.delete", name: "Löschen", parentId: "restarbeiten.edit.short.actions", order: 53, actionKind: "domainDelete" }),
-  element({ id: "restarbeiten.edit.short.field", name: "Texteingabe Kurztext/Gegenstand", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.short", order: 54, allowedOps: FIELD_LAYOUT, fieldKind: "text", componentKind: "input" }),
-  element({ id: "restarbeiten.edit.long", name: "Gruppe Langtext/Beschreibung", type: "group", role: "formFieldGroup", parentId: "restarbeiten.edit.fields", order: 60, allowedOps: GROUP_LAYOUT, componentKind: "fieldGroup" }),
-  element({ id: "restarbeiten.edit.long.headerZone", name: "Kopfzeile Langtext/Beschreibung", type: "group", role: "layoutGroup", parentId: "restarbeiten.edit.long", order: 61, allowedOps: [], componentKind: "layoutZone", selectionKind: "layoutZone" }),
-  element({ id: "restarbeiten.edit.long.label", name: "Bezeichnung Langtext/Beschreibung", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.long", order: 62, allowedOps: TEXT_LAYOUT, componentKind: "label", baseline: { width: 150, height: 22, minWidth: 90, maxWidth: 220, minHeight: 18, maxHeight: 48 }, operationEffects: { resizeWidth: "parentReflowRequired", resizeHeight: "parentReflowRequired" }, operationAffectedIds: { resizeWidth: ["restarbeiten.edit.long.headerZone", "restarbeiten.edit.long.field"], resizeHeight: ["restarbeiten.edit.long.headerZone", "restarbeiten.edit.long.field"] } }),
-  element({ id: "restarbeiten.edit.long.remaining", name: "Restzeichenanzeige Langtext", type: "label", role: "status", parentId: "restarbeiten.edit.long.headerZone", order: 63, allowedOps: ["move", "textResize", "setVisibility"], componentKind: "counter", baseline: { x: 0, y: 0, fontSize: 8.667, minFontSize: 6, maxFontSize: 10 } }),
-  domainButton({ id: "restarbeiten.edit.long.dictation", name: "Diktatbutton Langtext", parentId: "restarbeiten.edit.long.headerZone", order: 64, actionKind: "domainDictation", baseline: { width: 22, height: 22, minWidth: 20, maxWidth: 32, minHeight: 20, maxHeight: 32 }, operationEffects: { move: "groupWithChildren" }, operationAffectedIds: { move: ["restarbeiten.edit.long.dictation.icon"] } }),
-  element({ id: "restarbeiten.edit.long.dictation.icon", name: "Mikrofonsymbol Langtext", type: "componentPart", role: "layout", parentId: "restarbeiten.edit.long.dictation", order: 65, allowedOps: ICON_LAYOUT, componentKind: "icon", baseline: { width: 17, height: 17, minWidth: 12, maxWidth: 22, minHeight: 12, maxHeight: 22 } }),
-  element({ id: "restarbeiten.edit.long.field", name: "Texteingabe Langtext/Beschreibung", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.long", order: 66, allowedOps: FIELD_LAYOUT, fieldKind: "multilineText", componentKind: "textarea" }),
-  element({ id: "restarbeiten.edit.location", name: "Gruppe Verortung", type: "group", role: "fieldCollection", parentId: "restarbeiten.edit.area", order: 70, allowedOps: GROUP_LAYOUT, componentKind: "locationGroup" }),
-  ...[1, 2, 3, 4].flatMap((level, index) => [
-    element({ id: `restarbeiten.edit.location.${level}`, name: `Gruppe Verortung L${level}`, type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.location", order: 71 + index * 3, allowedOps: GROUP_LAYOUT, componentKind: "fieldGroup" }),
-    element({ id: `restarbeiten.edit.location.${level}.label`, name: `Bezeichnung Verortung L${level}`, type: "label", role: "fieldLabel", parentId: `restarbeiten.edit.location.${level}`, order: 72 + index * 3, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-    element({ id: `restarbeiten.edit.location.${level}.field`, name: `Eingabefeld Verortung L${level}`, type: "field", role: "dataFieldLayout", parentId: `restarbeiten.edit.location.${level}`, order: 73 + index * 3, allowedOps: FIELD_LAYOUT, fieldKind: "text", componentKind: "input" }),
-  ]),
-  element({ id: "restarbeiten.edit.meta", name: "Gruppe Status und Zuordnung", type: "group", role: "fieldCollection", parentId: "restarbeiten.edit.area", order: 90, allowedOps: GROUP_LAYOUT, componentKind: "metaGroup" }),
-  element({ id: "restarbeiten.edit.meta.status", name: "Gruppe Status", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.meta", order: 91, allowedOps: GROUP_LAYOUT, componentKind: "fieldGroup" }),
-  element({ id: "restarbeiten.edit.meta.status.label", name: "Bezeichnung Status", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.meta.status", order: 92, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "restarbeiten.edit.meta.status.field", name: "Eingabefeld Status", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.meta.status", order: 93, allowedOps: FIELD_LAYOUT, fieldKind: "select", componentKind: "select" }),
-  element({ id: "restarbeiten.edit.meta.due", name: "Gruppe Fertig bis", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.meta", order: 94, allowedOps: GROUP_LAYOUT, componentKind: "fieldGroup" }),
-  element({ id: "restarbeiten.edit.meta.due.label", name: "Bezeichnung Fertig bis", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.meta.due", order: 95, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "restarbeiten.edit.meta.due.field", name: "Eingabefeld Fertig bis", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.meta.due", order: 96, allowedOps: FIELD_LAYOUT, fieldKind: "date", componentKind: "dateInput" }),
-  element({ id: "restarbeiten.edit.meta.ampel", name: "Statussymbol Ampel", type: "statusIndicator", role: "status", parentId: "restarbeiten.edit.meta", order: 97, allowedOps: ["move", ...ICON_LAYOUT], componentKind: "statusIndicator", baseline: { x: 0, y: 0, width: 12, height: 12, minWidth: 7, maxWidth: 48, minHeight: 7, maxHeight: 48 } }),
-  element({ id: "restarbeiten.edit.meta.responsible", name: "Gruppe Verantwortlich", type: "fieldGroup", role: "formFieldGroup", parentId: "restarbeiten.edit.meta", order: 98, allowedOps: GROUP_LAYOUT, componentKind: "fieldGroup" }),
-  element({ id: "restarbeiten.edit.meta.responsible.label", name: "Bezeichnung Verantwortlich", type: "label", role: "fieldLabel", parentId: "restarbeiten.edit.meta.responsible", order: 99, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "restarbeiten.edit.meta.responsible.field", name: "Eingabefeld Verantwortlich", type: "field", role: "dataFieldLayout", parentId: "restarbeiten.edit.meta.responsible", order: 100, allowedOps: FIELD_LAYOUT, fieldKind: "select", componentKind: "select" }),
-  element({ id: "restarbeiten.edit.validation", name: "Status Pflichtfeldhinweis", type: "label", role: "status", parentId: "restarbeiten.edit.meta", order: 101, allowedOps: ["setVisibility"], componentKind: "validation" }),
-  domainButton({ id: "restarbeiten.edit.action.note", name: "Notizbutton", parentId: "restarbeiten.edit.meta", order: 102, actionKind: "domainNote" }),
-];
-
-const PROTOKOLL_GROUP_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight"]);
-const PROTOKOLL_COLUMN_LAYOUT = Object.freeze(["resizeWidth"]);
-
-const protokollScreenElements = [
-  element({ id: "protokoll.screen.root", name: "Protokoll-TopScreen", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: [], componentKind: "screen" }),
-  element({ id: "protokoll.header", name: "Protokoll-Kopfbereich", type: "area", role: "contentArea", parentId: "protokoll.screen.root", order: 10, allowedOps: GROUP_LAYOUT, componentKind: "header" }),
-  element({ id: "protokoll.header.titleGroup", name: "Gruppe Protokollbezeichnung", type: "group", role: "layoutGroup", parentId: "protokoll.header", order: 20, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "titleGroup" }),
-  element({ id: "protokoll.header.title", name: "Bezeichnung Protokoll", type: "label", role: "fieldLabel", parentId: "protokoll.header.titleGroup", order: 21, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "protokoll.header.keyword", name: "Schlagwort", type: "label", role: "dataFieldLayout", parentId: "protokoll.header.titleGroup", order: 22, allowedOps: TEXT_LAYOUT, componentKind: "interactiveLabel", lockedOps: DOMAIN_LOCKS }),
-  element({ id: "protokoll.header.context", name: "Protokollkontext", type: "label", role: "status", parentId: "protokoll.header.titleGroup", order: 23, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "protokoll.header.meta", name: "Gruppe Listenbezeichnungen", type: "group", role: "layoutGroup", parentId: "protokoll.header", order: 30, allowedOps: GROUP_LAYOUT, componentKind: "tableLegend" }),
-  element({ id: "protokoll.header.meta.due", name: "Bezeichnung Fertig bis", type: "label", role: "fieldLabel", parentId: "protokoll.header.meta", order: 31, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "protokoll.header.meta.status", name: "Bezeichnung Status", type: "label", role: "fieldLabel", parentId: "protokoll.header.meta", order: 32, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "protokoll.header.meta.responsible", name: "Bezeichnung Verantwortlich", type: "label", role: "fieldLabel", parentId: "protokoll.header.meta", order: 33, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "protokoll.topsScreen.quicklane", name: "Protokoll-Quicklane", type: "area", role: "layout", parentId: "protokoll.screen.root", order: 40, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "toolbar" }),
-  ...[
-    ["navigation", "Navigation", 41],
-    ["visibility", "Sichtbarkeit", 42],
-    ["filter", "TOP-Filter", 43],
-    ["output", "Ausgabe", 44],
-  ].map(([key, name, order]) => element({ id: `protokoll.topsScreen.quicklane.group.${key}`, name: `Gruppe ${name}`, type: "group", role: "layoutGroup", parentId: "protokoll.topsScreen.quicklane", order, allowedOps: GROUP_LAYOUT, componentKind: "toolbarGroup" })),
-  ...[
-    ["pin", "Fixieren", "navigation", 50],
-    ["action.project", "Projekt", "navigation", 51],
-    ["action.firms", "Firmen", "navigation", 52],
-    ["action.participants", "Teilnehmer", "navigation", 53],
-    ["action.ampel", "Ampel", "visibility", 54],
-    ["action.longtext", "Langtext", "visibility", 55],
-    ["action.topFilter", "TOP-Filter", "filter", 56],
-    ["action.preview", "PDF-Vorschau", "output", 57],
-    ["action.print", "Drucken", "output", 58],
-    ["action.mail", "E-Mail", "output", 59],
-  ].map(([key, name, group, order]) => domainButton({ id: `protokoll.topsScreen.quicklane.${key}`, name, parentId: `protokoll.topsScreen.quicklane.group.${group}`, order, actionKind: "domainAction" })),
-];
-
-const protokollListColumns = Object.freeze([
-  Object.freeze({ id: "protokoll.list.column.number", name: "TOP / Nummer", currentWidth: 64, minimumWidth: 40, maximumWidth: 220, widthSourceId: "--bbm-tops-list-number-col", order: 31, role: "metaColumn" }),
-  Object.freeze({ id: "protokoll.list.column.text", name: "Gegenstand / Kurztext / Langtext", currentWidth: 650, minimumWidth: 180, maximumWidth: 1400, widthSourceId: "--bbm-tops-list-text-col", order: 32, role: "contentColumn" }),
-  Object.freeze({ id: "protokoll.list.column.meta", name: "Status / Fertig bis / Verantwortlich", currentWidth: 74, minimumWidth: 50, maximumWidth: 420, widthSourceId: "--bbm-tops-list-meta-col", order: 33, role: "metaColumn" }),
-]);
-
-const protokollListElements = [
-  element({ id: "protokoll.list.root", name: "Protokoll-Listenbereich", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: [], componentKind: "sheetScrollOwner" }),
-  element({ id: "protokoll.list.canvas", name: "Protokoll-Dokumentfläche", type: "area", role: "contentArea", parentId: "protokoll.list.root", order: 10, allowedOps: [], componentKind: "documentCanvas" }),
-  element({ id: "protokoll.list.paper", name: "Protokoll-Dokumentblatt", type: "group", role: "layoutGroup", parentId: "protokoll.list.canvas", order: 20, allowedOps: [], componentKind: "documentPaper" }),
-  element({ id: "protokoll.list.table", name: "Protokoll-TOP-Liste", type: "group", role: "contentTable", parentId: "protokoll.list.paper", order: 30, allowedOps: [], componentKind: "existingContentTable" }),
-  ...protokollListColumns.map((column) => element({ id: column.id, name: column.name, type: "group", role: column.role, parentId: "protokoll.list.table", order: column.order, allowedOps: PROTOKOLL_COLUMN_LAYOUT, columnRole: column.role, componentKind: "logicalColumn", baseline: { width: column.currentWidth, minWidth: column.minimumWidth, maxWidth: column.maximumWidth } })),
-];
-
-const protokollEditElements = [
-  element({ id: "protokoll.edit.root", name: "Protokoll-Eingabebereich", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: ZONE_HEIGHT_LAYOUT, componentKind: "fixedEditArea", baseline: { width: 940, height: 300, minWidth: 320, maxWidth: 1880, minHeight: 160, maxHeight: 720 } }),
-  element({ id: "protokoll.edit.canvas", name: "Protokoll-Eingabefläche", type: "area", role: "formArea", parentId: "protokoll.edit.root", order: 10, allowedOps: [], componentKind: "editCanvas" }),
-  element({ id: "protokoll.edit.workbench", name: "Gruppe TOP-Bearbeitung", type: "group", role: "layoutGroup", parentId: "protokoll.edit.canvas", order: 20, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "workbench" }),
-  element({ id: "protokoll.edit.header", name: "Gruppe TOP-Bearbeitungskopf", type: "group", role: "layoutGroup", parentId: "protokoll.edit.workbench", order: 30, allowedOps: GROUP_LAYOUT, componentKind: "header" }),
-  element({ id: "protokoll.edit.header.label", name: "Bezeichnung TOP bearbeiten", type: "label", role: "fieldLabel", parentId: "protokoll.edit.header", order: 31, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "protokoll.edit.text", name: "Gruppe Textbearbeitung", type: "group", role: "fieldCollection", parentId: "protokoll.edit.workbench", order: 40, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "editbox" }),
-  element({ id: "protokoll.edit.short", name: "Gruppe Kurztext", type: "fieldGroup", role: "formFieldGroup", parentId: "protokoll.edit.text", order: 41, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "fieldGroup" }),
-  element({ id: "protokoll.edit.short.label", name: "Bezeichnung Kurztext", type: "label", role: "fieldLabel", parentId: "protokoll.edit.short", order: 42, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "protokoll.edit.short.field", name: "Eingabefeld Kurztext", type: "field", role: "dataFieldLayout", parentId: "protokoll.edit.short", order: 43, allowedOps: FIELD_LAYOUT, fieldKind: "text", componentKind: "input" }),
-  element({ id: "protokoll.edit.long", name: "Gruppe Langtext", type: "fieldGroup", role: "formFieldGroup", parentId: "protokoll.edit.text", order: 50, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "fieldGroup" }),
-  element({ id: "protokoll.edit.long.label", name: "Bezeichnung Langtext", type: "label", role: "fieldLabel", parentId: "protokoll.edit.long", order: 51, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-  element({ id: "protokoll.edit.long.field", name: "Eingabefeld Langtext", type: "field", role: "dataFieldLayout", parentId: "protokoll.edit.long", order: 52, allowedOps: FIELD_LAYOUT, fieldKind: "multilineText", componentKind: "textarea" }),
-  element({ id: "protokoll.edit.meta", name: "Gruppe Status und Zuordnung", type: "group", role: "fieldCollection", parentId: "protokoll.edit.workbench", order: 60, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "metaPanel" }),
-  element({ id: "protokoll.edit.flags", name: "Gruppe Kennzeichnungen", type: "group", role: "layoutGroup", parentId: "protokoll.edit.meta", order: 61, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "flagGroup" }),
-  ...[
-    ["status", "Status", "select", 70],
-    ["due", "Fertig bis", "date", 80],
-    ["responsible", "Verantwortlich", "select", 90],
-  ].flatMap(([key, name, fieldKind, order]) => [
-    element({ id: `protokoll.edit.${key}`, name: `Gruppe ${name}`, type: "fieldGroup", role: "formFieldGroup", parentId: "protokoll.edit.meta", order, allowedOps: PROTOKOLL_GROUP_LAYOUT, componentKind: "fieldGroup" }),
-    element({ id: `protokoll.edit.${key}.label`, name: `Bezeichnung ${name}`, type: "label", role: "fieldLabel", parentId: `protokoll.edit.${key}`, order: order + 1, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
-    element({ id: `protokoll.edit.${key}.field`, name: `Eingabefeld ${name}`, type: "field", role: "dataFieldLayout", parentId: `protokoll.edit.${key}`, order: order + 2, allowedOps: FIELD_LAYOUT, fieldKind, componentKind: fieldKind === "date" ? "dateInput" : "select" }),
-  ]),
-  element({ id: "protokoll.edit.ampel", name: "Statussymbol Ampel", type: "statusIndicator", role: "status", parentId: "protokoll.edit.meta", order: 100, allowedOps: ICON_LAYOUT, componentKind: "statusIndicator" }),
-];
 
 export const BBM_M80_ACTIVE_SCOPES = Object.freeze([
-  "restarbeiten.header.root",
-  "restarbeiten.list.root",
-  "restarbeiten.edit.root",
-  "protokoll.screen.root",
-  "protokoll.list.root",
-  "protokoll.edit.root",
+  "restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root",
+  "protokoll.screen.root", "protokoll.list.root", "protokoll.edit.root",
 ]);
 
 export const BBM_M80_ACTIVE_SCOPE_GROUPS = Object.freeze([
@@ -308,12 +50,7 @@ export const BBM_M80_ACTIVE_SCOPE_GROUPS = Object.freeze([
 ]);
 
 export const BBM_M80_REGISTRY_SCOPES = Object.freeze([
-  completeScope("restarbeiten.header.root", headerElements),
-  completeScope("restarbeiten.list.root", listElements),
-  completeScope("restarbeiten.edit.root", editElements),
-  completeScope("protokoll.screen.root", protokollScreenElements),
-  completeScope("protokoll.list.root", protokollListElements),
-  completeScope("protokoll.edit.root", protokollEditElements),
+  ...BBM_M80_ACTIVE_SCOPES.map(completeScope),
   blockedScope("bbm.shell", "Shell und Hauptnavigation"),
   blockedScope("bbm.home", "Start"),
   blockedScope("bbm.projects", "Projektverwaltung"),
@@ -329,14 +66,33 @@ export const BBM_M80_REGISTRY_SCOPES = Object.freeze([
   blockedScope("restarbeiten.output-preview", "Restarbeiten · Ausgabevorschau", "M81_pdf_excluded"),
 ]);
 
-const entries = new Map(BBM_M80_REGISTRY_SCOPES.flatMap((scope) => scope.elements).map((entry) => [entry.id, entry]));
+const entries = new Map(aggregate.elements.map((entry) => [entry.id, entry]));
+const components = new Map(aggregate.components.map((component) => [component.componentId, component]));
 
-export function getM80RegistryEntry(id) { return entries.get(String(id || "")) || null; }
+export function getM80RegistryEntry(id) {
+  return entries.get(String(id || "")) || null;
+}
+
+export function getM83ComponentContract(componentId) {
+  return components.get(String(componentId || "")) || null;
+}
+
+export function listM83ComponentContracts() {
+  return [...aggregate.components];
+}
+
 export function listM80RegistryScopes() {
   return BBM_M80_REGISTRY_SCOPES.map((scope) => ({
     ...scope,
+    componentIds: [...(scope.componentIds || [])],
     expectedElementIds: [...scope.expectedElementIds],
-    elements: scope.elements.map((entry) => ({ ...entry, baseline: { ...entry.baseline, spacing: { ...(entry.baseline?.spacing || {}) } }, spacingTargets: [...(entry.spacingTargets || [])], allowedOps: [...entry.allowedOps], lockedOps: [...entry.lockedOps] })),
+    elements: scope.elements.map((entry) => ({
+      ...entry,
+      baseline: { ...entry.baseline, spacing: { ...(entry.baseline?.spacing || {}) } },
+      spacingTargets: [...(entry.spacingTargets || [])],
+      allowedOps: [...entry.allowedOps],
+      lockedOps: [...entry.lockedOps],
+    })),
   }));
 }
 

--- a/src/renderer/ui-editor/m83ComponentContract.js
+++ b/src/renderer/ui-editor/m83ComponentContract.js
@@ -1,0 +1,114 @@
+import {
+  aggregateUiComponentContracts,
+  validateUiComponentContracts,
+} from "../../../node_modules/ui-editor-kit/dist/ui-component-contract.mjs";
+
+export const BBM_M83_SUPPORTED_OPERATIONS = Object.freeze([
+  "move", "resize", "resizeWidth", "resizeHeight", "textMove", "textResize", "setVisibility",
+  "spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset",
+  "fitTableToViewport", "resizeColumnsProportionally", "setHorizontalOverflowMode",
+  "setColumnWidthMode", "setColumnWrapMode", "setColumnOverflowMode", "setRowHeightMode",
+  "resetTableColumn", "resetTable",
+]);
+
+export const GROUP_LAYOUT = Object.freeze(["move", "setVisibility"]);
+export const ZONE_HEIGHT_LAYOUT = Object.freeze(["resizeHeight", "setVisibility"]);
+export const TEXT_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "textResize", "setVisibility"]);
+export const COMPACT_TEXT_LAYOUT = Object.freeze(["move", "textResize", "setVisibility"]);
+export const FIELD_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "textResize", "setVisibility"]);
+export const BUTTON_LAYOUT = Object.freeze(["move", "resizeWidth", "resizeHeight", "setVisibility"]);
+export const ICON_LAYOUT = Object.freeze(["resizeWidth", "resizeHeight", "setVisibility"]);
+export const TABLE_LAYOUT = Object.freeze(["resizeHeight", "setVisibility", "fitTableToViewport", "resizeColumnsProportionally", "setRowHeightMode", "resetTable"]);
+export const COLUMN_LAYOUT = Object.freeze(["resizeWidth", "textResize", "setVisibility", "setColumnWidthMode", "setColumnWrapMode", "setColumnOverflowMode", "resetTableColumn"]);
+export const SPACING_LAYOUT = Object.freeze(["spacingIncrease", "spacingDecrease", "spacingSet", "spacingReset"]);
+export const DOMAIN_LOCKS = Object.freeze(["executeTargetAction", "modifyDomainData", "createRecord", "deleteRecord"]);
+
+export function defaultM83Baseline(values = {}) {
+  return Object.freeze({
+    x: 0, y: 0, width: 100, height: 24, textOffsetX: 0, textOffsetY: 0,
+    fontSize: 12, visible: true, spacing: {}, minWidth: 8, maxWidth: 2400, minHeight: 8, maxHeight: 1600,
+    ...values,
+  });
+}
+
+export function m83Element(values) {
+  const allowedOps = Object.freeze([...(values.allowedOps || [])]);
+  const selectionKind = values.selectionKind || ({
+    root: "layoutZone", area: "layoutZone", group: "group", fieldGroup: "group",
+    label: values.role === "status" ? "statusText" : "label", field: "field", button: "button",
+    componentPart: "icon", statusIndicator: "icon", table: "table", tableHeader: "tableHeader",
+    tableBody: "tableBody", tableRow: "tableRow", tableColumn: "column", tableHeaderCell: "tableHeaderCell",
+    tableDataCell: "tableDataCell", tableFooter: "tableFooter", tableViewport: "tableViewport",
+    horizontalScrollArea: "horizontalScrollArea",
+  }[values.type] || "element");
+  return Object.freeze({
+    visible: true,
+    editable: allowedOps.length > 0,
+    ...values,
+    stableIdSource: "declaration",
+    semanticKey: values.semanticKey || values.id,
+    registrationStatus: values.registrationStatus || (allowedOps.length > 0 ? "editorEnabled" : "editorContainer"),
+    refKey: values.refKey || values.id,
+    baseline: defaultM83Baseline(values.baseline),
+    selectionKind,
+    selectionLevels: Object.freeze([...(values.selectionLevels || [selectionKind])]),
+    spacingTargets: Object.freeze([...(values.spacingTargets || [])]),
+    operationEffects: Object.freeze({
+      ...Object.fromEntries(allowedOps.map((operation) => [operation,
+        selectionKind === "group" ? "groupWithChildren" : selectionKind === "layoutZone" ? "layoutZone" : "elementOnly"])),
+      ...(values.operationEffects || {}),
+    }),
+    operationAffectedIds: Object.freeze({ ...(values.operationAffectedIds || {}) }),
+    geometry: Object.freeze({ maximumStoredOffset: 2400, ...(values.geometry || {}) }),
+    allowedOps,
+    lockedOps: Object.freeze([...(values.lockedOps || [])]),
+  });
+}
+
+export function m83DomainButton(values) {
+  return m83Element({
+    ...values,
+    type: "button",
+    role: "domainActionLayout",
+    allowedOps: values.allowedOps || BUTTON_LAYOUT,
+    lockedOps: DOMAIN_LOCKS,
+    actionKind: values.actionKind || "domain",
+  });
+}
+
+export function m83Slot(slotId, element, options = {}) {
+  return Object.freeze({
+    slotId,
+    required: options.required !== false,
+    referenceKind: options.referenceKind || "single",
+    presence: options.presence || "always",
+    requirements: Object.freeze({
+      directSelection: element?.editable === true,
+      ...(options.requirements || {}),
+    }),
+    element,
+  });
+}
+
+export function m83Component({ componentId, scopeId, requiredSlots, slots }) {
+  return Object.freeze({
+    componentId,
+    scopeId,
+    requiredSlots: Object.freeze([...(requiredSlots || [])]),
+    slots: Object.freeze([...(slots || [])]),
+  });
+}
+
+export function aggregateBbmM83Components(components) {
+  const aggregate = aggregateUiComponentContracts(components);
+  const validation = validateUiComponentContracts({
+    components: aggregate.components,
+    registryElements: aggregate.elements,
+    supportedOperations: BBM_M83_SUPPORTED_OPERATIONS,
+  });
+  if (!validation.ok) {
+    const details = validation.errors.map((entry) => `${entry.code}: ${entry.componentId || "?"}/${entry.slotId || entry.elementId || "?"}`).join("; ");
+    throw Object.assign(new Error(`BBM-Komponentenvertrag unvollstaendig: ${details}`), { code: "component_contract_invalid", details: validation.errors });
+  }
+  return aggregate;
+}

--- a/ui-editor-target.json
+++ b/ui-editor-target.json
@@ -7,8 +7,8 @@
   "integrationMode": "existing-app",
   "contractVersion": "1.2",
   "adapterVersion": "1.2",
-  "registryVersion": 12,
-  "registryFingerprint": "sha256:4d0a4c27786d64e6c80cfe5d6e57c1c32da1193cda307553334e588e0606241e",
+  "registryVersion": 13,
+  "registryFingerprint": "sha256:244a24360305f44467a07f4d7239547d3717989ada19a1cc5864fb652cc749a4",
   "registryStatus": "incomplete",
   "activeScopes": [
     "restarbeiten.header.root",
@@ -48,7 +48,7 @@
   "transportProtocolVersion": "1.0",
   "scopes": [
     { "scopeId": "restarbeiten.header.root", "status": "complete", "reason": null, "elementCount": 31, "missingReferenceCount": 0 },
-    { "scopeId": "restarbeiten.list.root", "status": "complete", "reason": null, "elementCount": 23, "missingReferenceCount": 0 },
+    { "scopeId": "restarbeiten.list.root", "status": "complete", "reason": null, "elementCount": 32, "missingReferenceCount": 0 },
     { "scopeId": "restarbeiten.edit.root", "status": "complete", "reason": null, "elementCount": 53, "missingReferenceCount": 0 },
     { "scopeId": "protokoll.screen.root", "status": "complete", "reason": null, "elementCount": 25, "missingReferenceCount": 0 },
     { "scopeId": "protokoll.list.root", "status": "complete", "reason": null, "elementCount": 7, "missingReferenceCount": 0 },


### PR DESCRIPTION
M83.0 ersetzt nachträgliche Einzelregistrierungen durch komponentennahe Vollverträge für die offiziellen Restarbeiten- und Protokoll-Scopes. Enthalten sind Pflichtslots, stabile Einzel- und Multi-Refs, Registryaggregation, Guardrails sowie die vollständige Meta-Startspalte mit Nr., Datum und Klasse. Die sichtbare Abnahme einschließlich Multi-Ref, Save und automatischem Zweitstart-Restore ist dokumentiert. docs/licensing.md ist nicht Bestandteil des Commits. Commit: b8a237b66d1ae14aea668eba3187c7bc8ab9c032