### PR TITLE
M86.3 Editorstart und Protokoll-Bedienbarkeit vereinheitlichen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -27,6 +27,16 @@
   blauer Titelakzent, Teilnehmer 34/32/30/72/18 mm, Vorbemerkung 500 Zeichen
   und gemeinsame TOP-Baseline 13/65/22.
 
+### M86.3 – Einheitlicher Editor-Start und Protokoll-Metaspalte
+
+- Status: `[A] abgenommen`; automatisierte Guardrails und die vollständige isolierte lokale Electron-Sichtabnahme sind grün.
+- Protokoll bleibt ohne Sidebar; Restarbeiten verwendet nun ebenfalls den bestehenden modulgebundenen Router-Shellvertrag ohne Sidebar und stellt beim Modulwechsel den jeweiligen Zielzustand wieder her.
+- Der gemeinsame Header-Launcher `UI-Editor öffnen` wird nur bei explizitem DEV-Buildkanal erzeugt, erzeugt/prüft vor dem Öffnen die bestehende Registry und aktiviert danach den bestehenden Modulscope.
+- Die Protokoll-Metaspalte bleibt im vorhandenen Workbench-Grid rechts neben Kurz-/Langtext. Entfernt wurde ausschließlich der frühere vertikale Responsive-Fallback; Registry, Baselines, PDF und Fachlogik bleiben unverändert.
+- M86.3.1 beseitigt den dauerhaft blockierenden Registry-Statushinweis, macht ihn nicht-interzeptierend und entfernt ihn zeitgesteuert. Die vorhandene Quicklane ist bei kurzen Viewports kompakt, per Fokus erreichbar und erhält bei schmalen Breiten einen reservierten 64-Pixel-Bereich ohne Überdeckung.
+- Sichtbar geprüft wurden drei Zeilen, Level-1 ein/aus, Text und Restzeichen, Meta-Felder, alle vorhandenen Workbenchaktionen, Headerdialoge/Tabfolge, Listenende, Editor öffnen/fokussieren sowie 1920×1080, 1600×900, 1366×768 und manuelles Verkleinern/Vergrößern.
+- Restarbeiten bestand die Kurzregression mit ausgeblendeter Sidebar, bedienbarem Editorbutton und entferntem Statushinweis. `npm test` und `npm run test:node` sind jeweils 8/8 grün; Commit/Push/PR/Merge: keiner.
+
 ### M85.2 – Restarbeiten-PDF-Satzweg vervollständigen und verriegeln
 
 - Status: `[A] abgenommen`; Restarbeiten verwendet aus Vorschau und Drucken

--- a/docs/M86_3_EDITOR_START_UND_META_REPARATUR.md
+++ b/docs/M86_3_EDITOR_START_UND_META_REPARATUR.md
@@ -1,0 +1,85 @@
+# M86.3 – Einheitlicher Editor-Start und Protokoll-Metaspalte
+
+## Ziel und Abgrenzung
+
+Protokoll und Restarbeiten verwenden im Arbeitsbereich keinen linken Navigationsbereich. Die vorhandene rechte Protokoll-Quicklane bleibt dieselbe Komponente; M86.3.1 korrigiert nur ihre vorhandene CSS-Geometrie und Erreichbarkeit. Beide Header erhalten ausschließlich in DEV-Builds den gemeinsamen Button `UI-Editor öffnen`.
+
+Es wurden keine PDF-/Druckwege, Fachwerte, Fachaktionen, Datenbank- oder IPC-Fachwege geändert. Der Button ist kein Editorziel und ergänzt deshalb keine Registry, Komponentenvertrag, Parent-Ebene oder Editoroperation.
+
+## Sidebar
+
+- Protokoll behält seinen bestehenden lokalen Ausblend-/Wiederherstellungsweg.
+- Restarbeiten setzt den vorhandenen Router-Shellvertrag `hideSidebar: true`. Der Router stellt beim Wechsel in andere Module deren eigenen Sidebarzustand wieder her; es gibt keine globale oder dauerhafte Sidebar-Deaktivierung.
+- Der isolierte Restarbeiten-Acceptance-Installer mountet den Screen bewusst ohne den normalen Modulrouter. Er verwendet deshalb nun ebenfalls den vorhandenen Router-Aufruf `_setSidebarVisibility(false)`. Der produktive Modulvertrag und die Fachlogik bleiben unverändert.
+
+## Development-only Editorstart
+
+Der gemeinsame Helper prüft den expliziten Build-Kanal. Nur `DEV` erzeugt den Button; Stable-Builds erzeugen kein Button-Element und besitzen keinen aktivierten Header-Launcher.
+
+Ein Klick erstellt den vorhandenen M80-Registrierungsdeskriptor neu, prüft den aktuellen vollständigen Modulscope beim nativen Öffnen/Fokussieren und sendet danach den vorhandenen `scopeChanged`-Pfad. Dadurch bleibt die Reihenfolge Refresh vor Open/Fokus erhalten. Die Header übergeben ausschließlich bestehende Scopes: `protokoll.screen.root` bzw. `restarbeiten.header.root`; die jeweils anderen bereits gemounteten Modulscopes bleiben Teil der vorhandenen Registry.
+
+## Metaspalte Protokoll
+
+Ursache war ausschließlich die Responsive-Regel bei `max-width: 640px`, die das vorhandene dreispaltige Workbench-Grid auf eine Spalte reduzierte. Entfernt wurde nur dieser Fallback. Das vorhandene Grid bleibt `Text | Gutter | Meta`; Meta, Status, Ampel, Fertig-bis, Verantwortlich und Kennzeichnungen verwenden weiterhin die bestehende rechte Workbench-Spalte.
+
+IDs, Parents, Baselines, Bounds und M83-Komponentenverträge bleiben unverändert. Es entstand weder ein neuer Wrapper noch ein zusätzlicher Scrollcontainer.
+
+## M86.3.1 – Erreichbarkeit und Bedienbarkeit
+
+### Ursachenbefund
+
+Die vier gemeldeten Symptome hatten nicht vier getrennte Strukturfehler:
+
+- **Listeneinträge:** Im neutralen isolierten Protokollbestand war kein Listen- oder Hit-Test-Defekt reproduzierbar. `sheet` war bereits vor der Reparatur der einzige aktive vertikale Scrollbesitzer; erste und letzte vollständige Zeile waren per Mausrad erreichbar und anklickbar. Es gab keinen zweiten Scrollcontainer und keine Zeile lief hinter die Editbox.
+- **Headerbuttons:** Im Ausgangszustand lag keine transparente Headerfläche über den Aktionen. `Protokoll beenden`, `Schliessen` und der Development-Button bestanden bereits den Mittelpunkt-Hit-Test. Die Tab-Reihenfolge erreichte Schlagwort, Abschluss, Schließen und Editorstart.
+- **Editboxbuttons:** Hier bestanden zwei reale Störungen. Der Registry-Statushinweis des Editorstarts war ein dauerhaftes `position: fixed`-Element mit sehr hohem Z-Index und standardmäßig aktiven Pointer-Events; er lag über dem unteren rechten Workbench-Bereich. Zusätzlich überdeckte die aufgeklappte 64-Pixel-Quicklane bei schmalen Renderbreiten die rechte Hälfte von `Papierkorb`.
+- **Restzeichenanzeigen:** Kurz- und Langtextzähler waren im neutralen Baselinezustand vorhanden, innerhalb der Editbox und hit-testbar. Das gemeldete Fehlen war kein Zähler- oder Griddefekt. Die Bedienprüfung belegt die Aktualisierung beider Werte nach echter Texteingabe jeweils um `-1`.
+- **Quicklane:** In der großen Höhenstufe fehlten rechnerisch zwei Pixel Innenhöhe; bei kurzen Viewports war die unverkleinerte vertikale Lane zu hoch. Im aufgeklappten Zustand fehlte bei schmaler Breite ein reservierter rechter Screenbereich.
+- **Restarbeiten-Acceptance:** Die Sidebar blieb nur dort sichtbar, weil der isolierte Diagnose-Installer den normalen Modulrouter und damit `shell.hideSidebar` umgeht. Der normale produktive Restarbeiten-Modulweg war nicht betroffen.
+
+Gespeicherte UI-Editor-Werte waren nicht ursächlich: Im frischen isolierten Profil lagen keine gespeicherten Transformationen auf Screen, Header, Liste, Editbox, Workbench oder Metaspalte. Die sichtbare 13/65/22-Listenanordnung entsprach der Baseline.
+
+### Reparaturen
+
+- Der Registry-Hinweis erhält `pointer-events: none` und wird nach einem erfolgreichen Refresh nach 2,4 Sekunden, bei einem Fehler nach 6 Sekunden tatsächlich aus dem DOM entfernt.
+- Die Quicklane öffnet zusätzlich mit `:focus-within`. Ihre vorhandenen Buttons werden bei niedrigen Viewports über zwei reine CSS-Höhenstufen komprimiert; es gibt weiterhin keinen internen Scrollcontainer.
+- Die Grundhöhe der Lane wurde um die fehlenden zwei Pixel erweitert. Unter 1100 Pixel Rendererbreite reserviert der bestehende Protokollscreen mit `padding-inline-end: 64px` exakt die Lane-Breite. Dadurch überdeckt die aufgeklappte Lane weder Header noch Workbenchaktionen.
+- Der isolierte Restarbeiten-Installer blendet die Shell-Sidebar über den bereits vorhandenen Router-Lebenszyklus aus.
+- Der bestehende Integrationstest verlangt nun ausdrücklich alle drei Quicklane-Öffnungszustände: Hover, `:focus-within` und `data-open`.
+
+Unverändert blieben DOM-Hierarchie, Parent-/Child-Struktur, Workbench-Grid `Text | Gutter | Meta`, Listen-Scrollstruktur, 13/65/22, Registryelemente, IDs, Refs, Baselines, Bounds, Editoroperationen, Fachlogik und PDF-/Druckwege.
+
+### Sichtabnahme
+
+Die Prüfung lief in echten lokalen Electron-Fenstern mit einem je Lauf frisch erzeugten, markierten und anschließend gelöschten Acceptance-Profil. Die Zielgrößen wurden unter dem realen lokalen Device-Scale-Faktor als entsprechende Renderer-Viewports geprüft:
+
+| Zielauflösung | Renderer-Viewport | Ergebnis |
+| --- | --- | --- |
+| 1920 × 1080 | 1155 × 575 | Header, Editbox, beide Zähler und alle sichtbaren Buttons hit-testbar; Listenanfang/-ende erreichbar; Quicklane 456/456 px ohne Überlauf |
+| 1600 × 900 | 962 × 467 | wie oben; Quicklane 386/386 px, reservierter rechter Bereich verhindert Überdeckung |
+| 1366 × 768 | 822 × 388 | wie oben; Quicklane 318/318 px, keine Überdeckung und kein horizontaler Scroll |
+
+Zusätzlich wurde von 900 × 430 wieder auf 962 × 467 vergrößert; beide Zustände blieben ohne horizontalen Dokumentüberlauf.
+
+Tatsächlich bedient wurden:
+
+- drei unterschiedliche Listenzeilen (`2.1`, `2.2`, `2.6`), Level-1 ein- und ausgeklappt sowie per Mausrad bis zum letzten Eintrag gescrollt;
+- der Level-1-Schalter nach fünf echten `Tab`-Schritten fokussiert, mit `PageDown` den Listenbereich gescrollt und über Klicks in die native Scrollbar-Spur das vollständig sichtbare, hit-testbare Listenende erreicht;
+- Kurztext und Langtext mit je einem eingegebenen Zeichen, beide Restzeichenzähler, Status, Termin, Verantwortlich sowie Wichtig/ToDo/Beschluss;
+- `+TOP`, `+Titel`, `Schieben` an/aus, `Papierkorb` nur für die zuvor im isolierten Profil erzeugten Testeinträge und `Rückgängig`;
+- Schlagwortdialog, `Protokoll beenden` mit sicherem `Abbrechen`, `Schliessen`/Rücksprung sowie die Tab-Navigation durch alle Headeraktionen;
+- Protokoll-Editorbutton zum Öffnen und ein zweites Mal zum Fokussieren. Genau ein `UiEditorManager` lief; der nicht blockierende Statushinweis verschwand und der Protokollscreen blieb danach bedienbar;
+- Restarbeiten-Editorbutton zum Öffnen und Fokussieren. Sidebar blieb ausgeblendet, Statushinweis verschwand und der Screen blieb bedienbar.
+
+### Automatisierte Prüfung
+
+Automatisiert sichern der M86.3-Guardrail sowie die bestehenden Restarbeiten-/Protokoll-, Launcher-, M83- und Vertragsprüfungen Sidebarvertrag, DEV/STABLE-Gating, Refresh-vor-Scope-Aktivierung, dreispaltige Meta-Anordnung, Quicklane-Fokus, Pointer-Verhalten und den einzigen Scrollbesitzer.
+
+- Gezielte Protokoll-, Workbench-/Header-, M86.3-, Restarbeiten-, M83-, Registry-, Selection- und Harness-Tests: grün.
+- `npm test`: 8/8 Gruppen grün.
+- `npm run test:node`: 8/8 Gruppen grün.
+- `scripts/ui-editor-contract-check.cjs` für die fünf geänderten UI-JavaScript-Dateien: 0 Fehler, keine neuen editorrelevanten Elemente.
+- Gezieltes ESLint aller geänderten JavaScript-Dateien: grün.
+- `git diff --check`: grün.
+
+M86.3 ist damit `[A] abgenommen`.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -71,6 +71,13 @@ Aktueller Stand:
 - [x] M63B M51/M52-Auswahl read-only an EditorScopeInspector anbinden
 - [x] M63C Kleine Layout-Bedienkonsole fuer ausgewaehltes Element
 - [x] M80.2 Restarbeiten-Header und Editbox direkt editierbar; Split gesperrt, Liste flexibel
+- [x] M86.3 Einheitlicher Editor-Start und Protokoll-Metaspalte reparieren
+
+## Statusupdate M86.3
+
+- Status: `[A] abgenommen`; automatisierte Guardrails und die vollständige isolierte lokale Electron-Abnahme für Protokoll und Restarbeiten sind grün.
+- Der gemeinsame DEV-Launcher bleibt außerhalb der Registry. Es wurden keine IDs, Parents, Baselines, Bounds oder erlaubten Operationen geändert.
+- M86.3.1 entfernt den nicht-interaktiven Registry-Hinweis zeitgesteuert, hält die bestehende Quicklane bei allen drei Zielgrößen erreichbar und reserviert bei schmalen Viewports ihre vorhandene Breite ohne neue DOM- oder Scrollstruktur.
 
 ## Statusupdate M80.2
 

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -160,6 +160,7 @@ const TEST_GROUPS = Object.freeze([
       ["m82-7-4AmpelEditing.test.cjs", "runM8274AmpelEditingTests"],
       ["m82-7-5LayoutPersistenceMetaElements.test.cjs", "runM8275LayoutPersistenceMetaElementsTests"],
       ["m83-0ComponentContracts.test.cjs", "runM830ComponentContractTests"],
+      ["m86-3EditorStartMetaRepair.test.cjs", "runM863EditorStartMetaRepairTests"],
       ["uiEditorAcceptanceIsolation.test.cjs", "runUiEditorAcceptanceIsolationTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),

--- a/scripts/tests/_diffGuardAllowances.cjs
+++ b/scripts/tests/_diffGuardAllowances.cjs
@@ -1,6 +1,7 @@
 const ALLOWED_PROTOKOLL_UI_DIFFS = new Set([
   "src/renderer/modules/protokoll/TopsScreenQuicklane.js",
   "src/renderer/modules/protokoll/TopsList.js",
+  "src/renderer/modules/protokoll/TopsHeader.js",
   "src/renderer/modules/protokoll/screens/TopsScreen.js",
   "src/renderer/modules/protokoll/styles/tops.css",
   "src/renderer/modules/protokoll/uiEditor/protokollUiElements.js",

--- a/scripts/tests/editorV2Registry.test.cjs
+++ b/scripts/tests/editorV2Registry.test.cjs
@@ -223,6 +223,7 @@ async function runEditorV2RegistryTests(run) {
   const allowedProtokollUiDiffs = new Set([
     "src/renderer/modules/protokoll/TopsScreenQuicklane.js",
     "src/renderer/modules/protokoll/TopsList.js",
+    "src/renderer/modules/protokoll/TopsHeader.js",
     "src/renderer/modules/protokoll/screens/TopsScreen.js",
     "src/renderer/modules/protokoll/styles/tops.css",
     "src/renderer/modules/protokoll/uiEditor/protokollUiElements.js",

--- a/scripts/tests/editorV2Selection.test.cjs
+++ b/scripts/tests/editorV2Selection.test.cjs
@@ -279,6 +279,7 @@ async function runEditorV2SelectionTests(run) {
   const allowedProtokollUiDiffs = new Set([
     "src/renderer/modules/protokoll/TopsScreenQuicklane.js",
     "src/renderer/modules/protokoll/TopsList.js",
+    "src/renderer/modules/protokoll/TopsHeader.js",
     "src/renderer/modules/protokoll/screens/TopsScreen.js",
     "src/renderer/modules/protokoll/styles/tops.css",
     "src/renderer/modules/protokoll/uiEditor/protokollUiElements.js",

--- a/scripts/tests/m86-3EditorStartMetaRepair.test.cjs
+++ b/scripts/tests/m86-3EditorStartMetaRepair.test.cjs
@@ -1,0 +1,111 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const ROOT = path.resolve(__dirname, "../..");
+const read = (file) => fs.readFileSync(path.join(ROOT, file), "utf8");
+
+function createFakeButtonDocument() {
+  const makeNode = () => ({
+    children: [], style: {}, attributes: {}, textContent: "", type: "", className: "", disabled: false,
+    appendChild(child) { this.children.push(child); return child; },
+    setAttribute(name, value) { this.attributes[name] = String(value); },
+    getAttribute(name) { return this.attributes[name] || null; },
+    addEventListener(type, listener) { this.listeners ||= {}; this.listeners[type] = listener; },
+    querySelector(selector) {
+      return this.children.find((child) => selector === '[data-bbm-development-ui-editor-open="true"]' && child.getAttribute?.("data-bbm-development-ui-editor-open") === "true") || null;
+    },
+  });
+  return { createElement: () => makeNode() };
+}
+
+async function runM863EditorStartMetaRepairTests(run) {
+  await run("M86.3 Sidebar: Restarbeiten nutzt den bestehenden modulgebundenen Sidebar-Lebenszyklus", () => {
+    assert.match(read("src/renderer/modules/restarbeiten/index.js"), /hideSidebar:\s*true/);
+    const router = read("src/renderer/app/Router.js");
+    assert.match(router, /this\._setSidebarVisibility\(!hideSidebar\)/);
+    assert.match(router, /sidebar\.style\.display\s*=\s*isVisible\s*\?\s*"flex"\s*:\s*"none"/);
+  });
+
+  await run("M86.3 Editorstart: gemeinsamer DEV-Launcher öffnet nach Registry-Refresh und aktiviert den expliziten Scope", async () => {
+    const navigation = await importEsmFromFile(path.join(ROOT, "src/renderer/app/coreShellNavigation.js"));
+    assert.equal(await navigation.isDevelopmentUiEditorBuild({ api: { appGetBuildChannel: async () => ({ ok: true, channel: "DEV" }) } }), true);
+    assert.equal(await navigation.isDevelopmentUiEditorBuild({ api: { appGetBuildChannel: async () => ({ ok: true, channel: "STABLE" }) } }), false);
+
+    const doc = createFakeButtonDocument();
+    const host = doc.createElement("div");
+    const button = await navigation.installDevelopmentUiEditorOpenButton({
+      host, scopeId: "protokoll.screen.root", doc,
+      buildApi: { appGetBuildChannel: async () => ({ ok: true, channel: "DEV" }) },
+    });
+    assert.equal(button.textContent, "UI-Editor öffnen");
+    assert.equal(button.getAttribute("data-bbm-development-ui-editor-open"), "true");
+    assert.equal(typeof button.listeners.click, "function");
+    const hidden = await navigation.installDevelopmentUiEditorOpenButton({
+      host: doc.createElement("div"), scopeId: "restarbeiten.header.root", doc,
+      buildApi: { appGetBuildChannel: async () => ({ ok: true, channel: "STABLE" }) },
+    });
+    assert.equal(hidden, null);
+
+    const source = read("src/renderer/app/coreShellNavigation.js");
+    assert.ok(source.indexOf("const result = await api.open(registration);") < source.indexOf('action: "scopeChanged"'));
+    assert.match(source, /scopeId:\s*activeScopeId/);
+  });
+
+  await run("M86.3 Module: beide Header verwenden dieselbe nicht editorregistrierte Entwicklungsaktion", () => {
+    const protokollHeader = read("src/renderer/modules/protokoll/TopsHeader.js");
+    const restarbeitenHeader = read("src/renderer/modules/restarbeiten/RestarbeitenFilterbar.js");
+    for (const source of [protokollHeader, restarbeitenHeader]) assert.match(source, /installDevelopmentUiEditorOpenButton/);
+    assert.match(protokollHeader, /scopeId:\s*"protokoll\.screen\.root"/);
+    assert.match(restarbeitenHeader, /scopeId:\s*"restarbeiten\.header\.root"/);
+    assert.doesNotMatch(protokollHeader, /data-ui-editor-id.*UI-Editor/);
+    assert.doesNotMatch(restarbeitenHeader, /data-ui-editor-id.*UI-Editor/);
+  });
+
+  await run("M86.3 Workbench: die rechte Meta-Spalte bleibt auch unterhalb des alten Responsive-Breakpoints im bestehenden Grid", () => {
+    const css = read("src/renderer/modules/protokoll/styles/tops.css");
+    assert.match(css, /grid-template-columns:\s*minmax\(0, 1fr\) clamp\(12px, 2\.2vw, 30px\) minmax\(180px, 214px\)/);
+    assert.doesNotMatch(css, /@media \(max-width: 640px\)[\s\S]*?\.bbm-tops-workbench-body\s*\{\s*grid-template-columns:\s*1fr/s);
+  });
+
+  await run("M86.3.1 Erreichbarkeit: Statushinweis blockiert keine Ziel-App und wird entfernt", () => {
+    const navigation = read("src/renderer/app/coreShellNavigation.js");
+    assert.match(navigation, /data-bbm-ui-editor-registry-status/);
+    assert.match(navigation, /pointer-events:none/);
+    assert.match(navigation, /state !== "checking"/);
+    assert.match(navigation, /status\.remove\?\.\(\)/);
+  });
+
+  await run("M86.3.1 Erreichbarkeit: kurzer Viewport komprimiert nur die bestehende Quicklane", () => {
+    const css = read("src/renderer/modules/protokoll/styles/tops.css");
+    assert.match(css, /@media \(max-width: 1100px\)[\s\S]*?\[data-bbm-tops-screen="true"\]\s*\{[\s\S]*?padding-inline-end:\s*64px/s);
+    assert.match(css, /\.bbm-tops-screen-quicklane\s*\{[\s\S]*?inset-block-start:\s*102px/s);
+    assert.match(css, /\.bbm-tops-screen-quicklane:focus-within/);
+    assert.match(css, /@media \(max-height: 520px\)[\s\S]*?inset-block-start:\s*72px[\s\S]*?\.bbm-tops-screen-quicklane__button\s*\{[\s\S]*?inline-size:\s*28px[\s\S]*?block-size:\s*28px/s);
+    assert.match(css, /@media \(max-height: 420px\)[\s\S]*?inset-block-start:\s*69px[\s\S]*?inset-block-end:\s*0[\s\S]*?\.bbm-tops-screen-quicklane__button\s*\{[\s\S]*?inline-size:\s*22px[\s\S]*?block-size:\s*22px/s);
+    assert.doesNotMatch(css, /\.bbm-tops-screen-quicklane[^{]*\{[^}]*overflow-y:\s*(auto|scroll)/s);
+  });
+
+  await run("M86.3.1 Erreichbarkeit: Liste bleibt einziger aktiver Protokoll-Scrollbesitzer", () => {
+    const css = read("src/renderer/modules/protokoll/styles/tops.css");
+    assert.match(css, /\[data-bbm-tops-screen-area="sheet"\]\s*\{[\s\S]*?min-height:\s*0[\s\S]*?overflow:\s*auto/s);
+    assert.match(css, /\[data-bbm-tops-screen-area="edit"\]\s*\{[\s\S]*?flex:\s*0 0 auto/s);
+    assert.doesNotMatch(css, /\.bbm-tops-workbench\s*\{[^}]*overflow-y:\s*(auto|scroll)/s);
+  });
+
+  await run("M86.3.1 Restarbeiten-Acceptance blendet die Shell-Sidebar ueber den vorhandenen Router aus", () => {
+    const diagnostic = read("src/renderer/ui-editor/m80Diagnostic.js");
+    assert.match(diagnostic, /if \(module === "protokoll"\)[\s\S]*?router\._setSidebarVisibility\?\.\(false\)/s);
+  });
+}
+
+if (require.main === module) {
+  runM863EditorStartMetaRepairTests(async (_name, fn) => fn()).then(() => {
+    if (!process.exitCode) console.log("m86-3EditorStartMetaRepair.test.cjs passed");
+  }).catch((error) => { console.error(error); process.exitCode = 1; });
+}
+
+module.exports = { runM863EditorStartMetaRepairTests };

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -404,7 +404,7 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(entry.moduleLabel, "Restarbeiten");
     assert.equal(entry.workScreenId, "restarbeitenWork");
     assert.equal(entry.navigation.project[0].key, "restarbeiten");
-    assert.equal(entry.shell.hideSidebar, false);
+    assert.equal(entry.shell.hideSidebar, true);
     assert.equal(typeof screenResolver.resolveModuleWorkScreenFromEntry(entry), "function");
   });
 
@@ -432,7 +432,7 @@ async function runRestarbeitenModuleTests(run) {
     const rendered = await renderRouteScreen();
     const text = collectText(rendered.root);
     assert.equal(rendered.pageTitle, "Restarbeiten");
-    assert.equal(rendered.sidebarVisible, true);
+    assert.equal(rendered.sidebarVisible, false);
     assert.equal(text.includes("Restarbeitenliste wird neu aufgebaut."), false);
     assert.equal(text.includes("Verortung"), false);
     assert.equal(text.includes("Tuer einstellen"), true);

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 116, "116 Suite-Einstiege einschließlich M86.2.2-Acceptance-Seeder");
+    assert.equal(suites.length, 117, "117 Suite-Einstiege einschließlich M86.3-Editorstartreparatur");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/scripts/tests/topsScreen.integration.test.cjs
+++ b/scripts/tests/topsScreen.integration.test.cjs
@@ -1403,7 +1403,10 @@ async function runTopsScreenIntegrationTests(run) {
       );
       assert.match(topsCss, /\.bbm-tops-screen-quicklane\s*\{[\s\S]*inline-size:\s*64px;/);
       assert.match(topsCss, /\.bbm-tops-screen-quicklane\s*\{[\s\S]*transform:\s*translateX\(46px\);/);
-      assert.match(topsCss, /\.bbm-tops-screen-quicklane:hover,\s*\.bbm-tops-screen-quicklane\[data-open="true"\]/);
+      assert.match(
+        topsCss,
+        /\.bbm-tops-screen-quicklane:hover,\s*\.bbm-tops-screen-quicklane:focus-within,\s*\.bbm-tops-screen-quicklane\[data-open="true"\]/
+      );
 
       for (const id of [
         "protokoll.topsScreen.quicklane.group.navigation",

--- a/src/renderer/app/coreShellNavigation.js
+++ b/src/renderer/app/coreShellNavigation.js
@@ -1,23 +1,50 @@
 import { createM80RegistrationDescriptor } from "../ui-editor/m80HostAdapter.js";
 
+const REGISTRY_STATUS_SUCCESS_DURATION_MS = 2400;
+const REGISTRY_STATUS_ERROR_DURATION_MS = 6000;
+let registryStatusRemovalTimer = null;
+
 function showRegistryRefreshStatus(message, state = "checking") {
   const doc = globalThis.document;
   if (!doc?.body || typeof doc.createElement !== "function") return;
+  if (registryStatusRemovalTimer) {
+    clearTimeout(registryStatusRemovalTimer);
+    registryStatusRemovalTimer = null;
+  }
   let status = doc.querySelector?.("[data-bbm-ui-editor-registry-status]");
   if (!status) {
     status = doc.createElement("div");
     status.setAttribute("data-bbm-ui-editor-registry-status", "true");
     status.setAttribute("role", "status");
     status.setAttribute("aria-live", "polite");
-    status.style.cssText = "position:fixed;right:18px;bottom:18px;z-index:2147482000;padding:9px 12px;border-radius:8px;background:#172033;color:#fff;box-shadow:0 8px 24px rgba(15,23,42,.24);font:600 12px/1.3 system-ui,sans-serif";
+    status.style.cssText = "position:fixed;right:18px;bottom:18px;z-index:2147482000;pointer-events:none;padding:9px 12px;border-radius:8px;background:#172033;color:#fff;box-shadow:0 8px 24px rgba(15,23,42,.24);font:600 12px/1.3 system-ui,sans-serif";
     doc.body.appendChild(status);
   }
   status.dataset.state = state;
   status.textContent = message;
+  if (state !== "checking") {
+    const duration = state === "blocked" ? REGISTRY_STATUS_ERROR_DURATION_MS : REGISTRY_STATUS_SUCCESS_DURATION_MS;
+    registryStatusRemovalTimer = setTimeout(() => {
+      status.remove?.();
+      registryStatusRemovalTimer = null;
+    }, duration);
+  }
+}
+
+export const DEVELOPMENT_UI_EDITOR_BUTTON_LABEL = "UI-Editor öffnen";
+
+export async function isDevelopmentUiEditorBuild({ api = globalThis.window?.bbmDb } = {}) {
+  if (typeof api?.appGetBuildChannel !== "function") return false;
+  try {
+    const result = await api.appGetBuildChannel();
+    return result?.ok === true && String(result?.channel || "").trim().toUpperCase() === "DEV";
+  } catch (_error) {
+    return false;
+  }
 }
 
 export async function openNativeUiEditor(context = {}) {
-  const api = window.uiEditor;
+  const api = context?.api || window.uiEditor;
   if (!api || typeof api.open !== "function") {
     alert("Der separate UI-Editor ist nicht installiert oder die sichere BBM-Brücke ist nicht verfügbar.");
     return { ok: false, errorCode: "electron_editor_not_installed" };
@@ -25,8 +52,17 @@ export async function openNativeUiEditor(context = {}) {
   if (typeof api.preparePdfContext === "function" && context?.projectId && context?.meetingId) {
     await api.preparePdfContext({ projectId: context?.projectId || null, meetingId: context?.meetingId || null });
   }
+  const registration = createM80RegistrationDescriptor();
+  const activeScopeId = String(context?.scopeId || "").trim();
+  if (activeScopeId && !registration.activeScopes.includes(activeScopeId)) {
+    const message = "Der UI-Editor kann für den aktuellen Entwicklungsbereich nicht geöffnet werden, weil der erwartete Scope nicht vollständig registriert ist.";
+    showRegistryRefreshStatus(message, "blocked");
+    alert(message);
+    return { ok: false, errorCode: "electron_editor_scope_not_active" };
+  }
+
   showRegistryRefreshStatus("UI-Registry wird geprüft …", "checking");
-  const result = await api.open(createM80RegistrationDescriptor());
+  const result = await api.open(registration);
   if (result?.ok) {
     showRegistryRefreshStatus(result.registryRefreshStatus === "changed" ? "UI-Registry aktualisiert." : "UI-Registry ist aktuell.", result.registryRefreshStatus || "current");
   } else {
@@ -35,7 +71,49 @@ export async function openNativeUiEditor(context = {}) {
   if (!result?.ok && result?.errorCode !== "electron_profile_user_cancelled") {
     alert(result?.message || "Der separate UI-Editor konnte nicht gestartet werden.");
   }
+
+  if (result?.ok && activeScopeId) {
+    const scopeResult = typeof api.sendTargetEvent === "function"
+      ? await api.sendTargetEvent({ action: "scopeChanged", scopeId: activeScopeId, registration })
+      : { ok: false, errorCode: "electron_editor_scope_activation_unavailable" };
+    if (!scopeResult?.ok) {
+      const message = "Der UI-Editor wurde geöffnet, aber der aktuelle Entwicklungsbereich konnte nicht aktiviert werden.";
+      showRegistryRefreshStatus(message, "blocked");
+      alert(message);
+      return { ok: false, errorCode: scopeResult?.errorCode || "electron_editor_scope_activation_failed" };
+    }
+  }
+
   return result;
+}
+
+export async function installDevelopmentUiEditorOpenButton({
+  host,
+  scopeId,
+  doc = globalThis.document,
+  buildApi = globalThis.window?.bbmDb,
+  uiEditorApi = globalThis.window?.uiEditor,
+} = {}) {
+  if (!host || !doc?.createElement || !await isDevelopmentUiEditorBuild({ api: buildApi })) return null;
+  if (host.querySelector?.('[data-bbm-development-ui-editor-open="true"]')) return null;
+
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.className = "bbm-development-ui-editor-open-button";
+  button.textContent = DEVELOPMENT_UI_EDITOR_BUTTON_LABEL;
+  button.setAttribute("data-bbm-development-ui-editor-open", "true");
+  button.style.cssText = "display:inline-flex;align-items:center;justify-content:center;min-height:28px;padding:4px 9px;border:1px solid #d3dfec;border-radius:7px;background:#f5f8fc;color:#1f344a;font:600 8.5pt/1.2 var(--bbm-font-ui,system-ui,sans-serif);white-space:nowrap;cursor:pointer;";
+  button.addEventListener("click", async () => {
+    if (button.disabled) return;
+    button.disabled = true;
+    try {
+      await openNativeUiEditor({ scopeId, api: uiEditorApi });
+    } finally {
+      button.disabled = false;
+    }
+  });
+  host.appendChild(button);
+  return button;
 }
 
 export function createCoreShellNavigationRouteDefs(router) {

--- a/src/renderer/modules/protokoll/TopsHeader.js
+++ b/src/renderer/modules/protokoll/TopsHeader.js
@@ -1,3 +1,5 @@
+import { installDevelopmentUiEditorOpenButton } from "../../app/coreShellNavigation.js";
+
 export class TopsHeader {
   constructor({
     onClose,
@@ -79,6 +81,10 @@ export class TopsHeader {
     };
 
     this.actionsWrap.append(this.btnEndMeeting, this.btnClose);
+    void installDevelopmentUiEditorOpenButton({
+      host: this.actionsWrap,
+      scopeId: "protokoll.screen.root",
+    });
     this.root.append(
       this.titleWrap,
       this.spacer,
@@ -106,7 +112,7 @@ export class TopsHeader {
     isBusy,
     canEditKeyword,
     showMetaLegend,
-    devLayoutMode,
+    devLayoutMode: _devLayoutMode,
   } = {}) {
     const busy = !!isBusy;
     const readOnly = !!isReadOnly;

--- a/src/renderer/modules/protokoll/styles/tops.css
+++ b/src/renderer/modules/protokoll/styles/tops.css
@@ -44,6 +44,12 @@
   font-family: var(--bbm-top-text-font-family);
 }
 
+@media (max-width: 1100px) {
+  [data-bbm-tops-screen="true"] {
+    padding-inline-end: 64px;
+  }
+}
+
 [data-bbm-tops-screen-area="sheet"] {
   flex: 1 1 auto;
   min-height: 0;
@@ -414,7 +420,7 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
 
 .bbm-tops-screen-quicklane {
   position: fixed;
-  inset-block-start: 104px;
+  inset-block-start: 102px;
   inset-inline-end: 0;
   inset-block-end: 16px;
   z-index: 12030;
@@ -436,6 +442,7 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
 }
 
 .bbm-tops-screen-quicklane:hover,
+.bbm-tops-screen-quicklane:focus-within,
 .bbm-tops-screen-quicklane[data-open="true"] {
   transform: translateX(0);
   border-color: rgba(29, 78, 216, 0.42);
@@ -592,6 +599,67 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
 .bbm-tops-screen-quicklane-filter-menu button[data-active="true"] {
   border-color: #93c5fd;
   background: #eff6ff;
+}
+
+@media (max-height: 520px) {
+  .bbm-tops-screen-quicklane {
+    inset-block-start: 72px;
+    inset-block-end: 8px;
+    gap: 4px;
+    padding-block: 4px;
+  }
+
+  .bbm-tops-screen-quicklane__group {
+    gap: 3px;
+    padding-block-end: 4px;
+  }
+
+  .bbm-tops-screen-quicklane__button {
+    inline-size: 28px;
+    block-size: 28px;
+  }
+
+  .bbm-tops-screen-quicklane-icon {
+    min-inline-size: 20px;
+    min-block-size: 20px;
+    font-size: 17px;
+  }
+
+  .bbm-tops-screen-quicklane-icon--ampel {
+    block-size: 26px;
+    min-block-size: 26px;
+  }
+}
+
+@media (max-height: 420px) {
+  .bbm-tops-screen-quicklane {
+    inset-block-start: 69px;
+    inset-block-end: 0;
+    gap: 3px;
+    padding-block: 3px;
+  }
+
+  .bbm-tops-screen-quicklane__group {
+    gap: 2px;
+    padding-block-end: 3px;
+  }
+
+  .bbm-tops-screen-quicklane__button {
+    inline-size: 22px;
+    block-size: 22px;
+    border-radius: 6px;
+  }
+
+  .bbm-tops-screen-quicklane-icon {
+    min-inline-size: 18px;
+    min-block-size: 18px;
+    font-size: 15px;
+  }
+
+  .bbm-tops-screen-quicklane-icon--ampel {
+    block-size: 20px;
+    min-block-size: 20px;
+  }
 }
 
 [data-bbm-tops-list-v2="true"] {
@@ -1524,14 +1592,6 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
 
   .bbm-tops-list-row-meta {
     grid-column: 1 / -1;
-  }
-
-  .bbm-tops-workbench-body {
-    grid-template-columns: 1fr;
-  }
-
-  .bbm-tops-workbench-gutter {
-    display: none;
   }
 
   .bbm-tops-meta-field-date .bbm-tops-input {

--- a/src/renderer/modules/restarbeiten/RestarbeitenFilterbar.js
+++ b/src/renderer/modules/restarbeiten/RestarbeitenFilterbar.js
@@ -1,5 +1,6 @@
 import { RESTARBEITEN_STATUS_OPTIONS } from "./domain/restarbeitenRules.js";
 import { beginM83ComponentBinding, registerM80Ref } from "../../ui-editor/m80Refs.js";
+import { installDevelopmentUiEditorOpenButton } from "../../app/coreShellNavigation.js";
 
 const DEFAULT_LOCATION_LABELS = ["Haus", "Geschoss", "Einheit", "Raum"];
 
@@ -153,6 +154,10 @@ export function buildRestarbeitenFilterbar({
   });
   registerM80Ref("restarbeiten.filterbar.actions", actions);
   actions.appendChild(closeBtn);
+  void installDevelopmentUiEditorOpenButton({
+    host: actions,
+    scopeId: "restarbeiten.header.root",
+  });
 
   root.append(locationGroup, classGroup, metaGroup, actions);
   registerM80Ref("restarbeiten.filterbar", root);

--- a/src/renderer/modules/restarbeiten/index.js
+++ b/src/renderer/modules/restarbeiten/index.js
@@ -33,7 +33,7 @@ export function getRestarbeitenModuleEntry() {
     screens: buildRestarbeitenModuleScreens(),
     navigation: buildRestarbeitenModuleNavigation(),
     shell: Object.freeze({
-      hideSidebar: false,
+      hideSidebar: true,
     }),
   });
 }

--- a/src/renderer/ui-editor/m80Diagnostic.js
+++ b/src/renderer/ui-editor/m80Diagnostic.js
@@ -37,6 +37,7 @@ export async function installBbmM80DiagnosticPilot({ router, module = "restarbei
 export async function installBbmM80DiagnosticModule({ router, module = "restarbeiten", isolatedAcceptance = false } = {}) {
   if (module === "protokoll") return installProtokollAcceptancePilot({ router, isolatedAcceptance });
   if (!router?.contentRoot) throw new Error("M80-Diagnose braucht den vorhandenen BBM-Inhaltsbereich.");
+  router._setSidebarVisibility?.(false);
   const screen = new RestarbeitenScreen({
     router: null,
     projectId: null,


### PR DESCRIPTION
M86.3 vereinheitlicht den Development-only Editorstart für Protokoll und Restarbeiten, hält beide Module ohne Sidebar und repariert die Bedienbarkeit im Protokoll. Enthalten sind der gemeinsame Header-Button „UI-Editor öffnen“ mit Registry-/Vertragsrefresh, die rechts neben Kurz-/Langtext verbleibende Metaspalte, ein klickdurchlässiger und zeitlich entfernter Registry-Hinweis, eine bei kleinen Viewports erreichbare Quicklane sowie die vollständige Erreichbarkeit von Liste, Header, Editbox und Restzeichen. Sichtbar geprüft wurden 1920×1080, 1600×900 und 1366×768. Keine PDF-Änderung, keine neue Registry, keine DOM-Hierarchie- oder Fachlogikänderung. `docs/licensing.md` und `design-reference/` sind nicht Bestandteil des Commits. Commit: `07c13dcd981793a36e8ed46403035ea8f3a76c8e`.