### PR TITLE
M86.4 blockierte Protokollaktionen nach Löschen freigeben

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -37,6 +37,20 @@
 - Sichtbar geprüft wurden drei Zeilen, Level-1 ein/aus, Text und Restzeichen, Meta-Felder, alle vorhandenen Workbenchaktionen, Headerdialoge/Tabfolge, Listenende, Editor öffnen/fokussieren sowie 1920×1080, 1600×900, 1366×768 und manuelles Verkleinern/Vergrößern.
 - Restarbeiten bestand die Kurzregression mit ausgeblendeter Sidebar, bedienbarem Editorbutton und entferntem Statushinweis. `npm test` und `npm run test:node` sind jeweils 8/8 grün; Commit/Push/PR/Merge: keiner.
 
+### M86.4 – Globaler Klickblocker
+
+- Status: `[A]`; der Fehler wurde auf dem unveränderten Ausgangsstand `ed2cbd2031f44a8df0dbbd78e440a75886ec175e` reproduziert und anschließend minimal repariert.
+- Reproduktion: Nach `TOP 2.6 wählen → +TOP → Schieben aktivieren → Papierkorb` blieb der gerenderte Protokollscreen im Schreibzustand. Header-, Workbench- und Quicklane-Aktionen trugen weiter `disabled`, obwohl der Store bereits `isWriting: false` enthielt. Der UI-Editor-Launcher blieb als getrennte Entwicklungsaktion enabled.
+- Ursache: `_handleWorkbenchDelete()` synchronisierte den Screen noch während `isWriting: true`; der `finally`-Block setzte nur den Store zurück. Ohne abschließendes `_syncScreenState()` blieb der DOM-Zustand veraltet. Es gab kein blockierendes Overlay, keinen verwaisten Backdrop, kein Root-`inert`, kein globales `pointer-events: none` und keinen dauerhaft abfangenden Capture-Listener.
+- Reparatur: Direkt nach `this.store.setState({ isWriting: false })` wird einmal der bestehende Screen-Synchronisationsweg aufgerufen. Registry, Komponentenverträge, IDs, Parent-Struktur, PDF und Fachlogik blieben unverändert.
+- Vorher traf `elementFromPoint` die betroffenen Buttons weiterhin, aber `disabled` verhinderte ihre Fachaktivierung; nachher treffen die Mittelpunkte von `UI-Editor öffnen`, `Protokoll beenden`, `+TOP`, `Papierkorb` und sichtbaren Listenzeilen jeweils den Button oder ein zulässiges Kind. Alle Ketten bis `HTML` sind sichtbar, nicht inert und haben `pointer-events: auto`.
+- Der unveränderte Acceptance-Launcher lief mit demselben isolierten Profil zweimal (`run 1/2 exit=0`, `run 2/2 exit=0`). In beiden Läufen bestand nach dem nativen Editorfokus der kritische Ablauf `Zeile → +TOP → Papierkorb`; die temporäre Wurzel wurde anschließend automatisch entfernt.
+- Die vollständige Protokoll-Bedienmatrix wurde nach Editorfokus bei 1920×1080, 1600×900 und 1366×768 wiederholt: Header, drei Listenzeilen, Status, Termin, Verantwortlich, +Titel, +TOP, Schieben, Papierkorb, Level-1 auf/zu, Abbruchdialog, Schließen und Quicklane. Die protokollierten Klicks waren vertrauenswürdig und nicht verhindert. `Rückgängig` wurde im nativen Editor nach einer reversiblen 1-DIP-Änderung ausgeführt.
+- Restarbeiten bestand bei denselben drei Viewports die Kurzregression mit UI-Editor, Filter, Listenzeile, `Neu` und Quicklane; nach Editorfokus blieben Root und Fachscreen ohne `inert` und ohne aktiven Backdrop.
+- Neuer Guardrail: `scripts/tests/m86-4GlobalClickBlocker.test.cjs` sichert den Schreibzustands-Lebenszyklus, Kernbutton-Hit-Tests, Registry-Hinweis, Hinweisentfernung, Dialog-/Backdrop-Grundzustand, Editorlauncher und Zwei-Start-/Restarbeiten-Regeln ab.
+- Prüfung: Protokoll-Integration, Restarbeiten-Modultest, M86.3, M83, `npm test` und `npm run test:node` jeweils 8/8, gezieltes ESLint ohne Fehler, UI-Editor-Vertragscheck und `git diff --check` grün. `docs/licensing.md` blieb unangetastet mit SHA-256 `02AE66A8873C74869539F13F734B7CE43BC63B6EF37DA553A40C27A4F514D784`.
+- Commit/Push/PR/Merge: keiner. Nächster offener Schritt: keiner für M86.4.
+
 ### M85.2 – Restarbeiten-PDF-Satzweg vervollständigen und verriegeln
 
 - Status: `[A] abgenommen`; Restarbeiten verwendet aus Vorschau und Drucken

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -72,6 +72,18 @@ Aktueller Stand:
 - [x] M63C Kleine Layout-Bedienkonsole fuer ausgewaehltes Element
 - [x] M80.2 Restarbeiten-Header und Editbox direkt editierbar; Split gesperrt, Liste flexibel
 - [x] M86.3 Einheitlicher Editor-Start und Protokoll-Metaspalte reparieren
+- [x] M86.4 Globalen Klickblocker reproduzieren und reparieren
+
+## Statusupdate M86.4
+
+- Status: `[A]`. Der flächige Klickausfall wurde auf dem unveränderten Main-Ausgangspunkt nach `TOP wählen → +TOP → Schieben → Papierkorb` reproduziert.
+- Blockierender Zustand war kein Overlay, Backdrop, Root-`inert`, globales `pointer-events: none` oder Editorfokus, sondern ein veralteter gerenderter `disabled`-Zustand: Der Store war nach dem Löschen bereits wieder bei `isWriting: false`, der Screen war danach aber nicht erneut synchronisiert worden.
+- `_handleWorkbenchDelete()` ruft nach dem Zurücksetzen des Schreibzustands jetzt den vorhandenen `_syncScreenState()`-Weg auf. Es wurden keine Registry-, Komponentenvertrags-, Parent-, ID-, UI-Struktur-, PDF- oder Fachlogikänderungen vorgenommen.
+- Der neue M86.4-Guardrail reproduzierte die fehlende Freigabesynchronisierung vor der Reparatur rot und prüft danach zusätzlich Kernbutton-Hit-Tests, Registry-Hinweis/Entfernung, Dialog-/Backdrop-Grundzustand, Editorlauncher sowie Zwei-Start-/Restarbeiten-Regeln.
+- Sichtprüfung: vollständige Protokollmatrix und Restarbeiten-Kurzregression nach nativem Editorfokus bei 1920×1080, 1600×900 und 1366×768. Alle erfassten Fachklicks waren vertrauenswürdig und nicht verhindert; `Rückgängig` wurde im nativen Editor praktisch ausgeführt.
+- Der vorgesehene zweifache Acceptance-Start lief mit demselben isolierten Profil zweimal mit Exit 0; beide Läufe bestanden `Zeile → +TOP → Papierkorb`, und die temporäre Profilwurzel wurde entfernt.
+- `npm test` und `npm run test:node` liefen jeweils 8/8 grün. Restarbeiten-, M86.3-, M83-, Vertrags-, ESLint- und Diff-Prüfungen sind grün. `docs/licensing.md` blieb mit dem verbindlichen Schutz-Hash unangetastet.
+- Commit/Push/PR/Merge: keiner. Für M86.4 ist kein weiterer Schritt offen.
 
 ## Statusupdate M86.3
 

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -161,6 +161,7 @@ const TEST_GROUPS = Object.freeze([
       ["m82-7-5LayoutPersistenceMetaElements.test.cjs", "runM8275LayoutPersistenceMetaElementsTests"],
       ["m83-0ComponentContracts.test.cjs", "runM830ComponentContractTests"],
       ["m86-3EditorStartMetaRepair.test.cjs", "runM863EditorStartMetaRepairTests"],
+      ["m86-4GlobalClickBlocker.test.cjs", "runM864GlobalClickBlockerTests"],
       ["uiEditorAcceptanceIsolation.test.cjs", "runUiEditorAcceptanceIsolationTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),

--- a/scripts/tests/m86-4GlobalClickBlocker.test.cjs
+++ b/scripts/tests/m86-4GlobalClickBlocker.test.cjs
@@ -1,0 +1,296 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const ROOT = path.resolve(__dirname, "../..");
+const read = (file) => fs.readFileSync(path.join(ROOT, file), "utf8");
+
+function createStore(initialState = {}) {
+  let state = { ...initialState };
+  return {
+    getState() {
+      return state;
+    },
+    setState(patch = {}) {
+      state = { ...state, ...patch };
+      return state;
+    },
+  };
+}
+
+function createFakeDocument() {
+  const body = {
+    children: [],
+    appendChild(node) {
+      node.parentElement = this;
+      this.children.push(node);
+      return node;
+    },
+    removeChild(node) {
+      const index = this.children.indexOf(node);
+      if (index >= 0) this.children.splice(index, 1);
+      node.parentElement = null;
+      return node;
+    },
+  };
+
+  const doc = {
+    body,
+    createElement(tagName) {
+      return {
+        tagName: String(tagName || "").toUpperCase(),
+        children: [],
+        dataset: {},
+        attributes: {},
+        style: { cssText: "" },
+        disabled: false,
+        appendChild(node) {
+          node.parentElement = this;
+          this.children.push(node);
+          return node;
+        },
+        setAttribute(name, value) {
+          this.attributes[name] = String(value);
+        },
+        getAttribute(name) {
+          return this.attributes[name] ?? null;
+        },
+        addEventListener(type, handler) {
+          this.listeners ||= {};
+          this.listeners[type] = handler;
+        },
+        remove() {
+          this.parentElement?.removeChild?.(this);
+        },
+        getBoundingClientRect() {
+          return this.rect || { left: 0, top: 0, width: 0, height: 0, right: 0, bottom: 0 };
+        },
+      };
+    },
+    querySelector(selector) {
+      if (selector !== "[data-bbm-ui-editor-registry-status]") return null;
+      return body.children.find((node) => node.getAttribute?.("data-bbm-ui-editor-registry-status") === "true") || null;
+    },
+    elementFromPoint(x, y) {
+      for (const node of [...body.children].reverse()) {
+        const rect = node.getBoundingClientRect?.() || {};
+        const inside = x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+        if (!inside || /pointer-events\s*:\s*none/i.test(node.style?.cssText || "")) continue;
+        if (String(node.style?.display || "") === "none") continue;
+        return node;
+      }
+      return null;
+    },
+  };
+  return doc;
+}
+
+function place(doc, node, left, top, width = 100, height = 28) {
+  node.rect = { left, top, width, height, right: left + width, bottom: top + height };
+  doc.body.appendChild(node);
+  return node;
+}
+
+function assertMidpointHit(doc, target) {
+  const rect = target.getBoundingClientRect();
+  assert.strictEqual(doc.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2), target);
+}
+
+async function runM864GlobalClickBlockerTests(run) {
+  const TopsScreen = (await importEsmFromFile(
+    path.join(ROOT, "src/renderer/modules/protokoll/screens/TopsScreen.js")
+  )).default;
+  const navigation = await importEsmFromFile(path.join(ROOT, "src/renderer/app/coreShellNavigation.js"));
+  const popupCommon = await importEsmFromFile(path.join(ROOT, "src/renderer/ui/popupCommon.js"));
+
+  await run("M86.4 Protokoll: Loeschen synchronisiert die UI nach Ende des Schreibzustands", async () => {
+    const deletedTop = {
+      id: 101,
+      meeting_id: 21,
+      level: 2,
+      number: 6,
+      title: "M86 Klicktest",
+      longtext: "",
+      status: "-",
+      is_carried_over: 0,
+      is_hidden: 0,
+      parent_top_id: 10,
+    };
+    const nextTop = {
+      id: 102,
+      meeting_id: 21,
+      level: 2,
+      number: 7,
+      title: "Naechster TOP",
+      longtext: "",
+      status: "-",
+      is_carried_over: 0,
+      is_hidden: 0,
+      parent_top_id: 10,
+    };
+    const store = createStore({
+      projectId: 7,
+      meetingId: 21,
+      tops: [deletedTop, nextTop],
+      selectedTopId: deletedTop.id,
+      editor: { title: deletedTop.title, longtext: "", status: "-" },
+      isReadOnly: false,
+      isWriting: false,
+      isMoveMode: true,
+    });
+    const coreTargets = ["Protokoll beenden", "Schliessen", "+Titel", "+TOP", "Schieben", "Papierkorb"]
+      .map((label) => ({ label, disabled: false }));
+    const syncStates = [];
+    const screen = {
+      store,
+      commands: {
+        async saveDraft() {
+          return { ok: true };
+        },
+        async deleteSelectedTop() {
+          store.setState({ tops: [nextTop], selectedTopId: null });
+          return { ok: true };
+        },
+        selectTop(topId) {
+          store.setState({ selectedTopId: topId ?? null });
+        },
+        updateDraft(editor) {
+          store.setState({ editor: editor || {} });
+        },
+        toggleMoveMode(forceValue) {
+          store.setState({ isMoveMode: !!forceValue });
+        },
+      },
+      _getDeleteSelectionCandidateId: TopsScreen.prototype._getDeleteSelectionCandidateId,
+      async _autoFixNumberGapsAfterDelete() {
+        return true;
+      },
+      _setCreateParentTopId(topId) {
+        store.setState({ createParentTopId: topId ?? null });
+      },
+      _syncScreenState() {
+        const busy = !!store.getState().isWriting;
+        syncStates.push(busy);
+        for (const target of coreTargets) target.disabled = busy;
+      },
+    };
+
+    await TopsScreen.prototype._handleWorkbenchDelete.call(screen);
+
+    assert.equal(store.getState().isWriting, false);
+    assert.equal(store.getState().selectedTopId, nextTop.id);
+    assert.equal(store.getState().isMoveMode, false);
+    assert.deepEqual(syncStates, [true, false], "die letzte UI-Synchronisierung muss im freigegebenen Zustand laufen");
+    for (const target of coreTargets) assert.equal(target.disabled, false, target.label);
+  });
+
+  await run("M86.4 Hit-Test: Registry-Hinweis blockiert keinen Kernbutton und wird entfernt", async () => {
+    const previousDocument = globalThis.document;
+    const previousWindow = globalThis.window;
+    const previousSetTimeout = globalThis.setTimeout;
+    const doc = createFakeDocument();
+    const removalCallbacks = [];
+    const coreTargets = [
+      place(doc, doc.createElement("button"), 10, 10),
+      place(doc, doc.createElement("button"), 120, 10),
+      place(doc, doc.createElement("button"), 230, 10),
+      place(doc, doc.createElement("button"), 340, 10),
+      place(doc, doc.createElement("div"), 10, 60, 430, 32),
+    ];
+    globalThis.document = doc;
+    globalThis.window = { document: doc };
+    globalThis.setTimeout = (callback) => {
+      removalCallbacks.push(callback);
+      return removalCallbacks.length;
+    };
+
+    try {
+      const result = await navigation.openNativeUiEditor({
+        api: {
+          async open() {
+            return { ok: true, registryRefreshStatus: "current" };
+          },
+        },
+      });
+      assert.equal(result.ok, true);
+      const status = doc.querySelector("[data-bbm-ui-editor-registry-status]");
+      assert.ok(status);
+      assert.match(status.style.cssText, /pointer-events:none/);
+      for (const target of coreTargets) assertMidpointHit(doc, target);
+      assert.equal(removalCallbacks.length, 1);
+      removalCallbacks[0]();
+      assert.equal(doc.querySelector("[data-bbm-ui-editor-registry-status]"), null);
+    } finally {
+      globalThis.document = previousDocument;
+      globalThis.window = previousWindow;
+      globalThis.setTimeout = previousSetTimeout;
+    }
+  });
+
+  await run("M86.4 Dialogschutz: ein nicht geoeffneter Backdrop ist weder sichtbar noch im Dokument", () => {
+    const previousDocument = globalThis.document;
+    const doc = createFakeDocument();
+    globalThis.document = doc;
+    try {
+      const overlay = popupCommon.createPopupOverlay();
+      assert.equal(overlay.dataset.bbmPopupOverlay, "1");
+      assert.equal(overlay.style.display, "none");
+      assert.equal(doc.body.children.includes(overlay), false);
+      const screenSource = read("src/renderer/modules/protokoll/screens/TopsScreen.js");
+      assert.doesNotMatch(screenSource, /\.inert\s*=|setAttribute\(\s*["']inert["']/);
+    } finally {
+      globalThis.document = previousDocument;
+    }
+  });
+
+  await run("M86.4 Editorfokus: der gemeinsame DEV-Launcher gibt seinen Button nach dem Start wieder frei", async () => {
+    const doc = createFakeDocument();
+    const host = doc.createElement("div");
+    let editorOpened = 0;
+    const button = await navigation.installDevelopmentUiEditorOpenButton({
+      host,
+      scopeId: "",
+      doc,
+      buildApi: { appGetBuildChannel: async () => ({ ok: true, channel: "DEV" }) },
+      uiEditorApi: {
+        async open() {
+          editorOpened += 1;
+          return { ok: true, registryRefreshStatus: "current" };
+        },
+        async sendTargetEvent() {
+          return { ok: true };
+        },
+      },
+    });
+
+    await button.listeners.click();
+
+    assert.equal(editorOpened, 1);
+    assert.equal(button.disabled, false);
+  });
+
+  await run("M86.4 Start- und Modulguard: zwei Acceptance-Laeufe und Restarbeiten bleiben abgesichert", () => {
+    const acceptanceRunner = read("scripts/runIsolatedUiEditorAcceptance.cjs");
+    const restarbeitenModule = read("src/renderer/modules/restarbeiten/index.js");
+    const restarbeitenFilterbar = read("src/renderer/modules/restarbeiten/RestarbeitenFilterbar.js");
+    assert.match(acceptanceRunner, /async function runAcceptance\(\{ runs = 2,/);
+    assert.match(acceptanceRunner, /if \(runs !== 2\) throw new Error\("UI_EDITOR_ACCEPTANCE_REQUIRES_TWO_RUNS"\)/);
+    assert.match(restarbeitenModule, /hideSidebar:\s*true/);
+    assert.match(restarbeitenFilterbar, /installDevelopmentUiEditorOpenButton/);
+    assert.doesNotMatch(`${restarbeitenModule}\n${restarbeitenFilterbar}`, /\.inert\s*=|pointer-events\s*:\s*none/);
+  });
+}
+
+if (require.main === module) {
+  runM864GlobalClickBlockerTests(async (_name, fn) => fn()).then(() => {
+    if (!process.exitCode) console.log("m86-4GlobalClickBlocker.test.cjs passed");
+  }).catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { runM864GlobalClickBlockerTests };

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 117, "117 Suite-Einstiege einschließlich M86.3-Editorstartreparatur");
+    assert.equal(suites.length, 118, "118 Suite-Einstiege einschließlich M86.4-Klickblockerreparatur");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/src/renderer/modules/protokoll/screens/TopsScreen.js
+++ b/src/renderer/modules/protokoll/screens/TopsScreen.js
@@ -1400,6 +1400,7 @@ export default class TopsScreen {
       this._syncScreenState();
     } finally {
       this.store.setState({ isWriting: false });
+      this._syncScreenState();
     }
   }
 


### PR DESCRIPTION
M86.4 behebt den reproduzierten globalen Klickblocker im Protokoll nach der Sequenz `TOP 2.6 → +TOP → Schieben → Papierkorb`. Ursache war ein veralteter `disabled`-Zustand: Nach `isWriting: false` wurde die UI nicht erneut synchronisiert. Die Produktivänderung ergänzt genau diese minimale Synchronisierung. Enthalten sind ein harter Regressionstest sowie die dokumentierte sichtbare Prüfung bei 1920×1080, 1600×900 und 1366×768, jeweils auch nach nativem Editorfokus. Keine Registry-, PDF- oder Fachlogikänderung außerhalb der UI-Freigabereparatur. `docs/licensing.md` und `design-reference/` sind nicht Bestandteil des Commits. Commit: `54e314d2bcbe9cf9fc134dea354703969f297f82`.