### PR TITLE
M86.5 Protokoll-Layout stabilisieren

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -51,6 +51,15 @@
 - Prüfung: Protokoll-Integration, Restarbeiten-Modultest, M86.3, M83, `npm test` und `npm run test:node` jeweils 8/8, gezieltes ESLint ohne Fehler, UI-Editor-Vertragscheck und `git diff --check` grün. `docs/licensing.md` blieb unangetastet mit SHA-256 `02AE66A8873C74869539F13F734B7CE43BC63B6EF37DA553A40C27A4F514D784`.
 - Commit/Push/PR/Merge: keiner. Nächster offener Schritt: keiner für M86.4.
 
+### M86.5 – Protokoll-Layout-Reparatur
+
+- Status: `[A]`; der Protokollscreen erhält eine sichere Flex-Aufteilung aus Header, Liste und Editbox.
+- Ursache: Der Listenbereich hatte keine feste flexible Basis, die Editbox durfte über unpassende Höhenwerte bis 720 px wachsen und die Workbench-Kopfzeile verwendete starre Mindestspalten. Dadurch konnten Liste, Editbox und Aktionsgruppen bei engem Platz gegeneinander kollabieren.
+- Reparatur: `sheet` bleibt der einzige vertikale Scrollbesitzer; Screen und Liste verwenden `flex: 1 1 0`. Die Editbox ist regulär auf 190–300 px begrenzt und wird nur in der vorhandenen niedrigen Höhenstufe auf 160 px kompakt dargestellt; die Workbench bleibt dabei geschützt und der Header verwendet eine flexible statt starrer Mindestspalten. Für 900×430 wird ausschließlich die bestehende Header-/Workbench-Geometrie verdichtet; die Meta-Felder bleiben rechts neben Kurz- und Langtext und vollständig sichtbar.
+- Unverändert: Registrystruktur, IDs, Parents, Fachlogik, PDF/Druck und Restarbeiten.
+- Neuer Guardrail: `scripts/tests/m86-5ProtokollLayoutRepair.test.cjs`.
+- Commit/Push/PR/Merge: keiner.
+
 ### M85.2 – Restarbeiten-PDF-Satzweg vervollständigen und verriegeln
 
 - Status: `[A] abgenommen`; Restarbeiten verwendet aus Vorschau und Drucken

--- a/docs/M86_5_PROTOKOLL_LAYOUT_REPARATUR.md
+++ b/docs/M86_5_PROTOKOLL_LAYOUT_REPARATUR.md
@@ -1,0 +1,51 @@
+# M86.5 – Protokoll-Layout-Reparatur
+
+Status: `[P]` – technische Reparatur und automatisierte Tests grün; die sichtbare Kleinformat-Abnahme bei 900×430 ist noch offen.
+
+Finaler Status: `[A]` – die erneute sichtbare Electron-Prüfung bei 900×430 zeigt Header, scrollbare Liste, Workbench, Meta-Felder und Quicklane ohne horizontales Ausweichen. Der obige `[P]`-Eintrag beschreibt den zwischenzeitlichen Befund vor der Verdichtung.
+
+## Befund und Ursache
+
+Der isolierte Acceptance-Start mit vorhandenen Protokolldaten zeigte den
+Protokollscreen ohne gespeichertes Profil. Der Screen besaß bereits eine
+scrollbare `sheet`-Fläche, aber keine robuste Flex-Basis für den Listenanteil.
+Gleichzeitig konnten gespeicherte Editbox-Höhen zwischen 160 und 720 px liegen,
+obwohl der Workbench-Grundinhalt selbst mindestens 178 px benötigt. Der
+Header-Grid verlangte außerdem zwei starre Mindestspalten; bei engem Platz
+drückte dies die Aktionsgruppen auseinander.
+
+Es gab keinen Overlay-, Backdrop-, `pointer-events`- oder `inert`-Fehler und
+keine Ursache in gespeicherten Werten des frischen isolierten Profils.
+
+## Reparaturregel
+
+- Der Screen und die Liste verwenden eine klare flexible Basis; nur `sheet`
+  bleibt der vertikale Scrollbesitzer.
+- Die sichtbare Editbox ist im Renderer normalerweise auf mindestens 190 px
+  geschützt und auf höchstens 300 px begrenzt. In der bestehenden niedrigen
+  Quicklane-Höhenstufe wird derselbe Inhalt kompakt bei mindestens 160 px
+  dargestellt. Die bestehende Registry und ihre gespeicherten Werte bleiben
+  unverändert; der CSS-Schutz begrenzt deren sichtbare Wirkung.
+- Die Workbench behält mindestens 178 px Inhaltshöhe.
+- Der Workbench-Header verwendet eine flexible erste Spalte statt starrer
+  180/220-px-Mindestspalten. Die vorhandene Meta-Spalte bleibt rechts neben
+  dem Textbereich.
+
+## Abgrenzung
+
+Es wurden keine IDs, Parent-Beziehungen, Registryelemente, Fachaktionen,
+PDF-/Druckwege oder Restarbeiten-Dateien geändert.
+
+## Prüfschutz
+
+`scripts/tests/m86-5ProtokollLayoutRepair.test.cjs` prüft die Flex-/Scroll-
+und Höhenregeln, die Workbench-Aktionsleiste sowie die sicheren bestehenden
+Editbox-Bounds. Der Restarbeiten-Quellpfad wird als unverändert abgegrenzt.
+
+## Sichtprüfung
+
+Die isolierte Electron-Prüfung umfasst 1920×1080, 1600×900, 1366×768 und
+900×430. Bei 900×430 werden nur vorhandene Header-, Workbench- und
+Meta-Abstände verdichtet; Kurztext, Langtext, Restzeichen, Status,
+Verantwortlich, Fertig-bis und Quicklane bleiben sichtbar, ohne eine zweite
+vertikale oder horizontale Scrollfläche einzuführen.

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -73,6 +73,15 @@ Aktueller Stand:
 - [x] M80.2 Restarbeiten-Header und Editbox direkt editierbar; Split gesperrt, Liste flexibel
 - [x] M86.3 Einheitlicher Editor-Start und Protokoll-Metaspalte reparieren
 - [x] M86.4 Globalen Klickblocker reproduzieren und reparieren
+- [x] M86.5 Protokoll-Layout im flexiblen Screenrahmen reparieren
+
+## Statusupdate M86.5
+
+- Status: `[A]`. Die vorhandene Protokollstruktur blieb unverändert; korrigiert wurden ausschließlich Flex-Basis, sichere Editbox-Höhen und die starre Workbench-Header-Geometrie. Die 900×430-Abnahme verdichtet ausschließlich diese vorhandenen Bereiche; Meta-Felder bleiben vollständig rechts neben Kurz- und Langtext sichtbar.
+- Der Listenbereich ist der einzige vertikale Scrollbesitzer. Header, Workbench, Meta-Spalte und Quicklane behalten ihre bestehenden Rollen und Eltern.
+- Der Renderer begrenzt die sichtbare Editbox auf sichere Höhen; bestehende Registry-Bounds, IDs und gespeicherte Layoutformate bleiben unverändert, damit kein Registry-/Manifestwechsel entsteht.
+- Restarbeiten, Registrystruktur, IDs, Parents, PDF/Druck und Fachaktionen wurden nicht geändert. Der neue M86.5-Guardrail sowie M83, M86.3 und M86.4 prüfen die Abgrenzung.
+- Commit/Push/PR/Merge: keiner.
 
 ## Statusupdate M86.4
 

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -162,6 +162,7 @@ const TEST_GROUPS = Object.freeze([
       ["m83-0ComponentContracts.test.cjs", "runM830ComponentContractTests"],
       ["m86-3EditorStartMetaRepair.test.cjs", "runM863EditorStartMetaRepairTests"],
       ["m86-4GlobalClickBlocker.test.cjs", "runM864GlobalClickBlockerTests"],
+      ["m86-5ProtokollLayoutRepair.test.cjs", "runM865ProtokollLayoutRepairTests"],
       ["uiEditorAcceptanceIsolation.test.cjs", "runUiEditorAcceptanceIsolationTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),

--- a/scripts/tests/m86-5ProtokollLayoutRepair.test.cjs
+++ b/scripts/tests/m86-5ProtokollLayoutRepair.test.cjs
@@ -1,0 +1,32 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "../..");
+const read = (file) => fs.readFileSync(path.join(ROOT, file), "utf8");
+
+async function runM865ProtokollLayoutRepairTests(run) {
+  await run("M86.5: Protokoll verteilt Header, Sheet und Editbox mit sicheren Flexgrenzen", () => {
+    const css = read("src/renderer/modules/protokoll/styles/tops.css");
+    assert.match(css, /\[data-bbm-tops-screen="true"\]\s*\{[\s\S]*?flex:\s*1 1 0;[\s\S]*?max-height:\s*100%/);
+    assert.match(css, /\[data-bbm-tops-screen="true"\]\s*\{[\s\S]*?overflow:\s*hidden/);
+    assert.match(css, /\[data-bbm-tops-screen-area="sheet"\]\s*\{[\s\S]*?flex:\s*1 1 0;[\s\S]*?overflow:\s*auto;[\s\S]*?overflow-x:\s*hidden/);
+    assert.match(css, /\[data-bbm-tops-screen-area="edit"\]\s*\{[\s\S]*?min-height:\s*190px;[\s\S]*?max-height:\s*min\(300px, calc\(100% - 120px\)\)/);
+    assert.match(css, /\.bbm-tops-workbench\s*\{[\s\S]*?min-height:\s*178px;[\s\S]*?box-sizing:\s*border-box/);
+    assert.match(css, /\.bbm-tops-workbench-header\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto auto/);
+    assert.match(css, /\.bbm-tops-workbench-body\s*\{[\s\S]*?min-width:\s*0/);
+    assert.match(css, /@media \(max-height: 520px\)[\s\S]*?\[data-bbm-tops-screen-area="edit"\][\s\S]*?min-height:\s*160px[\s\S]*?\.bbm-tops-workbench\s*\{[\s\S]*?min-height:\s*148px/s);
+    assert.match(css, /@media \(max-height: 520px\)[\s\S]*?\[data-bbm-tops-header-v2="true"\][\s\S]*?min-height:\s*42px[\s\S]*?\.bbm-tops-header-line3,[\s\S]*?display:\s*none\s*!important/s);
+    assert.match(css, /@media \(max-height: 520px\)[\s\S]*?\.bbm-tops-workbench-editbox \.editbox-label\s*\{[\s\S]*?flex-direction:\s*row/s);
+    assert.match(css, /@media \(max-height: 520px\)[\s\S]*?\.bbm-tops-meta-due-with-ampel \.status-ampel-group\s*\{[\s\S]*?flex-direction:\s*row/s);
+    assert.match(css, /\.bbm-tops-meta-fields\s*\{[\s\S]*?flex-direction:\s*column/s);
+  });
+  await run("M86.5: Restarbeiten bleibt ausserhalb der Protokollreparatur", () => {
+    const css = read("src/renderer/modules/restarbeiten/styles/restarbeiten.css");
+    assert.doesNotMatch(css, /bbm-tops-workbench|bbm-tops-screen-area/);
+  });
+}
+if (require.main === module) runM865ProtokollLayoutRepairTests(async (_name, fn) => fn()).then(() => console.log("m86-5ProtokollLayoutRepair.test.cjs passed")).catch((error) => { console.error(error); process.exitCode = 1; });
+module.exports = { runM865ProtokollLayoutRepairTests };

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 118, "118 Suite-Einstiege einschließlich M86.4-Klickblockerreparatur");
+    assert.equal(suites.length, 119, "119 Suite-Einstiege einschließlich M86.5-Protokolllayoutreparatur");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/src/renderer/modules/protokoll/styles/tops.css
+++ b/src/renderer/modules/protokoll/styles/tops.css
@@ -37,8 +37,13 @@
 [data-bbm-tops-screen="true"] {
   display: flex;
   flex-direction: column;
+  flex: 1 1 0;
   height: 100%;
+  max-height: 100%;
   min-height: 0;
+  width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
   background: var(--bbm-tops-bg);
   color: var(--bbm-tops-text);
   font-family: var(--bbm-top-text-font-family);
@@ -51,9 +56,10 @@
 }
 
 [data-bbm-tops-screen-area="sheet"] {
-  flex: 1 1 auto;
+  flex: 1 1 0;
   min-height: 0;
   overflow: auto;
+  overflow-x: hidden;
   padding: 12px 22px 14px;
   background: var(--bbm-tops-bg);
 }
@@ -89,9 +95,14 @@
 
 [data-bbm-tops-screen-area="edit"] {
   flex: 0 0 auto;
+  min-height: 190px;
+  max-height: min(300px, calc(100% - 120px));
   border-top: 1px solid var(--bbm-tops-line);
   background: var(--bbm-tops-bg);
   padding: 6px 10px 8px;
+  width: 100%;
+  box-sizing: border-box;
+  overflow-x: hidden;
   display: none;
 }
 
@@ -101,6 +112,8 @@
 
 [data-bbm-tops-screen-edit-canvas="true"] {
   width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   max-width: var(--bbm-tops-doc-width);
   margin: 0 auto;
 }
@@ -1058,11 +1071,14 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
   border-radius: 8px;
   box-shadow: 0 6px 14px rgba(15, 23, 42, 0.06);
   padding: 4px 6px 6px;
+  min-height: 178px;
+  box-sizing: border-box;
+  min-width: 0;
 }
 
 .bbm-tops-workbench-header {
   display: grid;
-  grid-template-columns: minmax(180px, 1fr) auto minmax(220px, 1fr);
+  grid-template-columns: minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 4px;
   padding-bottom: 4px;
@@ -1101,6 +1117,7 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
   grid-template-columns: minmax(0, 1fr) clamp(12px, 2.2vw, 30px) minmax(180px, 214px);
   gap: 0;
   align-items: stretch;
+  min-width: 0;
 }
 
 .bbm-tops-workbench-left {
@@ -1386,6 +1403,7 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
   border-radius: 8px;
   background: linear-gradient(180deg, #f8fbff 0%, #eef6ff 100%);
   align-content: start;
+  min-width: 0;
 }
 
 .bbm-tops-meta-flags {
@@ -1596,5 +1614,147 @@ button.bbm-tops-btn.bbm-tops-btn-end-meeting[data-action="end-meeting"]:focus-vi
 
   .bbm-tops-meta-field-date .bbm-tops-input {
     width: 100%;
+  }
+}
+
+@media (max-height: 520px) {
+  [data-bbm-tops-header-v2="true"] {
+    align-items: center;
+    gap: 5px;
+    min-height: 42px;
+    padding-block: 3px;
+  }
+
+  .bbm-tops-header-title-wrap {
+    gap: 0;
+    padding-block: 0;
+  }
+
+  .bbm-tops-header-line1 {
+    font-size: 8pt;
+    line-height: 1;
+  }
+
+  .bbm-tops-header-line2 {
+    font-size: 7.5pt;
+    line-height: 1;
+  }
+
+  .bbm-tops-header-line3,
+  .bbm-tops-header-meta-legend {
+    display: none !important;
+  }
+
+  .bbm-tops-header-actions {
+    gap: 3px;
+  }
+
+  .bbm-tops-header-actions .bbm-tops-btn,
+  .bbm-tops-header-actions button {
+    min-height: 22px;
+    padding: 2px 6px;
+    font-size: 8.5pt;
+    white-space: nowrap;
+  }
+
+  [data-bbm-tops-screen-area="edit"] {
+    min-height: 160px;
+  }
+
+  .bbm-tops-workbench {
+    min-height: 148px;
+    gap: 2px;
+    padding: 2px 4px 3px;
+  }
+
+  .bbm-tops-workbench-header {
+    gap: 2px;
+    padding-bottom: 1px;
+  }
+
+  .bbm-tops-workbench-header .bbm-tops-workbench-btn {
+    min-height: 20px;
+    padding: 1px 5px;
+    font-size: 8pt;
+  }
+
+  .bbm-tops-workbench-left-title {
+    font-size: 8pt;
+    line-height: 1;
+  }
+
+  .bbm-tops-workbench-body {
+    grid-template-columns: minmax(0, 1fr) 8px minmax(150px, 180px);
+  }
+
+  .bbm-tops-workbench-editbox,
+  .bbm-tops-meta-panel {
+    gap: 1px;
+    padding: 2px 4px;
+  }
+
+  .bbm-tops-workbench-editbox .bbm-tops-editbox-row {
+    gap: 4px;
+  }
+
+  .bbm-tops-workbench-editbox .bbm-tops-editbox-label-cell {
+    flex-basis: 74px;
+    min-width: 74px;
+  }
+
+  .bbm-tops-workbench-editbox .editbox-label {
+    flex-direction: row;
+    align-items: baseline;
+    gap: 3px;
+  }
+
+  .bbm-tops-workbench-editbox .editbox-counter {
+    font-size: 6.5pt;
+    line-height: 1;
+  }
+
+  .bbm-tops-workbench-editbox .bbm-tops-editbox-long-wrap,
+  .bbm-tops-workbench-editbox .bbm-tops-editbox-long-wrap .bbm-tops-editbox-field-cell,
+  .bbm-tops-workbench-editbox .bbm-tops-editbox-long-wrap .editbox-textarea {
+    min-height: 28px;
+  }
+
+  .bbm-tops-meta-panel :is(.bbm-tops-input, .status-ampel-select, .status-ampel-date, .responsible-field-select) {
+    min-height: 18px;
+    padding-block: 1px;
+  }
+
+  .bbm-tops-meta-cell,
+  .bbm-tops-meta-row,
+  .bbm-tops-meta-due-with-ampel .status-ampel-group {
+    gap: 1px;
+  }
+
+  .bbm-tops-meta-due-with-ampel.status-ampel-field {
+    gap: 3px;
+  }
+
+  .bbm-tops-meta-due-with-ampel .status-ampel-label,
+  .bbm-tops-meta-flags .editbox-flag {
+    font-size: 7pt;
+  }
+
+  .bbm-tops-meta-due-with-ampel .status-ampel-group {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .bbm-tops-meta-due-with-ampel .status-ampel-label {
+    white-space: nowrap;
+  }
+
+  .bbm-tops-meta-flags,
+  .bbm-tops-meta-flags .editbox-flags {
+    gap: 4px 6px;
+    padding-bottom: 2px;
+  }
+
+  .bbm-tops-meta-row {
+    gap: 4px;
   }
 }


### PR DESCRIPTION
M86.5 stabilisiert das Protokoll-Layout im aktuellen main. Enthalten sind eine robuste Header–Liste–Editbox-Aufteilung, ausschließlich der Listenbereich als vertikaler Scrollbesitzer, eine begrenzte und vollständig sichtbare Editbox, die rechts angeordnete Metaspalte sowie eine verdichtete Kleinformatdarstellung bei 900×430 ohne neue DOM-, Scroll-, Registry-, PDF- oder Fachlogikstruktur. Sichtbar geprüft wurden 1920×1080, 1600×900, 1366×768 und 900×430; zusätzlich zwei isolierte Acceptance-Starts sowie eine reversible UI-Editor-Höhenänderung mit Verwerfen. `docs/licensing.md` und `design-reference/` sind nicht Bestandteil des Commits. Commit: `a4875c33107e1da6de43b22e14a539f529e4a24b`.