### PR TITLE
M86.6 Breitensteuerung für content-box korrigieren

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,12 @@
 # STATUS.md — BBM-Produktiv
 
+### M86.6 – Richtungskorrekte Breitenänderung der Protokoll-Metagruppe
+
+- Status: `[A]`; die bestehende generische Breitenoperation setzt bei `content-box` wieder die sichtbare Außenbreite als bestätigten Zielwert um.
+- Ursache war nicht das Vorzeichen im UI-Editor-kit: Der Controller sendete bereits den korrekten absoluten Zielwert. Der BBM-Apply-Weg schrieb ihn jedoch als Inhaltsbreite und addierte damit statisches Padding/Rand-Chrome bei jedem Schritt erneut; `−` und `+` vergrößerten beide sichtbar.
+- Der generische Apply-Weg zieht nun nur bei `content-box` das aus aktuellem Readback ermittelte horizontale Chrome ab. Registry, IDs, Parents, Refs, DOM, CSS-Struktur, Scroll, PDF, Restarbeiten und Fachlogik bleiben unverändert; bestehende Bounds und Host-Readback gelten weiter.
+- Sichtprüfung im isolierten Protokollprofil: drei Minus, zwei Plus, Rückgängig, Mindestgrenze, Speichern, zweiter automatischer Start, Original und Verwerfen bestanden; der Acceptance-Launcher beendete beide Läufe mit Exit 0 und entfernte das temporäre Profil. `npm test` und `npm run test:node` sind jeweils 8/8 grün. Commit/Push/PR/Merge: keiner.
+
 ### M86.2 – Protokoll-PDF-Leitdesign
 
 - Status: `[A] abgenommen`; technische Umsetzung, automatisierter

--- a/docs/UI_INSPEKTOR_AUFGABENHEFT.md
+++ b/docs/UI_INSPEKTOR_AUFGABENHEFT.md
@@ -74,6 +74,17 @@ Aktueller Stand:
 - [x] M86.3 Einheitlicher Editor-Start und Protokoll-Metaspalte reparieren
 - [x] M86.4 Globalen Klickblocker reproduzieren und reparieren
 - [x] M86.5 Protokoll-Layout im flexiblen Screenrahmen reparieren
+- [x] M86.6 Breiten-Schritt der Protokoll-Metagruppe richtungskorrekt anwenden
+
+## Statusupdate M86.6
+
+- Status: `[A]`. Die registrierte Protokoll-Metagruppe `Gruppe Status und Zuordnung` und ihre bestehenden Feldgruppen behalten unverändert Registry, IDs, Parents, Refs, DOM-Struktur, CSS-Layout, Scrollbesitz und Fachlogik.
+- Ursache: Der UI-Editor-kit-Controller berechnete und sendete bereits den korrekten signierten absoluten Zielwert. Der generische BBM-Apply-Weg setzte bei `content-box` jedoch die sichtbare Außenbreite direkt als Inhaltsbreite. Das statische Padding/Rand-Chrome wurde dadurch jedes Mal zusätzlich addiert: sowohl `−` als auch `+` vergrößerten sichtbar.
+- Reparatur: Der bestehende generische Breitenweg ermittelt vor dem Schreiben ausschließlich für `content-box` die aktuelle Differenz aus Außen- und Inhaltsbreite und zieht sie vom bestätigten Zielwert ab. `border-box`, vorhandene Registry-Bounds, Host-Readback und die signierte Delta-Berechnung bleiben unverändert; es gibt keine neue willkürliche Begrenzung und keine Vorzeichenumkehr.
+- Neuer Regressionstest: `M86.6 BBM 28` deckt `protokoll.edit.meta` mit realistischem content-box-Chrome ab und prüft Minus, Plus, sichtbaren tatsächlichen Readback sowie die bestehenden Min-/Max-Bounds. Der vorhandene M82.3-Guardrail prüft nun denselben generischen Außenbreitenvertrag statt der überholten Padding-Formel.
+- Sichtabnahme im isolierten Protokollprofil: In der bestehenden Metagruppe ergaben drei Minus und zwei Plus vom Startwert `92,396614…` netto `91,372177…`; Rückgängig ergab `90,375938…`, das direkte Unterschreiten der Grenze wurde auf `7,998119…` begrenzt. Speichern, automatischer zweiter Start mit geladenem Layout, Original/Verwerfen und die automatische Profilbereinigung liefen durchgehend mit `run 1/2 exit=0` und `run 2/2 exit=0`.
+- Keine Registry-, PDF-, Fachlogik-, Restarbeiten- oder UI-Editor-kit-Änderung. `npm test` und `npm run test:node` liefen jeweils 8/8 grün; Vertrags-, Host-, Persistenz- und Diff-Prüfungen sind grün. Der globale Lintbestand bleibt mit 16 fremden Fehlern rot, die geänderte Ziel-Datei lintet fehlerfrei.
+- Commit/Push/PR/Merge: keiner.
 
 ## Statusupdate M86.5
 

--- a/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
+++ b/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
@@ -59,7 +59,7 @@ async function runM823BbmSpacerCompactUiTests(run) {
   await run("M82.3 BBM 10: Electron-Abbildung speichert Spacing-Intent", () => assert.match(refSource, /uiEditorSpacing/));
   await run("M82.3 BBM 11: reservierter Platz wird zur Trackbreite addiert", () => assert.match(refSource, /elementWidth = bounded[\s\S]*slotWidth = elementWidth \+ reservedWidth/));
   await run("M82.3 BBM 12: generische Gruppenabstände bilden Padding und Gap ab", () => assert.match(refSource, /paddingLeft[\s\S]*columnGap[\s\S]*rowGap/));
-  await run("M82.3 BBM 12a: Gruppenpadding wird ohne fremdes Boxmodell von der Inhaltsbreite abgezogen", () => assert.match(refSource, /horizontalPadding[\s\S]*desiredWidth - horizontalPadding/));
+  await run("M82.3 BBM 12a: content-box-Gruppen erhalten die sichtbare Außenbreite trotz Padding und Rand", () => assert.match(refSource, /currentBounds[\s\S]*horizontalChrome[\s\S]*desiredWidth - horizontalChrome/));
   await run("M82.3 BBM 12b: responsive Gruppenbaseline wird vor dem Start-Restore einmalig erfasst", () => assert.match(host, /capturedRuntimeBaselines[\s\S]*snapshotM80State[\s\S]*capturedBaseline/));
   await run("M82.3 BBM 13: Freier Platz ist Standardentscheidung", () => assert.equal(widthRisk().suggestedActions[0], RISK_ACTIONS.PRESERVE_SPACE));
   await run("M82.3 BBM 14: Nachrücken ist separate Entscheidung", () => assert.ok(widthRisk().suggestedActions.includes(RISK_ACTIONS.REFLOW_NEIGHBORS)));

--- a/scripts/tests/m82-7-4AmpelEditing.test.cjs
+++ b/scripts/tests/m82-7-4AmpelEditing.test.cjs
@@ -21,6 +21,7 @@ class FakeElement {
     this.hidden = false;
     this.isConnected = true;
     this._rect = { left: 0, top: 0, width: 96, height: 24, ...rect };
+    this._horizontalChrome = Number(rect.horizontalChrome) || 0;
     this.style = { setProperty(name, value) { this[name] = value; }, getPropertyValue(name) { return this[name] || ""; } };
     this.classList = {
       contains: (name) => this.className.split(/\s+/).includes(name),
@@ -37,7 +38,8 @@ class FakeElement {
   appendChild(child) { this.append(child); return child; }
   replaceChildren(...children) { this.children = []; this.append(...children); }
   getBoundingClientRect() {
-    const width = Number.parseFloat(this.style.width) || this._rect.width;
+    const configuredWidth = Number.parseFloat(this.style.width);
+    const width = Number.isFinite(configuredWidth) ? configuredWidth + this._horizontalChrome : this._rect.width;
     const height = Number.parseFloat(this.style.height) || this._rect.height;
     return { left: this._rect.left, top: this._rect.top, width, height, right: this._rect.left + width, bottom: this._rect.top + height };
   }
@@ -57,7 +59,7 @@ function createDocument() {
 
 function computedStyle(element) {
   const bounds = element.getBoundingClientRect();
-  return { ...element.style, display: element.style.display || "", width: `${bounds.width}px`, height: `${bounds.height}px`, paddingLeft: "0px", paddingTop: "0px", fontSize: "12px", boxSizing: "border-box" };
+  return { ...element.style, display: element.style.display || "", width: element.style.width || `${bounds.width - element._horizontalChrome}px`, height: `${bounds.height}px`, paddingLeft: "0px", paddingTop: "0px", fontSize: "12px", boxSizing: element.style.boxSizing || "border-box" };
 }
 
 function submit(host, operation, payload, changeId, source = "m82-7-4-test") {
@@ -139,6 +141,33 @@ async function runM8274AmpelEditingTests(run) {
     await run("M82.7.4 BBM 25: sichtbarer positiver Nachbar wird wieder einbezogen", () => { refs.applyM80State(AMPEL_ID, { ...refs.snapshotM80State(AMPEL_ID), width: 12 }, "resizeWidth"); validation._rect.height = 12; const geometry = refs.snapshotM80Geometry(); assert.equal(host.collectM80GeometryNeighbors(entry, geometry, geometry).some((item) => item.elementId === VALIDATION_ID), true); });
     await run("M82.7.4 BBM 26: detached, display-none, NaN und Infinity sind inaktiv", () => { const candidate = byId.get(VALIDATION_ID); const before = refs.snapshotM80Geometry(); const after = refs.snapshotM80Geometry(); validation.isConnected = false; assert.equal(host.isM80GeometryNeighborActive(candidate, before, after), false); validation.isConnected = true; validation.style.display = "none"; assert.equal(host.isM80GeometryNeighborActive(candidate, before, after), false); validation.style.display = ""; before.set(VALIDATION_ID, { left: 0, top: 0, width: Number.NaN, height: 12 }); assert.equal(host.isM80GeometryNeighborActive(candidate, before, after), false); before.set(VALIDATION_ID, { left: 0, top: 0, width: Number.POSITIVE_INFINITY, height: 12 }); assert.equal(host.isM80GeometryNeighborActive(candidate, before, after), false); });
     await run("M82.7.4 BBM 27: echte sichtbare Kollision bleibt blockiert", () => { refs.applyM80State(AMPEL_ID, { ...refs.snapshotM80State(AMPEL_ID), width: 12 }, "resizeWidth"); const result = submit(host, "resizeWidth", { width: 17 }, "real-collision", "ui-editor-panel"); assert.equal(result.success, false); assert.equal(result.errorCode, "geometry_risk_confirmation_required"); assert.equal(result.geometryRisk.affectedNeighbors.some((item) => item.elementId === VALIDATION_ID && item.overlapBounds), true); assert.equal(refs.snapshotM80State(AMPEL_ID).width, 12); });
+    await run("M86.6 BBM 28: generische content-box-Breite verwendet die sichtbare aktuelle Breite ohne Richtungsumkehr", () => {
+      const meta = new FakeElement("DIV", { width: 213.99435424804688, height: 134.3984832763672, horizontalChrome: 20.19735717773438 });
+      meta.style.boxSizing = "content-box";
+      refs.registerM80Ref("protokoll.edit.meta", meta);
+      refs.completeM80PilotRender();
+      const original = refs.snapshotM80State("protokoll.edit.meta").width;
+      const minusTarget = Math.max(160, original - 1);
+      const minus = host.handleM80EditorRequest({ action: "submitChange", scopeId: "protokoll.edit.root", changeRequest: { changeId: "m86-6-minus", elementId: "protokoll.edit.meta", operation: "resizeWidth", payload: { width: minusTarget }, source: "target-app-start" } }).changeResult;
+      assert.equal(minus.success, true, minus.message);
+      assert.ok(Math.abs(minus.newState.width - minusTarget) <= 0.01);
+      assert.ok(minus.newState.width < original);
+      const plusTarget = Math.min(420, minus.newState.width + 1);
+      const plus = host.handleM80EditorRequest({ action: "submitChange", scopeId: "protokoll.edit.root", changeRequest: { changeId: "m86-6-plus", elementId: "protokoll.edit.meta", operation: "resizeWidth", payload: { width: plusTarget }, source: "target-app-start" } }).changeResult;
+      assert.equal(plus.success, true, plus.message);
+      assert.ok(Math.abs(plus.newState.width - plusTarget) <= 0.01);
+      assert.ok(plus.newState.width > minus.newState.width);
+      assert.ok(Math.abs(refs.snapshotM80State("protokoll.edit.meta").width - plusTarget) <= 0.01);
+      assert.ok(Math.abs(meta.getBoundingClientRect().width - plusTarget) <= 0.01);
+      const minimum = host.handleM80EditorRequest({ action: "submitChange", scopeId: "protokoll.edit.root", changeRequest: { changeId: "m86-6-minimum", elementId: "protokoll.edit.meta", operation: "resizeWidth", payload: { width: 1 }, source: "target-app-start" } }).changeResult;
+      assert.equal(minimum.success, true, minimum.message);
+      assert.ok(minimum.newState.width >= 8);
+      assert.ok(minimum.newState.width < plus.newState.width);
+      assert.ok(Math.abs(meta.getBoundingClientRect().width - minimum.newState.width) <= 0.01);
+      const maximum = host.handleM80EditorRequest({ action: "submitChange", scopeId: "protokoll.edit.root", changeRequest: { changeId: "m86-6-maximum", elementId: "protokoll.edit.meta", operation: "resizeWidth", payload: { width: 9999 }, source: "target-app-start" } }).changeResult;
+      assert.equal(maximum.success, true, maximum.message);
+      assert.ok(Math.abs(maximum.newState.width - 2400) <= 0.01);
+    });
     await run("M82.7.4 BBM 28: licensing-Dokumentation hat weiterhin den Schutz-Hash", () => { const hash = crypto.createHash("sha256").update(fs.readFileSync(path.join(ROOT, "docs/licensing.md"))).digest("hex").toUpperCase(); assert.equal(hash, "02AE66A8873C74869539F13F734B7CE43BC63B6EF37DA553A40C27A4F514D784"); });
   } finally {
     refs.resetM80PilotWorkingStatesForDiagnostic();

--- a/src/renderer/ui-editor/m80Refs.js
+++ b/src/renderer/ui-editor/m80Refs.js
@@ -146,8 +146,13 @@ function applyGeneric(element, state, entry, requestedOperation = null) {
   }
   if ((operations.has("resize") || operations.has("resizeWidth")) && applies("resize", "resizeWidth")) {
     const desiredWidth = bounded(entry, "width", state.width, 1);
-    const horizontalPadding = finite(state.spacing?.groupPaddingLeft) + finite(state.spacing?.groupPaddingRight);
-    const contentWidth = styleOf(element).boxSizing === "border-box" ? desiredWidth : Math.max(1, desiredWidth - horizontalPadding);
+    const style = styleOf(element);
+    const currentBounds = rectOf(element);
+    const currentContentWidth = Number.parseFloat(style.width);
+    const horizontalChrome = style.boxSizing === "border-box" || !Number.isFinite(currentContentWidth)
+      ? 0
+      : Math.max(0, currentBounds.width - currentContentWidth);
+    const contentWidth = style.boxSizing === "border-box" ? desiredWidth : Math.max(1, desiredWidth - horizontalChrome);
     element.style.width = px(contentWidth);
   }
   if ((operations.has("resize") || operations.has("resizeHeight")) && applies("resize", "resizeHeight")) element.style.height = px(bounded(entry, "height", state.height, 1));


### PR DESCRIPTION
M86.6 korrigiert die generische Breitensteuerung für `content-box`-Elemente im UI-Editor. Ursache war, dass die Außenbreite fälschlich als Inhaltsbreite behandelt wurde; dadurch vergrößerten Minus und Plus die sichtbare Breite. Die Reparatur zieht die aktuelle Box-Chrome-Differenz nur bei `content-box` vom bestätigten Zielwert ab. Sichtbar geprüft wurden drei Minus-, zwei Plus-Schritte, Undo, Mindestgrenze, Speichern, zweiter Acceptance-Start und Verwerfen. Keine Registry-, PDF-, CSS-Struktur- oder Fachlogikänderung. `docs/licensing.md` und `design-reference/` sind nicht Bestandteil des Commits. Commit: `117f31a00bf8992b1c8199257c6ce86dbeef5535`.