### PR TITLE
M86.7 Protokoll-Buttons vollständig editorfähig registrieren

### DIFF
--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -163,6 +163,7 @@ const TEST_GROUPS = Object.freeze([
       ["m86-3EditorStartMetaRepair.test.cjs", "runM863EditorStartMetaRepairTests"],
       ["m86-4GlobalClickBlocker.test.cjs", "runM864GlobalClickBlockerTests"],
       ["m86-5ProtokollLayoutRepair.test.cjs", "runM865ProtokollLayoutRepairTests"],
+      ["m86-7ProtokollButtonContracts.test.cjs", "runM867ProtokollButtonContractTests"],
       ["uiEditorAcceptanceIsolation.test.cjs", "runUiEditorAcceptanceIsolationTests"],
       ["testHarnessOrchestration.test.cjs", "runTestHarnessOrchestrationTests"],
     ]),

--- a/scripts/tests/_diffGuardAllowances.cjs
+++ b/scripts/tests/_diffGuardAllowances.cjs
@@ -2,7 +2,9 @@ const ALLOWED_PROTOKOLL_UI_DIFFS = new Set([
   "src/renderer/modules/protokoll/TopsScreenQuicklane.js",
   "src/renderer/modules/protokoll/TopsList.js",
   "src/renderer/modules/protokoll/TopsHeader.js",
+  "src/renderer/modules/protokoll/TopsWorkbench.uiEditorContract.js",
   "src/renderer/modules/protokoll/screens/TopsScreen.js",
+  "src/renderer/modules/protokoll/screens/TopsScreen.uiEditorContract.js",
   "src/renderer/modules/protokoll/styles/tops.css",
   "src/renderer/modules/protokoll/uiEditor/protokollUiElements.js",
 ]);

--- a/scripts/tests/editorV2Registry.test.cjs
+++ b/scripts/tests/editorV2Registry.test.cjs
@@ -224,7 +224,9 @@ async function runEditorV2RegistryTests(run) {
     "src/renderer/modules/protokoll/TopsScreenQuicklane.js",
     "src/renderer/modules/protokoll/TopsList.js",
     "src/renderer/modules/protokoll/TopsHeader.js",
+    "src/renderer/modules/protokoll/TopsWorkbench.uiEditorContract.js",
     "src/renderer/modules/protokoll/screens/TopsScreen.js",
+    "src/renderer/modules/protokoll/screens/TopsScreen.uiEditorContract.js",
     "src/renderer/modules/protokoll/styles/tops.css",
     "src/renderer/modules/protokoll/uiEditor/protokollUiElements.js",
   ]);

--- a/scripts/tests/editorV2Selection.test.cjs
+++ b/scripts/tests/editorV2Selection.test.cjs
@@ -280,7 +280,9 @@ async function runEditorV2SelectionTests(run) {
     "src/renderer/modules/protokoll/TopsScreenQuicklane.js",
     "src/renderer/modules/protokoll/TopsList.js",
     "src/renderer/modules/protokoll/TopsHeader.js",
+    "src/renderer/modules/protokoll/TopsWorkbench.uiEditorContract.js",
     "src/renderer/modules/protokoll/screens/TopsScreen.js",
+    "src/renderer/modules/protokoll/screens/TopsScreen.uiEditorContract.js",
     "src/renderer/modules/protokoll/styles/tops.css",
     "src/renderer/modules/protokoll/uiEditor/protokollUiElements.js",
   ]);

--- a/scripts/tests/m80-1RegistrationRefresh.test.cjs
+++ b/scripts/tests/m80-1RegistrationRefresh.test.cjs
@@ -83,7 +83,7 @@ async function runM801RegistrationRefreshTests(run) {
       document.body.appendChild(rendered.root);
       const registration = rendered.registration;
       runtimeRegistration = structuredClone(registration);
-      assert.equal(registration.registryVersion, 13);
+      assert.equal(registration.registryVersion, 15);
       assert.equal(registration.registryStatus, "incomplete");
       assert.deepEqual(registration.activeScopes, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root"]);
       const complete = registration.registryScopes.filter((scope) => scope.status === "complete");

--- a/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
+++ b/scripts/tests/m80-2HeaderEditboxLayout.test.cjs
@@ -15,7 +15,7 @@ async function runM802HeaderEditboxLayoutTests(run) {
   const elements = complete.flatMap((scope) => scope.elements);
 
   await run("M80.2 Registry: Header, Liste und Editbox sind direkt aktiv; Split ist gesperrt", () => {
-    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 13);
+    assert.equal(registryModule.BBM_M80_REGISTRY_VERSION, 15);
     assert.deepEqual(registryModule.BBM_M80_ACTIVE_SCOPES, [
       "restarbeiten.header.root",
       "restarbeiten.list.root",

--- a/scripts/tests/m80ElectronUiEditor.test.cjs
+++ b/scripts/tests/m80ElectronUiEditor.test.cjs
@@ -49,8 +49,8 @@ class MockChild extends EventEmitter {
   kill() { this.exit(0); return true; }
 }
 class MockClient extends EventEmitter {
-  constructor() { super(); this.connected = false; this.handshaken = false; this.events = []; this.requests = []; this.child = null; }
-  async connect() { this.connected = true; this.handshaken = true; return { action: "handshakeAccepted" }; }
+  constructor() { super(); this.connected = false; this.handshaken = false; this.events = []; this.requests = []; this.child = null; this.onConnect = null; }
+  async connect() { this.connected = true; this.handshaken = true; this.connectProbe = this.onConnect?.(); return { action: "handshakeAccepted" }; }
   sendEvent(action, payload = {}) { this.events.push({ action, ...payload }); if (action === "shutdownEditor") setImmediate(() => this.child?.exit()); return this.connected; }
   request(action) { this.requests.push(action); return Promise.resolve({ action: `${action}Accepted` }); }
   respond(message, payload, error) { this.response = { message, payload, error }; return true; }
@@ -204,8 +204,15 @@ async function runM80ElectronUiEditorTests(run) {
       profileRootResolver: () => "C:\\trusted\\profiles", ensureDirectory: () => {},
     });
     controller.registerIpc();
+    client.onConnect = () => {
+      client.emit("message", { messageType: "request", messageId: "initial-registry", payload: { action: "getRegistry" } });
+      return handlers.get("uiEditor:respond")(null, { requestId: "initial-registry", ok: true, payload: { registryScopes: registrationScopes } });
+    };
     const first = await handlers.get("uiEditor:open")(null, registration); const second = await handlers.get("uiEditor:open")(null, registration);
+    await client.connectProbe;
     assert.equal(first.started, true); assert.equal(second.focused, true); assert.equal(spawns, 1);
+    assert.equal(client.response.error, undefined, "Die Erstregistrierung muss bereits im Pipe-Handshake gegen den Session-Snapshot validiert werden.");
+    assert.equal(client.response.payload.registryScopes.length, registrationScopes.length);
     assert.equal(client.events.filter((event) => event.action === "activateEditor").length, 1);
 
     client.emit("message", { messageType: "request", messageId: "request-0001", payload: { action: "getRegistry" } });

--- a/scripts/tests/m82-1BbmFeintuning.test.cjs
+++ b/scripts/tests/m82-1BbmFeintuning.test.cjs
@@ -24,7 +24,7 @@ async function runM821BbmFeintuningTests(run) {
   const editbox = read("src/renderer/modules/restarbeiten/RestarbeitenEditbox.js");
   const css = read("src/renderer/modules/restarbeiten/styles/restarbeiten.css");
 
-  await run("M82.1 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 13));
+  await run("M82.1 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 15));
   await run("M82.1 BBM 02: Manifestversion folgt der Registry", () => assert.equal(manifest.registryVersion, registry.BBM_M80_REGISTRY_VERSION));
   await run("M82.1 BBM 03: Manifestfingerprint ist aktuell", () => assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)));
   await run("M82.1/M82.6 BBM 04: beide Referenzmodule besitzen je drei aktive Scopes", () => assert.deepEqual(registry.BBM_M80_ACTIVE_SCOPES, ["restarbeiten.header.root", "restarbeiten.list.root", "restarbeiten.edit.root", "protokoll.screen.root", "protokoll.list.root", "protokoll.edit.root"]));

--- a/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
+++ b/scripts/tests/m82-3BbmSpacerCompactUi.test.cjs
@@ -47,7 +47,7 @@ async function runM823BbmSpacerCompactUiTests(run) {
     groupWidthEditable,
   });
 
-  await run("M82.3 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 13));
+  await run("M82.3 BBM 01: Registryversion bleibt konsistent", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 15));
   await run("M82.3 BBM 02: Manifest folgt Registry und Fingerprint", () => { assert.equal(manifest.registryVersion, registry.BBM_M80_REGISTRY_VERSION); assert.equal(manifest.registryFingerprint, createRegistryFingerprint(scopes)); });
   await run("M82.3 BBM 03: Kurztextbezeichnung besitzt reservierte Breite", () => assert.deepEqual(label.baseline.spacing, { reservedWidth: 40 }));
   await run("M82.3 BBM 04: Kurztextbezeichnung erlaubt Spacer davor und danach", () => assert.deepEqual(label.spacingTargets, ["beforeElement", "afterElement", "reservedWidth"]));

--- a/scripts/tests/m82-7-5LayoutPersistenceMetaElements.test.cjs
+++ b/scripts/tests/m82-7-5LayoutPersistenceMetaElements.test.cjs
@@ -55,7 +55,7 @@ async function runM8275LayoutPersistenceMetaElementsTests(run) {
   global.window = { getComputedStyle: computedStyle, dispatchEvent() {}, uiEditor: {} };
 
   try {
-    await run("M82.7.5 BBM 01: Registryversion kennzeichnet den erweiterten Vertrag", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 13));
+    await run("M82.7.5 BBM 01: Registryversion kennzeichnet den erweiterten Vertrag", () => assert.equal(registry.BBM_M80_REGISTRY_VERSION, 15));
     await run("M82.7.5 BBM 02: Listenscope enthaelt den vollstaendigen Komponentenvertrag", () => assert.equal(scope.elements.length, 32));
     await run("M82.7.5 BBM 03: alle bestaetigten stabilen IDs sind exakt registriert", () => [...headerIds, ...rowIds].forEach((id) => assert.ok(byId.has(id), id)));
     await run("M82.7.5 BBM 04: Header-Kinder besitzen den existierenden Meta-Header als Parent", () => headerIds.forEach((id) => assert.equal(byId.get(id).parentId, "restarbeiten.list.table.meta.header")));

--- a/scripts/tests/m83-0ComponentContracts.test.cjs
+++ b/scripts/tests/m83-0ComponentContracts.test.cjs
@@ -41,7 +41,7 @@ async function runM830ComponentContractTests(run) {
 
   await run("M83.0 BBM 01: alle offiziellen Scopes stammen aus acht komponentennahen Vertraegen", () => {
     assert.equal(contracts.length, 8); assert.deepEqual([...contractIds].sort(), [...registryIds].sort()); assert.equal(new Set(contractIds).size, contractIds.length);
-    for (const component of contracts) assert.deepEqual([...component.requiredSlots].sort(), component.slots.map((slot) => slot.slotId).sort(), component.componentId);
+    for (const component of contracts) assert.deepEqual([...component.requiredSlots].sort(), component.slots.filter((slot) => slot.required).map((slot) => slot.slotId).sort(), component.componentId);
   });
   await run("M83.0 BBM 02: Meta-Startspalte deklariert Spalte, Kopf, Nr., Datum, Klasse und reale Zusatzinhalte", () => {
     const ids = new Set(listContract.slots.map((slot) => slot.element.id));
@@ -55,7 +55,7 @@ async function runM830ComponentContractTests(run) {
     assert.doesNotMatch(source, /data-bbm-restarbeiten-record-id|app\.db|item\.id|databaseId|recordId/); assert.ok(contractIds.every((id) => !/(?:^|\.)\d{4,}(?:\.|$)|[0-9a-f]{8}-[0-9a-f-]{27,}/i.test(id)));
   });
   await run("M83.0 BBM 05: Restarbeiten-Liste, Editbox und Protokoll sind vollstaendig gebuendelt", () => {
-    assert.deepEqual(Object.fromEntries(contracts.map((component) => [component.componentId, component.slots.length])), { "bbm.restarbeiten.filterbar": 31, "bbm.restarbeiten.list": 32, "bbm.restarbeiten.editbox": 53, "bbm.protokoll.screen": 10, "bbm.protokoll.quicklane": 15, "bbm.protokoll.list.shell": 4, "bbm.protokoll.list.columns": 3, "bbm.protokoll.editbox": 24 });
+    assert.deepEqual(Object.fromEntries(contracts.map((component) => [component.componentId, component.slots.length])), { "bbm.restarbeiten.filterbar": 31, "bbm.restarbeiten.list": 32, "bbm.restarbeiten.editbox": 53, "bbm.protokoll.screen": 14, "bbm.protokoll.quicklane": 19, "bbm.protokoll.list.shell": 4, "bbm.protokoll.list.columns": 3, "bbm.protokoll.editbox": 36 });
   });
 
   const previous = { document: global.document, window: global.window, Element: global.Element, CustomEvent: global.CustomEvent };

--- a/scripts/tests/m86-7ProtokollButtonContracts.test.cjs
+++ b/scripts/tests/m86-7ProtokollButtonContracts.test.cjs
@@ -1,0 +1,116 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const ROOT = path.resolve(__dirname, "../..");
+const read = (relativePath) => fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+
+const BUTTONS = Object.freeze([
+  ["protokoll.header.action.endMeeting", "protokoll.header.actions", "btnEndMeeting"],
+  ["protokoll.header.action.close", "protokoll.header.actions", "btnClose"],
+  ["protokoll.header.action.openUiEditor", "protokoll.header.actions", "uiEditorOpenButton"],
+  ["protokoll.edit.header.action.addTitle", "protokoll.edit.header.addActions", "btnL1"],
+  ["protokoll.edit.header.action.addTop", "protokoll.edit.header.addActions", "btnChild"],
+  ["protokoll.edit.header.action.move", "protokoll.edit.header.primaryActions", "btnMove"],
+  ["protokoll.edit.header.action.delete", "protokoll.edit.header.primaryActions", "btnDelete"],
+  ["protokoll.edit.short.action.dictation", "protokoll.edit.short.label", "shortDictateButton"],
+  ["protokoll.edit.long.action.dictation", "protokoll.edit.long.label", "longDictateButton"],
+  ["protokoll.edit.dictation.status.action.undo", "protokoll.edit.dictation.status", "dictationUndoButton"],
+  ["protokoll.edit.long.correction.action.open", "protokoll.edit.long.correction", "dictionaryCorrectionButton"],
+  ["protokoll.topsScreen.quicklane.pin", "protokoll.topsScreen.quicklane.group.navigation", "group.children[index]"],
+  ["protokoll.topsScreen.quicklane.action.project", "protokoll.topsScreen.quicklane.group.navigation", "group.children[index]"],
+  ["protokoll.topsScreen.quicklane.action.firms", "protokoll.topsScreen.quicklane.group.navigation", "group.children[index]"],
+  ["protokoll.topsScreen.quicklane.action.participants", "protokoll.topsScreen.quicklane.group.navigation", "group.children[index]"],
+  ["protokoll.topsScreen.quicklane.action.ampel", "protokoll.topsScreen.quicklane.group.visibility", "group.children[index]"],
+  ["protokoll.topsScreen.quicklane.action.longtext", "protokoll.topsScreen.quicklane.group.visibility", "group.children[index]"],
+  ["protokoll.topsScreen.quicklane.action.topFilter", "protokoll.topsScreen.quicklane.group.filter", "group.children[index]"],
+  ["protokoll.topsScreen.quicklane.action.preview", "protokoll.topsScreen.quicklane.group.output", "group.children[index]"],
+  ["protokoll.topsScreen.quicklane.action.print", "protokoll.topsScreen.quicklane.group.output", "group.children[index]"],
+  ["protokoll.topsScreen.quicklane.action.mail", "protokoll.topsScreen.quicklane.group.output", "group.children[index]"],
+  ["protokoll.topsScreen.quicklane.filter.option.all", "protokoll.topsScreen.quicklane.filter.menu", "menu.children[index]"],
+  ["protokoll.topsScreen.quicklane.filter.option.todo", "protokoll.topsScreen.quicklane.filter.menu", "menu.children[index]"],
+  ["protokoll.topsScreen.quicklane.filter.option.decision", "protokoll.topsScreen.quicklane.filter.menu", "menu.children[index]"],
+]);
+
+class FakeElement {
+  constructor(tagName = "DIV") {
+    this.tagName = tagName; this.nodeName = tagName; this.parentElement = null; this.children = []; this.dataset = {}; this.attributes = {}; this.isConnected = true;
+    this.style = { setProperty(name, value) { this[name] = value; }, getPropertyValue(name) { return this[name] || ""; } };
+  }
+  setAttribute(name, value) { this.attributes[name] = String(value); if (name.startsWith("data-")) this.dataset[name.slice(5).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())] = String(value); }
+  getAttribute(name) { return this.attributes[name] || null; }
+  getBoundingClientRect() { return { left: 0, top: 0, width: 120, height: 28, right: 120, bottom: 28 }; }
+}
+
+async function runM867ProtokollButtonContractTests(run) {
+  const registry = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Registry.js"));
+  const refs = await importEsmFromFile(path.join(ROOT, "src/renderer/ui-editor/m80Refs.js"));
+  const entries = new Map(registry.listM80RegistryScopes().filter((scope) => scope.scopeId.startsWith("protokoll.")).flatMap((scope) => scope.elements.map((entry) => [entry.id, entry])));
+  const screenSource = read("src/renderer/modules/protokoll/screens/TopsScreen.js");
+  const quicklaneSource = read("src/renderer/modules/protokoll/TopsScreenQuicklane.js");
+
+  await run("M86.7 01: jedes bekannte sichtbare Protokoll-Buttonziel ist einzeln, begrenzt und parent-korrekt deklariert", () => {
+    assert.equal(new Set(BUTTONS.map(([id]) => id)).size, BUTTONS.length);
+    for (const [id, parentId] of BUTTONS) {
+      const entry = entries.get(id);
+      assert.ok(entry, `missing contract ${id}`);
+      assert.equal(entry.type, "button", id);
+      assert.equal(entry.parentId, parentId, id);
+      assert.equal(entries.has(parentId), true, `${id} -> ${parentId}`);
+      assert.equal(entry.editable, true, id);
+      assert.deepEqual(entry.allowedOps, ["move", "resizeWidth", "resizeHeight", "setVisibility"], id);
+      assert.equal(entry.baseline.minWidth > 0 && entry.baseline.maxWidth >= entry.baseline.minWidth, true, id);
+      assert.equal(entry.baseline.minHeight > 0 && entry.baseline.maxHeight >= entry.baseline.minHeight, true, id);
+      for (const locked of ["executeTargetAction", "modifyDomainData", "createRecord", "deleteRecord"]) assert.equal(entry.lockedOps.includes(locked), true, `${id}: ${locked}`);
+    }
+  });
+
+  await run("M86.7 02: produktive Bindungen verwenden nur die echten vorhandenen Button-Refs, ohne Wrapper oder DOM-Suche", () => {
+    for (const [id, , ref] of BUTTONS.filter(([id]) => !id.includes("quicklane") && id !== "protokoll.header.action.openUiEditor")) {
+      assert.match(screenSource, new RegExp(`registerM80Ref\\("${id.replace(/\\./g, "\\\\.")}", [^\\n]*${ref}`), id);
+    }
+    assert.match(quicklaneSource, /registerM80Ref\(buttonId, group\.children\[index\]\)/);
+    assert.match(quicklaneSource, /registerM80Ref\(`protokoll\.topsScreen\.quicklane\.filter\.option\.\$\{option\.mode\}`, menu\.children\[index\]\)/);
+    assert.doesNotMatch(screenSource.slice(screenSource.indexOf("  _registerUiEditorRefs() {"), screenSource.indexOf("  _buildProtocolScreenRegions() {")), /createElement|appendChild|insertBefore|querySelector/);
+  });
+
+  await run("M86.7 03: DEV-Button ist bedingt, Release bleibt ohne unvollständigen Slot und DEV-Ref ist direkt", () => {
+    const slot = registry.getM83ComponentContract("bbm.protokoll.screen").slots.find((entry) => entry.slotId === "protokoll.header.action.openUiEditor");
+    assert.deepEqual({ required: slot.required, referenceKind: slot.referenceKind, presence: slot.presence, directSelection: slot.requirements.directSelection }, { required: false, referenceKind: "multi", presence: "whenVisibleInstances", directSelection: true });
+    assert.match(read("src/renderer/modules/protokoll/TopsHeader.js"), /this\.uiEditorOpenButtonReady = installDevelopmentUiEditorOpenButton/);
+    assert.match(screenSource, /registerM80Ref\("protokoll\.header\.action\.openUiEditor", button\)/);
+    assert.match(screenSource, /registerM80MultiRef\("protokoll\.header\.action\.openUiEditor", header\.uiEditorOpenButton \? \[header\.uiEditorOpenButton\] : \[\], header\.actionsWrap\)/);
+    assert.match(quicklaneSource, /registerM80MultiRef\("protokoll\.topsScreen\.quicklane\.filter\.menu", \[\], this\.root\)/);
+  });
+
+  const previous = { document: global.document, window: global.window, Element: global.Element, CustomEvent: global.CustomEvent };
+  global.Element = FakeElement;
+  global.CustomEvent = class { constructor(type) { this.type = type; } };
+  global.document = { createElement: (tag) => new FakeElement(tag), querySelector: () => null };
+  global.window = { getComputedStyle: () => ({ width: "120px", height: "28px", paddingLeft: "0px", paddingTop: "0px", fontSize: "12px", boxSizing: "border-box" }), dispatchEvent() {} };
+  try {
+    await run("M86.7 04: jeder Button ist direkt selektierbar; doppelte IDs und fehlende Pflicht-Refs bleiben blockiert", () => {
+      refs.resetM80PilotWorkingStatesForDiagnostic(); refs.beginM80PilotRender();
+      const targets = new Map();
+      for (const [id, entry] of entries) {
+        if (entry.type !== "button" || id === "protokoll.header.action.openUiEditor" || id.includes("quicklane.filter.")) continue;
+        const target = new FakeElement("BUTTON"); targets.set(id, target); refs.registerM80Ref(id, target);
+        assert.equal(refs.getM80IdFromTarget(target), id, id);
+      }
+      assert.throws(() => refs.registerM80Ref("protokoll.header.action.close", new FakeElement("BUTTON")), (error) => error.code === "component_single_ref_duplicate");
+      assert.throws(() => refs.validateM83ComponentReferences(["bbm.protokoll.screen"]), (error) => error.code === "component_reference_contract_invalid" && error.details.some((entry) => entry.code === "component_slot_reference_missing" && entry.slotId === "protokoll.header"));
+    });
+  } finally {
+    refs.resetM80PilotWorkingStatesForDiagnostic(); global.document = previous.document; global.window = previous.window; global.Element = previous.Element; global.CustomEvent = previous.CustomEvent;
+  }
+}
+
+module.exports = { runM867ProtokollButtonContractTests };
+if (require.main === module) {
+  let failed = false;
+  const run = async (name, test) => { try { await test(); console.log(`ok - ${name}`); } catch (error) { failed = true; console.error(`not ok - ${name}`); console.error(error?.stack || error); } };
+  runM867ProtokollButtonContractTests(run).then(() => { if (failed) process.exitCode = 1; }).catch((error) => { process.exitCode = 1; console.error(error?.stack || error); });
+}

--- a/scripts/tests/testHarnessOrchestration.test.cjs
+++ b/scripts/tests/testHarnessOrchestration.test.cjs
@@ -12,7 +12,7 @@ async function runTestHarnessOrchestrationTests(run) {
   await run("Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert", () => {
     const suites = TEST_GROUPS.flatMap((group) => group.suites.map(([moduleName, exportName]) => `${moduleName}#${exportName}`));
     assert.equal(TEST_GROUPS.length, 8);
-    assert.equal(suites.length, 119, "119 Suite-Einstiege einschließlich M86.5-Protokolllayoutreparatur");
+    assert.equal(suites.length, 120, "120 Suite-Einstiege einschließlich M86.7-Protokollbuttonverträge");
     assert.equal(new Set(suites).size, suites.length);
     for (const suite of suites) assert.equal(fs.existsSync(path.resolve(__dirname, suite.split("#")[0])), true, suite);
     assert.equal(TEST_GROUPS.filter((group) => group.includeStoragePathTests).length, 1);

--- a/src/main/ui-editor/electronUiEditorSession.js
+++ b/src/main/ui-editor/electronUiEditorSession.js
@@ -347,10 +347,13 @@ class ElectronUiEditorSessionController {
       });
       this.child.once("exit", () => { void this.#disposeSession("editor_process_exited", false); });
       this.child.once("error", (error) => { void this.#disposeSession(error?.code || "editor_process_error", false); });
+      // The native peer requests the registry as part of its initial handshake.
+      // Make the immutable snapshot available before opening that pipe so the
+      // renderer response is validated against this very session.
+      this.currentRegistration = registrationSnapshot;
       this.client = await this.#connectWithRetry(identifiers, contract);
       this.client.on("disconnect", () => { void this.#disposeSession("editor_disconnected", false); });
       this.client.on("connectionError", (_error) => { void _error; });
-      this.currentRegistration = registrationSnapshot;
       this.#startHeartbeat();
       return { ok: true, started: true, focused: false, sessionId: identifiers.sessionId, registryRefreshStatus: "changed" };
     } catch (error) {

--- a/src/renderer/modules/protokoll/TopsHeader.js
+++ b/src/renderer/modules/protokoll/TopsHeader.js
@@ -81,9 +81,13 @@ export class TopsHeader {
     };
 
     this.actionsWrap.append(this.btnEndMeeting, this.btnClose);
-    void installDevelopmentUiEditorOpenButton({
+    this.uiEditorOpenButton = null;
+    this.uiEditorOpenButtonReady = installDevelopmentUiEditorOpenButton({
       host: this.actionsWrap,
       scopeId: "protokoll.screen.root",
+    }).then((button) => {
+      this.uiEditorOpenButton = button;
+      return button;
     });
     this.root.append(
       this.titleWrap,

--- a/src/renderer/modules/protokoll/TopsScreenQuicklane.js
+++ b/src/renderer/modules/protokoll/TopsScreenQuicklane.js
@@ -1,5 +1,5 @@
 import { getTopFilterBadge, getTopFilterLabel, normalizeTopFilterMode } from "./topFilterMode.js";
-import { beginM83ComponentBinding, completeM80PilotRender, registerM80Ref } from "../../ui-editor/m80Refs.js";
+import { beginM83ComponentBinding, completeM80PilotRender, registerM80MultiRef, registerM80Ref } from "../../ui-editor/m80Refs.js";
 
 const ICON_CLASS = "bbm-tops-screen-quicklane-icon";
 const AMPEL_STATUS_ICON_URL = "./assets/icons/ampel-status.svg";
@@ -244,6 +244,8 @@ export class TopsScreenQuicklane {
       registerM80Ref(groupId, group);
       buttonIds.forEach((buttonId, index) => registerM80Ref(buttonId, group.children[index]));
     }
+    registerM80MultiRef("protokoll.topsScreen.quicklane.filter.menu", [], this.root);
+    FILTER_OPTIONS.forEach((option) => registerM80MultiRef(`protokoll.topsScreen.quicklane.filter.option.${option.mode}`, [], this.root));
     completeM80PilotRender();
   }
 
@@ -272,6 +274,11 @@ export class TopsScreenQuicklane {
     }
     this.filterMenu = menu;
     this.root.appendChild(menu);
+    registerM80Ref("protokoll.topsScreen.quicklane.filter.menu", menu);
+    FILTER_OPTIONS.forEach((option, index) => {
+      registerM80Ref(`protokoll.topsScreen.quicklane.filter.option.${option.mode}`, menu.children[index]);
+    });
+    completeM80PilotRender();
   }
 
   _togglePinned() {

--- a/src/renderer/modules/protokoll/TopsWorkbench.uiEditorContract.js
+++ b/src/renderer/modules/protokoll/TopsWorkbench.uiEditorContract.js
@@ -5,6 +5,7 @@ import {
   TEXT_LAYOUT,
   ZONE_HEIGHT_LAYOUT,
   m83Component,
+  m83DomainButton,
   m83Element,
   m83Slot,
 } from "../../ui-editor/m83ComponentContract.js";
@@ -17,12 +18,24 @@ const elements = [
   m83Element({ id: "protokoll.edit.workbench", name: "Gruppe TOP-Bearbeitung", type: "group", role: "layoutGroup", parentId: "protokoll.edit.canvas", order: 20, allowedOps: groupLayout, componentKind: "workbench" }),
   m83Element({ id: "protokoll.edit.header", name: "Gruppe TOP-Bearbeitungskopf", type: "group", role: "layoutGroup", parentId: "protokoll.edit.workbench", order: 30, allowedOps: GROUP_LAYOUT, componentKind: "header" }),
   m83Element({ id: "protokoll.edit.header.label", name: "Bezeichnung TOP bearbeiten", type: "label", role: "fieldLabel", parentId: "protokoll.edit.header", order: 31, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  m83Element({ id: "protokoll.edit.header.addActions", name: "Gruppe TOP anlegen", type: "group", role: "layoutGroup", parentId: "protokoll.edit.header", order: 32, allowedOps: GROUP_LAYOUT, componentKind: "actionGroup" }),
+  m83DomainButton({ id: "protokoll.edit.header.action.addTitle", name: "+Titel", parentId: "protokoll.edit.header.addActions", order: 33, actionKind: "createTitle" }),
+  m83DomainButton({ id: "protokoll.edit.header.action.addTop", name: "+TOP", parentId: "protokoll.edit.header.addActions", order: 34, actionKind: "createTop" }),
+  m83Element({ id: "protokoll.edit.header.primaryActions", name: "Gruppe TOP-Aktionen", type: "group", role: "layoutGroup", parentId: "protokoll.edit.header", order: 35, allowedOps: GROUP_LAYOUT, componentKind: "actionGroup" }),
+  m83DomainButton({ id: "protokoll.edit.header.action.move", name: "Schieben", parentId: "protokoll.edit.header.primaryActions", order: 36, actionKind: "moveTop" }),
+  m83DomainButton({ id: "protokoll.edit.header.action.delete", name: "Papierkorb", parentId: "protokoll.edit.header.primaryActions", order: 37, actionKind: "deleteTop" }),
   m83Element({ id: "protokoll.edit.text", name: "Gruppe Textbearbeitung", type: "group", role: "fieldCollection", parentId: "protokoll.edit.workbench", order: 40, allowedOps: groupLayout, componentKind: "editbox" }),
   ...[["short", "Kurztext", "text", 41], ["long", "Langtext", "multilineText", 50]].flatMap(([key, name, fieldKind, order]) => [
     m83Element({ id: `protokoll.edit.${key}`, name: `Gruppe ${name}`, type: "fieldGroup", role: "formFieldGroup", parentId: "protokoll.edit.text", order, allowedOps: groupLayout, componentKind: "fieldGroup" }),
     m83Element({ id: `protokoll.edit.${key}.label`, name: `Bezeichnung ${name}`, type: "label", role: "fieldLabel", parentId: `protokoll.edit.${key}`, order: order + 1, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
     m83Element({ id: `protokoll.edit.${key}.field`, name: `Eingabefeld ${name}`, type: "field", role: "dataFieldLayout", parentId: `protokoll.edit.${key}`, order: order + 2, allowedOps: FIELD_LAYOUT, fieldKind, componentKind: fieldKind === "text" ? "input" : "textarea" }),
   ]),
+  m83DomainButton({ id: "protokoll.edit.short.action.dictation", name: "Diktat starten Kurztext", parentId: "protokoll.edit.short.label", order: 44, actionKind: "dictationShort" }),
+  m83DomainButton({ id: "protokoll.edit.long.action.dictation", name: "Diktat starten Langtext", parentId: "protokoll.edit.long.label", order: 54, actionKind: "dictationLong" }),
+  m83Element({ id: "protokoll.edit.dictation.status", name: "Diktatstatus", type: "group", role: "layoutGroup", parentId: "protokoll.edit.text", order: 55, allowedOps: groupLayout, componentKind: "dictationStatus" }),
+  m83DomainButton({ id: "protokoll.edit.dictation.status.action.undo", name: "Rückgängig", parentId: "protokoll.edit.dictation.status", order: 56, actionKind: "dictationUndo" }),
+  m83Element({ id: "protokoll.edit.long.correction", name: "Gruppe Diktatkorrektur", type: "group", role: "layoutGroup", parentId: "protokoll.edit.long.label", order: 57, allowedOps: groupLayout, componentKind: "dictionaryCorrection" }),
+  m83DomainButton({ id: "protokoll.edit.long.correction.action.open", name: "Korrektur", parentId: "protokoll.edit.long.correction", order: 58, actionKind: "dictionaryCorrection" }),
   m83Element({ id: "protokoll.edit.meta", name: "Gruppe Status und Zuordnung", type: "group", role: "fieldCollection", parentId: "protokoll.edit.workbench", order: 60, allowedOps: groupLayout, componentKind: "metaPanel" }),
   m83Element({ id: "protokoll.edit.flags", name: "Gruppe Kennzeichnungen", type: "group", role: "layoutGroup", parentId: "protokoll.edit.meta", order: 61, allowedOps: groupLayout, componentKind: "flagGroup" }),
   ...[["status", "Status", "select", 70], ["due", "Fertig bis", "date", 80], ["responsible", "Verantwortlich", "select", 90]].flatMap(([key, name, fieldKind, order]) => [
@@ -35,8 +48,10 @@ const elements = [
 
 export const PROTOKOLL_EDIT_REQUIRED_SLOTS = Object.freeze([
   scopeId, "protokoll.edit.canvas", "protokoll.edit.workbench", "protokoll.edit.header", "protokoll.edit.header.label", "protokoll.edit.text",
+  "protokoll.edit.header.addActions", "protokoll.edit.header.action.addTitle", "protokoll.edit.header.action.addTop", "protokoll.edit.header.primaryActions", "protokoll.edit.header.action.move", "protokoll.edit.header.action.delete",
   "protokoll.edit.short", "protokoll.edit.short.label", "protokoll.edit.short.field",
   "protokoll.edit.long", "protokoll.edit.long.label", "protokoll.edit.long.field",
+  "protokoll.edit.short.action.dictation", "protokoll.edit.long.action.dictation", "protokoll.edit.dictation.status", "protokoll.edit.dictation.status.action.undo", "protokoll.edit.long.correction", "protokoll.edit.long.correction.action.open",
   "protokoll.edit.meta", "protokoll.edit.flags",
   ...["status", "due", "responsible"].flatMap((key) => [`protokoll.edit.${key}`, `protokoll.edit.${key}.label`, `protokoll.edit.${key}.field`]),
   "protokoll.edit.ampel",

--- a/src/renderer/modules/protokoll/screens/TopsScreen.js
+++ b/src/renderer/modules/protokoll/screens/TopsScreen.js
@@ -43,6 +43,7 @@ import {
   beginM80PilotRender,
   beginM83ComponentBinding,
   completeM80PilotRender,
+  registerM80MultiRef,
   registerM80Ref,
 } from "../../../ui-editor/m80Refs.js";
 
@@ -225,6 +226,15 @@ export default class TopsScreen {
     registerM80Ref("protokoll.header.meta.due", header.metaLegendDue);
     registerM80Ref("protokoll.header.meta.status", header.metaLegendStatus);
     registerM80Ref("protokoll.header.meta.responsible", header.metaLegendResponsible);
+    registerM80Ref("protokoll.header.actions", header.actionsWrap);
+    registerM80Ref("protokoll.header.action.endMeeting", header.btnEndMeeting);
+    registerM80Ref("protokoll.header.action.close", header.btnClose);
+    registerM80MultiRef("protokoll.header.action.openUiEditor", header.uiEditorOpenButton ? [header.uiEditorOpenButton] : [], header.actionsWrap);
+    void header.uiEditorOpenButtonReady?.then((button) => {
+      if (!button || this.header !== header) return;
+      registerM80Ref("protokoll.header.action.openUiEditor", button);
+      completeM80PilotRender();
+    });
     registerM80Ref("protokoll.list.root", this.sheetArea);
     registerM80Ref("protokoll.list.canvas", this.sheetCanvas);
     registerM80Ref("protokoll.list.paper", this.sheetPaper);
@@ -235,6 +245,12 @@ export default class TopsScreen {
     registerM80Ref("protokoll.edit.workbench", workbench.root);
     registerM80Ref("protokoll.edit.header", workbench.header);
     registerM80Ref("protokoll.edit.header.label", workbench.leftHeaderTitle);
+    registerM80Ref("protokoll.edit.header.addActions", workbench.headerAddActions);
+    registerM80Ref("protokoll.edit.header.action.addTitle", workbench.btnL1);
+    registerM80Ref("protokoll.edit.header.action.addTop", workbench.btnChild);
+    registerM80Ref("protokoll.edit.header.primaryActions", workbench.headerPrimaryActions);
+    registerM80Ref("protokoll.edit.header.action.move", workbench.btnMove);
+    registerM80Ref("protokoll.edit.header.action.delete", workbench.btnDelete);
     registerM80Ref("protokoll.edit.text", workbench.sharedEditboxCore.root);
     registerM80Ref("protokoll.edit.short", editbox.shortWrap);
     registerM80Ref("protokoll.edit.short.label", editbox.shortLabel);
@@ -242,6 +258,12 @@ export default class TopsScreen {
     registerM80Ref("protokoll.edit.long", editbox.longWrap);
     registerM80Ref("protokoll.edit.long.label", editbox.longLabel);
     registerM80Ref("protokoll.edit.long.field", editbox.longInput);
+    registerM80Ref("protokoll.edit.short.action.dictation", workbench.sharedEditboxCore.shortDictateButton);
+    registerM80Ref("protokoll.edit.long.action.dictation", workbench.sharedEditboxCore.longDictateButton);
+    registerM80Ref("protokoll.edit.dictation.status", workbench.sharedEditboxCore.dictationStatusBar);
+    registerM80Ref("protokoll.edit.dictation.status.action.undo", workbench.sharedEditboxCore.dictationUndoButton);
+    registerM80Ref("protokoll.edit.long.correction", workbench.sharedEditboxCore.dictionaryCorrectionBar);
+    registerM80Ref("protokoll.edit.long.correction.action.open", workbench.sharedEditboxCore.dictionaryCorrectionButton);
     registerM80Ref("protokoll.edit.meta", meta.root);
     registerM80Ref("protokoll.edit.flags", meta.flagsMetaRow);
     registerM80Ref("protokoll.edit.status", status.statusWrap);

--- a/src/renderer/modules/protokoll/screens/TopsScreen.uiEditorContract.js
+++ b/src/renderer/modules/protokoll/screens/TopsScreen.uiEditorContract.js
@@ -11,7 +11,7 @@ import {
 const scopeId = "protokoll.screen.root";
 const protokollGroupLayout = Object.freeze(["move", "resizeWidth", "resizeHeight"]);
 
-const elements = [
+const screenElements = [
   m83Element({ id: scopeId, name: "Protokoll-TopScreen", type: "root", role: "scopeRoot", parentId: null, order: 0, allowedOps: [], componentKind: "screen" }),
   m83Element({ id: "protokoll.header", name: "Protokoll-Kopfbereich", type: "area", role: "contentArea", parentId: scopeId, order: 10, allowedOps: GROUP_LAYOUT, componentKind: "header" }),
   m83Element({ id: "protokoll.header.titleGroup", name: "Gruppe Protokollbezeichnung", type: "group", role: "layoutGroup", parentId: "protokoll.header", order: 20, allowedOps: protokollGroupLayout, componentKind: "titleGroup" }),
@@ -22,6 +22,13 @@ const elements = [
   m83Element({ id: "protokoll.header.meta.due", name: "Bezeichnung Fertig bis", type: "label", role: "fieldLabel", parentId: "protokoll.header.meta", order: 31, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
   m83Element({ id: "protokoll.header.meta.status", name: "Bezeichnung Status", type: "label", role: "fieldLabel", parentId: "protokoll.header.meta", order: 32, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
   m83Element({ id: "protokoll.header.meta.responsible", name: "Bezeichnung Verantwortlich", type: "label", role: "fieldLabel", parentId: "protokoll.header.meta", order: 33, allowedOps: TEXT_LAYOUT, componentKind: "label" }),
+  m83Element({ id: "protokoll.header.actions", name: "Gruppe Protokoll-Aktionen", type: "group", role: "layoutGroup", parentId: "protokoll.header", order: 40, allowedOps: GROUP_LAYOUT, componentKind: "actionGroup" }),
+  m83DomainButton({ id: "protokoll.header.action.endMeeting", name: "Protokoll beenden", parentId: "protokoll.header.actions", order: 41, actionKind: "endMeeting" }),
+  m83DomainButton({ id: "protokoll.header.action.close", name: "Schliessen", parentId: "protokoll.header.actions", order: 42, actionKind: "close" }),
+  m83DomainButton({ id: "protokoll.header.action.openUiEditor", name: "UI-Editor öffnen", parentId: "protokoll.header.actions", order: 43, actionKind: "developmentOpenUiEditor" }),
+];
+
+const quicklaneElements = [
   m83Element({ id: "protokoll.topsScreen.quicklane", name: "Protokoll-Quicklane", type: "area", role: "layout", parentId: scopeId, order: 40, allowedOps: protokollGroupLayout, componentKind: "toolbar" }),
   ...[["navigation", "Navigation", 41], ["visibility", "Sichtbarkeit", 42], ["filter", "TOP-Filter", 43], ["output", "Ausgabe", 44]].map(([key, name, order]) => m83Element({ id: `protokoll.topsScreen.quicklane.group.${key}`, name: `Gruppe ${name}`, type: "group", role: "layoutGroup", parentId: "protokoll.topsScreen.quicklane", order, allowedOps: GROUP_LAYOUT, componentKind: "toolbarGroup" })),
   ...[
@@ -29,11 +36,23 @@ const elements = [
     ["action.ampel", "Ampel", "visibility", 54], ["action.longtext", "Langtext", "visibility", 55], ["action.topFilter", "TOP-Filter", "filter", 56],
     ["action.preview", "PDF-Vorschau", "output", 57], ["action.print", "Drucken", "output", 58], ["action.mail", "E-Mail", "output", 59],
   ].map(([key, name, group, order]) => m83DomainButton({ id: `protokoll.topsScreen.quicklane.${key}`, name, parentId: `protokoll.topsScreen.quicklane.group.${group}`, order, actionKind: "domainAction" })),
+  m83Element({ id: "protokoll.topsScreen.quicklane.filter.menu", name: "TOP-Filterauswahl", type: "group", role: "layoutGroup", parentId: "protokoll.topsScreen.quicklane", order: 60, allowedOps: GROUP_LAYOUT, componentKind: "transientMenu" }),
+  ...[["all", "Alle", 61], ["todo", "ToDo", 62], ["decision", "Beschluss", 63]].map(([key, name, order]) => m83DomainButton({ id: `protokoll.topsScreen.quicklane.filter.option.${key}`, name, parentId: "protokoll.topsScreen.quicklane.filter.menu", order, actionKind: "filter" })),
 ];
+
+const elements = [...screenElements, ...quicklaneElements];
+const optionalScreenSlotIds = new Set(["protokoll.header.action.openUiEditor"]);
+const optionalQuicklaneSlotIds = new Set([
+  "protokoll.topsScreen.quicklane.filter.menu",
+  "protokoll.topsScreen.quicklane.filter.option.all",
+  "protokoll.topsScreen.quicklane.filter.option.todo",
+  "protokoll.topsScreen.quicklane.filter.option.decision",
+]);
 
 export const PROTOKOLL_SCREEN_REQUIRED_SLOTS = Object.freeze([
   scopeId, "protokoll.header", "protokoll.header.titleGroup", "protokoll.header.title", "protokoll.header.keyword", "protokoll.header.context",
   "protokoll.header.meta", "protokoll.header.meta.due", "protokoll.header.meta.status", "protokoll.header.meta.responsible",
+  "protokoll.header.actions", "protokoll.header.action.endMeeting", "protokoll.header.action.close",
 ]);
 export const PROTOKOLL_QUICKLANE_REQUIRED_SLOTS = Object.freeze([
   "protokoll.topsScreen.quicklane",
@@ -47,7 +66,10 @@ export const protokollScreenUiEditorContract = m83Component({
   componentId: "bbm.protokoll.screen",
   scopeId,
   requiredSlots: PROTOKOLL_SCREEN_REQUIRED_SLOTS,
-  slots: elements.slice(0, 10).map((entry) => m83Slot(entry.id, entry, {
+  slots: screenElements.map((entry) => m83Slot(entry.id, entry, {
+    required: !optionalScreenSlotIds.has(entry.id),
+    referenceKind: optionalScreenSlotIds.has(entry.id) ? "multi" : "single",
+    presence: optionalScreenSlotIds.has(entry.id) ? "whenVisibleInstances" : "always",
     requirements: { textResize: entry.type === "label", move: entry.allowedOps.includes("move") },
   })),
 });
@@ -56,7 +78,10 @@ export const protokollQuicklaneUiEditorContract = m83Component({
   componentId: "bbm.protokoll.quicklane",
   scopeId,
   requiredSlots: PROTOKOLL_QUICKLANE_REQUIRED_SLOTS,
-  slots: elements.slice(10).map((entry) => m83Slot(entry.id, entry, {
+  slots: quicklaneElements.map((entry) => m83Slot(entry.id, entry, {
+    required: !optionalQuicklaneSlotIds.has(entry.id),
+    referenceKind: optionalQuicklaneSlotIds.has(entry.id) ? "multi" : "single",
+    presence: optionalQuicklaneSlotIds.has(entry.id) ? "whenVisibleInstances" : "always",
     requirements: { move: entry.allowedOps.includes("move") },
   })),
 });

--- a/src/renderer/ui-editor/m80Registry.js
+++ b/src/renderer/ui-editor/m80Registry.js
@@ -6,7 +6,7 @@ import { protokollListColumnsUiEditorContract, protokollListUiEditorContract } f
 import { protokollEditUiEditorContract } from "../modules/protokoll/TopsWorkbench.uiEditorContract.js";
 import { aggregateBbmM83Components } from "./m83ComponentContract.js";
 
-export const BBM_M80_REGISTRY_VERSION = 13;
+export const BBM_M80_REGISTRY_VERSION = 15;
 export const BBM_M80_REGISTRY_STATUS = "incomplete";
 
 export const BBM_M83_COMPONENT_CONTRACTS = Object.freeze([

--- a/ui-editor-target.json
+++ b/ui-editor-target.json
@@ -7,8 +7,8 @@
   "integrationMode": "existing-app",
   "contractVersion": "1.2",
   "adapterVersion": "1.2",
-  "registryVersion": 13,
-  "registryFingerprint": "sha256:efbfce1737d4690b96d4add9cfee129db742c44e9fdd7512e4b8db252cf681d5",
+  "registryVersion": 15,
+  "registryFingerprint": "sha256:e0161dc468095ec8dee69c9caf0d6468959a9f3691b06096c1951fb3ed98ccf8",
   "registryStatus": "incomplete",
   "activeScopes": [
     "restarbeiten.header.root",
@@ -50,9 +50,9 @@
     { "scopeId": "restarbeiten.header.root", "status": "complete", "reason": null, "elementCount": 31, "missingReferenceCount": 0 },
     { "scopeId": "restarbeiten.list.root", "status": "complete", "reason": null, "elementCount": 32, "missingReferenceCount": 0 },
     { "scopeId": "restarbeiten.edit.root", "status": "complete", "reason": null, "elementCount": 53, "missingReferenceCount": 0 },
-    { "scopeId": "protokoll.screen.root", "status": "complete", "reason": null, "elementCount": 25, "missingReferenceCount": 0 },
+    { "scopeId": "protokoll.screen.root", "status": "complete", "reason": null, "elementCount": 33, "missingReferenceCount": 0 },
     { "scopeId": "protokoll.list.root", "status": "complete", "reason": null, "elementCount": 7, "missingReferenceCount": 0 },
-    { "scopeId": "protokoll.edit.root", "status": "complete", "reason": null, "elementCount": 24, "missingReferenceCount": 0 },
+    { "scopeId": "protokoll.edit.root", "status": "complete", "reason": null, "elementCount": 36, "missingReferenceCount": 0 },
     { "scopeId": "bbm.remaining", "status": "blocked", "reason": "registration_inventory_pending", "elementCount": 0, "missingReferenceCount": 0 },
     { "scopeId": "pdf.bbm.protocol", "status": "complete", "reason": null, "elementCount": 28, "missingReferenceCount": 0 }
   ],
@@ -65,5 +65,5 @@
     ]
   },
   "installedAt": "2026-07-27T00:00:00+00:00",
-  "updatedAt": "2026-07-27T00:00:00+00:00"
+  "updatedAt": "2026-08-02T00:00:00+00:00"
 }


### PR DESCRIPTION
M86.7 registriert die sichtbaren Protokoll-Buttons komponentennah und vollständig für den bestehenden UI-Editor. Enthalten sind stabile IDs, direkte DOM-Refs, gültige Parents, Baselines, Bounds und erlaubte Layoutoperationen für Header-, Workbench- und Quicklane-Aktionen. Zusätzlich wurde der Start-Handshake repariert, sodass der Sessionsnapshot bereits vor der ersten Registry-Anfrage verfügbar ist. Zwei isolierte Acceptance-Starts sowie Save/Restore wurden bestätigt. Keine neue Sammelregistry, keine DOM-Erkennung, keine Wrapper-, Scroll- oder Fachlogikänderung. `docs/licensing.md` und `design-reference/` sind nicht Bestandteil des Commits. Commit: `94de4ca96c5a9368b7b90579c7bc7927d9abaa4a`.