### PR TITLE
Restarbeiten-Filterbar und Editbox zentrieren

### DIFF
--- a/scripts/tests/m82-1BbmFeintuning.test.cjs
+++ b/scripts/tests/m82-1BbmFeintuning.test.cjs
@@ -78,7 +78,7 @@ async function runM821BbmFeintuningTests(run) {
   await run("M82.1 BBM 30: Layout und Icon-Trennung sind real im Renderer verankert", () => { assert.match(editbox, /\.headerZone/); assert.match(editbox, /dictation\.icon/); assert.match(css, /min-height:\s*190px/); assert.match(css, /overflow:\s*auto/); });
   await run("M84.0 BBM 30a: Editbox bleibt im bestehenden Flex-Arbeitsbereich unten und gibt Höhe an die Liste frei", () => {
     assert.match(css, /\.bbm-restarbeiten-workspace__list\s*\{[\s\S]*flex:\s*1 1 0/);
-    assert.match(css, /\.bbm-restarbeiten-workspace__edit\s*\{[\s\S]*flex:\s*0 0 auto[\s\S]*align-items:\s*flex-end/);
+    assert.match(css, /\.bbm-restarbeiten-workspace__edit\s*\{[\s\S]*flex:\s*0 0 auto[\s\S]*align-items:\s*center/);
     assert.match(css, /\.bbm-restarbeiten-editbox\s*\{[\s\S]*height:\s*248px[\s\S]*min-height:\s*190px/);
     assert.match(css, /@media \(max-height:\s*850px\)[\s\S]*\.bbm-restarbeiten-editbox\s*\{[\s\S]*height:\s*220px/);
   });

--- a/scripts/tests/m82-6TopScreenModuleClosure.test.cjs
+++ b/scripts/tests/m82-6TopScreenModuleClosure.test.cjs
@@ -47,7 +47,10 @@ async function runM826TopScreenModuleClosureTests(run) {
   await run("M82.6 BBM 10: alte Overflow-Regeln sind entfernt", () => assert.doesNotMatch(css, /bbm-restarbeiten-table-(viewport|scroll-area)/));
   await run("M82.6 BBM 11: nur die vorhandene Mitte scrollt vertikal", () => assert.match(css, /\.bbm-restarbeiten-main\s*\{[\s\S]*?overflow-x:\s*hidden;[\s\S]*?overflow-y:\s*auto;/));
   await run("M82.6 BBM 12: TopScreen behaelt Kopf, Liste und Editbox", () => ["bbm-restarbeiten-header", "bbm-restarbeiten-workspace__list", "bbm-restarbeiten-workspace__edit"].forEach((name) => assert.match(screen, new RegExp(name))));
-  await run("M82.6 BBM 13: A4-nahe Listenblattbreite bleibt 900 px", () => assert.match(css, /\.bbm-restarbeiten-paper\s*\{[\s\S]*?width:\s*min\(100%,\s*900px\)/));
+  await run("M82.6 BBM 13: A4-nahe Listenblattbreite nutzt den gemeinsamen 900-px-Breitenanker", () => {
+    assert.match(css, /--bbm-restarbeiten-content-width:\s*min\(900px,\s*calc\(100vw - 88px\)\)/);
+    assert.match(css, /\.bbm-restarbeiten-paper\s*\{[\s\S]*?width:\s*var\(--bbm-restarbeiten-content-width\)/);
+  });
   await run("M82.6 BBM 14: Protokoll-TopsScreen blieb bytegleich", () => assert.equal(sha256("src/renderer/views/TopsScreen.js"), "0826FDC88D2D454D384F0D64CC6678AC356E2BFD73041B9336E89266EF57D1B3"));
   await run("M82.6 BBM 15: Protokoll-TopScreen-CSS blieb bytegleich", () => assert.equal(sha256("src/renderer/tops/styles/tops.css"), "93863CA66367BF145DD4E5E50F78811A784BFE8AE70BBE50996249306DF084CB"));
   await run("M82.6 BBM 16: Protokoll besitzt weiterhin genau den mittleren Sheet-Scrollbereich", () => { const protocolCss = read("src/renderer/tops/styles/tops.css"); assert.match(protocolCss, /\[data-bbm-tops-screen-area="sheet"\][\s\S]*?overflow:\s*auto/); assert.match(protocolCss, /\[data-bbm-tops-screen-area="edit"\][\s\S]*?flex:\s*0 0 auto/); });

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1054,9 +1054,9 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(css.includes('--bbm-rest-font-family: "Noto Sans", Arial, sans-serif;'), true);
       assert.equal(css.includes(".bbm-restarbeiten-screen,\n.bbm-restarbeiten-screen button,\n.bbm-restarbeiten-screen input,\n.bbm-restarbeiten-screen select,\n.bbm-restarbeiten-screen textarea {\n  font-family: var(--bbm-rest-font-family);"), true);
       assert.equal(css.includes(".bbm-restarbeiten-filterbar [data-ui-editor-id=\"restarbeiten.filterbar.group.meta\"] .bbm-restarbeiten-field span,\n.bbm-restarbeiten-filterbar [data-ui-editor-id=\"restarbeiten.filterbar.group.meta\"] .bbm-restarbeiten-field input,\n.bbm-restarbeiten-filterbar [data-ui-editor-id=\"restarbeiten.filterbar.group.meta\"] .bbm-restarbeiten-field select {\n  color: var(--bbm-muted);\n  font-size: 6.5pt;\n  font-weight: 400;\n  line-height: 1.1;"), true);
-      assert.equal(css.includes(".bbm-restarbeiten-filter-group {\n  grid-auto-flow: column;\n  grid-auto-columns: minmax(104px, auto);\n  align-items: center;"), true);
-      assert.equal(css.includes(".bbm-restarbeiten-filterbar .bbm-restarbeiten-class-toggle {\n  flex-direction: row;\n  align-items: center;\n  justify-content: center;\n  gap: 4px;"), true);
-      assert.equal(css.includes(".bbm-restarbeiten-filterbar .bbm-restarbeiten-class-toggle button {\n  min-height: var(--bbm-rest-control-height);\n  margin: 0;\n  padding: 4px 7px;"), true);
+      assert.equal(css.includes(".bbm-restarbeiten-filter-group {\n  grid-auto-flow: column;\n  grid-auto-columns: minmax(94px, auto);\n  align-items: center;"), true);
+      assert.equal(css.includes(".bbm-restarbeiten-filterbar .bbm-restarbeiten-class-toggle {\n  flex-direction: row;\n  align-items: center;\n  justify-content: center;\n  gap: 6px;"), true);
+      assert.equal(css.includes(".bbm-restarbeiten-filterbar .bbm-restarbeiten-class-toggle button {\n  min-width: 46px;\n  min-height: 26px;\n  margin: 0;\n  padding: 2px 6px;"), true);
     } finally {
       globalThis.document = prevDocument;
     }
@@ -1753,6 +1753,14 @@ async function runRestarbeitenModuleTests(run) {
     assert.equal(css.includes("grid-template-rows: auto minmax(0, 1fr);"), true);
     assert.equal(css.includes("flex-direction: column;"), true);
     assert.equal(css.includes("--bbm-restarbeiten-list-height"), false);
+    assert.equal(css.includes("--bbm-restarbeiten-content-width: min(900px, calc(100vw - 88px));"), true);
+    assert.equal(css.includes(".bbm-restarbeiten-filterbar {\n  width: var(--bbm-restarbeiten-content-width);"), true);
+    assert.equal(css.includes(".bbm-restarbeiten-paper {\n  width: var(--bbm-restarbeiten-content-width);"), true);
+    assert.equal(css.includes(".bbm-restarbeiten-editbox {\n  width: var(--bbm-restarbeiten-content-width);"), true);
+    assert.equal(css.includes(".bbm-restarbeiten-workspace__edit {\n  flex: 0 0 auto;\n  max-height: calc(100% - 180px);\n  overflow: auto;\n  scrollbar-gutter: stable both-edges;\n  display: flex;\n  align-items: center;"), true);
+    assert.equal(css.includes("overflow-y: auto;\n  scrollbar-gutter: stable both-edges;\n  padding: 10px 0 12px;"), true);
+    assert.equal(css.includes(".bbm-restarbeiten-filterbar .bbm-restarbeiten-class-toggle button {\n  min-width: 46px;\n  min-height: 26px;"), true);
+    assert.equal(css.includes("@media (max-height: 520px)"), true);
     assert.equal(css.includes(".bbm-restarbeiten-main {\n  min-height: 0;\n  overflow-x: hidden;\n  overflow-y: auto;"), true);
     assert.equal(css.includes(".bbm-restarbeiten-screen {\n  min-height: 0;\n  height: 100%;\n  max-height: 100%;"), true);
     assert.equal(css.includes(".bbm-restarbeiten-record__number {\n  font-size: 8.5pt;\n  font-weight: 600;\n  line-height: 1.15;"), true);

--- a/src/renderer/modules/restarbeiten/styles/restarbeiten.css
+++ b/src/renderer/modules/restarbeiten/styles/restarbeiten.css
@@ -29,6 +29,7 @@
   --bbm-rest-radius-control: 6px;
   --bbm-rest-control-height: 28px;
   --bbm-rest-panel-gap: 8px;
+  --bbm-restarbeiten-content-width: min(900px, calc(100vw - 88px));
 }
 
 .bbm-restarbeiten-screen {
@@ -52,6 +53,9 @@
   max-width: 100%;
   max-height: 240px;
   overflow: auto;
+  display: grid;
+  justify-items: center;
+  align-content: start;
 }
 
 .bbm-restarbeiten-workspace {
@@ -79,8 +83,9 @@
   flex: 0 0 auto;
   max-height: calc(100% - 180px);
   overflow: auto;
+  scrollbar-gutter: stable both-edges;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
 }
 
 .bbm-restarbeiten-workspace__list > .bbm-restarbeiten-main {
@@ -114,8 +119,9 @@
 }
 
 .bbm-restarbeiten-filterbar {
-  margin: 0 72px 6px 16px;
-  padding: 9px 12px;
+  width: var(--bbm-restarbeiten-content-width);
+  margin: 0 auto 6px;
+  padding: 8px 10px;
   box-sizing: border-box;
   height: auto;
   max-height: 220px;
@@ -124,6 +130,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--bbm-rest-panel-gap);
+  justify-content: center;
   align-items: center;
   border-radius: var(--bbm-rest-radius-panel);
 }
@@ -137,9 +144,9 @@
 
 .bbm-restarbeiten-filter-group {
   grid-auto-flow: column;
-  grid-auto-columns: minmax(104px, auto);
+  grid-auto-columns: minmax(94px, auto);
   align-items: center;
-  gap: 4px 7px;
+  gap: 4px 6px;
   align-self: center;
 }
 
@@ -153,7 +160,7 @@
 }
 
 .bbm-restarbeiten-filterbar [data-ui-editor-id="restarbeiten.filterbar.meta.responsible"] {
-  min-width: 132px;
+  min-width: 118px;
 }
 
 .bbm-restarbeiten-filter-group__title,
@@ -219,19 +226,21 @@
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: 6px;
 }
 
 .bbm-restarbeiten-filterbar .bbm-restarbeiten-class-toggle button {
-  min-height: var(--bbm-rest-control-height);
+  min-width: 46px;
+  min-height: 26px;
   margin: 0;
-  padding: 4px 7px;
+  padding: 2px 6px;
   border: 1px solid var(--bbm-line);
   border-radius: var(--bbm-rest-radius-control);
   background: var(--bbm-panel);
   color: var(--bbm-muted);
-  font-size: var(--bbm-rest-label-font-size);
+  font-size: 7pt;
   line-height: 1.1;
+  text-align: center;
 }
 
 .bbm-restarbeiten-class-toggle {
@@ -397,16 +406,18 @@
   min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
-  padding: 10px 72px 12px 16px;
+  scrollbar-gutter: stable both-edges;
+  padding: 10px 0 12px;
 }
 
 .bbm-restarbeiten-sheet {
   display: grid;
-  justify-content: center;
+  justify-items: center;
+  width: 100%;
 }
 
 .bbm-restarbeiten-paper {
-  width: min(100%, 900px);
+  width: var(--bbm-restarbeiten-content-width);
   min-width: 0;
   min-height: 720px;
   aspect-ratio: 210 / 297;
@@ -712,14 +723,14 @@
 }
 
 .bbm-restarbeiten-editbox {
-  margin: 6px 72px 12px 16px;
+  width: var(--bbm-restarbeiten-content-width);
+  margin: 6px auto 12px;
   border-radius: var(--bbm-rest-radius-panel);
   padding: 8px 10px;
   box-sizing: border-box;
   min-width: 320px;
   height: 248px;
   min-height: 190px;
-  max-width: calc(100% - 88px);
   max-height: min(480px, calc(100vh - 360px));
   overflow: hidden;
   display: block;
@@ -1000,6 +1011,55 @@
 
   .bbm-restarbeiten-editbox {
     height: 220px;
+  }
+}
+
+@media (max-height: 520px) {
+  .bbm-restarbeiten-header {
+    min-height: 0;
+    max-height: 116px;
+  }
+
+  .bbm-restarbeiten-filterbar {
+    gap: 4px;
+    padding: 4px 8px;
+    margin-bottom: 4px;
+  }
+
+  .bbm-restarbeiten-filter-group {
+    grid-auto-columns: minmax(82px, auto);
+    gap: 2px 5px;
+  }
+
+  .bbm-restarbeiten-filterbar [data-ui-editor-id="restarbeiten.filterbar.meta.responsible"] {
+    min-width: 104px;
+  }
+
+  .bbm-restarbeiten-workspace__list {
+    min-height: 96px;
+  }
+
+  .bbm-restarbeiten-workspace__edit {
+    max-height: calc(100% - 96px);
+  }
+
+  .bbm-restarbeiten-main {
+    padding-top: 4px;
+    padding-bottom: 6px;
+  }
+
+  .bbm-restarbeiten-editbox {
+    height: 136px;
+    min-height: 132px;
+    max-height: 136px;
+    margin-top: 3px;
+    margin-bottom: 3px;
+    padding: 6px 8px;
+  }
+
+  .bbm-restarbeiten-editbox__editor-area {
+    grid-template-columns: minmax(220px, 1fr) 90px 90px;
+    gap: 4px;
   }
 }
 


### PR DESCRIPTION
Die Restarbeiten-UI wird im produktiven CSS verdichtet und auf einen gemeinsamen zentralen Breitenanker ausgerichtet. Filterbar, Liste und Editbox nutzen `--bbm-restarbeiten-content-width`; die Filterbar ist auf maximal 900 px begrenzt und zentriert. Die Buttons `Alle`, `Rest` und `Mangel` sind kompakter und besitzen sichtbaren Abstand. Die Editbox ist horizontal zentriert und gleich breit wie die Liste. Sichtprüfung bei 1920×1080, 1600×900, 1366×768 und 900×430 ohne Horizontaloverflow; bei 900×430 bleibt die Editbox vollständig sichtbar. Keine Fachlogik-, PDF-, Druck-, Datenbank-, Registry- oder Protokolländerung. `docs/licensing.md` und `design-reference/` sind nicht Bestandteil des Commits. Commit: `b88afb83c5a54dab2f6f3a10c2a86cd2d9c475fd`.