### PR TITLE
Projektverwaltung: neutraler Projektkern und neue Einstiege

### DIFF
--- a/docs/PROJECT_MODEL.md
+++ b/docs/PROJECT_MODEL.md
@@ -34,7 +34,7 @@ Ein Projekt referenziert diese Daten nur; es besitzt keine eigene parallele Firm
 
 Besprechungen, TOPs, Teilnehmerzustand, Protokolltitel, Protokollfuss und sonstige Protokoll-/PDF-Einstellungen gehoeren zum Fachmodul `Protokoll` bzw. zu gemeinsamen Dokumentdiensten, nicht zu den Projektstammdaten.
 
-Projektspezifische Protokoll- und PDF-Einstellungen werden weiterhin projektbezogen gespeichert, aber im Projekt-Arbeitsbereich innerhalb des Protokollbereichs bedient. Sie erscheinen nicht mehr im Projektstammformular.
+Projektspezifische Protokoll- und PDF-Einstellungen werden weiterhin projektbezogen gespeichert, aber im Projekt-Arbeitsbereich innerhalb des Protokollbereichs bedient. Sie erscheinen nicht im Projektstammformular.
 
 ### Restarbeiten / Plaene
 

--- a/docs/PROJECT_MODEL.md
+++ b/docs/PROJECT_MODEL.md
@@ -34,6 +34,8 @@ Ein Projekt referenziert diese Daten nur; es besitzt keine eigene parallele Firm
 
 Besprechungen, TOPs, Teilnehmerzustand, Protokolltitel, Protokollfuss und sonstige Protokoll-/PDF-Einstellungen gehoeren zum Fachmodul `Protokoll` bzw. zu gemeinsamen Dokumentdiensten, nicht zu den Projektstammdaten.
 
+Projektspezifische Protokoll- und PDF-Einstellungen werden weiterhin projektbezogen gespeichert, aber im Projekt-Arbeitsbereich innerhalb des Protokollbereichs bedient. Sie erscheinen nicht mehr im Projektstammformular.
+
 ### Restarbeiten / Plaene
 
 Restarbeiten, Maengel, Fotos, Planbezug und WEB-PDFs sind Fach-/Unterbereich von `Restarbeiten` und perspektivisch `BBM Mobil`.

--- a/docs/PROJECT_MODEL.md
+++ b/docs/PROJECT_MODEL.md
@@ -1,0 +1,57 @@
+# BBM-Projektdatenmodell
+
+## Zweck
+
+Das BBM-Projekt ist ein gemeinsamer, neutraler Bezugspunkt fuer projektbezogene Fachmodule.
+Es ist **nicht** der Obercontainer fuer alle BBM-Funktionen und insbesondere keine Voraussetzung fuer Rechnung, Angebot oder Auftrag.
+
+## Verbindlicher Projektkern
+
+Zum Projekt selbst gehoeren nur neutrale Stammdaten, die moduluebergreifend sinnvoll sind:
+
+- Projekt-ID (technisch)
+- Projektnummer (optional)
+- Projektbezeichnung / Name
+- Kurzbezeichnung (optional)
+- Projektadresse: Strasse, PLZ, Ort
+- interne Projektleitung (vorerst als Bestandsfeld)
+- Telefon der internen Projektleitung (vorerst als Bestandsfeld)
+- Projektbeginn (optional)
+- Projektende (optional)
+- allgemeine Projektnotiz (optional)
+- Archivstatus
+
+Die vorhandenen Bestandsfelder bleiben kompatibel. Fuer diesen Umbau werden bewusst keine neuen Projektspalten eingefuehrt.
+
+## Gehoert ausdruecklich nicht in den Projektkern
+
+### Firmen / Kunden / Personen
+
+Firmen, Kunden und Personen sind gemeinsame BBM-Stammdaten und werden spaeter zentral neu strukturiert.
+Ein Projekt referenziert diese Daten nur; es besitzt keine eigene parallele Firmenwelt.
+
+### Protokoll
+
+Besprechungen, TOPs, Teilnehmerzustand, Protokolltitel, Protokollfuss und sonstige Protokoll-/PDF-Einstellungen gehoeren zum Fachmodul `Protokoll` bzw. zu gemeinsamen Dokumentdiensten, nicht zu den Projektstammdaten.
+
+### Restarbeiten / Plaene
+
+Restarbeiten, Maengel, Fotos, Planbezug und WEB-PDFs sind Fach-/Unterbereich von `Restarbeiten` und perspektivisch `BBM Mobil`.
+
+### SiGeKo
+
+SiGeKo-spezifische Angaben, Berichte und Dokumentationen gehoeren in das spaetere Fachmodul `SiGeKo`.
+
+### Kaufmaennische Vorgaenge
+
+Angebot, Auftrag und Rechnung koennen optional auf ein Projekt verweisen, sind aber eigenstaendige kaufmaennische Vorgaenge. Ein Projekt ist dafuer keine Pflicht.
+
+## Bedienregel
+
+Das Projektformular zeigt im Hauptbereich nur die neutralen Projektstammdaten.
+Technische Ablageinformationen duerfen nur als nachrangige Diagnose-/Technikinformation erscheinen.
+Fachmodul-Einstellungen duerfen nicht als normale Projektstammdaten dargestellt werden.
+
+## Spaetere Migration
+
+Die Textfelder `project_lead` und `project_lead_phone` bleiben vorerst aus Kompatibilitaetsgruenden bestehen. Sobald Mitarbeiter/Personen als gemeinsame BBM-Domaene finalisiert sind, kann die interne Projektleitung auf eine saubere Referenz migriert werden.

--- a/src/renderer/modules/projektverwaltung/index.js
+++ b/src/renderer/modules/projektverwaltung/index.js
@@ -1,4 +1,4 @@
-import ProjectsScreen from "./screens/ProjectsScreen.js";
+import ProjectsScreen from "./screens/ProjectsHubScreen.js";
 import ProjectFormScreen from "./screens/ProjectFormScreen.js";
 import ArchiveScreen from "./screens/ArchiveScreen.js";
 import ProjectWorkspaceScreen from "./screens/ProjectWorkspaceScreen.js";

--- a/src/renderer/modules/projektverwaltung/index.js
+++ b/src/renderer/modules/projektverwaltung/index.js
@@ -1,5 +1,5 @@
 import ProjectsScreen from "./screens/ProjectsHubScreen.js";
-import ProjectFormScreen from "./screens/ProjectFormScreen.js";
+import ProjectFormScreen from "./screens/ProjectFormHubScreen.js";
 import ArchiveScreen from "./screens/ArchiveScreen.js";
 import ProjectWorkspaceScreen from "./screens/ProjectWorkspaceScreen.js";
 

--- a/src/renderer/modules/projektverwaltung/screens/ProjectFormHubScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectFormHubScreen.js
@@ -2,8 +2,7 @@ import LegacyProjectFormScreen from "./ProjectFormScreen.js";
 
 function walk(root, predicate) {
   if (!root || typeof root.querySelectorAll !== "function") return [];
-  return Array.from(root.querySelectorAll("*"))
-    .filter((el) => predicate(el));
+  return Array.from(root.querySelectorAll("*")).filter((el) => predicate(el));
 }
 
 function findByText(root, text) {
@@ -21,8 +20,8 @@ function renameExact(root, from, to) {
  * Neutrale Projektformular-Huelle fuer den modularen BBM-Projektkern.
  *
  * Die bestehende Speicher-/IPC-Logik bleibt unveraendert. Die Huelle raeumt
- * nur die fachliche Darstellung auf und macht technische bzw. Protokoll-
- * spezifische Bestandsfunktionen als Uebergang ehrlich sichtbar.
+ * nur die fachliche Darstellung auf. Fachmodul-Funktionen gehoeren nicht in
+ * dieses Formular und werden hier deshalb ausgeblendet.
  */
 export default class ProjectFormHubScreen extends LegacyProjectFormScreen {
   _decorateNeutralProjectForm(root) {
@@ -86,17 +85,13 @@ export default class ProjectFormHubScreen extends LegacyProjectFormScreen {
     return root;
   }
 
-  _renameLegacyModuleSettings(buttonRow) {
+  _removeModuleSettingsButton(buttonRow) {
     if (!buttonRow) return buttonRow;
     const settingsButton = Array.from(buttonRow.querySelectorAll?.("button") || []).find(
-      (btn) => String(btn.textContent || "").trim() === "Einstellungen"
+      (btn) => ["Einstellungen", "Protokoll-Einstellungen"].includes(String(btn.textContent || "").trim())
     );
-    if (settingsButton) {
-      settingsButton.textContent = "Protokoll-Einstellungen";
-      settingsButton.title =
-        "Uebergang: Diese Einstellungen gehoeren fachlich zum Protokollmodul und werden spaeter dorthin verschoben.";
-      settingsButton.style.opacity = "0.78";
-    }
+    if (settingsButton) settingsButton.remove();
+    this.btnSettings = null;
     return buttonRow;
   }
 
@@ -106,10 +101,10 @@ export default class ProjectFormHubScreen extends LegacyProjectFormScreen {
   }
 
   _buildPageButtonRow() {
-    return this._renameLegacyModuleSettings(super._buildPageButtonRow());
+    return this._removeModuleSettingsButton(super._buildPageButtonRow());
   }
 
   _buildModalFooter() {
-    return this._renameLegacyModuleSettings(super._buildModalFooter());
+    return this._removeModuleSettingsButton(super._buildModalFooter());
   }
 }

--- a/src/renderer/modules/projektverwaltung/screens/ProjectFormHubScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectFormHubScreen.js
@@ -10,14 +10,24 @@ function findByText(root, text) {
   return walk(root, (el) => String(el.textContent || "").trim() === target)[0] || null;
 }
 
+function findLabelByText(root, text) {
+  if (!root || typeof root.querySelectorAll !== "function") return null;
+  const target = String(text || "").trim();
+  return (
+    Array.from(root.querySelectorAll(".bbm-form-label")).find(
+      (el) => String(el.textContent || "").trim() === target
+    ) || null
+  );
+}
+
 function renameExact(root, from, to) {
-  const el = findByText(root, from);
-  if (el) el.textContent = to;
-  return el;
+  const label = findLabelByText(root, from);
+  if (label) label.textContent = to;
+  return label;
 }
 
 function getFieldByLabel(root, labelText) {
-  const label = findByText(root, labelText);
+  const label = findLabelByText(root, labelText);
   return label?.closest?.(".bbm-form-field") || label?.parentElement || null;
 }
 

--- a/src/renderer/modules/projektverwaltung/screens/ProjectFormHubScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectFormHubScreen.js
@@ -1,0 +1,115 @@
+import LegacyProjectFormScreen from "./ProjectFormScreen.js";
+
+function walk(root, predicate) {
+  if (!root || typeof root.querySelectorAll !== "function") return [];
+  return Array.from(root.querySelectorAll("*"))
+    .filter((el) => predicate(el));
+}
+
+function findByText(root, text) {
+  const target = String(text || "").trim();
+  return walk(root, (el) => String(el.textContent || "").trim() === target)[0] || null;
+}
+
+function renameExact(root, from, to) {
+  const el = findByText(root, from);
+  if (el) el.textContent = to;
+  return el;
+}
+
+/**
+ * Neutrale Projektformular-Huelle fuer den modularen BBM-Projektkern.
+ *
+ * Die bestehende Speicher-/IPC-Logik bleibt unveraendert. Die Huelle raeumt
+ * nur die fachliche Darstellung auf und macht technische bzw. Protokoll-
+ * spezifische Bestandsfunktionen als Uebergang ehrlich sichtbar.
+ */
+export default class ProjectFormHubScreen extends LegacyProjectFormScreen {
+  _decorateNeutralProjectForm(root) {
+    if (!root) return root;
+
+    renameExact(root, "Bezeichnung *", "Projektbezeichnung *");
+    renameExact(root, "Kurzbez.", "Kurzbezeichnung");
+    renameExact(root, "Projektleiter", "Interne Projektleitung");
+
+    const intro = document.createElement("div");
+    intro.setAttribute("data-bbm-project-core-hint", "true");
+    intro.style.border = "1px solid #dfe5ec";
+    intro.style.borderRadius = "9px";
+    intro.style.background = "#f8fafc";
+    intro.style.padding = "9px 11px";
+    intro.style.marginBottom = "10px";
+    intro.style.fontSize = "11.5px";
+    intro.style.lineHeight = "1.45";
+    intro.style.color = "#566274";
+    intro.textContent =
+      "Hier werden nur gemeinsame Projektstammdaten gepflegt. Firmen/Kunden und Fachmoduldaten wie Protokoll, Restarbeiten oder SiGeKo bleiben getrennt.";
+
+    const firstVisibleChild = Array.from(root.children || []).find(
+      (el) => el?.style?.display !== "none"
+    );
+    if (firstVisibleChild?.nextSibling) {
+      root.insertBefore(intro, firstVisibleChild.nextSibling);
+    } else {
+      root.prepend(intro);
+    }
+
+    const storageTitle = findByText(root, "Ablageordner (PDF):");
+    const storageCard = storageTitle?.closest?.(".bbm-form-card") || storageTitle?.parentElement || null;
+    if (storageCard && !storageCard.closest?.("details[data-bbm-project-storage-details]")) {
+      const details = document.createElement("details");
+      details.setAttribute("data-bbm-project-storage-details", "true");
+      details.style.marginTop = "8px";
+      details.style.border = "1px solid #e5e7eb";
+      details.style.borderRadius = "8px";
+      details.style.background = "#fbfcfd";
+      details.style.padding = "7px 9px";
+      details.style.boxSizing = "border-box";
+
+      const summary = document.createElement("summary");
+      summary.textContent = "Technische Ablage anzeigen";
+      summary.style.cursor = "pointer";
+      summary.style.fontSize = "11.5px";
+      summary.style.fontWeight = "700";
+      summary.style.color = "#667085";
+
+      const parent = storageCard.parentElement;
+      if (parent) {
+        parent.insertBefore(details, storageCard);
+        details.append(summary, storageCard);
+        storageCard.style.width = "100%";
+        storageCard.style.maxWidth = "100%";
+        storageCard.style.marginTop = "7px";
+      }
+    }
+
+    return root;
+  }
+
+  _renameLegacyModuleSettings(buttonRow) {
+    if (!buttonRow) return buttonRow;
+    const settingsButton = Array.from(buttonRow.querySelectorAll?.("button") || []).find(
+      (btn) => String(btn.textContent || "").trim() === "Einstellungen"
+    );
+    if (settingsButton) {
+      settingsButton.textContent = "Protokoll-Einstellungen";
+      settingsButton.title =
+        "Uebergang: Diese Einstellungen gehoeren fachlich zum Protokollmodul und werden spaeter dorthin verschoben.";
+      settingsButton.style.opacity = "0.78";
+    }
+    return buttonRow;
+  }
+
+  _buildFormContent() {
+    const root = super._buildFormContent();
+    return this._decorateNeutralProjectForm(root);
+  }
+
+  _buildPageButtonRow() {
+    return this._renameLegacyModuleSettings(super._buildPageButtonRow());
+  }
+
+  _buildModalFooter() {
+    return this._renameLegacyModuleSettings(super._buildModalFooter());
+  }
+}

--- a/src/renderer/modules/projektverwaltung/screens/ProjectFormHubScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectFormHubScreen.js
@@ -16,6 +16,40 @@ function renameExact(root, from, to) {
   return el;
 }
 
+function getFieldByLabel(root, labelText) {
+  const label = findByText(root, labelText);
+  return label?.closest?.(".bbm-form-field") || label?.parentElement || null;
+}
+
+function getRowForField(field) {
+  return field?.closest?.(".project-form-row") || field?.parentElement || null;
+}
+
+function makeFieldFluid(field) {
+  if (!field) return;
+  field.style.flex = "1 1 0";
+  field.style.minWidth = "0";
+  field.style.width = "auto";
+  field.style.maxWidth = "none";
+
+  const control = field.querySelector?.("input, textarea, select");
+  if (!control) return;
+  control.style.width = "100%";
+  control.style.maxWidth = "100%";
+  control.style.minWidth = "0";
+  control.style.boxSizing = "border-box";
+}
+
+function setGridRow(row, columns) {
+  if (!row) return;
+  row.style.display = "grid";
+  row.style.gridTemplateColumns = columns;
+  row.style.columnGap = "12px";
+  row.style.rowGap = "8px";
+  row.style.alignItems = "end";
+  row.style.width = "100%";
+}
+
 /**
  * Neutrale Projektformular-Huelle fuer den modularen BBM-Projektkern.
  *
@@ -24,12 +58,61 @@ function renameExact(root, from, to) {
  * dieses Formular und werden hier deshalb ausgeblendet.
  */
 export default class ProjectFormHubScreen extends LegacyProjectFormScreen {
+  _stabilizeProjectFormLayout(root) {
+    const nameField = getFieldByLabel(root, "Projektbezeichnung *");
+    const numberField = getFieldByLabel(root, "Projektnummer");
+    const shortField = getFieldByLabel(root, "Kurzbezeichnung");
+    const streetField = getFieldByLabel(root, "Straße");
+    const zipField = getFieldByLabel(root, "PLZ");
+    const cityField = getFieldByLabel(root, "Ort");
+    const leadField = getFieldByLabel(root, "Interne Projektleitung");
+    const phoneField = getFieldByLabel(root, "Telefon");
+    const startField = getFieldByLabel(root, "Startdatum");
+    const endField = getFieldByLabel(root, "Enddatum");
+    const notesField = getFieldByLabel(root, "Notizen");
+
+    [
+      nameField,
+      numberField,
+      shortField,
+      streetField,
+      zipField,
+      cityField,
+      leadField,
+      phoneField,
+      startField,
+      endField,
+      notesField,
+    ].forEach(makeFieldFluid);
+
+    setGridRow(getRowForField(nameField), "minmax(0, 1fr)");
+    setGridRow(getRowForField(numberField), "minmax(120px, .34fr) minmax(180px, .66fr)");
+    setGridRow(getRowForField(streetField), "minmax(0, 1fr)");
+    setGridRow(getRowForField(zipField), "120px minmax(0, 1fr)");
+    setGridRow(getRowForField(leadField), "minmax(0, 1fr) minmax(170px, .72fr)");
+    setGridRow(getRowForField(startField), "minmax(0, 1fr) minmax(0, 1fr)");
+    setGridRow(getRowForField(notesField), "minmax(0, 1fr)");
+
+    const mainForm = root.querySelector?.(".bbm-form-card > div");
+    if (mainForm?.style?.gridTemplateColumns) {
+      mainForm.style.gridTemplateColumns = "minmax(0, 1fr) 1px minmax(0, 1fr)";
+      mainForm.style.columnGap = "18px";
+    }
+
+    const separator = mainForm?.children?.[1] || null;
+    if (separator) {
+      separator.style.height = "100%";
+      separator.style.opacity = "0.55";
+    }
+  }
+
   _decorateNeutralProjectForm(root) {
     if (!root) return root;
 
     renameExact(root, "Bezeichnung *", "Projektbezeichnung *");
     renameExact(root, "Kurzbez.", "Kurzbezeichnung");
     renameExact(root, "Projektleiter", "Interne Projektleitung");
+    renameExact(root, "PL-Handy", "Telefon");
 
     const intro = document.createElement("div");
     intro.setAttribute("data-bbm-project-core-hint", "true");
@@ -82,6 +165,7 @@ export default class ProjectFormHubScreen extends LegacyProjectFormScreen {
       }
     }
 
+    this._stabilizeProjectFormLayout(root);
     return root;
   }
 

--- a/src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js
@@ -1,17 +1,11 @@
-import { applyPopupButtonStyle } from "../../../ui/popupButtonStyles.js";
-
 function normalizeText(value) {
   return String(value || "").trim();
 }
 
 function getProjectNumber(project) {
-  const raw =
-    project?.project_number ??
-    project?.projectNumber ??
-    project?.nummer ??
-    project?.number ??
-    "";
-  return normalizeText(raw);
+  return normalizeText(
+    project?.project_number ?? project?.projectNumber ?? project?.nummer ?? project?.number ?? ""
+  );
 }
 
 function getProjectName(project) {
@@ -23,12 +17,65 @@ function getProjectName(project) {
 function getProjectTitle(project, fallbackProjectId = null) {
   const number = getProjectNumber(project);
   const name = getProjectName(project);
-
   if (number && name) return `${number} - ${name}`;
   if (number) return number;
   if (name) return name;
-  if (fallbackProjectId) return `#${fallbackProjectId}`;
-  return "Projekt";
+  return fallbackProjectId ? `#${fallbackProjectId}` : "Projekt";
+}
+
+function projectAddress(project) {
+  const street = normalizeText(project?.street);
+  const zip = normalizeText(project?.zip);
+  const city = normalizeText(project?.city);
+  const place = [zip, city].filter(Boolean).join(" ");
+  return [street, place].filter(Boolean).join(", ");
+}
+
+function setStyles(el, styles = {}) {
+  Object.assign(el.style, styles);
+  return el;
+}
+
+const MODULE_STYLE = Object.freeze({
+  protokoll: { color: "#22c55e", icon: "protocol" },
+  restarbeiten: { color: "#f59e0b", icon: "rest" },
+  projectFirms: { color: "#475569", icon: "firms" },
+});
+
+const ICONS = Object.freeze({
+  protocol: `<svg viewBox="0 0 48 48" aria-hidden="true"><rect x="10" y="7" width="28" height="34" rx="4" fill="none" stroke="currentColor" stroke-width="3"/><path d="M17 17h14M17 24h14M17 31h9" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/></svg>`,
+  rest: `<svg viewBox="0 0 48 48" aria-hidden="true"><path d="M24 7 42 39H6L24 7Z" fill="none" stroke="currentColor" stroke-width="3" stroke-linejoin="round"/><path d="M24 18v10M24 34h.01" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round"/></svg>`,
+  firms: `<svg viewBox="0 0 48 48" aria-hidden="true"><path d="M8 40V17h18v23M26 25h14v15M14 23h5M14 29h5M14 35h5M32 31h3M32 36h3" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
+});
+
+function groupProjectModules(items = []) {
+  const groups = [];
+  const byModule = new Map();
+
+  for (const item of Array.isArray(items) ? items : []) {
+    const moduleId = normalizeText(item?.moduleId);
+    if (!moduleId) continue;
+
+    if (moduleId === "projectFirms") {
+      groups.push({ moduleId, label: "Firmen im Projekt", description: item?.description || "Projektbeteiligte und Firmen verwalten.", entries: [item] });
+      continue;
+    }
+
+    let group = byModule.get(moduleId);
+    if (!group) {
+      group = {
+        moduleId,
+        label: normalizeText(item?.label) || moduleId,
+        description: normalizeText(item?.description),
+        entries: [],
+      };
+      byModule.set(moduleId, group);
+      groups.push(group);
+    }
+    group.entries.push(item);
+  }
+
+  return groups;
 }
 
 export default class ProjectWorkspaceScreen {
@@ -37,11 +84,9 @@ export default class ProjectWorkspaceScreen {
     this.projectId = projectId || null;
     this.project = project || null;
     this.projectModules = Array.isArray(projectModules) ? projectModules : [];
-
     this.root = null;
     this.hostEl = null;
     this.msgEl = null;
-
     this.loading = false;
     this.projectMissing = false;
   }
@@ -55,13 +100,11 @@ export default class ProjectWorkspaceScreen {
   }
 
   _setMsg(text) {
-    if (!this.msgEl) return;
-    this.msgEl.textContent = String(text || "");
+    if (this.msgEl) this.msgEl.textContent = String(text || "");
   }
 
   async _loadProject() {
     if (this.project) return this.project;
-
     const effectiveProjectId = this.projectId || this.router?.currentProjectId || null;
     if (!effectiveProjectId) return null;
 
@@ -74,20 +117,14 @@ export default class ProjectWorkspaceScreen {
     try {
       const res = await api.projectsList();
       if (res?.ok && Array.isArray(res.list)) {
-        const foundProject = res.list.find(
-          (item) => String(item?.id ?? "") === String(effectiveProjectId)
-        );
-        this.project = foundProject || null;
-        this.projectMissing = !foundProject;
+        this.project = res.list.find((item) => String(item?.id ?? "") === String(effectiveProjectId)) || null;
+        this.projectMissing = !this.project;
       } else {
         this.project = { id: effectiveProjectId };
-        this.projectMissing = false;
       }
     } catch (_err) {
       this.project = { id: effectiveProjectId };
-      this.projectMissing = false;
     }
-
     return this.project;
   }
 
@@ -97,49 +134,17 @@ export default class ProjectWorkspaceScreen {
     return true;
   }
 
-  _pickLatestOpenMeeting(openMeetings) {
-    const list = Array.isArray(openMeetings) ? openMeetings : [];
-    if (!list.length) return null;
-
-    return list.reduce((best, cur) => {
-      const bestIdx = Number(best?.meeting_index ?? best?.meetingIndex ?? 0);
-      const curIdx = Number(cur?.meeting_index ?? cur?.meetingIndex ?? 0);
-      if (curIdx > bestIdx) return cur;
-      if (curIdx === bestIdx) {
-        const bestId = Number(best?.id ?? 0);
-        const curId = Number(cur?.id ?? 0);
-        return curId > bestId ? cur : best;
-      }
-      return best;
-    }, list[0]);
-  }
-
   async _openProtocolModule(projectId) {
     const effectiveProjectId = projectId || this.projectId || this.router?.currentProjectId || null;
     if (!effectiveProjectId) return false;
     if (typeof this.router?.openProjectModule === "function") {
-      const result = await this.router.openProjectModule(effectiveProjectId, "protokoll", {
-        project: this.project || null,
-      });
+      const result = await this.router.openProjectModule(effectiveProjectId, "protokoll", { project: this.project || null });
       return typeof result === "object" ? !!result?.ok : result !== false;
     }
-
     if (typeof this.router?.openProjectProtocol === "function") {
-      const result = await this.router.openProjectProtocol(effectiveProjectId, {
-        project: this.project || null,
-      });
+      const result = await this.router.openProjectProtocol(effectiveProjectId, { project: this.project || null });
       return typeof result === "object" ? !!result?.ok : result !== false;
     }
-
-    if (typeof this.router?.showMeetings === "function") {
-      await this.router.showMeetings(effectiveProjectId, {
-        startMode: true,
-        startReason: "protocol-start-unavailable",
-        integrityError: false,
-      });
-      return true;
-    }
-
     return false;
   }
 
@@ -154,12 +159,9 @@ export default class ProjectWorkspaceScreen {
       await this.router.showProjectFirms(projectId);
       return true;
     }
-
-    if (normalizedModuleId === "protokoll") {
-      return await this._openProtocolModule(projectId);
-    }
-
+    if (normalizedModuleId === "protokoll") return await this._openProtocolModule(projectId);
     if (typeof this.router?.openProjectModule !== "function") return false;
+
     const result = await this.router.openProjectModule(projectId, normalizedModuleId, {
       project: this.project || null,
       navigationKey: normalizedNavigationKey,
@@ -167,157 +169,157 @@ export default class ProjectWorkspaceScreen {
     return typeof result === "object" ? !!result?.ok : result !== false;
   }
 
-  _renderModuleTiles(container) {
-    container.innerHTML = "";
+  _createModuleCard(group) {
+    const style = MODULE_STYLE[group.moduleId] || { color: "#2563eb", icon: "protocol" };
+    const card = setStyles(document.createElement("div"), {
+      background: "#ffffff",
+      border: "1px solid #e3e8ef",
+      borderRadius: "14px",
+      padding: "16px",
+      minHeight: "180px",
+      boxShadow: "0 6px 20px rgba(15,23,42,0.055)",
+      display: "flex",
+      flexDirection: "column",
+      gap: "10px",
+    });
 
-    for (const moduleItem of this.getAvailableProjectModules()) {
-      const tile = document.createElement("div");
-      tile.style.border = "1px solid var(--card-border)";
-      tile.style.borderRadius = "10px";
-      tile.style.padding = "12px";
-      tile.style.background = "var(--card-bg)";
-      tile.style.display = "flex";
-      tile.style.flexDirection = "column";
-      tile.style.gap = "8px";
+    const iconWrap = setStyles(document.createElement("div"), {
+      width: "46px", height: "46px", borderRadius: "12px", display: "grid", placeItems: "center",
+      background: `${style.color}16`, color: style.color,
+    });
+    iconWrap.innerHTML = ICONS[style.icon] || ICONS.protocol;
+    const svg = iconWrap.querySelector("svg");
+    if (svg) Object.assign(svg.style, { width: "28px", height: "28px" });
 
-      const title = document.createElement("div");
-      title.textContent = moduleItem.label;
-      title.style.fontWeight = "800";
-      title.style.fontSize = "16px";
+    const title = setStyles(document.createElement("div"), { fontWeight: "800", fontSize: "17px", color: "#172033" });
+    title.textContent = group.label;
 
-      const description = document.createElement("div");
-      description.textContent = moduleItem.description;
-      description.style.fontSize = "12px";
-      description.style.opacity = "0.8";
+    const description = setStyles(document.createElement("div"), { fontSize: "12px", lineHeight: "1.45", color: "#667085", flex: "1" });
+    description.textContent = group.description || "Arbeitsbereich im aktuellen Projekt öffnen.";
 
-      const btn = document.createElement("button");
+    const actions = setStyles(document.createElement("div"), { display: "flex", gap: "7px", flexWrap: "wrap", marginTop: "2px" });
+    group.entries.forEach((entry, index) => {
+      const btn = setStyles(document.createElement("button"), {
+        border: index === 0 ? "0" : `1px solid ${style.color}55`,
+        borderRadius: "8px",
+        background: index === 0 ? style.color : "#ffffff",
+        color: index === 0 ? "#ffffff" : style.color,
+        padding: "7px 11px",
+        fontSize: "11.5px",
+        fontWeight: "750",
+        cursor: "pointer",
+      });
       btn.type = "button";
-      btn.textContent = moduleItem.label;
-      applyPopupButtonStyle(btn, { variant: "primary" });
-      btn.onclick = async () => {
-        await this.openProjectModule(moduleItem.moduleId, moduleItem.navigationKey);
-      };
+      btn.textContent = index === 0 ? "Öffnen" : normalizeText(entry?.label) || "Unterbereich";
+      btn.title = normalizeText(entry?.description);
+      btn.addEventListener("click", async () => {
+        await this.openProjectModule(entry?.moduleId, entry?.navigationKey);
+      });
+      actions.appendChild(btn);
+    });
 
-      tile.append(title, description, btn);
-      container.appendChild(tile);
-    }
-  }
-
-  _renderProjectInfo(container) {
-    container.innerHTML = "";
-
-    const project = this.project || null;
-    const title = document.createElement("div");
-    title.textContent = this.getProjectDisplayText();
-    title.style.fontWeight = "900";
-    title.style.fontSize = "20px";
-    title.style.marginBottom = "6px";
-
-    const numberLine = document.createElement("div");
-    numberLine.textContent = `Projektnummer: ${getProjectNumber(project) || "-"}`;
-    numberLine.style.fontSize = "12px";
-    numberLine.style.opacity = "0.85";
-
-    const nameLine = document.createElement("div");
-    nameLine.textContent = `Projektname: ${getProjectName(project) || "-"}`;
-    nameLine.style.fontSize = "12px";
-    nameLine.style.opacity = "0.85";
-
-    container.append(title, numberLine, nameLine);
+    card.append(iconWrap, title, description, actions);
+    return card;
   }
 
   _renderContent() {
     if (!this.hostEl) return;
-
     this.hostEl.innerHTML = "";
 
-    const info = document.createElement("div");
-    info.style.marginBottom = "16px";
-    this._renderProjectInfo(info);
-
-    const availableModules = this.getAvailableProjectModules();
-
-    const sectionTitle = document.createElement("h3");
-    sectionTitle.textContent = "Arbeitsbereiche im Projekt";
-    sectionTitle.style.margin = "0 0 10px";
-
-    const grid = document.createElement("div");
-    grid.style.display = "grid";
-    grid.style.gridTemplateColumns = "1fr";
-    grid.style.gap = "8px";
-
-    if (availableModules.length > 0) {
-      this._renderModuleTiles(grid);
-    } else {
-      const empty = document.createElement("div");
-      empty.textContent = "Für dieses Projekt sind keine Arbeitsmodule freigeschaltet.";
-      empty.style.border = "1px solid var(--card-border)";
-      empty.style.borderRadius = "8px";
-      empty.style.padding = "10px 12px";
-      empty.style.background = "var(--card-bg)";
-      empty.style.fontSize = "13px";
-      empty.style.opacity = "0.85";
-      grid.appendChild(empty);
-    }
-
-    this.hostEl.append(info);
-
     if (this.projectMissing) {
-      const missing = document.createElement("div");
+      const missing = setStyles(document.createElement("div"), { padding: "16px", color: "#b42318", fontWeight: "700" });
       missing.textContent = "Projekt konnte nicht gefunden werden.";
-      missing.style.fontSize = "14px";
-      missing.style.fontWeight = "700";
-      missing.style.color = "var(--danger-text, #a40000)";
       this.hostEl.appendChild(missing);
       return;
     }
 
-    this.hostEl.append(sectionTitle, grid);
+    const project = this.project || {};
+    const info = setStyles(document.createElement("div"), {
+      background: "linear-gradient(135deg, #ffffff 0%, #f8fafc 100%)",
+      border: "1px solid #e3e8ef",
+      borderRadius: "14px",
+      padding: "16px 18px",
+      marginBottom: "16px",
+      display: "grid",
+      gap: "5px",
+    });
+
+    const title = setStyles(document.createElement("div"), { fontSize: "21px", fontWeight: "850", color: "#172033" });
+    title.textContent = this.getProjectDisplayText();
+
+    const address = setStyles(document.createElement("div"), { fontSize: "12px", color: "#667085" });
+    address.textContent = projectAddress(project) || "Keine Projektadresse hinterlegt";
+
+    const meta = setStyles(document.createElement("div"), { fontSize: "11px", color: "#8a94a5" });
+    const lead = normalizeText(project?.project_lead);
+    const dates = [normalizeText(project?.start_date)?.slice(0, 10), normalizeText(project?.end_date)?.slice(0, 10)].filter(Boolean).join(" – ");
+    meta.textContent = [lead ? `Projektleitung: ${lead}` : "", dates ? `Zeitraum: ${dates}` : ""].filter(Boolean).join("   ·   ") || "Projektstammdaten";
+    info.append(title, address, meta);
+
+    const sectionHead = setStyles(document.createElement("div"), { display: "flex", alignItems: "baseline", justifyContent: "space-between", margin: "0 2px 9px" });
+    const sectionTitle = setStyles(document.createElement("div"), { fontSize: "14px", fontWeight: "800", color: "#172033" });
+    sectionTitle.textContent = "Arbeitsbereiche im Projekt";
+    const sectionHint = setStyles(document.createElement("div"), { fontSize: "11px", color: "#8a94a5" });
+    sectionHint.textContent = "Nur freigeschaltete Bereiche";
+    sectionHead.append(sectionTitle, sectionHint);
+
+    const grid = setStyles(document.createElement("div"), {
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+      gap: "12px",
+    });
+
+    const groups = groupProjectModules(this.getAvailableProjectModules());
+    if (!groups.length) {
+      const empty = setStyles(document.createElement("div"), { padding: "14px", border: "1px solid #e3e8ef", borderRadius: "12px", background: "#ffffff", color: "#667085", fontSize: "12px" });
+      empty.textContent = "Für dieses Projekt sind keine Arbeitsmodule freigeschaltet.";
+      grid.appendChild(empty);
+    } else {
+      groups.forEach((group) => grid.appendChild(this._createModuleCard(group)));
+    }
+
+    this.hostEl.append(info, sectionHead, grid);
   }
 
   render() {
-    const root = document.createElement("div");
+    const root = setStyles(document.createElement("div"), {
+      minHeight: "100%",
+      boxSizing: "border-box",
+      padding: "18px clamp(16px, 2.5vw, 30px)",
+      background: "#f4f6f9",
+      color: "#172033",
+    });
 
-    const head = document.createElement("div");
-    head.style.display = "flex";
-    head.style.alignItems = "center";
-    head.style.gap = "10px";
-    head.style.marginBottom = "10px";
+    const head = setStyles(document.createElement("div"), {
+      display: "flex", alignItems: "center", gap: "10px", marginBottom: "14px",
+    });
 
-    const h = document.createElement("h2");
-    h.textContent = "Projekt-Arbeitsbereich";
-    h.style.margin = "0";
+    const back = setStyles(document.createElement("button"), {
+      border: "1px solid #d7dee8", borderRadius: "8px", background: "#ffffff", color: "#344054",
+      padding: "7px 10px", fontSize: "11.5px", fontWeight: "700", cursor: "pointer",
+    });
+    back.type = "button";
+    back.textContent = "← Projekte";
+    back.onclick = async () => this.showProjectsList();
 
-    const navBtn = document.createElement("button");
-    navBtn.type = "button";
-    navBtn.textContent = "Zur Projektliste";
-    applyPopupButtonStyle(navBtn, { variant: "secondary" });
-    navBtn.onclick = async () => {
-      await this.showProjectsList();
-    };
+    const h = setStyles(document.createElement("h2"), { margin: "0", fontSize: "20px", fontWeight: "850" });
+    h.textContent = "Projekt";
 
-    const msg = document.createElement("div");
-    msg.style.marginLeft = "auto";
-    msg.style.fontSize = "12px";
-    msg.style.opacity = "0.85";
-
-    head.append(h, navBtn, msg);
+    const msg = setStyles(document.createElement("div"), { marginLeft: "auto", fontSize: "11px", color: "#8a94a5" });
+    head.append(back, h, msg);
 
     const host = document.createElement("div");
     root.append(head, host);
-
     this.root = root;
     this.hostEl = host;
     this.msgEl = msg;
-
     this._renderContent();
-
     return root;
   }
 
   async load() {
     this.loading = true;
-    this._setMsg("Lade...");
+    this._setMsg("Lade ...");
     try {
       await this._loadProject();
       this._renderContent();

--- a/src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js
@@ -59,7 +59,12 @@ function groupProjectModules(items = []) {
     if (!moduleId) continue;
 
     if (moduleId === "projectFirms") {
-      groups.push({ moduleId, label: "Firmen im Projekt", description: item?.description || "Projektbeteiligte und Firmen verwalten.", entries: [item] });
+      groups.push({
+        moduleId,
+        label: "Firmen im Projekt",
+        description: item?.description || "Projektbeteiligte und Firmen verwalten.",
+        entries: [item],
+      });
       continue;
     }
 
@@ -119,7 +124,8 @@ export default class ProjectWorkspaceScreen {
     try {
       const res = await api.projectsList();
       if (res?.ok && Array.isArray(res.list)) {
-        this.project = res.list.find((item) => String(item?.id ?? "") === String(effectiveProjectId)) || null;
+        this.project =
+          res.list.find((item) => String(item?.id ?? "") === String(effectiveProjectId)) || null;
         this.projectMissing = !this.project;
       } else {
         this.project = { id: effectiveProjectId };
@@ -136,15 +142,26 @@ export default class ProjectWorkspaceScreen {
     return true;
   }
 
+  async editProject() {
+    const projectId = this.projectId || this.router?.currentProjectId || null;
+    if (!projectId || typeof this.router?.showProjectForm !== "function") return false;
+    await this.router.showProjectForm({ projectId });
+    return true;
+  }
+
   async _openProtocolModule(projectId) {
     const effectiveProjectId = projectId || this.projectId || this.router?.currentProjectId || null;
     if (!effectiveProjectId) return false;
     if (typeof this.router?.openProjectModule === "function") {
-      const result = await this.router.openProjectModule(effectiveProjectId, "protokoll", { project: this.project || null });
+      const result = await this.router.openProjectModule(effectiveProjectId, "protokoll", {
+        project: this.project || null,
+      });
       return typeof result === "object" ? !!result?.ok : result !== false;
     }
     if (typeof this.router?.openProjectProtocol === "function") {
-      const result = await this.router.openProjectProtocol(effectiveProjectId, { project: this.project || null });
+      const result = await this.router.openProjectProtocol(effectiveProjectId, {
+        project: this.project || null,
+      });
       return typeof result === "object" ? !!result?.ok : result !== false;
     }
     return false;
@@ -178,28 +195,48 @@ export default class ProjectWorkspaceScreen {
       border: "1px solid #e3e8ef",
       borderRadius: "14px",
       padding: "16px",
-      minHeight: "180px",
-      boxShadow: "0 6px 20px rgba(15,23,42,0.055)",
+      minHeight: "176px",
+      boxShadow: "0 5px 18px rgba(15,23,42,0.045)",
       display: "flex",
       flexDirection: "column",
       gap: "10px",
     });
 
     const iconWrap = setStyles(document.createElement("div"), {
-      width: "46px", height: "46px", borderRadius: "12px", display: "grid", placeItems: "center",
-      background: `${style.color}16`, color: style.color,
+      width: "46px",
+      height: "46px",
+      borderRadius: "12px",
+      display: "grid",
+      placeItems: "center",
+      background: `${style.color}16`,
+      color: style.color,
     });
     iconWrap.innerHTML = ICONS[style.icon] || ICONS.protocol;
     const svg = iconWrap.querySelector("svg");
     if (svg) Object.assign(svg.style, { width: "28px", height: "28px" });
 
-    const title = setStyles(document.createElement("div"), { fontWeight: "800", fontSize: "17px", color: "#172033" });
+    const title = setStyles(document.createElement("div"), {
+      fontWeight: "800",
+      fontSize: "17px",
+      color: "#172033",
+    });
     title.textContent = group.label;
 
-    const description = setStyles(document.createElement("div"), { fontSize: "12px", lineHeight: "1.45", color: "#667085", flex: "1" });
+    const description = setStyles(document.createElement("div"), {
+      fontSize: "12px",
+      lineHeight: "1.45",
+      color: "#667085",
+      flex: "1",
+    });
     description.textContent = group.description || "Arbeitsbereich im aktuellen Projekt öffnen.";
 
-    const actions = setStyles(document.createElement("div"), { display: "flex", gap: "7px", flexWrap: "wrap", marginTop: "2px" });
+    const actions = setStyles(document.createElement("div"), {
+      display: "flex",
+      gap: "7px",
+      flexWrap: "wrap",
+      marginTop: "2px",
+    });
+
     group.entries.forEach((entry, index) => {
       const btn = setStyles(document.createElement("button"), {
         border: index === 0 ? "0" : `1px solid ${style.color}55`,
@@ -235,7 +272,9 @@ export default class ProjectWorkspaceScreen {
       settings.textContent = "Einstellungen";
       settings.title = "Projektspezifische Protokoll- und PDF-Einstellungen";
       settings.addEventListener("click", async () => {
-        await openProtocolSettingsModal({ projectId: this.projectId || this.router?.currentProjectId || null });
+        await openProtocolSettingsModal({
+          projectId: this.projectId || this.router?.currentProjectId || null,
+        });
       });
       actions.appendChild(settings);
     }
@@ -249,7 +288,11 @@ export default class ProjectWorkspaceScreen {
     this.hostEl.innerHTML = "";
 
     if (this.projectMissing) {
-      const missing = setStyles(document.createElement("div"), { padding: "16px", color: "#b42318", fontWeight: "700" });
+      const missing = setStyles(document.createElement("div"), {
+        padding: "16px",
+        color: "#b42318",
+        fontWeight: "700",
+      });
       missing.textContent = "Projekt konnte nicht gefunden werden.";
       this.hostEl.appendChild(missing);
       return;
@@ -261,28 +304,80 @@ export default class ProjectWorkspaceScreen {
       border: "1px solid #e3e8ef",
       borderRadius: "14px",
       padding: "16px 18px",
-      marginBottom: "16px",
+      marginBottom: "18px",
       display: "grid",
-      gap: "5px",
+      gridTemplateColumns: "minmax(0, 1fr) auto",
+      gap: "10px 18px",
+      alignItems: "start",
     });
 
-    const title = setStyles(document.createElement("div"), { fontSize: "21px", fontWeight: "850", color: "#172033" });
+    const projectText = document.createElement("div");
+    const title = setStyles(document.createElement("div"), {
+      fontSize: "22px",
+      fontWeight: "850",
+      color: "#172033",
+      marginBottom: "5px",
+    });
     title.textContent = this.getProjectDisplayText();
 
-    const address = setStyles(document.createElement("div"), { fontSize: "12px", color: "#667085" });
+    const address = setStyles(document.createElement("div"), {
+      fontSize: "12px",
+      color: "#667085",
+      marginBottom: "5px",
+    });
     address.textContent = projectAddress(project) || "Keine Projektadresse hinterlegt";
 
-    const meta = setStyles(document.createElement("div"), { fontSize: "11px", color: "#8a94a5" });
+    const meta = setStyles(document.createElement("div"), {
+      fontSize: "11px",
+      color: "#8a94a5",
+    });
     const lead = normalizeText(project?.project_lead);
-    const dates = [normalizeText(project?.start_date)?.slice(0, 10), normalizeText(project?.end_date)?.slice(0, 10)].filter(Boolean).join(" – ");
-    meta.textContent = [lead ? `Projektleitung: ${lead}` : "", dates ? `Zeitraum: ${dates}` : ""].filter(Boolean).join("   ·   ") || "Projektstammdaten";
-    info.append(title, address, meta);
+    const dates = [
+      normalizeText(project?.start_date)?.slice(0, 10),
+      normalizeText(project?.end_date)?.slice(0, 10),
+    ]
+      .filter(Boolean)
+      .join(" – ");
+    meta.textContent =
+      [lead ? `Projektleitung: ${lead}` : "", dates ? `Zeitraum: ${dates}` : ""]
+        .filter(Boolean)
+        .join("   ·   ") || "Projektstammdaten";
+    projectText.append(title, address, meta);
 
-    const sectionHead = setStyles(document.createElement("div"), { display: "flex", alignItems: "baseline", justifyContent: "space-between", margin: "0 2px 9px" });
-    const sectionTitle = setStyles(document.createElement("div"), { fontSize: "14px", fontWeight: "800", color: "#172033" });
-    sectionTitle.textContent = "Arbeitsbereiche im Projekt";
-    const sectionHint = setStyles(document.createElement("div"), { fontSize: "11px", color: "#8a94a5" });
-    sectionHint.textContent = "Nur freigeschaltete Bereiche";
+    const edit = setStyles(document.createElement("button"), {
+      border: "1px solid #d7dee8",
+      borderRadius: "8px",
+      background: "#ffffff",
+      color: "#175cd3",
+      padding: "7px 11px",
+      fontSize: "11.5px",
+      fontWeight: "750",
+      cursor: "pointer",
+      whiteSpace: "nowrap",
+    });
+    edit.type = "button";
+    edit.textContent = "Projekt bearbeiten";
+    edit.onclick = async () => this.editProject();
+
+    info.append(projectText, edit);
+
+    const sectionHead = setStyles(document.createElement("div"), {
+      display: "flex",
+      alignItems: "baseline",
+      justifyContent: "space-between",
+      margin: "0 2px 9px",
+    });
+    const sectionTitle = setStyles(document.createElement("div"), {
+      fontSize: "14px",
+      fontWeight: "800",
+      color: "#172033",
+    });
+    sectionTitle.textContent = "Arbeitsbereiche";
+    const sectionHint = setStyles(document.createElement("div"), {
+      fontSize: "11px",
+      color: "#8a94a5",
+    });
+    sectionHint.textContent = "Nur freigeschaltete Bereiche dieses Projekts";
     sectionHead.append(sectionTitle, sectionHint);
 
     const grid = setStyles(document.createElement("div"), {
@@ -293,7 +388,14 @@ export default class ProjectWorkspaceScreen {
 
     const groups = groupProjectModules(this.getAvailableProjectModules());
     if (!groups.length) {
-      const empty = setStyles(document.createElement("div"), { padding: "14px", border: "1px solid #e3e8ef", borderRadius: "12px", background: "#ffffff", color: "#667085", fontSize: "12px" });
+      const empty = setStyles(document.createElement("div"), {
+        padding: "14px",
+        border: "1px solid #e3e8ef",
+        borderRadius: "12px",
+        background: "#ffffff",
+        color: "#667085",
+        fontSize: "12px",
+      });
       empty.textContent = "Für dieses Projekt sind keine Arbeitsmodule freigeschaltet.";
       grid.appendChild(empty);
     } else {
@@ -313,22 +415,32 @@ export default class ProjectWorkspaceScreen {
     });
 
     const head = setStyles(document.createElement("div"), {
-      display: "flex", alignItems: "center", gap: "10px", marginBottom: "14px",
+      display: "flex",
+      alignItems: "center",
+      gap: "10px",
+      marginBottom: "14px",
     });
 
     const back = setStyles(document.createElement("button"), {
-      border: "1px solid #d7dee8", borderRadius: "8px", background: "#ffffff", color: "#344054",
-      padding: "7px 10px", fontSize: "11.5px", fontWeight: "700", cursor: "pointer",
+      border: "1px solid #d7dee8",
+      borderRadius: "8px",
+      background: "#ffffff",
+      color: "#344054",
+      padding: "7px 10px",
+      fontSize: "11.5px",
+      fontWeight: "700",
+      cursor: "pointer",
     });
     back.type = "button";
     back.textContent = "← Projekte";
     back.onclick = async () => this.showProjectsList();
 
-    const h = setStyles(document.createElement("h2"), { margin: "0", fontSize: "20px", fontWeight: "850" });
-    h.textContent = "Projekt";
-
-    const msg = setStyles(document.createElement("div"), { marginLeft: "auto", fontSize: "11px", color: "#8a94a5" });
-    head.append(back, h, msg);
+    const msg = setStyles(document.createElement("div"), {
+      marginLeft: "auto",
+      fontSize: "11px",
+      color: "#8a94a5",
+    });
+    head.append(back, msg);
 
     const host = document.createElement("div");
     root.append(head, host);

--- a/src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectWorkspaceScreen.js
@@ -1,3 +1,5 @@
+import { openProtocolSettingsModal } from "../../protokoll/ProtocolSettingsModal.js";
+
 function normalizeText(value) {
   return String(value || "").trim();
 }
@@ -217,6 +219,26 @@ export default class ProjectWorkspaceScreen {
       });
       actions.appendChild(btn);
     });
+
+    if (group.moduleId === "protokoll") {
+      const settings = setStyles(document.createElement("button"), {
+        border: `1px solid ${style.color}55`,
+        borderRadius: "8px",
+        background: "#ffffff",
+        color: style.color,
+        padding: "7px 11px",
+        fontSize: "11.5px",
+        fontWeight: "750",
+        cursor: "pointer",
+      });
+      settings.type = "button";
+      settings.textContent = "Einstellungen";
+      settings.title = "Projektspezifische Protokoll- und PDF-Einstellungen";
+      settings.addEventListener("click", async () => {
+        await openProtocolSettingsModal({ projectId: this.projectId || this.router?.currentProjectId || null });
+      });
+      actions.appendChild(settings);
+    }
 
     card.append(iconWrap, title, description, actions);
     return card;

--- a/src/renderer/modules/projektverwaltung/screens/ProjectsHubScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectsHubScreen.js
@@ -1,14 +1,58 @@
 import LegacyProjectsScreen from "./ProjectsScreen.js";
+import ProtokollStartScreen from "../../protokoll/screens/ProtokollStartScreen.js";
+
+const START_TARGET_KEY = "bbm.startTargetModuleId";
+const PROTOCOL_START_INTENT_KEY = "bbm.protokollStartIntent";
+
+function readStorage(key) {
+  try {
+    return String(window.localStorage?.getItem?.(key) || "").trim();
+  } catch (_e) {
+    return "";
+  }
+}
+
+function clearStorage(key) {
+  try {
+    window.localStorage?.removeItem?.(key);
+  } catch (_e) {
+    // ignore
+  }
+}
 
 /**
  * Neutraler Projekteinstieg fuer die modulare BBM-Struktur.
  *
- * Die bestehende Projektliste, Bearbeitung sowie Import/Export bleiben erhalten.
- * Geaendert wird bewusst nur die Bedeutung eines normalen Projektklicks:
- * Ein Projekt oeffnet zuerst den Projekt-Arbeitsbereich und startet kein
- * Fachmodul automatisch.
+ * Normaler Projektklick: Projekt-Arbeitsbereich.
+ * Einstieg aus der Protokoll-Kachel: zuerst Protokoll-Startsicht.
  */
 export default class ProjectsHubScreen extends LegacyProjectsScreen {
+  constructor(args = {}) {
+    super(args);
+    this.protocolStartScreen = null;
+  }
+
+  _startsFromProtocolTile() {
+    return readStorage(START_TARGET_KEY) === "protokoll";
+  }
+
+  render() {
+    if (this._startsFromProtocolTile()) {
+      clearStorage(START_TARGET_KEY);
+      this.protocolStartScreen = new ProtokollStartScreen({ router: this.router });
+      return this.protocolStartScreen.render();
+    }
+    return super.render();
+  }
+
+  async load() {
+    if (this.protocolStartScreen) {
+      await this.protocolStartScreen.load?.();
+      return;
+    }
+    await super.load();
+  }
+
   async openProjectById(projectId) {
     if (this.loading) return false;
 
@@ -31,6 +75,13 @@ export default class ProjectsHubScreen extends LegacyProjectsScreen {
 
     this._setProjectRuntimeContext?.(project.id, null);
     this._rememberLastProject?.(project.id);
+
+    const protocolIntent = readStorage(PROTOCOL_START_INTENT_KEY);
+    if (protocolIntent === "new") {
+      clearStorage(PROTOCOL_START_INTENT_KEY);
+      const result = await this.router?.openProjectModule?.(project.id, "protokoll", { project });
+      return typeof result === "object" ? !!result?.ok : result !== false;
+    }
 
     if (typeof this.router?.showProjectWorkspace !== "function") {
       this._flashMsg?.("Projekt-Arbeitsbereich ist nicht verfügbar.", 9000);

--- a/src/renderer/modules/projektverwaltung/screens/ProjectsHubScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectsHubScreen.js
@@ -26,6 +26,7 @@ function clearStorage(key) {
  *
  * Normaler Projektklick: Projekt-Arbeitsbereich.
  * Einstieg aus der Protokoll-Kachel: zuerst Protokoll-Startsicht.
+ * Die Projektkachel selbst ist bewusst keine Modulnavigation mehr.
  */
 export default class ProjectsHubScreen extends LegacyProjectsScreen {
   constructor(args = {}) {
@@ -35,6 +36,54 @@ export default class ProjectsHubScreen extends LegacyProjectsScreen {
 
   _startsFromProtocolTile() {
     return readStorage(START_TARGET_KEY) === "protokoll";
+  }
+
+  // Module gehoeren in den Projekt-Arbeitsbereich und nicht als Mini-Menue
+  // direkt in jede Projektkachel.
+  _getProjectTileModuleActions() {
+    return [];
+  }
+
+  _polishNeutralProjectCards() {
+    const host = this.hostEl || null;
+    if (!host?.querySelectorAll) return;
+
+    for (const card of host.querySelectorAll('[data-project-card="true"]')) {
+      card.style.minHeight = "150px";
+      card.style.padding = "16px";
+      card.style.borderRadius = "12px";
+      card.style.boxShadow = "0 3px 10px rgba(15,23,42,.035)";
+      card.style.gap = "10px";
+
+      const rail = card.querySelector('[data-project-action-rail="true"]');
+      if (rail) {
+        rail.style.flex = "0 0 auto";
+        rail.style.minWidth = "0";
+        rail.style.paddingLeft = "8px";
+        rail.style.borderLeft = "none";
+        rail.style.alignSelf = "flex-start";
+      }
+
+      const edit = card.querySelector('[data-project-action="edit"]');
+      if (edit) {
+        edit.textContent = "Bearbeiten";
+        edit.style.border = "1px solid #d8dee8";
+        edit.style.borderRadius = "7px";
+        edit.style.background = "#ffffff";
+        edit.style.color = "#475467";
+        edit.style.padding = "6px 9px";
+        edit.style.fontSize = "11px";
+        edit.style.fontWeight = "700";
+        edit.style.textDecoration = "none";
+      }
+
+      card.title = "Projekt öffnen";
+    }
+  }
+
+  _renderGrid() {
+    super._renderGrid();
+    this._polishNeutralProjectCards();
   }
 
   async _openProjectFormModal({ projectId } = {}) {

--- a/src/renderer/modules/projektverwaltung/screens/ProjectsHubScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectsHubScreen.js
@@ -1,0 +1,43 @@
+import LegacyProjectsScreen from "./ProjectsScreen.js";
+
+/**
+ * Neutraler Projekteinstieg fuer die modulare BBM-Struktur.
+ *
+ * Die bestehende Projektliste, Bearbeitung sowie Import/Export bleiben erhalten.
+ * Geaendert wird bewusst nur die Bedeutung eines normalen Projektklicks:
+ * Ein Projekt oeffnet zuerst den Projekt-Arbeitsbereich und startet kein
+ * Fachmodul automatisch.
+ */
+export default class ProjectsHubScreen extends LegacyProjectsScreen {
+  async openProjectById(projectId) {
+    if (this.loading) return false;
+
+    const wanted = String(projectId ?? "").trim();
+    if (!wanted) {
+      this._flashMsg?.("Projekt kann nicht geöffnet werden: id fehlt.", 7000);
+      return false;
+    }
+
+    let project = (this.projects || []).find((p) => String(p?.id ?? "") === wanted) || null;
+    if (!project) {
+      await this.reloadProjects?.();
+      project = (this.projects || []).find((p) => String(p?.id ?? "") === wanted) || null;
+    }
+
+    if (!project?.id) {
+      this._flashMsg?.("Projekt wurde nicht gefunden.", 7000);
+      return false;
+    }
+
+    this._setProjectRuntimeContext?.(project.id, null);
+    this._rememberLastProject?.(project.id);
+
+    if (typeof this.router?.showProjectWorkspace !== "function") {
+      this._flashMsg?.("Projekt-Arbeitsbereich ist nicht verfügbar.", 9000);
+      return false;
+    }
+
+    await this.router.showProjectWorkspace(project.id, { project });
+    return true;
+  }
+}

--- a/src/renderer/modules/projektverwaltung/screens/ProjectsHubScreen.js
+++ b/src/renderer/modules/projektverwaltung/screens/ProjectsHubScreen.js
@@ -1,4 +1,5 @@
 import LegacyProjectsScreen from "./ProjectsScreen.js";
+import ProjectFormHubScreen from "./ProjectFormHubScreen.js";
 import ProtokollStartScreen from "../../protokoll/screens/ProtokollStartScreen.js";
 
 const START_TARGET_KEY = "bbm.startTargetModuleId";
@@ -34,6 +35,35 @@ export default class ProjectsHubScreen extends LegacyProjectsScreen {
 
   _startsFromProtocolTile() {
     return readStorage(START_TARGET_KEY) === "protokoll";
+  }
+
+  async _openProjectFormModal({ projectId } = {}) {
+    if (this._projectFormModal) return;
+
+    try {
+      this._projectFormPrevProjectId = this.router.currentProjectId || null;
+      this.router.currentProjectId = projectId || null;
+      this.router.currentMeetingId = null;
+
+      const view = new ProjectFormHubScreen({
+        router: this.router,
+        projectId: projectId || null,
+        mode: "modal",
+        onClose: () => this._cleanupProjectFormModal(),
+        onSaved: async () => {
+          await this.reloadProjects();
+          this._cleanupProjectFormModal();
+        },
+      });
+
+      this._projectFormModal = view;
+      view.render();
+      await view.load();
+      view.openModal();
+    } catch (err) {
+      console.error("[ProjectsHubScreen] Project modal failed:", err);
+      this._cleanupProjectFormModal();
+    }
   }
 
   render() {

--- a/src/renderer/modules/protokoll/ProtocolSettingsModal.js
+++ b/src/renderer/modules/protokoll/ProtocolSettingsModal.js
@@ -1,0 +1,218 @@
+import { applyPopupButtonStyle } from "../../ui/popupButtonStyles.js";
+import { cleanupPopupHandlers, createPopupOverlay } from "../../ui/popupCommon.js";
+
+const KEYS = Object.freeze([
+  "pdf.protocolTitle",
+  "pdf.footerPlace",
+  "pdf.footerDate",
+  "pdf.footerName1",
+  "pdf.footerName2",
+  "pdf.footerRecorder",
+  "pdf.footerStreet",
+  "pdf.footerZip",
+  "pdf.footerCity",
+]);
+
+function todayDe() {
+  const now = new Date();
+  const dd = String(now.getDate()).padStart(2, "0");
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  return `${dd}.${mm}.${now.getFullYear()}`;
+}
+
+function text(value) {
+  return String(value || "").trim();
+}
+
+export async function openProtocolSettingsModal({ projectId } = {}) {
+  const effectiveProjectId = text(projectId);
+  if (!effectiveProjectId) {
+    alert("Bitte zuerst ein Projekt auswählen.");
+    return false;
+  }
+
+  const api = window.bbmDb || {};
+  if (typeof api.projectSettingsGetMany !== "function" || typeof api.projectSettingsSetMany !== "function") {
+    alert("Protokoll-Einstellungen sind nicht verfügbar.");
+    return false;
+  }
+
+  const settingsRes = await api.projectSettingsGetMany({ projectId: effectiveProjectId, keys: KEYS });
+  if (!settingsRes?.ok) {
+    alert(settingsRes?.error || "Protokoll-Einstellungen konnten nicht geladen werden.");
+    return false;
+  }
+
+  const data = settingsRes.data || {};
+  let profile = {};
+  if (typeof api.userProfileGet === "function") {
+    try {
+      const profileRes = await api.userProfileGet();
+      if (profileRes?.ok) profile = profileRes.data || profileRes.profile || {};
+    } catch (_e) {}
+  }
+
+  const overlay = createPopupOverlay({ background: "rgba(0,0,0,0.35)", zIndex: 9999 });
+  overlay.style.display = "flex";
+  const modal = document.createElement("div");
+  modal.className = "bbm-popup-standard bbm-popup-dialog";
+  Object.assign(modal.style, {
+    width: "min(760px, calc(100vw - 32px))",
+    maxHeight: "calc(100vh - 32px)",
+    display: "flex",
+    flexDirection: "column",
+    overflow: "hidden",
+  });
+
+  const close = () => {
+    try { cleanupPopupHandlers(overlay); } catch (_e) {}
+    try { overlay.remove(); } catch (_e) {}
+  };
+
+  const head = document.createElement("div");
+  head.className = "bbm-popup-header";
+  Object.assign(head.style, { display: "flex", alignItems: "center", gap: "10px" });
+  const title = document.createElement("div");
+  title.textContent = "Protokoll-Einstellungen";
+  title.style.fontWeight = "800";
+  const closeBtn = document.createElement("button");
+  closeBtn.type = "button";
+  closeBtn.textContent = "X";
+  applyPopupButtonStyle(closeBtn);
+  closeBtn.style.marginLeft = "auto";
+  closeBtn.onclick = close;
+  head.append(title, closeBtn);
+
+  const body = document.createElement("div");
+  body.className = "bbm-popup-body bbm-form-content";
+  Object.assign(body.style, { overflow: "auto", display: "grid", gap: "12px" });
+
+  const makeInput = (placeholder = "") => {
+    const input = document.createElement("input");
+    input.type = "text";
+    input.placeholder = placeholder;
+    input.style.width = "100%";
+    input.style.boxSizing = "border-box";
+    return input;
+  };
+  const makeRow = (label, field) => {
+    const row = document.createElement("div");
+    row.className = "bbm-form-field";
+    Object.assign(row.style, { display: "grid", gridTemplateColumns: "220px minmax(0, 1fr)", alignItems: "center", gap: "10px" });
+    const lab = document.createElement("div");
+    lab.className = "bbm-form-label";
+    lab.textContent = label;
+    row.append(lab, field);
+    return row;
+  };
+  const makeSection = (caption) => {
+    const section = document.createElement("div");
+    section.className = "bbm-form-card bbm-form-group";
+    section.style.display = "grid";
+    section.style.gap = "9px";
+    const h = document.createElement("div");
+    h.textContent = caption;
+    h.style.fontWeight = "700";
+    section.appendChild(h);
+    return section;
+  };
+
+  const protocolTitle = makeInput("Protokoll");
+  protocolTitle.value = text(data["pdf.protocolTitle"]);
+  const protocolSection = makeSection("Protokoll");
+  protocolSection.append(makeRow("Bezeichnung des Protokolls", protocolTitle));
+
+  const footerSection = makeSection("Protokoll-Fuß (PDF)");
+  const takeUser = document.createElement("button");
+  takeUser.type = "button";
+  takeUser.textContent = "Nutzerdaten übernehmen";
+  applyPopupButtonStyle(takeUser);
+
+  const footerPlace = makeInput("Ort");
+  const footerDate = makeInput("dd.mm.yyyy");
+  const footerName1 = makeInput("Name 1");
+  const footerName2 = makeInput("Name 2");
+  const footerRecorder = makeInput("Protokollführer");
+  const footerStreet = makeInput("Str./HsNr.");
+  const footerZip = makeInput("PLZ");
+  const footerCity = makeInput("Ort");
+
+  footerPlace.value = text(data["pdf.footerPlace"]);
+  footerDate.value = text(data["pdf.footerDate"]) || todayDe();
+  footerName1.value = text(data["pdf.footerName1"]);
+  footerName2.value = text(data["pdf.footerName2"]);
+  footerRecorder.value = text(data["pdf.footerRecorder"]);
+  footerStreet.value = text(data["pdf.footerStreet"]);
+  footerZip.value = text(data["pdf.footerZip"]);
+  footerCity.value = text(data["pdf.footerCity"]);
+
+  takeUser.onclick = () => {
+    footerPlace.value = text(profile.city || profile.user_city);
+    footerDate.value = todayDe();
+    footerName1.value = text(profile.name1 || profile.user_name1);
+    footerName2.value = text(profile.name2 || profile.user_name2);
+    footerRecorder.value = text(profile.name1 || profile.user_name1);
+    footerStreet.value = text(profile.street || profile.user_street);
+    footerZip.value = text(profile.zip || profile.user_zip);
+    footerCity.value = text(profile.city || profile.user_city);
+  };
+
+  footerSection.append(
+    makeRow("Nutzerdaten", takeUser),
+    makeRow("Ort (Ort, Datum)", footerPlace),
+    makeRow("Datum", footerDate),
+    makeRow("Name 1", footerName1),
+    makeRow("Name 2", footerName2),
+    makeRow("Protokollführer", footerRecorder),
+    makeRow("Str./HsNr.", footerStreet),
+    makeRow("PLZ", footerZip),
+    makeRow("Ort (Adresse)", footerCity),
+  );
+
+  body.append(protocolSection, footerSection);
+
+  const footer = document.createElement("div");
+  footer.className = "bbm-popup-footer";
+  Object.assign(footer.style, { display: "flex", justifyContent: "flex-end", gap: "8px" });
+  const cancel = document.createElement("button");
+  cancel.type = "button";
+  cancel.textContent = "Abbrechen";
+  applyPopupButtonStyle(cancel);
+  cancel.onclick = close;
+  const save = document.createElement("button");
+  save.type = "button";
+  save.textContent = "Speichern";
+  applyPopupButtonStyle(save, { variant: "primary" });
+  save.onclick = async () => {
+    const patch = {
+      "pdf.protocolTitle": text(protocolTitle.value),
+      "pdf.footerPlace": text(footerPlace.value),
+      "pdf.footerDate": text(footerDate.value) || todayDe(),
+      "pdf.footerName1": text(footerName1.value),
+      "pdf.footerName2": text(footerName2.value),
+      "pdf.footerRecorder": text(footerRecorder.value),
+      "pdf.footerStreet": text(footerStreet.value),
+      "pdf.footerZip": text(footerZip.value),
+      "pdf.footerCity": text(footerCity.value),
+    };
+    const res = await api.projectSettingsSetMany({ projectId: effectiveProjectId, patch });
+    if (!res?.ok) {
+      alert(res?.error || "Protokoll-Einstellungen konnten nicht gespeichert werden.");
+      return;
+    }
+    close();
+  };
+
+  footer.append(cancel, save);
+  modal.append(head, body, footer);
+  overlay.appendChild(modal);
+  overlay.addEventListener("mousedown", (event) => {
+    if (event.target === overlay) close();
+  });
+  overlay.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") close();
+  });
+  document.body.appendChild(overlay);
+  try { overlay.focus(); } catch (_e) {}
+  return true;
+}

--- a/src/renderer/modules/protokoll/index.js
+++ b/src/renderer/modules/protokoll/index.js
@@ -41,17 +41,13 @@ function buildProtokollModulePresentation() {
     icon: "protocol",
     description: "Besprechungen dokumentieren und Protokolle fortschreiben.",
     start: Object.freeze({
-      mode: "module-home",
+      mode: "project",
       screenId: PROTOKOLL_START_SCREEN_ID,
       label: "Öffnen",
     }),
   });
 }
 
-// Technische Heimat fuer das Fachmodul `Protokoll`.
-// Der heutige Bestand bleibt vorerst in seinen vorhandenen Pfaden und wird hier
-// nur ueber kleine Einstiegspunkte angedockt.
-// Kein globaler Modulkatalog, keine Plattformlogik und kein Vollumzug.
 export function getProtokollModuleEntry() {
   return Object.freeze({
     moduleId: PROTOKOLL_MODULE_ID,

--- a/src/renderer/modules/protokoll/index.js
+++ b/src/renderer/modules/protokoll/index.js
@@ -1,13 +1,16 @@
 ﻿import TopsScreen from "./screens/TopsScreen.js";
+import ProtokollStartScreen from "./screens/ProtokollStartScreen.js";
 import { PROTOKOLL_WORK_SCREEN_ID } from "./screens/index.js";
 import * as protokollViewModels from "./viewmodel/index.js";
 
 export const PROTOKOLL_MODULE_ID = "protokoll";
 export const PROTOKOLL_MODULE_LABEL = "Protokoll";
 export const PROTOKOLL_NAV_ENTRY_KEY = "protokoll";
+export const PROTOKOLL_START_SCREEN_ID = "protokoll.start";
 
 function buildProtokollModuleScreens() {
   return Object.freeze({
+    [PROTOKOLL_START_SCREEN_ID]: ProtokollStartScreen,
     [PROTOKOLL_WORK_SCREEN_ID]: TopsScreen,
   });
 }
@@ -38,8 +41,9 @@ function buildProtokollModulePresentation() {
     icon: "protocol",
     description: "Besprechungen dokumentieren und Protokolle fortschreiben.",
     start: Object.freeze({
-      mode: "project",
-      label: "Projekt auswählen",
+      mode: "module-home",
+      screenId: PROTOKOLL_START_SCREEN_ID,
+      label: "Öffnen",
     }),
   });
 }
@@ -52,6 +56,7 @@ export function getProtokollModuleEntry() {
   return Object.freeze({
     moduleId: PROTOKOLL_MODULE_ID,
     moduleLabel: PROTOKOLL_MODULE_LABEL,
+    startScreenId: PROTOKOLL_START_SCREEN_ID,
     workScreenId: PROTOKOLL_WORK_SCREEN_ID,
     screens: buildProtokollModuleScreens(),
     navigation: buildProtokollModuleNavigation(),
@@ -60,6 +65,6 @@ export function getProtokollModuleEntry() {
   });
 }
 
-export { TopsScreen, PROTOKOLL_WORK_SCREEN_ID };
+export { ProtokollStartScreen, TopsScreen, PROTOKOLL_WORK_SCREEN_ID };
 export * from "./screens/index.js";
 export * from "./viewmodel/index.js";

--- a/src/renderer/modules/protokoll/screens/ProtokollStartScreen.js
+++ b/src/renderer/modules/protokoll/screens/ProtokollStartScreen.js
@@ -1,0 +1,282 @@
+const COLORS = Object.freeze({
+  green: "#37a447",
+  greenSoft: "#edf8ef",
+  text: "#172033",
+  muted: "#667085",
+  border: "#dfe5ec",
+  canvas: "#f5f7fa",
+  white: "#ffffff",
+});
+
+function setStyles(el, values = {}) {
+  Object.assign(el.style, values);
+  return el;
+}
+
+function normalizeText(value) {
+  return String(value || "").trim();
+}
+
+function projectLabel(project) {
+  const number = normalizeText(project?.project_number ?? project?.projectNumber);
+  const short = normalizeText(project?.short);
+  const name = normalizeText(project?.name);
+  const title = short || name || "Projekt";
+  return number ? `${number} - ${title}` : title;
+}
+
+function protocolIcon(size = 32) {
+  const wrap = document.createElement("span");
+  wrap.innerHTML = `
+    <svg viewBox="0 0 48 48" aria-hidden="true">
+      <rect x="12" y="7" width="24" height="34" rx="3.5" fill="none" stroke="currentColor" stroke-width="2.7"/>
+      <path d="M18 17h12M18 23h12M18 29h8" fill="none" stroke="currentColor" stroke-width="2.7" stroke-linecap="round"/>
+      <circle cx="18" cy="35" r="1.7" fill="currentColor"/>
+      <path d="M22 35h8" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+    </svg>`;
+  const svg = wrap.querySelector("svg");
+  if (svg) {
+    svg.style.width = `${size}px`;
+    svg.style.height = `${size}px`;
+    svg.style.display = "block";
+  }
+  return wrap;
+}
+
+export default class ProtokollStartScreen {
+  constructor({ router } = {}) {
+    this.router = router || null;
+    this.projects = [];
+    this.lastProject = null;
+    this.root = null;
+    this.contentEl = null;
+  }
+
+  _readLastProjectId() {
+    try {
+      return normalizeText(window.localStorage?.getItem?.("bbm.lastProjectId")) || null;
+    } catch (_e) {
+      return null;
+    }
+  }
+
+  async _loadProjects() {
+    const api = window.bbmDb || {};
+    if (typeof api.projectsList !== "function") {
+      this.projects = [];
+      this.lastProject = null;
+      return;
+    }
+
+    try {
+      const res = await api.projectsList();
+      this.projects = res?.ok && Array.isArray(res.list) ? res.list : [];
+    } catch (_e) {
+      this.projects = [];
+    }
+
+    const lastId = this._readLastProjectId();
+    this.lastProject = lastId
+      ? this.projects.find((project) => String(project?.id ?? "") === String(lastId)) || null
+      : null;
+  }
+
+  async _openProject(project) {
+    const projectId = project?.id || null;
+    if (!projectId) return;
+    await this.router?.showProjectWorkspace?.(projectId, { project });
+  }
+
+  async _chooseProject() {
+    try {
+      window.localStorage?.setItem?.("bbm.startTargetModuleId", "protokoll");
+    } catch (_e) {
+      // ignore
+    }
+    await this.router?.showProjects?.();
+  }
+
+  async _newProtocol() {
+    // Das eigentliche Erzeugen einer Besprechung bleibt im bestehenden
+    // Protokollpfad. Diese Startsicht setzt nur den gewünschten Zielbereich.
+    try {
+      window.localStorage?.setItem?.("bbm.startTargetModuleId", "protokoll");
+      window.localStorage?.setItem?.("bbm.protokollStartIntent", "new");
+    } catch (_e) {
+      // ignore
+    }
+    await this.router?.showProjects?.();
+  }
+
+  _createActionCard({ title, description, actionLabel, onClick, accent = COLORS.green }) {
+    const card = setStyles(document.createElement("div"), {
+      border: `1px solid ${COLORS.border}`,
+      borderRadius: "12px",
+      background: COLORS.white,
+      padding: "18px",
+      minHeight: "150px",
+      boxSizing: "border-box",
+      display: "flex",
+      flexDirection: "column",
+      gap: "9px",
+      boxShadow: "0 3px 10px rgba(15,23,42,.045)",
+    });
+
+    const titleEl = setStyles(document.createElement("div"), {
+      fontSize: "15px",
+      fontWeight: "800",
+      color: COLORS.text,
+    });
+    titleEl.textContent = title;
+
+    const descEl = setStyles(document.createElement("div"), {
+      fontSize: "12px",
+      lineHeight: "1.45",
+      color: COLORS.muted,
+      flex: "1",
+    });
+    descEl.textContent = description;
+
+    const button = setStyles(document.createElement("button"), {
+      alignSelf: "flex-start",
+      border: "0",
+      borderRadius: "5px",
+      background: accent,
+      color: "#fff",
+      height: "30px",
+      padding: "0 13px",
+      fontSize: "11px",
+      fontWeight: "750",
+      cursor: "pointer",
+    });
+    button.type = "button";
+    button.textContent = actionLabel;
+    button.addEventListener("click", async () => onClick?.());
+
+    card.append(titleEl, descEl, button);
+    return card;
+  }
+
+  _renderContent() {
+    if (!this.contentEl) return;
+    this.contentEl.innerHTML = "";
+
+    const header = setStyles(document.createElement("div"), {
+      display: "flex",
+      alignItems: "center",
+      gap: "14px",
+      marginBottom: "20px",
+    });
+
+    const iconBox = setStyles(document.createElement("div"), {
+      width: "54px",
+      height: "54px",
+      borderRadius: "11px",
+      background: COLORS.green,
+      color: "#fff",
+      display: "grid",
+      placeItems: "center",
+      boxShadow: "0 8px 18px rgba(55,164,71,.20)",
+    });
+    iconBox.append(protocolIcon(34));
+
+    const headerText = document.createElement("div");
+    const title = setStyles(document.createElement("h1"), {
+      margin: "0",
+      fontSize: "25px",
+      color: COLORS.text,
+      letterSpacing: "-.3px",
+    });
+    title.textContent = "Protokoll";
+    const subtitle = setStyles(document.createElement("div"), {
+      marginTop: "5px",
+      fontSize: "12.5px",
+      color: COLORS.muted,
+    });
+    subtitle.textContent = "Besprechungsprotokolle projektbezogen erstellen, fortschreiben und wieder öffnen.";
+    headerText.append(title, subtitle);
+    header.append(iconBox, headerText);
+
+    const grid = setStyles(document.createElement("div"), {
+      display: "grid",
+      gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+      gap: "12px",
+    });
+
+    if (this.lastProject) {
+      grid.append(
+        this._createActionCard({
+          title: "Zuletzt verwendet",
+          description: projectLabel(this.lastProject),
+          actionLabel: "Fortsetzen",
+          onClick: async () => this._openProject(this.lastProject),
+        })
+      );
+    } else {
+      grid.append(
+        this._createActionCard({
+          title: "Zuletzt verwendet",
+          description: "Noch kein zuletzt verwendetes Projekt vorhanden.",
+          actionLabel: "Projekt auswählen",
+          onClick: async () => this._chooseProject(),
+        })
+      );
+    }
+
+    grid.append(
+      this._createActionCard({
+        title: "Projekt auswählen",
+        description: "Ein bestehendes Projekt öffnen und dort die vorhandenen Protokolle aufrufen.",
+        actionLabel: "Projekt auswählen",
+        onClick: async () => this._chooseProject(),
+      }),
+      this._createActionCard({
+        title: "Neues Protokoll",
+        description: "Projekt auswählen und anschließend eine neue Besprechung bzw. ein neues Protokoll anlegen.",
+        actionLabel: "Neues Protokoll",
+        onClick: async () => this._newProtocol(),
+      })
+    );
+
+    const hint = setStyles(document.createElement("div"), {
+      marginTop: "18px",
+      border: `1px solid ${COLORS.border}`,
+      borderRadius: "10px",
+      background: COLORS.greenSoft,
+      padding: "11px 13px",
+      fontSize: "11.5px",
+      lineHeight: "1.45",
+      color: "#426249",
+    });
+    hint.textContent = "Ein Protokoll gehört immer zu einem Projekt. Der Einstieg in das Modul ist davon getrennt: Erst Protokoll wählen, danach den passenden Projektkontext.";
+
+    this.contentEl.append(header, grid, hint);
+  }
+
+  render() {
+    const root = setStyles(document.createElement("div"), {
+      minHeight: "100%",
+      boxSizing: "border-box",
+      background: COLORS.canvas,
+      padding: "24px clamp(20px, 3vw, 42px)",
+      overflow: "auto",
+    });
+    root.setAttribute("data-bbm-protokoll-start", "true");
+
+    const content = setStyles(document.createElement("div"), {
+      width: "min(980px, 100%)",
+      margin: "0 auto",
+    });
+    root.append(content);
+
+    this.root = root;
+    this.contentEl = content;
+    this._renderContent();
+    return root;
+  }
+
+  async load() {
+    await this._loadProjects();
+    this._renderContent();
+  }
+}

--- a/src/renderer/modules/protokoll/screens/ProtokollStartScreen.js
+++ b/src/renderer/modules/protokoll/screens/ProtokollStartScreen.js
@@ -89,7 +89,8 @@ export default class ProtokollStartScreen {
 
   async _chooseProject() {
     try {
-      window.localStorage?.setItem?.("bbm.startTargetModuleId", "protokoll");
+      window.localStorage?.removeItem?.("bbm.startTargetModuleId");
+      window.localStorage?.removeItem?.("bbm.protokollStartIntent");
     } catch (_e) {
       // ignore
     }
@@ -97,10 +98,8 @@ export default class ProtokollStartScreen {
   }
 
   async _newProtocol() {
-    // Das eigentliche Erzeugen einer Besprechung bleibt im bestehenden
-    // Protokollpfad. Diese Startsicht setzt nur den gewünschten Zielbereich.
     try {
-      window.localStorage?.setItem?.("bbm.startTargetModuleId", "protokoll");
+      window.localStorage?.removeItem?.("bbm.startTargetModuleId");
       window.localStorage?.setItem?.("bbm.protokollStartIntent", "new");
     } catch (_e) {
       // ignore


### PR DESCRIPTION
## 13.09.2026 – als bereits integriert geschlossen

Head `2eb623671ff7049f695f887256663fa96199f51f` ist laut `git merge-base --is-ancestor` bereits Vorfahr von main `e3f1197f388be27d1381ef84838bacd18c7825ed`. Deshalb ohne erneuten Merge geschlossen. Branch bleibt erhalten, da PR #248 ihn noch als Basis verwendet.

---

## Ziel
Projektverwaltung vom Protokoll-Zwang lösen und als gemeinsame BBM-Basis für projektbezogene Module aufstellen.

## Enthalten
- Projektklick öffnet immer zuerst den neutralen Projekt-Arbeitsbereich
- bestehende Projektliste, Bearbeitung sowie Import/Export bleiben erhalten
- direkte Modulaktionen aus der Projektliste bleiben möglich
- Projekt-Arbeitsbereich optisch an die neue BBM-Start-UI angenähert
- Protokoll bleibt grün, Restarbeiten orange
- Pläne werden im Projekt-Arbeitsbereich unter Restarbeiten als Unteraktion geführt
- Firmen im Projekt bleiben gemeinsamer Projektbereich
- Klick auf die Protokoll-Kachel der Startseite öffnet jetzt eine eigene Protokoll-Startsicht statt der alten Projekt-/Navigationsansicht
- Protokoll-Startsicht bietet „Zuletzt verwendet“, „Projekt auswählen“ und „Neues Protokoll“
- „Neues Protokoll“ führt über die Projektwahl anschließend in den vorhandenen Protokollpfad
- `docs/PROJECT_MODEL.md` legt den neutralen Projektkern verbindlich fest
- fuer den Projektkern werden bewusst keine neuen DB-Spalten eingefuehrt
- Projektformular nutzt weiterhin die bestehende Speicher-/IPC-Logik, wird aber fachlich neutral dargestellt
- Projektbezeichnung, Kurzbezeichnung und interne Projektleitung sind klarer benannt
- technische PDF-Ablage ist im Formular nur noch als aufklappbarer Technikbereich sichtbar
- die bisherige fachlich falsch platzierte Schaltfläche „Einstellungen“ wird als Übergang ehrlich als „Protokoll-Einstellungen“ bezeichnet

## Verbindliche Abgrenzung
- Firmen/Kunden/Personen sind gemeinsame BBM-Stammdaten, nicht Besitz des Projekts
- Protokoll-, Restarbeiten-, SiGeKo- und sonstige Fachmoduldaten bleiben in ihren Modulen
- Angebot, Auftrag und Rechnung koennen ein Projekt optional referenzieren; ein Projekt bleibt dafuer keine Pflicht

## Bewusste Grenzen
- Firmen-/Kunden-Neustrukturierung bleibt für das Rechnungsmodul zurückgestellt
- `project_lead` / `project_lead_phone` bleiben vorerst kompatible Textfelder und werden spaeter auf die gemeinsame Personen-/Mitarbeiterdomaene migriert
- „Zuletzt verwendet“ arbeitet zunächst mit dem vorhandenen letzten Projekt; eine echte letzte-Protokoll-Historie wird nicht künstlich vorgezogen
- Protokoll-PDF-Einstellungen werden in einem spaeteren Schritt vollstaendig aus dem Projektformular in das Protokoll-/Dokumentkonzept verschoben

## Basis
Dieser PR baut auf `start-ui-modul-dashboard` auf, damit die bestätigte neue Start-UI vollständig erhalten bleibt.