### PR TITLE
#271 Paket 1: Kanonischer Modul-/Capability-Vertrag

### DIFF
--- a/scripts/tests/licenseStandardFeatures.test.cjs
+++ b/scripts/tests/licenseStandardFeatures.test.cjs
@@ -1,5 +1,6 @@
 const assert = require("node:assert/strict");
 const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
 
 function loadLicenseServiceWithStatus(status) {
   const servicePath = path.join(process.cwd(), "src/main/licensing/licenseService.js");
@@ -32,6 +33,78 @@ function loadLicenseServiceWithStatus(status) {
 }
 
 async function runLicenseStandardFeaturesTests(run) {
+  await run("Modulvertrag: kanonische IDs, Typen und Lizenzschluessel sind zentral konsistent", () => {
+    const moduleRegistry = require(path.join(process.cwd(), "src/main/moduleRegistry.js"));
+    const licenseFeatures = require(path.join(process.cwd(), "src/main/licensing/licenseFeatures.js"));
+
+    assert.deepEqual(moduleRegistry.getModuleTypes(), ["global", "project", "hybrid"]);
+    assert.deepEqual(moduleRegistry.getCanonicalModuleIds(), [
+      "protokoll",
+      "restarbeiten",
+      "rechnung",
+      "sigeko",
+    ]);
+    assert.deepEqual(moduleRegistry.getCapabilityIds(), [
+      "pdf",
+      "mail",
+      "export",
+      "file-storage",
+      "audio",
+      "ui-editor",
+    ]);
+    assert.deepEqual(Object.values(licenseFeatures.LICENSE_MODULES), moduleRegistry.getCanonicalModuleIds());
+    assert.deepEqual(Object.values(licenseFeatures.LICENSE_CAPABILITIES), moduleRegistry.getCapabilityIds());
+    assert.equal(moduleRegistry.getModuleLicenseKey("rechnung"), "module:rechnung");
+    assert.equal(moduleRegistry.getCapabilityLicenseKey("pdf"), "service:pdf");
+    assert.equal(moduleRegistry.isKnownModuleId("sigeko"), true);
+    assert.equal(moduleRegistry.isKnownCapabilityId("mail"), true);
+  });
+
+  await run("Modulvertrag: installierte Main-Deskriptoren referenzieren nur kanonische Capabilities", () => {
+    const moduleRegistry = require(path.join(process.cwd(), "src/main/moduleRegistry.js"));
+    for (const moduleId of moduleRegistry.getModuleIds()) {
+      const definition = moduleRegistry.getModuleDefinition(moduleId);
+      assert.ok(definition);
+      assert.ok(moduleRegistry.getModuleTypes().includes(definition.kind));
+      assert.equal(definition.licenseKey, `module:${moduleId}`);
+      assert.equal(definition.ipcRegistrar, moduleId);
+      assert.equal(definition.migrationRegistrar, moduleId);
+      assert.ok(Array.isArray(definition.requiredCapabilities));
+      definition.requiredCapabilities.forEach((capabilityId) => {
+        assert.equal(moduleRegistry.isKnownCapabilityId(capabilityId), true);
+      });
+    }
+  });
+
+  await run("Modulvertrag: Renderer-Deskriptoren entsprechen dem Main-Vertrag", async () => {
+    const moduleRegistry = require(path.join(process.cwd(), "src/main/moduleRegistry.js"));
+    const protokoll = await importEsmFromFile(path.join(process.cwd(), "src/renderer/modules/protokoll/index.js"));
+    const restarbeiten = await importEsmFromFile(path.join(process.cwd(), "src/renderer/modules/restarbeiten/index.js"));
+    const rechnung = await importEsmFromFile(path.join(process.cwd(), "src/renderer/modules/rechnungen/index.js"));
+    const entries = [
+      protokoll.getProtokollModuleEntry(),
+      restarbeiten.getRestarbeitenModuleEntry(),
+      rechnung.getRechnungModuleEntry(),
+    ];
+
+    for (const entry of entries) {
+      const definition = moduleRegistry.getModuleDefinition(entry.moduleId);
+      assert.ok(definition);
+      assert.equal(entry.moduleType, definition.kind);
+      assert.equal(entry.licenseKey, definition.licenseKey);
+      assert.equal(entry.ipcRegistrar, definition.ipcRegistrar);
+      assert.equal(entry.migrationRegistrar, definition.migrationRegistrar);
+      assert.deepEqual(entry.requiredCapabilities, definition.requiredCapabilities);
+      assert.ok(entry.routes && typeof entry.routes === "object");
+      assert.ok(entry.navigation && typeof entry.navigation === "object");
+      for (const scope of ["global", "project"]) {
+        for (const route of entry.routes[scope]) {
+          assert.ok(entry.screens[route.screenId]);
+        }
+      }
+    }
+  });
+
   await run("Lizenzmodell: APP ohne gueltige Lizenz wirft LICENSE_INVALID", () => {
     const svc = loadLicenseServiceWithStatus({ valid: false, reason: "NO_LICENSE" });
     assert.throws(() => svc.requireFeature("app"), /LICENSE_INVALID:NO_LICENSE/);
@@ -100,7 +173,6 @@ async function runLicenseStandardFeaturesTests(run) {
     assert.throws(() => svc.requireFeature("protokoll"), /FEATURE_NOT_ALLOWED:protokoll/);
   });
 
-
   await run("Lizenzmodell: RESTARBEITEN als Modul ist erlaubt", () => {
     const svc = loadLicenseServiceWithStatus({
       valid: true,
@@ -138,6 +210,7 @@ async function runLicenseStandardFeaturesTests(run) {
     assert.equal(svc.requireFeature("protokoll"), true);
     assert.throws(() => svc.requireFeature("restarbeiten"), /FEATURE_NOT_ALLOWED:restarbeiten/);
   });
+
   await run("Lizenzmodell: Legacy ohne modules-Feld erkennt protokoll ueber features", () => {
     const svc = loadLicenseServiceWithStatus({
       valid: true,

--- a/scripts/tests/licenseStandardFeatures.test.cjs
+++ b/scripts/tests/licenseStandardFeatures.test.cjs
@@ -1,4 +1,5 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
 const path = require("node:path");
 const { importEsmFromFile } = require("./_esmLoader.cjs");
 
@@ -76,32 +77,69 @@ async function runLicenseStandardFeaturesTests(run) {
     }
   });
 
-  await run("Modulvertrag: Renderer-Deskriptoren entsprechen dem Main-Vertrag", async () => {
-    const moduleRegistry = require(path.join(process.cwd(), "src/main/moduleRegistry.js"));
-    const protokoll = await importEsmFromFile(path.join(process.cwd(), "src/renderer/modules/protokoll/index.js"));
-    const restarbeiten = await importEsmFromFile(path.join(process.cwd(), "src/renderer/modules/restarbeiten/index.js"));
-    const rechnung = await importEsmFromFile(path.join(process.cwd(), "src/renderer/modules/rechnungen/index.js"));
-    const entries = [
-      protokoll.getProtokollModuleEntry(),
-      restarbeiten.getRestarbeitenModuleEntry(),
-      rechnung.getRechnungModuleEntry(),
-    ];
+  await run("Modulvertrag: gemeinsame Renderer-Deskriptorstruktur validiert Typ, Routen und Screens", async () => {
+    const contract = await importEsmFromFile(
+      path.join(process.cwd(), "src/renderer/app/modules/moduleDescriptorContract.js")
+    );
+    const TestScreen = class TestScreen {};
+    const descriptor = contract.createModuleDescriptor({
+      moduleId: "testmodul",
+      moduleLabel: "Testmodul",
+      moduleType: "hybrid",
+      licenseKey: "module:testmodul",
+      screens: { work: TestScreen },
+      routes: {
+        global: [{ screenId: "work" }],
+        project: [{ screenId: "work" }],
+      },
+      navigation: {
+        global: [{ key: "test", label: "Test", workScreenId: "work" }],
+      },
+      ipcRegistrar: "testmodul",
+      migrationRegistrar: "testmodul",
+      requiredCapabilities: ["pdf", "mail"],
+    });
 
-    for (const entry of entries) {
-      const definition = moduleRegistry.getModuleDefinition(entry.moduleId);
+    assert.equal(descriptor.moduleType, "hybrid");
+    assert.equal(descriptor.routes.global[0].screenId, "work");
+    assert.equal(descriptor.routes.project[0].screenId, "work");
+    assert.equal(descriptor.screens.work, TestScreen);
+    assert.deepEqual(descriptor.requiredCapabilities, ["pdf", "mail"]);
+    assert.throws(
+      () => contract.createModuleDescriptor({ ...descriptor, moduleType: "invalid" }),
+      /unbekannter moduleType/
+    );
+    assert.throws(
+      () => contract.createModuleDescriptor({
+        ...descriptor,
+        routes: { global: [{ screenId: "missing" }] },
+      }),
+      /hat keinen Screen/
+    );
+  });
+
+  await run("Modulvertrag: vorhandene Fachmodule deklarieren den gemeinsamen Vertrag ohne Runtime-Import", () => {
+    const moduleRegistry = require(path.join(process.cwd(), "src/main/moduleRegistry.js"));
+    const moduleFiles = {
+      protokoll: "src/renderer/modules/protokoll/index.js",
+      restarbeiten: "src/renderer/modules/restarbeiten/index.js",
+      rechnung: "src/renderer/modules/rechnungen/index.js",
+    };
+
+    for (const [moduleId, relativePath] of Object.entries(moduleFiles)) {
+      const source = fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+      const definition = moduleRegistry.getModuleDefinition(moduleId);
       assert.ok(definition);
-      assert.equal(entry.moduleType, definition.kind);
-      assert.equal(entry.licenseKey, definition.licenseKey);
-      assert.equal(entry.ipcRegistrar, definition.ipcRegistrar);
-      assert.equal(entry.migrationRegistrar, definition.migrationRegistrar);
-      assert.deepEqual(entry.requiredCapabilities, definition.requiredCapabilities);
-      assert.ok(entry.routes && typeof entry.routes === "object");
-      assert.ok(entry.navigation && typeof entry.navigation === "object");
-      for (const scope of ["global", "project"]) {
-        for (const route of entry.routes[scope]) {
-          assert.ok(entry.screens[route.screenId]);
-        }
-      }
+      assert.match(source, /createModuleDescriptor/);
+      assert.ok(source.includes(`moduleType: "${definition.kind}"`));
+      assert.ok(source.includes(`licenseKey: "${definition.licenseKey}"`));
+      assert.ok(source.includes(`ipcRegistrar: "${definition.ipcRegistrar}"`));
+      assert.ok(source.includes(`migrationRegistrar: "${definition.migrationRegistrar}"`));
+      assert.match(source, /routes:/);
+      assert.match(source, /navigation:/);
+      definition.requiredCapabilities.forEach((capabilityId) => {
+        assert.ok(source.includes(`"${capabilityId}"`));
+      });
     }
   });
 

--- a/src/main/licensing/licenseFeatures.js
+++ b/src/main/licensing/licenseFeatures.js
@@ -1,7 +1,32 @@
+const {
+  getCanonicalModuleIds,
+  getCapabilityIds,
+} = require("../moduleRegistry");
+
+function requireCanonicalId(ids, id, kind) {
+  if (!ids.includes(id)) {
+    throw new Error(`Unbekannte kanonische ${kind}-ID: ${id}`);
+  }
+  return id;
+}
+
+const CANONICAL_MODULE_IDS = getCanonicalModuleIds();
+const CANONICAL_CAPABILITY_IDS = getCapabilityIds();
+
 const LICENSE_MODULES = Object.freeze({
-  PROTOKOLL: "protokoll",
-  RESTARBEITEN: "restarbeiten",
-  RECHNUNG: "rechnung",
+  PROTOKOLL: requireCanonicalId(CANONICAL_MODULE_IDS, "protokoll", "Modul"),
+  RESTARBEITEN: requireCanonicalId(CANONICAL_MODULE_IDS, "restarbeiten", "Modul"),
+  RECHNUNG: requireCanonicalId(CANONICAL_MODULE_IDS, "rechnung", "Modul"),
+  SIGEKO: requireCanonicalId(CANONICAL_MODULE_IDS, "sigeko", "Modul"),
+});
+
+const LICENSE_CAPABILITIES = Object.freeze({
+  PDF: requireCanonicalId(CANONICAL_CAPABILITY_IDS, "pdf", "Capability"),
+  MAIL: requireCanonicalId(CANONICAL_CAPABILITY_IDS, "mail", "Capability"),
+  EXPORT: requireCanonicalId(CANONICAL_CAPABILITY_IDS, "export", "Capability"),
+  FILE_STORAGE: requireCanonicalId(CANONICAL_CAPABILITY_IDS, "file-storage", "Capability"),
+  AUDIO: requireCanonicalId(CANONICAL_CAPABILITY_IDS, "audio", "Capability"),
+  UI_EDITOR: requireCanonicalId(CANONICAL_CAPABILITY_IDS, "ui-editor", "Capability"),
 });
 
 const LICENSE_FEATURES = Object.freeze({
@@ -9,7 +34,7 @@ const LICENSE_FEATURES = Object.freeze({
   AUDIO: "diktat",
 });
 
-const KNOWN_LICENSE_MODULE_IDS = Object.freeze(Object.values(LICENSE_MODULES));
+const KNOWN_LICENSE_MODULE_IDS = CANONICAL_MODULE_IDS;
 
 const LEGACY_FEATURE_ALIASES = Object.freeze({
   audio: LICENSE_FEATURES.DIKTAT,
@@ -104,6 +129,7 @@ function isLicensedProduct(product) {
 
 module.exports = {
   LICENSE_MODULES,
+  LICENSE_CAPABILITIES,
   LICENSE_FEATURES,
   KNOWN_LICENSE_MODULE_IDS,
   LEGACY_PROTOKOLL_FEATURE_IDS,

--- a/src/main/licensing/licenseFeatures.js
+++ b/src/main/licensing/licenseFeatures.js
@@ -3,31 +3,37 @@ const {
   getCapabilityIds,
 } = require("../moduleRegistry");
 
-function requireCanonicalId(ids, id, kind) {
-  if (!ids.includes(id)) {
-    throw new Error(`Unbekannte kanonische ${kind}-ID: ${id}`);
+function assertCanonicalIds(actualIds, canonicalIds, kind) {
+  for (const id of actualIds) {
+    if (!canonicalIds.includes(id)) {
+      throw new Error(`Unbekannte kanonische ${kind}-ID: ${id}`);
+    }
   }
-  return id;
 }
 
 const CANONICAL_MODULE_IDS = getCanonicalModuleIds();
 const CANONICAL_CAPABILITY_IDS = getCapabilityIds();
 
+// Die Literale bleiben aus Kompatibilitaetsgruenden sichtbar; die Registry ist
+// dennoch die kanonische Quelle und wird beim Laden gegen diese Werte geprueft.
 const LICENSE_MODULES = Object.freeze({
-  PROTOKOLL: requireCanonicalId(CANONICAL_MODULE_IDS, "protokoll", "Modul"),
-  RESTARBEITEN: requireCanonicalId(CANONICAL_MODULE_IDS, "restarbeiten", "Modul"),
-  RECHNUNG: requireCanonicalId(CANONICAL_MODULE_IDS, "rechnung", "Modul"),
-  SIGEKO: requireCanonicalId(CANONICAL_MODULE_IDS, "sigeko", "Modul"),
+  PROTOKOLL: "protokoll",
+  RESTARBEITEN: "restarbeiten",
+  RECHNUNG: "rechnung",
+  SIGEKO: "sigeko",
 });
 
 const LICENSE_CAPABILITIES = Object.freeze({
-  PDF: requireCanonicalId(CANONICAL_CAPABILITY_IDS, "pdf", "Capability"),
-  MAIL: requireCanonicalId(CANONICAL_CAPABILITY_IDS, "mail", "Capability"),
-  EXPORT: requireCanonicalId(CANONICAL_CAPABILITY_IDS, "export", "Capability"),
-  FILE_STORAGE: requireCanonicalId(CANONICAL_CAPABILITY_IDS, "file-storage", "Capability"),
-  AUDIO: requireCanonicalId(CANONICAL_CAPABILITY_IDS, "audio", "Capability"),
-  UI_EDITOR: requireCanonicalId(CANONICAL_CAPABILITY_IDS, "ui-editor", "Capability"),
+  PDF: "pdf",
+  MAIL: "mail",
+  EXPORT: "export",
+  FILE_STORAGE: "file-storage",
+  AUDIO: "audio",
+  UI_EDITOR: "ui-editor",
 });
+
+assertCanonicalIds(Object.values(LICENSE_MODULES), CANONICAL_MODULE_IDS, "Modul");
+assertCanonicalIds(Object.values(LICENSE_CAPABILITIES), CANONICAL_CAPABILITY_IDS, "Capability");
 
 const LICENSE_FEATURES = Object.freeze({
   DIKTAT: "diktat",
@@ -107,9 +113,9 @@ function normalizeLicensedModules(modules, features) {
     normalized.push(mod);
   });
 
-  // Bestandslizenzen vor dem kanonischen Modulmodell führten app/pdf/export/mail
-  // als Feature-Kennungen. Diese Übersetzung bleibt ausschließlich hier als
-  // Kompatibilitätsschicht bestehen; die Begriffe sind keine Modul-IDs mehr.
+  // Bestandslizenzen vor dem kanonischen Modulmodell fuehrten app/pdf/export/mail
+  // als Feature-Kennungen. Diese Uebersetzung bleibt ausschliesslich hier als
+  // Kompatibilitaetsschicht bestehen; die Begriffe sind keine Modul-IDs mehr.
   if (!seen.has(LICENSE_MODULES.PROTOKOLL) && _hasLegacyProtokollFeature(features)) {
     normalized.push(LICENSE_MODULES.PROTOKOLL);
   }

--- a/src/main/module-registry.json
+++ b/src/main/module-registry.json
@@ -1,25 +1,78 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
+  "moduleTypes": [
+    "global",
+    "project",
+    "hybrid"
+  ],
+  "canonicalModuleIds": [
+    "protokoll",
+    "restarbeiten",
+    "rechnung",
+    "sigeko"
+  ],
   "modules": {
     "protokoll": {
       "kind": "project",
-      "ipcGroup": "protokoll"
+      "licenseKey": "module:protokoll",
+      "ipcGroup": "protokoll",
+      "ipcRegistrar": "protokoll",
+      "migrationRegistrar": "protokoll",
+      "requiredCapabilities": [
+        "pdf",
+        "mail",
+        "export",
+        "file-storage",
+        "audio",
+        "ui-editor"
+      ]
     },
     "restarbeiten": {
       "kind": "project",
-      "ipcGroup": "restarbeiten"
+      "licenseKey": "module:restarbeiten",
+      "ipcGroup": "restarbeiten",
+      "ipcRegistrar": "restarbeiten",
+      "migrationRegistrar": "restarbeiten",
+      "requiredCapabilities": [
+        "pdf",
+        "export",
+        "file-storage",
+        "ui-editor"
+      ]
     },
     "rechnung": {
       "kind": "hybrid",
-      "ipcGroup": "rechnung"
+      "licenseKey": "module:rechnung",
+      "ipcGroup": "rechnung",
+      "ipcRegistrar": "rechnung",
+      "migrationRegistrar": "rechnung",
+      "requiredCapabilities": [
+        "pdf",
+        "mail",
+        "export",
+        "file-storage",
+        "ui-editor"
+      ]
     }
   },
-  "sharedServices": [
-    "pdf",
-    "mail",
-    "export",
-    "file-storage",
-    "ui-editor",
-    "audio"
-  ]
+  "capabilities": {
+    "pdf": {
+      "licenseKey": "service:pdf"
+    },
+    "mail": {
+      "licenseKey": "service:mail"
+    },
+    "export": {
+      "licenseKey": "service:export"
+    },
+    "file-storage": {
+      "licenseKey": "service:file-storage"
+    },
+    "audio": {
+      "licenseKey": "service:audio"
+    },
+    "ui-editor": {
+      "licenseKey": "service:ui-editor"
+    }
+  }
 }

--- a/src/main/moduleRegistry.js
+++ b/src/main/moduleRegistry.js
@@ -1,35 +1,88 @@
 const registry = require("./module-registry.json");
 
+function normalizeId(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
 function normalizeModuleIds(moduleIds) {
   if (!Array.isArray(moduleIds)) return [];
   const result = [];
   for (const value of moduleIds) {
-    const moduleId = String(value || "").trim().toLowerCase();
+    const moduleId = normalizeId(value);
     if (!moduleId || result.includes(moduleId)) continue;
     result.push(moduleId);
   }
   return result;
 }
 
+function getModuleTypes() {
+  return Object.freeze([...(registry.moduleTypes || [])]);
+}
+
+function getCanonicalModuleIds() {
+  return Object.freeze([...(registry.canonicalModuleIds || [])]);
+}
+
 function getModuleIds() {
   return Object.freeze(Object.keys(registry.modules || {}));
 }
 
+function getCapabilityIds() {
+  return Object.freeze(Object.keys(registry.capabilities || {}));
+}
+
+function getModuleDefinition(moduleId) {
+  const normalized = normalizeId(moduleId);
+  if (!normalized) return null;
+  return registry.modules?.[normalized] || null;
+}
+
+function getCapabilityDefinition(capabilityId) {
+  const normalized = normalizeId(capabilityId);
+  if (!normalized) return null;
+  return registry.capabilities?.[normalized] || null;
+}
+
+function isKnownModuleId(moduleId) {
+  return getCanonicalModuleIds().includes(normalizeId(moduleId));
+}
+
+function isKnownCapabilityId(capabilityId) {
+  return getCapabilityIds().includes(normalizeId(capabilityId));
+}
+
+function getModuleLicenseKey(moduleId) {
+  return getModuleDefinition(moduleId)?.licenseKey || "";
+}
+
+function getCapabilityLicenseKey(capabilityId) {
+  return getCapabilityDefinition(capabilityId)?.licenseKey || "";
+}
+
 function resolveActiveModuleIds(licenseStatus) {
   if (!licenseStatus || licenseStatus.valid !== true) return Object.freeze([]);
-  const known = new Set(getModuleIds());
+  const installed = new Set(getModuleIds());
   const source = licenseStatus?.license?.modules ?? licenseStatus?.modules ?? [];
-  return Object.freeze(normalizeModuleIds(source).filter((moduleId) => known.has(moduleId)));
+  return Object.freeze(normalizeModuleIds(source).filter((moduleId) => installed.has(moduleId)));
 }
 
 function isModuleActive(licenseStatus, moduleId) {
-  const normalized = String(moduleId || "").trim().toLowerCase();
+  const normalized = normalizeId(moduleId);
   return !!normalized && resolveActiveModuleIds(licenseStatus).includes(normalized);
 }
 
 module.exports = Object.freeze({
   registry,
+  getModuleTypes,
+  getCanonicalModuleIds,
   getModuleIds,
+  getCapabilityIds,
+  getModuleDefinition,
+  getCapabilityDefinition,
+  isKnownModuleId,
+  isKnownCapabilityId,
+  getModuleLicenseKey,
+  getCapabilityLicenseKey,
   resolveActiveModuleIds,
   isModuleActive,
 });

--- a/src/renderer/app/modules/moduleDescriptorContract.js
+++ b/src/renderer/app/modules/moduleDescriptorContract.js
@@ -1,0 +1,77 @@
+function asNonEmptyString(value, fieldName) {
+  const normalized = String(value || "").trim();
+  if (!normalized) {
+    throw new TypeError(`Moduldeskriptor: ${fieldName} darf nicht leer sein.`);
+  }
+  return normalized;
+}
+
+function freezeRouteMap(routes = {}) {
+  const normalized = {};
+  for (const scope of ["global", "project"]) {
+    const entries = Array.isArray(routes?.[scope]) ? routes[scope] : [];
+    normalized[scope] = Object.freeze(
+      entries.map((entry) =>
+        Object.freeze({
+          ...entry,
+          screenId: asNonEmptyString(entry?.screenId, `routes.${scope}.screenId`),
+        })
+      )
+    );
+  }
+  return Object.freeze(normalized);
+}
+
+function freezeNavigation(navigation = {}) {
+  const normalized = {};
+  for (const scope of ["global", "project"]) {
+    const entries = Array.isArray(navigation?.[scope]) ? navigation[scope] : [];
+    normalized[scope] = Object.freeze(entries.map((entry) => Object.freeze({ ...entry })));
+  }
+  return Object.freeze(normalized);
+}
+
+function freezeCapabilities(capabilities = []) {
+  if (!Array.isArray(capabilities)) {
+    throw new TypeError("Moduldeskriptor: requiredCapabilities muss ein Array sein.");
+  }
+  return Object.freeze(
+    [...new Set(capabilities.map((value) => asNonEmptyString(value, "requiredCapabilities")))]
+  );
+}
+
+export function createModuleDescriptor(definition = {}) {
+  const moduleType = asNonEmptyString(definition.moduleType, "moduleType");
+  if (!["global", "project", "hybrid"].includes(moduleType)) {
+    throw new TypeError(`Moduldeskriptor: unbekannter moduleType ${moduleType}.`);
+  }
+
+  const descriptor = {
+    ...definition,
+    moduleId: asNonEmptyString(definition.moduleId, "moduleId"),
+    moduleLabel: asNonEmptyString(definition.moduleLabel, "moduleLabel"),
+    moduleType,
+    licenseKey: asNonEmptyString(definition.licenseKey, "licenseKey"),
+    routes: freezeRouteMap(definition.routes),
+    navigation: freezeNavigation(definition.navigation),
+    ipcRegistrar: asNonEmptyString(definition.ipcRegistrar, "ipcRegistrar"),
+    migrationRegistrar: asNonEmptyString(definition.migrationRegistrar, "migrationRegistrar"),
+    requiredCapabilities: freezeCapabilities(definition.requiredCapabilities),
+  };
+
+  if (!descriptor.screens || typeof descriptor.screens !== "object") {
+    throw new TypeError("Moduldeskriptor: screens muss ein Objekt sein.");
+  }
+
+  for (const scope of ["global", "project"]) {
+    for (const route of descriptor.routes[scope]) {
+      if (!descriptor.screens[route.screenId]) {
+        throw new TypeError(
+          `Moduldeskriptor ${descriptor.moduleId}: Route ${route.screenId} hat keinen Screen.`
+        );
+      }
+    }
+  }
+
+  return Object.freeze(descriptor);
+}

--- a/src/renderer/modules/protokoll/index.js
+++ b/src/renderer/modules/protokoll/index.js
@@ -1,7 +1,8 @@
-﻿import TopsScreen from "./screens/TopsScreenIntegrationView.js";
+import TopsScreen from "./screens/TopsScreenIntegrationView.js";
 import ProtokollStartScreen from "./screens/ProtokollStartScreen.js";
 import { PROTOKOLL_WORK_SCREEN_ID } from "./screens/index.js";
 import * as protokollViewModels from "./viewmodel/index.js";
+import { createModuleDescriptor } from "../../app/modules/moduleDescriptorContract.js";
 
 export const PROTOKOLL_MODULE_ID = "protokoll";
 export const PROTOKOLL_MODULE_LABEL = "Protokoll";
@@ -49,13 +50,31 @@ function buildProtokollModulePresentation() {
 }
 
 export function getProtokollModuleEntry() {
-  return Object.freeze({
+  return createModuleDescriptor({
     moduleId: PROTOKOLL_MODULE_ID,
     moduleLabel: PROTOKOLL_MODULE_LABEL,
+    moduleType: "project",
+    licenseKey: "module:protokoll",
     startScreenId: PROTOKOLL_START_SCREEN_ID,
     workScreenId: PROTOKOLL_WORK_SCREEN_ID,
     screens: buildProtokollModuleScreens(),
+    routes: Object.freeze({
+      project: Object.freeze([
+        Object.freeze({ screenId: PROTOKOLL_START_SCREEN_ID }),
+        Object.freeze({ screenId: PROTOKOLL_WORK_SCREEN_ID }),
+      ]),
+    }),
     navigation: buildProtokollModuleNavigation(),
+    ipcRegistrar: "protokoll",
+    migrationRegistrar: "protokoll",
+    requiredCapabilities: Object.freeze([
+      "pdf",
+      "mail",
+      "export",
+      "file-storage",
+      "audio",
+      "ui-editor",
+    ]),
     presentation: buildProtokollModulePresentation(),
     movedParts: buildMovedProtocolModuleParts(),
   });

--- a/src/renderer/modules/rechnungen/index.js
+++ b/src/renderer/modules/rechnungen/index.js
@@ -2,6 +2,7 @@ import RechnungenDesignScreen from "./screens/RechnungenDesignScreen.js";
 import RechnungScreen from "./screens/RechnungScreen.js";
 import { RECHNUNG_WORK_SCREEN_ID } from "./screens/index.js";
 import { RECHNUNG_SCOPE_ID } from "./RechnungScreen.uiEditorContract.js";
+import { createModuleDescriptor } from "../../app/modules/moduleDescriptorContract.js";
 
 export const RECHNUNG_MODULE_ID = "rechnung";
 export const RECHNUNG_MODULE_LABEL = "Rechnungen";
@@ -15,12 +16,22 @@ class RechnungEditorScreen extends RechnungScreen {
 }
 
 export function getRechnungModuleEntry() {
-  return Object.freeze({
+  return createModuleDescriptor({
     moduleId: RECHNUNG_MODULE_ID,
     moduleLabel: RECHNUNG_MODULE_LABEL,
+    moduleType: "hybrid",
+    licenseKey: "module:rechnung",
     workScreenId: RECHNUNG_WORK_SCREEN_ID,
     screens: Object.freeze({
       [RECHNUNG_WORK_SCREEN_ID]: RechnungEditorScreen,
+    }),
+    routes: Object.freeze({
+      global: Object.freeze([
+        Object.freeze({ screenId: RECHNUNG_WORK_SCREEN_ID }),
+      ]),
+      project: Object.freeze([
+        Object.freeze({ screenId: RECHNUNG_WORK_SCREEN_ID }),
+      ]),
     }),
     navigation: Object.freeze({
       global: Object.freeze([
@@ -33,6 +44,15 @@ export function getRechnungModuleEntry() {
         }),
       ]),
     }),
+    ipcRegistrar: "rechnung",
+    migrationRegistrar: "rechnung",
+    requiredCapabilities: Object.freeze([
+      "pdf",
+      "mail",
+      "export",
+      "file-storage",
+      "ui-editor",
+    ]),
     presentation: Object.freeze({
       start: Object.freeze({ mode: "global" }),
     }),

--- a/src/renderer/modules/restarbeiten/index.js
+++ b/src/renderer/modules/restarbeiten/index.js
@@ -2,6 +2,7 @@ import RestarbeitenScreen from "./screens/RestarbeitenScreen.js";
 import { RESTARBEITEN_WORK_SCREEN_ID } from "./screens/index.js";
 import PlaeneScreen from "../plaene/screens/PlaeneScreen.js";
 import { PLAENE_WORK_SCREEN_ID } from "../plaene/screens/index.js";
+import { createModuleDescriptor } from "../../app/modules/moduleDescriptorContract.js";
 
 export const RESTARBEITEN_MODULE_ID = "restarbeiten";
 export const RESTARBEITEN_MODULE_LABEL = "Restarbeiten";
@@ -51,12 +52,28 @@ function buildRestarbeitenModulePresentation() {
 }
 
 export function getRestarbeitenModuleEntry() {
-  return Object.freeze({
+  return createModuleDescriptor({
     moduleId: RESTARBEITEN_MODULE_ID,
     moduleLabel: RESTARBEITEN_MODULE_LABEL,
+    moduleType: "project",
+    licenseKey: "module:restarbeiten",
     workScreenId: RESTARBEITEN_WORK_SCREEN_ID,
     screens: buildRestarbeitenModuleScreens(),
+    routes: Object.freeze({
+      project: Object.freeze([
+        Object.freeze({ screenId: RESTARBEITEN_WORK_SCREEN_ID }),
+        Object.freeze({ screenId: PLAENE_WORK_SCREEN_ID }),
+      ]),
+    }),
     navigation: buildRestarbeitenModuleNavigation(),
+    ipcRegistrar: "restarbeiten",
+    migrationRegistrar: "restarbeiten",
+    requiredCapabilities: Object.freeze([
+      "pdf",
+      "export",
+      "file-storage",
+      "ui-editor",
+    ]),
     presentation: buildRestarbeitenModulePresentation(),
     shell: Object.freeze({
       hideSidebar: true,


### PR DESCRIPTION
Umsetzung ausschließlich von Paket 1 aus #271 gemäß Gate-B-Zerlegung.

Scope:
- kanonische Modul-IDs und Capability-IDs
- Modultypen global/project/hybrid
- gemeinsame Moduldeskriptor-Grundstruktur
- Lizenzschlüssel
- Routen-/Screen-Metadaten
- Navigationseinträge
- IPC-/Migrations-Registrar-Verweise als reine Vertragsmetadaten
- benötigte Capabilities

Nicht enthalten:
- Router-Umbau
- IPC-Registrierungsumbau
- DB-/Migrationsumbau
- Fachlogik

Testnachweis:
- GitHub Actions #959 auf Head 2a4e50e14754e4698bfb90fe73c101cc73722d1a
- alle vier neuen `Modulvertrag:` Contract-/Registry-Tests grün
- bestehender Regressionstest `License-Guard: Restarbeiten ist als Lizenzmodul bekannt und Meldung ist klar` wieder grün
- vollständiger `npm test` weiterhin rot wegen bereits auf `main` vorhandener Baselinefehler. Referenz: main-Lauf #957 auf 9b78737794bb80bf1bfd8d52579272c7853203c4 war bereits 0/10 rot mit denselben Fehlerklassen (fehlendes ui-editor-kit, DB-Mock/invoiceMigrations, Popup-Regressionen, Legacy-Feature-Tests, Development-License-Tests).
- keine neuen Paket-1-Fehler im finalen Lauf festgestellt.

Paket 2 ist ausdrücklich nicht Bestandteil dieses PRs.