### PR TITLE
#271 Paket 4: Modulare Fach-IPC-Registrierung

### DIFF
--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -256,6 +256,13 @@ Dabei gilt:
 - keine Parallelplaene anlegen
 - keine Fortschritte groesser schreiben, als sie technisch sind
 
+### Core #271 – Paket 4 modulare Fach-IPC-Registrierung
+
+- Fach-IPCs werden am Main-Kompositionspunkt nur fuer aktive, lizenzierte Module ueber den im Moduldeskriptor benannten Registrar registriert.
+- Protokoll, Restarbeiten und Rechnung besitzen kleine fachmoduleigene IPC-Registrare; `main.js` registriert keinen dieser Fach-IPC-Pfade mehr einzeln.
+- Registrierte Fachhandler pruefen die aktuelle Modulfreigabe bei jedem Aufruf erneut. Statische Preload-Funktionen erhalten bei inaktiven Modulen deshalb keinen ungeguardeten Handler.
+- Datenbankmigrationen, Providergrenzen und `OwnOrganization` bleiben den Core-Paketen 5 bis 7 vorbehalten; Gate B wird erst mit Paket 8 bewertet.
+
 
 
 ### M3 Restarbeiten-Datenmodell (neu)

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -4,6 +4,7 @@ const TEST_GROUPS = Object.freeze([
     label: "Kern, Protokoll und Projektfirmen",
     includeStoragePathTests: true,
     suites: Object.freeze([
+      ["moduleIpcRegistration.test.cjs", "runModuleIpcRegistrationTests"],
       ["m86-2-2ProtokollAcceptanceSeeder.test.cjs", "runM8622ProtokollAcceptanceSeederTests"],
       ["topsStore.test.cjs", "runTopsStoreTests"],
       ["topsSelectors.test.cjs", "runTopsSelectorsTests"],

--- a/scripts/tests/moduleIpcRegistration.test.cjs
+++ b/scripts/tests/moduleIpcRegistration.test.cjs
@@ -1,0 +1,120 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+function status(modules) {
+  return { valid: true, license: { modules } };
+}
+
+async function runModuleIpcRegistrationTests(run) {
+  await run("Paket 4: nur aktive Fachmodule registrieren eigene IPCs", () => {
+    const { registerActiveModuleIpcs } = require(path.join(process.cwd(), "src/main/moduleIpcRegistry.js"));
+    const handlers = new Map();
+    const calls = [];
+    const ipcMain = { handle: (channel, listener) => handlers.set(channel, listener) };
+    const registrars = {
+      protokoll: ({ ipcMain: guarded }) => {
+        calls.push("protokoll");
+        guarded.handle("protokoll:test", () => "ok");
+      },
+      restarbeiten: () => calls.push("restarbeiten"),
+      rechnung: () => calls.push("rechnung"),
+    };
+
+    const result = registerActiveModuleIpcs({
+      licenseStatus: status(["protokoll"]),
+      getLicenseStatus: () => status(["protokoll"]),
+      ipcMain,
+      registrars,
+    });
+
+    assert.deepEqual(calls, ["protokoll"]);
+    assert.deepEqual(result.registeredModuleIds, ["protokoll"]);
+    assert.deepEqual([...handlers.keys()], ["protokoll:test"]);
+  });
+
+  await run("Paket 4: Registrar wird ueber den Moduldeskriptor aufgeloest", () => {
+    const registryPath = path.join(process.cwd(), "src/main/module-registry.json");
+    const registry = require(registryPath);
+    const original = registry.modules.protokoll.ipcRegistrar;
+    registry.modules.protokoll.ipcRegistrar = "protokoll-adapter";
+    delete require.cache[path.join(process.cwd(), "src/main/moduleIpcRegistry.js")];
+    const { registerActiveModuleIpcs } = require(path.join(process.cwd(), "src/main/moduleIpcRegistry.js"));
+    const calls = [];
+    try {
+      registerActiveModuleIpcs({
+        licenseStatus: status(["protokoll"]),
+        getLicenseStatus: () => status(["protokoll"]),
+        ipcMain: { handle() {} },
+        registrars: { "protokoll-adapter": () => calls.push("adapter") },
+      });
+      assert.deepEqual(calls, ["adapter"]);
+    } finally {
+      registry.modules.protokoll.ipcRegistrar = original;
+      delete require.cache[path.join(process.cwd(), "src/main/moduleIpcRegistry.js")];
+    }
+  });
+
+  await run("Paket 4: registrierter Fach-IPC prueft die aktuelle Modulfreigabe erneut", async () => {
+    const { createGuardedIpcMain } = require(path.join(process.cwd(), "src/main/moduleIpcRegistry.js"));
+    const handlers = new Map();
+    let currentStatus = status(["rechnung"]);
+    const guarded = createGuardedIpcMain({
+      ipcMain: { handle: (channel, listener) => handlers.set(channel, listener) },
+      moduleId: "rechnung",
+      getLicenseStatus: () => currentStatus,
+    });
+    guarded.handle("rechnung:test", async () => ({ ok: true }));
+
+    assert.deepEqual(await handlers.get("rechnung:test")({}, {}), { ok: true });
+    currentStatus = status([]);
+    assert.throws(() => handlers.get("rechnung:test")({}, {}), /MODULE_NOT_ACTIVE:rechnung/);
+  });
+
+  await run("Paket 4: Main enthaelt keine statische Fach-IPC-Einzelregistrierung", () => {
+    const main = read("src/main/main.js");
+    assert.equal(main.includes('require("./ipc/meetingsIpc")'), false);
+    assert.equal(main.includes('require("./ipc/topsIpc")'), false);
+    assert.equal(main.includes('require("./ipc/restarbeitenIpc")'), false);
+    assert.equal(main.includes('require("./ipc/rechnungIpc")'), false);
+    assert.equal(main.includes("registerRechnungIpc({ ipcMain })"), false);
+    assert.match(main, /registrars:\s*moduleIpcRegistrars/);
+  });
+
+  await run("Paket 4: jedes installierte Fachmodul besitzt einen kleinen Registrar", () => {
+    const registry = JSON.parse(read("src/main/module-registry.json"));
+    const registrarCatalog = require(path.join(process.cwd(), "src/main/moduleIpcRegistrars.js"));
+    const moduleDirs = { protokoll: "protokoll", restarbeiten: "restarbeiten", rechnung: "rechnung" };
+    for (const [moduleId, definition] of Object.entries(registry.modules)) {
+      assert.equal(typeof registrarCatalog[definition.ipcRegistrar], "function");
+      const source = read(`src/main/modules/${moduleDirs[moduleId]}/registerIpc.js`);
+      assert.match(source, /function registerIpc/);
+      assert.equal(source.includes("ipcMain.handle"), false);
+    }
+  });
+
+  await run("Paket 4: Registrar-Katalog enthaelt keine Fachmodul-Sonderliste", () => {
+    const source = read("src/main/moduleIpcRegistrars.js");
+    assert.match(source, /getModuleIds\(\)\.map/);
+    assert.match(source, /modules\/\$\{registrarKey\}\/registerIpc/);
+    assert.equal(source.includes("protokoll:"), false);
+    assert.equal(source.includes("restarbeiten:"), false);
+    assert.equal(source.includes("rechnung:"), false);
+  });
+
+  await run("Paket 4: Preload-Fachzugriffe bleiben durch nicht registrierte oder geguardete Handler begrenzt", () => {
+    const preload = read("src/main/preload.js");
+    assert.match(preload, /rechnung:defaults/);
+    assert.match(preload, /restarbeiten:listByProject/);
+    const registrySource = read("src/main/moduleIpcRegistry.js");
+    assert.match(registrySource, /resolveActiveModuleIds/);
+    assert.match(registrySource, /createGuardedIpcMain/);
+    assert.match(registrySource, /MODULE_NOT_ACTIVE/);
+  });
+}
+
+module.exports = { runModuleIpcRegistrationTests };

--- a/src/main/ipc/meetingsIpc.js
+++ b/src/main/ipc/meetingsIpc.js
@@ -2,13 +2,13 @@
 // CONTRACT-VERSION: 1.0.0
 // src/main/ipc/meetingsIpc.js
 
-const { ipcMain } = require("electron");
+const { ipcMain: electronIpcMain } = require("electron");
 
 const meetingsRepo = require("../db/meetingsRepo");
 const meetingTopsRepo = require("../db/meetingTopsRepo");
 const { createMeetingService } = require("../domain/MeetingService");
 
-function registerMeetingsIpc() {
+function registerMeetingsIpc({ ipcMain = electronIpcMain } = {}) {
   const meetingService = createMeetingService({ meetingsRepo, meetingTopsRepo });
 
   ipcMain.handle("meetings:listByProject", (_e, projectId) => {

--- a/src/main/ipc/topsIpc.js
+++ b/src/main/ipc/topsIpc.js
@@ -2,7 +2,7 @@
 // CONTRACT-VERSION: 1.0.0
 // src/main/ipc/topsIpc.js
 
-const { ipcMain } = require("electron");
+const { ipcMain: electronIpcMain } = require("electron");
 const fs = require("fs");
 
 const topsRepo = require("../db/topsRepo");
@@ -924,7 +924,7 @@ function normalizeDisplayNumbers(list, meeting) {
   return items;
 }
 
-function registerTopsIpc() {
+function registerTopsIpc({ ipcMain = electronIpcMain } = {}) {
   const firmDirectory = getFirmDirectoryService();
   const topService = createTopService({ topsRepo, meetingsRepo, meetingTopsRepo });
 

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -36,8 +36,6 @@ if (uiEditorAcceptanceProfile.enabled) {
 
 // IPCs
 const { registerProjectsIpc } = require("./ipc/projectsIpc");
-const { registerMeetingsIpc } = require("./ipc/meetingsIpc");
-const { registerTopsIpc } = require("./ipc/topsIpc");
 const { registerCoreProjectFirmsIpc } = require("./core/projectFirmsCore");
 const { registerFirmDirectoryIpc } = require("./ipc/firmDirectoryIpc");
 const { registerParticipantsIpc } = require("./ipc/participantsIpc");
@@ -49,11 +47,10 @@ const { registerEditorIpc } = require("./ipc/editorIpc");
 const { registerProjectTransferIpc } = require("./ipc/projectTransferIpc");
 const { registerLicenseIpc, importLicenseFromFilePath } = require("./ipc/licenseIpc");
 const { registerAudioIpc } = require("./ipc/audioIpc");
-const { registerRestarbeitenIpc } = require("./ipc/restarbeitenIpc");
-const { registerRechnungIpc } = require("./ipc/rechnungIpc");
 const { registerUiEditorIpc } = require("./ipc/uiEditorIpc");
 const { registerActiveModuleIpcs } = require("./moduleIpcRegistry");
-const { checkLicense } = require("./licensing/licenseService");
+const moduleIpcRegistrars = require("./moduleIpcRegistrars");
+const { checkLicense, getStatus: getLicenseStatus } = require("./licensing/licenseService");
 const { loadCustomerSetup } = require("./licensing/licenseStorage");
 const {
   toLicenseErrorPayload,
@@ -589,16 +586,11 @@ app.whenReady().then(async () => {
   registerProjectTransferIpc();
   registerLicenseIpc();
   registerAudioIpc();
-  registerRechnungIpc({ ipcMain });
   registerActiveModuleIpcs({
     licenseStatus: checkLicense(),
-    registrars: {
-      protokoll: () => {
-        registerMeetingsIpc();
-        registerTopsIpc();
-      },
-      restarbeiten: () => registerRestarbeitenIpc({ ipcMain }),
-    },
+    getLicenseStatus,
+    ipcMain,
+    registrars: moduleIpcRegistrars,
   });
   uiEditorSessionController = registerUiEditorIpc({ app, ipcMain, getMainWindow: () => mainWindow });
   ipcMain.handle("uiEditor:getDiagnosticMode", () => {

--- a/src/main/moduleIpcRegistrars.js
+++ b/src/main/moduleIpcRegistrars.js
@@ -1,0 +1,8 @@
+const { getModuleDefinition, getModuleIds } = require("./moduleRegistry");
+
+const registrars = Object.fromEntries(getModuleIds().map((moduleId) => {
+  const registrarKey = getModuleDefinition(moduleId)?.ipcRegistrar;
+  return [registrarKey, (context) => require(`./modules/${registrarKey}/registerIpc`).registerIpc(context)];
+}));
+
+module.exports = Object.freeze(registrars);

--- a/src/main/moduleIpcRegistry.js
+++ b/src/main/moduleIpcRegistry.js
@@ -1,16 +1,46 @@
-const { resolveActiveModuleIds } = require("./moduleRegistry");
+const { getModuleDefinition, isModuleActive, resolveActiveModuleIds } = require("./moduleRegistry");
 
-function registerActiveModuleIpcs({ licenseStatus, registrars = {}, logger = console } = {}) {
+function createGuardedIpcMain({ ipcMain, moduleId, getLicenseStatus }) {
+  if (!ipcMain || typeof ipcMain.handle !== "function") {
+    throw new TypeError("ipcMain.handle ist fuer Modul-IPCs erforderlich");
+  }
+  if (typeof getLicenseStatus !== "function") {
+    throw new TypeError("getLicenseStatus ist fuer Modul-IPC-Guards erforderlich");
+  }
+
+  return Object.freeze({
+    handle(channel, listener) {
+      return ipcMain.handle(channel, (event, ...args) => {
+        if (!isModuleActive(getLicenseStatus(), moduleId)) {
+          const error = new Error(`MODULE_NOT_ACTIVE:${moduleId}`);
+          error.code = "MODULE_NOT_ACTIVE";
+          throw error;
+        }
+        return listener(event, ...args);
+      });
+    },
+  });
+}
+
+function registerActiveModuleIpcs({
+  licenseStatus,
+  getLicenseStatus = () => licenseStatus,
+  ipcMain,
+  registrars = {},
+  logger = console,
+} = {}) {
   const activeModuleIds = resolveActiveModuleIds(licenseStatus);
   const registeredModuleIds = [];
 
   for (const moduleId of activeModuleIds) {
-    const registrar = registrars[moduleId];
+    const registrarKey = getModuleDefinition(moduleId)?.ipcRegistrar;
+    const registrar = registrars[registrarKey];
     if (typeof registrar !== "function") {
-      logger?.warn?.(`[main] no IPC registrar for active module: ${moduleId}`);
+      logger?.warn?.(`[main] no IPC registrar for active module: ${moduleId} (${registrarKey || "none"})`);
       continue;
     }
-    registrar();
+    const guardedIpcMain = createGuardedIpcMain({ ipcMain, moduleId, getLicenseStatus });
+    registrar({ ipcMain: guardedIpcMain, moduleId });
     registeredModuleIds.push(moduleId);
   }
 
@@ -20,4 +50,4 @@ function registerActiveModuleIpcs({ licenseStatus, registrars = {}, logger = con
   });
 }
 
-module.exports = Object.freeze({ registerActiveModuleIpcs });
+module.exports = Object.freeze({ createGuardedIpcMain, registerActiveModuleIpcs });

--- a/src/main/modules/protokoll/registerIpc.js
+++ b/src/main/modules/protokoll/registerIpc.js
@@ -1,0 +1,9 @@
+const { registerMeetingsIpc } = require("../../ipc/meetingsIpc");
+const { registerTopsIpc } = require("../../ipc/topsIpc");
+
+function registerIpc({ ipcMain } = {}) {
+  registerMeetingsIpc({ ipcMain });
+  registerTopsIpc({ ipcMain });
+}
+
+module.exports = Object.freeze({ registerIpc });

--- a/src/main/modules/rechnung/registerIpc.js
+++ b/src/main/modules/rechnung/registerIpc.js
@@ -1,0 +1,7 @@
+const { registerRechnungIpc } = require("../../ipc/rechnungIpc");
+
+function registerIpc({ ipcMain } = {}) {
+  return registerRechnungIpc({ ipcMain });
+}
+
+module.exports = Object.freeze({ registerIpc });

--- a/src/main/modules/restarbeiten/registerIpc.js
+++ b/src/main/modules/restarbeiten/registerIpc.js
@@ -1,0 +1,7 @@
+const { registerRestarbeitenIpc } = require("../../ipc/restarbeitenIpc");
+
+function registerIpc({ ipcMain } = {}) {
+  return registerRestarbeitenIpc({ ipcMain });
+}
+
+module.exports = Object.freeze({ registerIpc });


### PR DESCRIPTION
## Ziel
Paket 4 aus #271/#277: modulare Fach-IPC-Registrierung.

## Umgesetzt
- aktive Fachmodule werden über den im Moduldeskriptor benannten IPC-Registrar aufgelöst
- Protokoll, Restarbeiten und Rechnung besitzen kleine modulnahe Registrare
- `main.js` registriert keine Fach-IPC-Einzelpfade mehr; insbesondere Rechnung nicht mehr bedingungslos
- inaktive Module registrieren keine Handler
- registrierte Fachhandler prüfen die aktuelle Modulfreigabe bei jedem Aufruf erneut
- statische Preload-Funktionen laufen damit nur gegen registrierte und geguardete Handler

## Nicht enthalten
- keine DB-/Migrationsänderung (Paket 5)
- keine PDF-/Mail-/Export-Providergrenze (Paket 6)
- keine OwnOrganization-Änderung (Paket 7)
- keine Fachlogik, UI- oder PDF-Änderung

## Tests
- 7/7 neue Paket-4-Tests grün
- ESLint: 0 Fehler; 3 bereits vorhandene Warnungen in `topsIpc.js`/`main.js`
- relevante Core-/Protokoll-, Restarbeiten-, Rechnung- und Lizenzgruppen ausgeführt
- vollständiges `npm test` ausgeführt

## Baselineabgrenzung
Der Volltest bleibt wie der direkte `main`-Ausgangsstand rot. Bekannte unveränderte Klassen:
- fehlende `ui-editor-kit`-Artefakte
- `db.transaction is not a function` über `invoiceMigrations`
- alte APP/PDF/MAIL/EXPORT-Alias-Erwartungen
- bestehende Development-License/MainHeader-Erwartungen
- bestehende Popup-Abweichungen

Die neuen Paket-4-Tests laufen im vollständigen Core-Gruppenlauf vor den bekannten Baselineabbrüchen vollständig grün.