### PR TITLE
Core #271 Paket 5: Modulare DB-Migrationen

### DIFF
--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -263,6 +263,14 @@ Dabei gilt:
 - Registrierte Fachhandler pruefen die aktuelle Modulfreigabe bei jedem Aufruf erneut. Statische Preload-Funktionen erhalten bei inaktiven Modulen deshalb keinen ungeguardeten Handler.
 - Datenbankmigrationen, Providergrenzen und `OwnOrganization` bleiben den Core-Paketen 5 bis 7 vorbehalten; Gate B wird erst mit Paket 8 bewertet.
 
+### Core #271 – Paket 5 modulare DB-Migrationen
+
+- Die gemeinsame SQLite-Datei bleibt bestehen; Core- und Fachmigrationen werden logisch getrennt registriert.
+- Der Core erzeugt und prueft seine neutralen Tabellen ohne `meetings`, `tops` oder `meeting_tops` vorauszusetzen.
+- Protokoll, Restarbeiten und Rechnung binden ihre vorhandenen Schemafunktionen ueber die im Moduldeskriptor benannten Migrationsregistrare ein.
+- Der aktive Lizenz-/Modulumfang steuert beim App-Start dieselben Fachmodule fuer Migrationen und IPCs; Bestandsmigrationen bleiben idempotent und erhalten vorhandene Daten.
+- Providergrenzen und `OwnOrganization` bleiben den Paketen 6 und 7 vorbehalten; Gate B wird erst mit Paket 8 bewertet.
+
 
 
 ### M3 Restarbeiten-Datenmodell (neu)

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -4,6 +4,7 @@ const TEST_GROUPS = Object.freeze([
     label: "Kern, Protokoll und Projektfirmen",
     includeStoragePathTests: true,
     suites: Object.freeze([
+      ["moduleMigrationRegistration.test.cjs", "runModuleMigrationRegistrationTests"],
       ["moduleIpcRegistration.test.cjs", "runModuleIpcRegistrationTests"],
       ["m86-2-2ProtokollAcceptanceSeeder.test.cjs", "runM8622ProtokollAcceptanceSeederTests"],
       ["topsStore.test.cjs", "runTopsStoreTests"],

--- a/scripts/tests/moduleMigrationRegistration.test.cjs
+++ b/scripts/tests/moduleMigrationRegistration.test.cjs
@@ -1,0 +1,118 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Database = require("better-sqlite3");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+function tableNames(db) {
+  return db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all().map((row) => row.name);
+}
+
+function withDatabase(callback) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-paket5-"));
+  const dbPath = path.join(dir, "app.db");
+  const db = new Database(dbPath);
+  try {
+    db.pragma("foreign_keys = ON");
+    return callback(db, dbPath);
+  } finally {
+    db.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function runModuleMigrationRegistrationTests(run) {
+  await run("Paket 5: Core-Schema funktioniert ohne Protokolltabellen", () => withDatabase((db, dbPath) => {
+    const { ensureSchema, isDbLikelyEmpty } = require(path.join(process.cwd(), "src/main/db/database.js"));
+    db.exec("CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL)");
+    ensureSchema(db, { moduleIds: [] });
+    const tables = tableNames(db);
+    assert.ok(tables.includes("projects"));
+    assert.ok(tables.includes("firms"));
+    assert.equal(tables.includes("meetings"), false);
+    assert.equal(tables.includes("tops"), false);
+    assert.equal(tables.includes("meeting_tops"), false);
+    assert.equal(tables.includes("restarbeiten_items"), false);
+    assert.equal(tables.includes("invoices"), false);
+    db.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("core-1", "Core ohne Protokoll");
+    assert.equal(isDbLikelyEmpty(dbPath), false);
+  }));
+
+  await run("Paket 5: nur ausgewaehlte Fachmigrationen laufen", () => withDatabase((db) => {
+    const { ensureSchema } = require(path.join(process.cwd(), "src/main/db/database.js"));
+    db.exec("CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL)");
+    const migrated = ensureSchema(db, { moduleIds: ["restarbeiten"] });
+    const tables = tableNames(db);
+    assert.deepEqual(migrated, ["restarbeiten"]);
+    assert.ok(tables.includes("restarbeiten_items"));
+    assert.equal(tables.includes("meetings"), false);
+    assert.equal(tables.includes("invoices"), false);
+  }));
+
+  await run("Paket 5: alle installierten Module migrieren gemeinsam in derselben SQLite-Datei", () => withDatabase((db) => {
+    const { ensureSchema } = require(path.join(process.cwd(), "src/main/db/database.js"));
+    db.exec("CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL)");
+    const migrated = ensureSchema(db, { moduleIds: ["protokoll", "restarbeiten", "rechnung"] });
+    const tables = tableNames(db);
+    assert.deepEqual(migrated, ["protokoll", "restarbeiten", "rechnung"]);
+    assert.ok(tables.includes("meetings"));
+    assert.ok(tables.includes("tops"));
+    assert.ok(tables.includes("restarbeiten_items"));
+    assert.ok(tables.includes("invoices"));
+  }));
+
+  await run("Paket 5: Bestands-DB wird idempotent und ohne Datenverlust migriert", () => withDatabase((db) => {
+    const { ensureSchema } = require(path.join(process.cwd(), "src/main/db/database.js"));
+    db.exec(`
+      CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+      CREATE TABLE meetings (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, meeting_index INTEGER NOT NULL, title TEXT);
+      INSERT INTO projects (id, name) VALUES ('p-1', 'Bestand');
+      INSERT INTO meetings (id, project_id, meeting_index, title) VALUES ('m-1', 'p-1', 1, 'Jour fixe');
+    `);
+    ensureSchema(db, { moduleIds: ["protokoll", "restarbeiten", "rechnung"] });
+    ensureSchema(db, { moduleIds: ["protokoll", "restarbeiten", "rechnung"] });
+    assert.equal(db.prepare("SELECT name FROM projects WHERE id = 'p-1'").get().name, "Bestand");
+    assert.equal(db.prepare("SELECT title FROM meetings WHERE id = 'm-1'").get().title, "Jour fixe");
+    const meeting = db.prepare("SELECT created_at, updated_at FROM meetings WHERE id = 'm-1'").get();
+    assert.ok(meeting.created_at);
+    assert.ok(meeting.updated_at);
+    assert.ok(tableNames(db).includes("invoices"));
+  }));
+
+  await run("Paket 5: Migrationsregistrare folgen dem Deskriptor ohne Fachmodul-Sonderliste", () => {
+    const catalog = require(path.join(process.cwd(), "src/main/moduleMigrationRegistrars.js"));
+    const registry = JSON.parse(read("src/main/module-registry.json"));
+    for (const [moduleId, definition] of Object.entries(registry.modules)) {
+      assert.equal(typeof catalog[definition.migrationRegistrar], "function");
+      assert.match(read(`src/main/modules/${moduleId}/registerMigrations.js`), /function registerMigrations/);
+    }
+    const source = read("src/main/moduleMigrationRegistrars.js");
+    assert.match(source, /getModuleIds\(\)\.map/);
+    assert.equal(source.includes("protokoll:"), false);
+    assert.equal(source.includes("restarbeiten:"), false);
+    assert.equal(source.includes("rechnung:"), false);
+  });
+
+  await run("Paket 5: Main konfiguriert Migrationen aus demselben Lizenzstatus wie Fach-IPCs", () => {
+    const main = read("src/main/main.js");
+    assert.match(main, /const licenseStatus = checkLicense\(\)/);
+    assert.match(main, /configureDatabaseMigrations\(licenseStatus\)/);
+    assert.match(main, /registerActiveModuleIpcs\(\{\s*licenseStatus,/s);
+  });
+
+  await run("Paket 5: DB-Leerheitspruefung setzt keine Protokolltabellen voraus", () => {
+    const database = read("src/main/db/database.js");
+    const start = database.indexOf("function isDbLikelyEmpty");
+    const end = database.indexOf("function ensureLegacyImportCopy", start);
+    const source = database.slice(start, end);
+    assert.match(source, /coreTables = \["projects", "firms"\]/);
+    assert.equal(source.includes('"meetings"'), false);
+    assert.equal(source.includes('"tops"'), false);
+  });
+}
+
+module.exports = { runModuleMigrationRegistrationTests };

--- a/src/main/db/database.js
+++ b/src/main/db/database.js
@@ -6,8 +6,12 @@ const { app } = require("electron");
 const path = require("path");
 const { ensureInvoiceSchema } = require("./invoiceMigrations");
 const { ensureFirmUsagesSchema } = require("./firmUsagesRepo");
+const { getModuleIds, resolveActiveModuleIds } = require("../moduleRegistry");
+const moduleMigrationRegistrars = require("../moduleMigrationRegistrars");
+const { runModuleMigrations } = require("../moduleMigrationRegistry");
 
 let db;
+let configuredModuleIds = null;
 
 function getDbPaths() {
   const userDataPath = app.getPath("userData");
@@ -44,7 +48,7 @@ function isDbLikelyEmpty(dbPath, compareLegacyPath = null) {
   let probeDb = null;
   try {
     probeDb = new Database(dbPath, { readonly: true, fileMustExist: true });
-    const coreTables = ["projects", "firms", "meetings", "tops"];
+    const coreTables = ["projects", "firms"];
     const placeholders = coreTables.map(() => "?").join(",");
     const present = probeDb
       .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name IN (${placeholders})`)
@@ -54,9 +58,7 @@ function isDbLikelyEmpty(dbPath, compareLegacyPath = null) {
 
     const projectCount = probeDb.prepare(`SELECT COUNT(*) AS c FROM projects`).get()?.c || 0;
     const firmsCount = probeDb.prepare(`SELECT COUNT(*) AS c FROM firms`).get()?.c || 0;
-    const meetingCount = probeDb.prepare(`SELECT COUNT(*) AS c FROM meetings`).get()?.c || 0;
-    const topsCount = probeDb.prepare(`SELECT COUNT(*) AS c FROM tops`).get()?.c || 0;
-    const totalRows = projectCount + firmsCount + meetingCount + topsCount;
+    const totalRows = projectCount + firmsCount;
     if (totalRows > 0) return false;
 
     if (compareLegacyPath && fs.existsSync(compareLegacyPath)) {
@@ -1777,28 +1779,59 @@ function migrateLegacyTopsToMeetingTops(dbConn) {
   ensureTopsSoftDeleteColumns(dbConn);
 }
 
-function ensureSchema(dbConn) {
+function ensureCoreSchema(dbConn) {
   // ✅ Projekte zuerst
   ensureProjectsSchema(dbConn);
   ensureUserProfileSchema(dbConn);
+
+  ensureFirmsAndPersonsSchema(dbConn);
+  ensureProjectGlobalFirmsSchema(dbConn);
+  ensureProjectFirmsAndPersonsSchema(dbConn);
+  ensureFirmUsesSchema(dbConn);
+  ensureFirmUsagesSchema(dbConn);
+
+  ensureProjectSettingsSchema(dbConn);
+  ensureProjectCandidatesSchema(dbConn);
+  ensureDictionarySchema(dbConn);
+  ensureTableLayoutsSchema(dbConn);
+  ensureAppSettingsSchema(dbConn);
+  ensureLicenseAdminSchema(dbConn);
+}
+
+function ensureProtokollSchema(dbConn) {
+  if (!tableExists(dbConn, "meetings")) {
+    dbConn.exec(`
+      CREATE TABLE IF NOT EXISTS meetings (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        meeting_index INTEGER NOT NULL,
+        title TEXT,
+        is_closed INTEGER NOT NULL DEFAULT 0,
+        pdf_show_ampel INTEGER,
+        todo_snapshot_json TEXT,
+        next_meeting_enabled INTEGER,
+        next_meeting_date TEXT,
+        next_meeting_time TEXT,
+        next_meeting_place TEXT,
+        next_meeting_extra TEXT,
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+        FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+      );
+    `);
+  }
 
   // meetings: is_closed + created_at + updated_at müssen existieren
   if (!columnExists(dbConn, "meetings", "is_closed")) {
     dbConn.exec(`ALTER TABLE meetings ADD COLUMN is_closed INTEGER NOT NULL DEFAULT 0;`);
   }
   if (!columnExists(dbConn, "meetings", "created_at")) {
-    dbConn.exec(`
-      ALTER TABLE meetings
-      ADD COLUMN created_at TEXT NOT NULL
-      DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'));
-    `);
+    dbConn.exec(`ALTER TABLE meetings ADD COLUMN created_at TEXT;`);
+    dbConn.prepare(`UPDATE meetings SET created_at = ? WHERE created_at IS NULL`).run(new Date().toISOString());
   }
   if (!columnExists(dbConn, "meetings", "updated_at")) {
-    dbConn.exec(`
-      ALTER TABLE meetings
-      ADD COLUMN updated_at TEXT NOT NULL
-      DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'));
-    `);
+    dbConn.exec(`ALTER TABLE meetings ADD COLUMN updated_at TEXT;`);
+    dbConn.prepare(`UPDATE meetings SET updated_at = COALESCE(created_at, ?) WHERE updated_at IS NULL`).run(new Date().toISOString());
   }
 
   if (!columnExists(dbConn, "meetings", "pdf_show_ampel")) {
@@ -1875,26 +1908,26 @@ function ensureSchema(dbConn) {
   ensureMeetingTopsContactColumns(dbConn);
   ensureMeetingTopsTaskFlagColumns(dbConn);
   ensureTopsSoftDeleteColumns(dbConn);
-  ensureFirmsAndPersonsSchema(dbConn);
-  ensureProjectGlobalFirmsSchema(dbConn);
-  ensureProjectFirmsAndPersonsSchema(dbConn);
-  ensureFirmUsesSchema(dbConn);
-  ensureFirmUsagesSchema(dbConn);
-
-  ensureProjectSettingsSchema(dbConn);
-  ensureProjectCandidatesSchema(dbConn);
   ensureMeetingParticipantsSchema(dbConn);
   ensureAudioImportsSchema(dbConn);
   ensureTranscriptsSchema(dbConn);
   ensureAudioSuggestionsSchema(dbConn);
   ensureAudioTermCorrectionsSchema(dbConn);
+}
 
-  ensureDictionarySchema(dbConn);
-  ensureTableLayoutsSchema(dbConn);
-  ensureRestarbeitenSchema(dbConn);
-  ensureAppSettingsSchema(dbConn);
-  ensureLicenseAdminSchema(dbConn);
-  ensureInvoiceSchema(dbConn);
+function configureDatabaseMigrations(licenseStatus) {
+  configuredModuleIds = [...resolveActiveModuleIds(licenseStatus)];
+  return Object.freeze([...configuredModuleIds]);
+}
+
+function ensureSchema(dbConn, { moduleIds = configuredModuleIds ?? getModuleIds() } = {}) {
+  ensureCoreSchema(dbConn);
+  return runModuleMigrations({
+    db: dbConn,
+    moduleIds,
+    registrars: moduleMigrationRegistrars,
+    migrations: { ensureProtokollSchema, ensureRestarbeitenSchema, ensureInvoiceSchema },
+  });
 }
 
 function initDatabase() {
@@ -1940,23 +1973,6 @@ function initDatabase() {
       archived_at TEXT
     );
 
-    CREATE TABLE IF NOT EXISTS meetings (
-      id TEXT PRIMARY KEY,
-      project_id TEXT NOT NULL,
-      meeting_index INTEGER NOT NULL,
-      title TEXT,
-      is_closed INTEGER NOT NULL DEFAULT 0,
-      pdf_show_ampel INTEGER,
-      todo_snapshot_json TEXT,
-      next_meeting_enabled INTEGER,
-      next_meeting_date TEXT,
-      next_meeting_time TEXT,
-      next_meeting_place TEXT,
-      next_meeting_extra TEXT,
-      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-      updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
-      FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
-    );
   `);
 
   ensureSchema(db);
@@ -1967,6 +1983,10 @@ function initDatabase() {
 module.exports = {
   initDatabase,
   closeDatabase,
+  configureDatabaseMigrations,
+  ensureCoreSchema,
+  ensureProtokollSchema,
+  ensureSchema,
   ensureFirmUsesSchema,
   getDbPaths,
   getDatabaseDiagnostics,

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -59,7 +59,7 @@ const {
   enforceLicensedFeature,
 } = require("./licensing/featureGuard");
 const { appSettingsGetMany, appSettingsSetMany } = require("./db/appSettingsRepo");
-const { getDatabaseDiagnostics, importLegacyIntoActive } = require("./db/database");
+const { configureDatabaseMigrations, getDatabaseDiagnostics, importLegacyIntoActive } = require("./db/database");
 const firmsRepo = require("./db/firmsRepo");
 const personsRepo = require("./db/personsRepo");
 const { buildStoragePreviewPaths } = require("./ipc/projectStoragePaths");
@@ -574,6 +574,8 @@ async function maybePromptLegacyMigration(win) {
 
 app.whenReady().then(async () => {
   // ✅ IPCs zuerst registrieren (verhindert "No handler registered" beim invoke)
+  const licenseStatus = checkLicense();
+  configureDatabaseMigrations(licenseStatus);
   registerProjectsIpc();
   registerCoreProjectFirmsIpc();
   registerFirmDirectoryIpc();
@@ -587,7 +589,7 @@ app.whenReady().then(async () => {
   registerLicenseIpc();
   registerAudioIpc();
   registerActiveModuleIpcs({
-    licenseStatus: checkLicense(),
+    licenseStatus,
     getLicenseStatus,
     ipcMain,
     registrars: moduleIpcRegistrars,

--- a/src/main/moduleMigrationRegistrars.js
+++ b/src/main/moduleMigrationRegistrars.js
@@ -1,0 +1,8 @@
+const { getModuleDefinition, getModuleIds } = require("./moduleRegistry");
+
+const registrars = Object.fromEntries(getModuleIds().map((moduleId) => {
+  const registrarKey = getModuleDefinition(moduleId)?.migrationRegistrar;
+  return [registrarKey, (context) => require(`./modules/${registrarKey}/registerMigrations`).registerMigrations(context)];
+}));
+
+module.exports = Object.freeze(registrars);

--- a/src/main/moduleMigrationRegistry.js
+++ b/src/main/moduleMigrationRegistry.js
@@ -1,0 +1,25 @@
+const { getModuleDefinition, getModuleIds } = require("./moduleRegistry");
+
+function normalizeModuleIds(moduleIds) {
+  if (!Array.isArray(moduleIds)) return [];
+  const installed = new Set(getModuleIds());
+  return [...new Set(moduleIds.map((value) => String(value || "").trim().toLowerCase()))]
+    .filter((moduleId) => installed.has(moduleId));
+}
+
+function runModuleMigrations({ db, moduleIds, registrars = {}, migrations = {}, logger = console } = {}) {
+  const migratedModuleIds = [];
+  for (const moduleId of normalizeModuleIds(moduleIds)) {
+    const registrarKey = getModuleDefinition(moduleId)?.migrationRegistrar;
+    const registrar = registrars[registrarKey];
+    if (typeof registrar !== "function") {
+      logger?.warn?.(`[db] no migration registrar for module: ${moduleId} (${registrarKey || "none"})`);
+      continue;
+    }
+    registrar({ db, moduleId, migrations });
+    migratedModuleIds.push(moduleId);
+  }
+  return Object.freeze(migratedModuleIds);
+}
+
+module.exports = Object.freeze({ normalizeModuleIds, runModuleMigrations });

--- a/src/main/modules/protokoll/registerMigrations.js
+++ b/src/main/modules/protokoll/registerMigrations.js
@@ -1,0 +1,5 @@
+function registerMigrations({ db, migrations } = {}) {
+  return migrations.ensureProtokollSchema(db);
+}
+
+module.exports = Object.freeze({ registerMigrations });

--- a/src/main/modules/rechnung/registerMigrations.js
+++ b/src/main/modules/rechnung/registerMigrations.js
@@ -1,0 +1,5 @@
+function registerMigrations({ db, migrations } = {}) {
+  return migrations.ensureInvoiceSchema(db);
+}
+
+module.exports = Object.freeze({ registerMigrations });

--- a/src/main/modules/restarbeiten/registerMigrations.js
+++ b/src/main/modules/restarbeiten/registerMigrations.js
@@ -1,0 +1,5 @@
+function registerMigrations({ db, migrations } = {}) {
+  return migrations.ensureRestarbeitenSchema(db);
+}
+
+module.exports = Object.freeze({ registerMigrations });


### PR DESCRIPTION
## Paket 5 – Modulare DB-Migrationen / Core ohne Protokolltabellen

Bezug: #271, Gesamtplan #277

### Scope
- gemeinsame SQLite-Datei beibehalten, Core- und Fachmigrationen logisch trennen
- Fachmigrationen ausschließlich über Deskriptor/Registrar für Protokoll, Restarbeiten und Rechnung registrieren
- Core-Schema und DB-Leerheitsprüfung ohne Voraussetzung von `meetings`, `tops` oder `meeting_tops`
- derselbe ermittelte Lizenzstatus steuert Fachmigrationen und Fach-IPCs
- bestehende Protokoll-DB idempotent und datenbewahrend migrieren

Keine SiGeKo-Fachentwicklung, keine Erweiterung der Rechnungsfachlogik, keine Protokoll-/Restarbeiten-Umbauten außerhalb der Providerregistrierung.

### Nachweis
- Pakettest `moduleMigrationRegistration.test.cjs`: 7/7
- `restarbeitenDataModel.test.cjs`: 16/16
- `rechnungCentralCustomers.test.cjs`: 3/3
- `firmDirectory.test.cjs`: 12/12
- `tableLayoutsRepo.test.cjs`: 6/6
- Core-Gruppe: neue Paket-5- und Paket-4-Tests grün; danach ausschließlich bekannte Baselinefehler
- Vollregression `npm test`: 0/10 Gruppen wie Baseline; keine neue Fehlerklasse
- ESLint: 0 Fehler (nur bekannte Warnungen)
- `git diff --check`: grün

### Baselineabgrenzung
Bekannt und nicht durch Paket 5 verursacht:
- fehlende `ui-editor-kit`-Artefakte/-Module
- DB-Mock ohne `db.transaction` über `invoiceMigrations`
- bestehende Popup-Standardfehler
- bestehende Lizenz-Alias-/FeatureGuard-/Development-License-/MainHeader-Erwartungen

Gate B wird mit diesem PR ausdrücklich noch nicht als erfüllt bewertet.