### PR TITLE
Core #271 Paket 6: Fachneutrale Providergrenzen

### DIFF
--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -271,6 +271,14 @@ Dabei gilt:
 - Der aktive Lizenz-/Modulumfang steuert beim App-Start dieselben Fachmodule fuer Migrationen und IPCs; Bestandsmigrationen bleiben idempotent und erhalten vorhandene Daten.
 - Providergrenzen und `OwnOrganization` bleiben den Paketen 6 und 7 vorbehalten; Gate B wird erst mit Paket 8 bewertet.
 
+### Core #271 – Paket 6 fachneutrale Providergrenzen
+
+- `PdfDocumentProvider`, `MailPayloadProvider` und `ExportProvider` bilden eine gemeinsame technische Anschlussgrenze ohne Fachimporte.
+- Jeder Provider ist eindeutig einem Modul und einem von diesem Modul gelieferten Fachtyp zugeordnet; das Fachmodul liefert ViewModel/Payload und Layout- bzw. Exportregeln.
+- Die neutrale Registry akzeptiert Provider nur, wenn das Modul die passende Capability im kanonischen Deskriptor deklariert.
+- Bestehende PDF-, Mail- und Exportengines sowie ihre produktiven Abläufe bleiben unverändert; eine tiefe Bereinigung ist ausdrücklich nicht Teil dieses Pakets.
+- `OwnOrganization` bleibt Paket 7 vorbehalten; Gate B wird erst mit Paket 8 bewertet.
+
 
 
 ### M3 Restarbeiten-Datenmodell (neu)

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -4,6 +4,7 @@ const TEST_GROUPS = Object.freeze([
     label: "Kern, Protokoll und Projektfirmen",
     includeStoragePathTests: true,
     suites: Object.freeze([
+      ["moduleServiceProviders.test.cjs", "runModuleServiceProviderTests"],
       ["moduleMigrationRegistration.test.cjs", "runModuleMigrationRegistrationTests"],
       ["moduleIpcRegistration.test.cjs", "runModuleIpcRegistrationTests"],
       ["m86-2-2ProtokollAcceptanceSeeder.test.cjs", "runM8622ProtokollAcceptanceSeederTests"],

--- a/scripts/tests/moduleServiceProviders.test.cjs
+++ b/scripts/tests/moduleServiceProviders.test.cjs
@@ -1,0 +1,90 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+async function runModuleServiceProviderTests(run) {
+  const {
+    PROVIDER_KINDS,
+    PdfDocumentProvider,
+    MailPayloadProvider,
+    ExportProvider,
+    createModuleServiceProviderRegistry,
+  } = require(path.join(process.cwd(), "src/main/moduleServiceProviders.js"));
+
+  await run("Paket 6: PDF-Provider trennt Technik von Fach-ViewModel und Layoutregeln", () => {
+    const registry = createModuleServiceProviderRegistry();
+    registry.register(PdfDocumentProvider({
+      moduleId: "protokoll",
+      type: "protocol",
+      provide: ({ input }) => ({ documentType: "protocol", viewModel: input, layoutRules: { header: "protocol" } }),
+    }));
+    registry.register(PdfDocumentProvider({
+      moduleId: "rechnung",
+      type: "invoice",
+      provide: ({ input }) => ({ documentType: "invoice", viewModel: input, layoutRules: { header: "invoice" } }),
+    }));
+
+    const protocol = registry.provide({ kind: PROVIDER_KINDS.PDF_DOCUMENT, moduleId: "protokoll", type: "protocol", input: { meetingId: "m1" } });
+    const invoice = registry.provide({ kind: PROVIDER_KINDS.PDF_DOCUMENT, moduleId: "rechnung", type: "invoice", input: { invoiceId: "i1" } });
+    assert.deepEqual(protocol, { documentType: "protocol", viewModel: { meetingId: "m1" }, layoutRules: { header: "protocol" } });
+    assert.deepEqual(invoice, { documentType: "invoice", viewModel: { invoiceId: "i1" }, layoutRules: { header: "invoice" } });
+  });
+
+  await run("Paket 6: Mail-Provider liefert fachlichen Payload an gemeinsamen Dienst", () => {
+    const registry = createModuleServiceProviderRegistry();
+    registry.register(MailPayloadProvider({
+      moduleId: "rechnung",
+      type: "invoice",
+      provide: ({ input }) => ({ to: input.to, subject: `Rechnung ${input.number}`, attachments: input.files }),
+    }));
+    assert.deepEqual(
+      registry.provide({ kind: PROVIDER_KINDS.MAIL_PAYLOAD, moduleId: "rechnung", type: "invoice", input: { to: ["a@example.test"], number: "42", files: ["42.pdf"] } }),
+      { to: ["a@example.test"], subject: "Rechnung 42", attachments: ["42.pdf"] }
+    );
+  });
+
+  await run("Paket 6: Export-Provider kapselt fachliche Exportregeln", () => {
+    const registry = createModuleServiceProviderRegistry();
+    registry.register(ExportProvider({
+      moduleId: "restarbeiten",
+      type: "list",
+      provide: ({ input }) => ({ fileName: "restarbeiten.csv", rows: input.items }),
+    }));
+    assert.deepEqual(
+      registry.provide({ kind: PROVIDER_KINDS.EXPORT, moduleId: "restarbeiten", type: "list", input: { items: [{ id: "r1" }] } }),
+      { fileName: "restarbeiten.csv", rows: [{ id: "r1" }] }
+    );
+  });
+
+  await run("Paket 6: Provider benoetigt die deklarierte Modul-Capability", () => {
+    const registry = createModuleServiceProviderRegistry();
+    assert.throws(() => registry.register(MailPayloadProvider({
+      moduleId: "restarbeiten",
+      type: "notice",
+      provide: () => ({}),
+    })), /deklariert Capability mail nicht/);
+  });
+
+  await run("Paket 6: Provider sind pro Modul und Fachtyp eindeutig", () => {
+    const registry = createModuleServiceProviderRegistry();
+    const provider = PdfDocumentProvider({ moduleId: "rechnung", type: "invoice", provide: () => ({}) });
+    registry.register(provider);
+    assert.throws(() => registry.register(provider), /bereits registriert/);
+    assert.equal(registry.resolve({ kind: PROVIDER_KINDS.PDF_DOCUMENT, moduleId: "protokoll", type: "invoice" }), null);
+  });
+
+  await run("Paket 6: neutrale Providergrenze importiert keine Fachimplementierung", () => {
+    const shared = read("src/shared/providers/serviceProviderRegistry.cjs");
+    const bridge = read("src/main/moduleServiceProviders.js");
+    for (const forbidden of ["protokoll", "restarbeiten", "rechnung", "PrintShell", "MailFlow", "projectTransferIpc"]) {
+      assert.equal(shared.includes(forbidden), false, forbidden);
+      assert.equal(bridge.includes(forbidden), false, forbidden);
+    }
+  });
+}
+
+module.exports = { runModuleServiceProviderTests };

--- a/src/main/moduleServiceProviders.js
+++ b/src/main/moduleServiceProviders.js
@@ -1,0 +1,20 @@
+const moduleRegistry = require("./module-registry.json");
+const {
+  PROVIDER_KINDS,
+  PdfDocumentProvider,
+  MailPayloadProvider,
+  ExportProvider,
+  createServiceProviderRegistry,
+} = require("../shared/providers/serviceProviderRegistry.cjs");
+
+function createModuleServiceProviderRegistry() {
+  return createServiceProviderRegistry({ moduleDefinitions: moduleRegistry.modules });
+}
+
+module.exports = Object.freeze({
+  PROVIDER_KINDS,
+  PdfDocumentProvider,
+  MailPayloadProvider,
+  ExportProvider,
+  createModuleServiceProviderRegistry,
+});

--- a/src/shared/providers/serviceProviderRegistry.cjs
+++ b/src/shared/providers/serviceProviderRegistry.cjs
@@ -1,0 +1,96 @@
+const PROVIDER_KINDS = Object.freeze({
+  PDF_DOCUMENT: "pdf-document",
+  MAIL_PAYLOAD: "mail-payload",
+  EXPORT: "export",
+});
+
+const CAPABILITY_BY_KIND = Object.freeze({
+  [PROVIDER_KINDS.PDF_DOCUMENT]: "pdf",
+  [PROVIDER_KINDS.MAIL_PAYLOAD]: "mail",
+  [PROVIDER_KINDS.EXPORT]: "export",
+});
+
+function requiredText(value, label) {
+  const normalized = String(value || "").trim();
+  if (!normalized) throw new TypeError(`${label} fehlt.`);
+  return normalized;
+}
+
+function createProvider(kind, { moduleId, type, provide } = {}) {
+  const normalizedKind = requiredText(kind, "Provider-Art");
+  if (!Object.values(PROVIDER_KINDS).includes(normalizedKind)) {
+    throw new TypeError(`Unbekannte Provider-Art: ${normalizedKind}`);
+  }
+  const normalizedModuleId = requiredText(moduleId, "Modul-ID");
+  const normalizedType = requiredText(type, "Fachtyp");
+  if (typeof provide !== "function") throw new TypeError("Provider-Funktion fehlt.");
+
+  return Object.freeze({
+    kind: normalizedKind,
+    capability: CAPABILITY_BY_KIND[normalizedKind],
+    moduleId: normalizedModuleId,
+    type: normalizedType,
+    provide,
+  });
+}
+
+function PdfDocumentProvider(definition) {
+  return createProvider(PROVIDER_KINDS.PDF_DOCUMENT, definition);
+}
+
+function MailPayloadProvider(definition) {
+  return createProvider(PROVIDER_KINDS.MAIL_PAYLOAD, definition);
+}
+
+function ExportProvider(definition) {
+  return createProvider(PROVIDER_KINDS.EXPORT, definition);
+}
+
+function providerKey({ kind, moduleId, type }) {
+  return [kind, moduleId, type].map((value) => requiredText(value, "Provider-Schluessel")).join(":");
+}
+
+function createServiceProviderRegistry({ moduleDefinitions = {} } = {}) {
+  const providers = new Map();
+
+  function register(provider) {
+    const capability = CAPABILITY_BY_KIND[provider?.kind];
+    if (!capability || provider?.capability !== capability || typeof provider?.provide !== "function") {
+      throw new TypeError("Ungueltiger Service-Provider.");
+    }
+    const definition = moduleDefinitions[provider.moduleId];
+    const requiredCapabilities = definition?.requiredCapabilities || [];
+    if (!definition || !requiredCapabilities.includes(capability)) {
+      throw new Error(`Modul ${provider.moduleId} deklariert Capability ${capability} nicht.`);
+    }
+    const key = providerKey(provider);
+    if (providers.has(key)) throw new Error(`Service-Provider bereits registriert: ${key}`);
+    providers.set(key, provider);
+    return provider;
+  }
+
+  function resolve({ kind, moduleId, type } = {}) {
+    return providers.get(providerKey({ kind, moduleId, type })) || null;
+  }
+
+  function provide(request = {}) {
+    const provider = resolve(request);
+    if (!provider) return null;
+    return provider.provide(Object.freeze({ ...request, moduleId: provider.moduleId, type: provider.type }));
+  }
+
+  function list({ moduleId = "", kind = "" } = {}) {
+    return [...providers.values()].filter((provider) =>
+      (!moduleId || provider.moduleId === moduleId) && (!kind || provider.kind === kind));
+  }
+
+  return Object.freeze({ register, resolve, provide, list });
+}
+
+module.exports = Object.freeze({
+  PROVIDER_KINDS,
+  PdfDocumentProvider,
+  MailPayloadProvider,
+  ExportProvider,
+  createServiceProviderRegistry,
+});


### PR DESCRIPTION
## Paket 6 – Fachneutrale PDF-/Mail-/Export-Providergrenzen

Bezug: #271, Gesamtplan #277

### Scope
- neutrale Verträge `PdfDocumentProvider`, `MailPayloadProvider` und `ExportProvider`
- Registry-Auflösung nach Providerart, Modul-ID und Fachtyp
- Capability-Prüfung ausschließlich gegen kanonische Moduldeskriptoren
- Fachmodule liefern Fach-ViewModel/Payload und Layout-/Exportregeln; die gemeinsame Grenze importiert keine Fachimplementierung
- bestehende produktive PDF-, Mail- und Exportengine bleibt unverändert

Keine Engine-Neuentwicklung, keine SiGeKo-Fachentwicklung und keine Erweiterung von Rechnungs-/Protokoll-/Restarbeiten-Fachlogik.

### Nachweis
- Pakettest `moduleServiceProviders.test.cjs`: 6/6
- Mail-Payload: 6/6
- Ausgabegruppe bis bekannte fehlende `ui-editor-kit`-Abhängigkeit grün, einschließlich Print-Modi und Print-Layouts
- Vollregression `npm test`: 0/10 Gruppen wie Baseline; neue Pakettests 6/6, keine neue Fehlerklasse
- ESLint: 0 Fehler
- `git diff --check`: grün

### Baselineabgrenzung
Unverändert bekannt:
- fehlende `ui-editor-kit`-Artefakte/-Module
- DB-Mock ohne `db.transaction` über `invoiceMigrations`
- drei Popup-Standardfehler
- Lizenz-Alias-/FeatureGuard-/Development-License-/MainHeader-Erwartungen

Gate B wird mit diesem PR ausdrücklich noch nicht als erfüllt bewertet.