### PR TITLE
Core #271 Paket 7: OwnOrganization-Identitätsgrenze

### DIFF
--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -279,6 +279,14 @@ Dabei gilt:
 - Bestehende PDF-, Mail- und Exportengines sowie ihre produktiven Abläufe bleiben unverändert; eine tiefe Bereinigung ist ausdrücklich nicht Teil dieses Pakets.
 - `OwnOrganization` bleibt Paket 7 vorbehalten; Gate B wird erst mit Paket 8 bewertet.
 
+### Core #271 – Paket 7 OwnOrganization-Identitaetsgrenze
+
+- `OwnOrganization` ist ein neutraler, unveraenderlicher Core-Vertrag fuer die eigene Betreiberorganisation und wird weiterhin aus dem bestehenden `user_profile` persistiert.
+- Eigene Organisation und Lizenzsubjekt sind getrennte Identitaeten; `customerName` oder `licenseId` werden nicht als Organisationsstammdaten interpretiert.
+- Getrennte Core-IPC-/Preload-Einstiege stellen den Vertrag bereit, ohne bestehende `userProfile`-Kompatibilitaet zu brechen.
+- `InvoiceIssuerProfile`, Empfaenger-/Aussteller-Snapshots und sonstige Rechnungsfachidentitaeten bleiben ausserhalb dieses Pakets.
+- Gate B wird erst mit Paket 8 nach der Gesamtregression bewertet.
+
 
 
 ### M3 Restarbeiten-Datenmodell (neu)

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -4,6 +4,7 @@ const TEST_GROUPS = Object.freeze([
     label: "Kern, Protokoll und Projektfirmen",
     includeStoragePathTests: true,
     suites: Object.freeze([
+      ["ownOrganizationBoundary.test.cjs", "runOwnOrganizationBoundaryTests"],
       ["moduleServiceProviders.test.cjs", "runModuleServiceProviderTests"],
       ["moduleMigrationRegistration.test.cjs", "runModuleMigrationRegistrationTests"],
       ["moduleIpcRegistration.test.cjs", "runModuleIpcRegistrationTests"],

--- a/scripts/tests/ownOrganizationBoundary.test.cjs
+++ b/scripts/tests/ownOrganizationBoundary.test.cjs
@@ -1,0 +1,74 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+async function runOwnOrganizationBoundaryTests(run) {
+  const {
+    OWN_ORGANIZATION_ID,
+    createOwnOrganization,
+    toUserProfilePatch,
+  } = require(path.join(process.cwd(), "src/shared/identity/ownOrganization.cjs"));
+
+  await run("Paket 7: OwnOrganization besitzt einen neutralen kanonischen Vertrag", () => {
+    const organization = createOwnOrganization({
+      name1: "BBM Betrieb",
+      street: "Werkweg 2",
+      zip: "54321",
+      city: "Sitzstadt",
+      email: "info@example.test",
+      iban: "DE001",
+    });
+    assert.equal(organization.identityType, "own-organization");
+    assert.equal(organization.id, OWN_ORGANIZATION_ID);
+    assert.equal(organization.legalName, "BBM Betrieb");
+    assert.deepEqual(organization.address, { street: "Werkweg 2", zip: "54321", city: "Sitzstadt", country: "" });
+    assert.equal(organization.contact.email, "info@example.test");
+    assert.equal(organization.bank.iban, "DE001");
+    assert.equal(Object.isFrozen(organization), true);
+  });
+
+  await run("Paket 7: LicenseSubject wird nicht als OwnOrganization interpretiert", () => {
+    const licenseSubject = Object.freeze({ customerName: "Lizenzkunde AG", licenseId: "LIC-7" });
+    const organization = createOwnOrganization(licenseSubject);
+    assert.equal(organization.legalName, "");
+    assert.equal(Object.hasOwn(organization, "customerName"), false);
+    assert.equal(Object.hasOwn(organization, "licenseId"), false);
+    assert.notStrictEqual(organization, licenseSubject);
+  });
+
+  await run("Paket 7: bestehendes user_profile bleibt persistente Core-Quelle", () => {
+    const patch = toUserProfilePatch({ legalName: "Eigene GmbH", address: { city: "Wedel" }, bank: { iban: "DE777" } });
+    assert.equal(patch.name1, "Eigene GmbH");
+    assert.equal(patch.city, "Wedel");
+    assert.equal(patch.iban, "DE777");
+    const repo = read("src/main/db/ownOrganizationRepo.js");
+    assert.match(repo, /getUserProfile/);
+    assert.match(repo, /upsertUserProfile/);
+    assert.equal(repo.includes("invoice"), false);
+  });
+
+  await run("Paket 7: Core-IPC stellt OwnOrganization getrennt vom Lizenzstatus bereit", () => {
+    const ipc = read("src/main/ipc/settingsIpc.js");
+    const preload = read("src/main/preload.js");
+    assert.match(ipc, /ownOrganization:get/);
+    assert.match(ipc, /ownOrganization:upsert/);
+    assert.match(preload, /ownOrganizationGet/);
+    assert.match(preload, /ownOrganizationUpsert/);
+    assert.equal(read("src/shared/identity/ownOrganization.cjs").includes("licensing"), false);
+  });
+
+  await run("Paket 7: Rechnungsspezifische Identitaeten und Snapshots bleiben ausserhalb", () => {
+    const contract = read("src/shared/identity/ownOrganization.cjs");
+    const repo = read("src/main/db/ownOrganizationRepo.js");
+    for (const forbidden of ["InvoiceIssuerProfile", "issuer_snapshot", "recipient_snapshot", "invoiceRepository"]) {
+      assert.equal(contract.includes(forbidden), false, forbidden);
+      assert.equal(repo.includes(forbidden), false, forbidden);
+    }
+  });
+}
+
+module.exports = { runOwnOrganizationBoundaryTests };

--- a/src/main/db/ownOrganizationRepo.js
+++ b/src/main/db/ownOrganizationRepo.js
@@ -1,0 +1,12 @@
+const { getUserProfile, upsertUserProfile } = require("./userProfileRepo");
+const { createOwnOrganization, toUserProfilePatch } = require("../../shared/identity/ownOrganization.cjs");
+
+function getOwnOrganization() {
+  return createOwnOrganization(getUserProfile() || {});
+}
+
+function upsertOwnOrganization(input = {}) {
+  return createOwnOrganization(upsertUserProfile(toUserProfilePatch(input)) || {});
+}
+
+module.exports = Object.freeze({ getOwnOrganization, upsertOwnOrganization });

--- a/src/main/ipc/settingsIpc.js
+++ b/src/main/ipc/settingsIpc.js
@@ -10,6 +10,7 @@ const {
 } = require("../db/database");
 const { appSettingsGetMany, appSettingsSetMany, appSettingsGetManyWithDb, appSettingsSetManyWithDb } = require("../db/appSettingsRepo");
 const { getUserProfile, upsertUserProfile } = require("../db/userProfileRepo");
+const { getOwnOrganization, upsertOwnOrganization } = require("../db/ownOrganizationRepo");
 const { createDictionaryService } = require("../services/dictionary/DictionaryService");
 const firmsRepo = require("../db/firmsRepo");
 const projectFirmsRepo = require("../db/projectFirmsRepo");
@@ -757,6 +758,22 @@ function registerSettingsIpc() {
     try {
       const profile = getUserProfile();
       return { ok: true, profile };
+    } catch (err) {
+      return { ok: false, error: err?.message || String(err) };
+    }
+  });
+
+  ipcMain.handle("ownOrganization:get", async () => {
+    try {
+      return { ok: true, organization: getOwnOrganization() };
+    } catch (err) {
+      return { ok: false, error: err?.message || String(err) };
+    }
+  });
+
+  ipcMain.handle("ownOrganization:upsert", async (_evt, payload) => {
+    try {
+      return { ok: true, organization: upsertOwnOrganization(payload || {}) };
     } catch (err) {
       return { ok: false, error: err?.message || String(err) };
     }

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -270,6 +270,8 @@ contextBridge.exposeInMainWorld("bbmDb", {
   // ============================================================
   userProfileGet: () => ipcRenderer.invoke("userProfile:get"),
   userProfileUpsert: (data) => ipcRenderer.invoke("userProfile:upsert", data),
+  ownOrganizationGet: () => ipcRenderer.invoke("ownOrganization:get"),
+  ownOrganizationUpsert: (data) => ipcRenderer.invoke("ownOrganization:upsert", data),
 
   // ============================================================
   // Restarbeiten

--- a/src/shared/identity/ownOrganization.cjs
+++ b/src/shared/identity/ownOrganization.cjs
@@ -1,0 +1,66 @@
+const OWN_ORGANIZATION_ID = "own-organization";
+
+function text(value) {
+  return String(value ?? "").trim();
+}
+
+function createOwnOrganization(source = {}) {
+  return Object.freeze({
+    identityType: "own-organization",
+    id: OWN_ORGANIZATION_ID,
+    legalName: text(source.legalName ?? source.name1),
+    additionalName: text(source.additionalName ?? source.name2),
+    address: Object.freeze({
+      street: text(source.address?.street ?? source.street),
+      zip: text(source.address?.zip ?? source.zip),
+      city: text(source.address?.city ?? source.city),
+      country: text(source.address?.country ?? source.country),
+    }),
+    contact: Object.freeze({
+      phone: text(source.contact?.phone ?? source.phone),
+      email: text(source.contact?.email ?? source.email),
+      website: text(source.contact?.website ?? source.website),
+    }),
+    logoPath: text(source.logoPath ?? source.logo_path),
+    taxNumber: text(source.taxNumber ?? source.tax_number),
+    vatId: text(source.vatId ?? source.vat_id),
+    bank: Object.freeze({
+      iban: text(source.bank?.iban ?? source.iban),
+      bic: text(source.bank?.bic ?? source.bic),
+      name: text(source.bank?.name ?? source.bank_name),
+    }),
+    legal: Object.freeze({
+      commercialRegister: text(source.legal?.commercialRegister ?? source.commercial_register),
+      registerNumber: text(source.legal?.registerNumber ?? source.register_number),
+      managingDirector: text(source.legal?.managingDirector ?? source.managing_director),
+      notice: text(source.legal?.notice ?? source.legal_notice),
+    }),
+  });
+}
+
+function toUserProfilePatch(source = {}) {
+  const organization = createOwnOrganization(source);
+  return Object.freeze({
+    name1: organization.legalName,
+    name2: organization.additionalName,
+    street: organization.address.street,
+    zip: organization.address.zip,
+    city: organization.address.city,
+    country: organization.address.country,
+    phone: organization.contact.phone,
+    email: organization.contact.email,
+    website: organization.contact.website,
+    logo_path: organization.logoPath,
+    tax_number: organization.taxNumber,
+    vat_id: organization.vatId,
+    iban: organization.bank.iban,
+    bic: organization.bank.bic,
+    bank_name: organization.bank.name,
+    commercial_register: organization.legal.commercialRegister,
+    register_number: organization.legal.registerNumber,
+    managing_director: organization.legal.managingDirector,
+    legal_notice: organization.legal.notice,
+  });
+}
+
+module.exports = Object.freeze({ OWN_ORGANIZATION_ID, createOwnOrganization, toUserProfilePatch });


### PR DESCRIPTION
## Paket 7 – OwnOrganization-Identitätsgrenze

Bezug: #271, Gesamtplan #277

### Scope
- neutraler, unveränderlicher `OwnOrganization`-Core-Vertrag
- bestehendes `user_profile` bleibt persistente Quelle
- getrennte Core-IPC-/Preload-Einstiege für Lesen und Aktualisieren
- explizite Trennung von `LicenseSubject`: `customerName` und `licenseId` werden nicht als Organisationsstammdaten interpretiert
- bestehende `userProfile`-API bleibt kompatibel

Keine Implementierung von `InvoiceIssuerProfile`, Empfänger-/Aussteller-Snapshots oder sonstiger Rechnungsfachidentität.

### Nachweis
- Pakettest `ownOrganizationBoundary.test.cjs`: 5/5
- Profil-, Lizenzdarstellungs- und Rechnungsstammdaten-Regressionen: 11/11
- Core-Gruppe: Pakete 4–7 grün bis zu den bekannten Baselineabbrüchen
- Vollregression `npm test`: 0/10 Gruppen wie Baseline; keine neue Fehlerklasse
- ESLint: 0 Fehler, nur bestehende Warnungen
- `git diff --check`: grün

### Baselineabgrenzung
Unverändert: fehlendes `ui-editor-kit`, DB-Mock ohne `db.transaction`, drei Popup-Standardfehler sowie Lizenz-Alias-/FeatureGuard-/Development-License-/MainHeader-Erwartungen.

Gate B wird mit diesem PR ausdrücklich noch nicht als erfüllt bewertet; die Gesamtbewertung folgt ausschließlich in Paket 8.