### PR TITLE
Core #271 Paket 8: Gate-B-Gesamtregression

### DIFF
--- a/docs/GATE_B_REGRESSION.md
+++ b/docs/GATE_B_REGRESSION.md
@@ -1,0 +1,48 @@
+# Gate B – Core bereit
+
+Stand: 2026-09-06, Core-Paket 8 zu #271 / Gesamtplan #277.
+
+## Ergebnis
+
+**Gate B ist erfuellt.** Neue bzw. reaktivierte Fachmodule koennen ohne neuen Core-Sonderfall registriert, global oder projektbezogen geoeffnet, aus dem aktiven Modulset navigiert, lizenziert, per Fach-IPC aktiviert und mit eigenen Migrationen eingebunden werden.
+
+## Kriteriennachweis
+
+| Kriterium aus #277 | Nachweis | Ergebnis |
+| --- | --- | --- |
+| Module ohne Core-Sonderfall registrierbar | kanonischer Deskriptorvertrag; keine Modul-ID-Verzweigung im generischen Router/Main | erfuellt |
+| globale und projektbezogene Module generisch oeffnbar | `moduleRouteRuntime`; global/project/hybrid; Rechnung hybrid ohne Projektkontext | erfuellt |
+| Modulnavigation aus aktivem Modulset | aktive Katalogauflösung; unlizenzierte Rechnung liefert kein aktives Modul | erfuellt |
+| Lizenz/Capabilities konsistent | getrennte `module:*`- und `service:*`-IDs aus einer kanonischen Registry | erfuellt |
+| Fach-IPC modular registriert | aktive Module registrieren ausschließlich ihren Deskriptor-Registrar | erfuellt |
+| Fachmigrationen modular registriert | modulbezogene Registrare in gemeinsamer SQLite-Datei; Bestandsdaten bleiben erhalten | erfuellt |
+| Core ohne Protokolltabellen/-fachlogik | Core-Schema ohne `meetings`, `tops`, `meeting_tops` und ohne Fachmodule getestet | erfuellt |
+| PDF/Mail/Export fachneutral anschliessbar | neutrale Providervertraege, Mehrmodulauflösung und Capability-Prüfung | erfuellt |
+
+Die zusaetzliche P0-Vorgabe `LicenseSubject != OwnOrganization` ist ebenfalls erfuellt.
+
+## Automatisierte Regression
+
+- `gateBRegression.test.cjs`: 9/9 gruen.
+- Core-Pakete 4 bis 7: 25/25 gezielte Paketpruefungen gruen.
+- Restarbeiten-Datenmodell, zentrale Rechnungskunden, FirmDirectory und Projektfirmen-Core: 37/37 gruen.
+- Routing-/Navigation und Modulvertrag: alle Kriterienpruefungen gruen.
+- Vollregression `npm test`: 0/10 Gruppen, aber keine neue Fehlerklasse gegenueber der dokumentierten Baseline.
+
+## Baselineabgrenzung
+
+Die neun bekannten roten Einzeltests bleiben:
+
+1. `meetingTopsRepo` – Test-DB-Mock besitzt kein `db.transaction`; der Fehler laeuft ueber die bestehende `invoiceMigrations`-Initialisierung.
+2. Drei bestehende Popup-Standard-Erwartungen.
+3. `moduleAccessState` – fehlende `ui-editor-kit`-Artefakte/-Module.
+4. Historische APP/PDF/MAIL/EXPORT-Alias-Erwartung.
+5. Historische FeatureGuard-Standardfeature-Erwartung.
+6. Development-License-Diagnostic-Modulliste.
+7. Development-License/MainHeader-Kennzeichnung.
+
+Weitere Gruppen brechen beim Laden fehlender `ui-editor-kit`-Artefakte ab. Diese Fehler waren vor den Core-Paketen vorhanden, sind in #271 dokumentiert und wurden durch Paket 8 weder veraendert noch als neuer Paketfehler bewertet.
+
+## Scopegrenze
+
+Gate B gibt den Core-Vorbau frei. Es meldet keine SiGeKo-Fachentwicklung, keine Rechnungsfachintegration, keine Bereinigung der bekannten Testbaseline und kein Release-/Windows-Installer-Gate als abgeschlossen.

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -287,6 +287,14 @@ Dabei gilt:
 - `InvoiceIssuerProfile`, Empfaenger-/Aussteller-Snapshots und sonstige Rechnungsfachidentitaeten bleiben ausserhalb dieses Pakets.
 - Gate B wird erst mit Paket 8 nach der Gesamtregression bewertet.
 
+### Core #271 – Paket 8 Gate-B-Gesamtregression
+
+- Alle acht Gate-B-Kriterien aus #277 sind durch `gateBRegression.test.cjs` und die bestehenden Router-, Modul-, Core- und Fachregressionen nachgewiesen.
+- Core ohne Protokolltabellen, aktive Einzelmodule, nicht lizenzierte Rechnung, modulare IPCs/Migrationen, Bestands-DB und Mehrmodul-Provider sind explizit abgedeckt.
+- Die Vollregression bleibt bei den bereits vor Paket 4 dokumentierten neun Einzeltestfehlern und den fehlenden `ui-editor-kit`-Artefakten; keine neue Fehlerklasse ist hinzugekommen.
+- Der vollständige Kriterien- und Baselinebericht steht in `docs/GATE_B_REGRESSION.md`.
+- **Gate B ist erfuellt.** Diese Bewertung bezieht sich ausschließlich auf den Core-Vorbau #271/#277 und zieht keine Fachentwicklung vor.
+
 
 
 ### M3 Restarbeiten-Datenmodell (neu)

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -4,6 +4,7 @@ const TEST_GROUPS = Object.freeze([
     label: "Kern, Protokoll und Projektfirmen",
     includeStoragePathTests: true,
     suites: Object.freeze([
+      ["gateBRegression.test.cjs", "runGateBRegressionTests"],
       ["ownOrganizationBoundary.test.cjs", "runOwnOrganizationBoundaryTests"],
       ["moduleServiceProviders.test.cjs", "runModuleServiceProviderTests"],
       ["moduleMigrationRegistration.test.cjs", "runModuleMigrationRegistrationTests"],

--- a/scripts/tests/gateBRegression.test.cjs
+++ b/scripts/tests/gateBRegression.test.cjs
@@ -1,0 +1,124 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Database = require("better-sqlite3");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+function withDatabase(callback) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-gate-b-"));
+  const db = new Database(path.join(dir, "app.db"));
+  try {
+    db.pragma("foreign_keys = ON");
+    db.exec("CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL)");
+    return callback(db);
+  } finally {
+    db.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function runGateBRegressionTests(run) {
+  const moduleRegistry = require(path.join(process.cwd(), "src/main/moduleRegistry.js"));
+
+  await run("Paket 8 / Gate B: Module sind ohne Core-Sonderfall vollstaendig registrierbar", () => {
+    for (const moduleId of moduleRegistry.getModuleIds()) {
+      const definition = moduleRegistry.getModuleDefinition(moduleId);
+      for (const key of ["kind", "licenseKey", "ipcRegistrar", "migrationRegistrar", "requiredCapabilities"]) {
+        assert.ok(definition[key], `${moduleId}.${key}`);
+      }
+    }
+    for (const source of [read("src/renderer/app/Router.js"), read("src/main/main.js")]) {
+      assert.doesNotMatch(source, /if\s*\(\s*moduleId\s*===\s*["'](?:rechnung|protokoll|restarbeiten)["']/);
+    }
+  });
+
+  await run("Paket 8 / Gate B: globale und projektbezogene Module sind generisch oeffnbar", () => {
+    const routeRuntime = read("src/renderer/app/modules/moduleRouteRuntime.js");
+    assert.match(routeRuntime, /moduleType === "global" \|\| moduleType === "hybrid"/);
+    assert.match(routeRuntime, /moduleType === "project" \|\| moduleType === "hybrid"/);
+    assert.match(routeRuntime, /normalizedScope === "project" && !projectId/);
+    assert.equal(moduleRegistry.getModuleDefinition("rechnung").kind, "hybrid");
+    assert.equal(moduleRegistry.getModuleDefinition("protokoll").kind, "project");
+  });
+
+  await run("Paket 8 / Gate B: Modulnavigation folgt ausschliesslich dem aktiven Modulset", () => {
+    const status = { valid: true, license: { modules: ["rechnung", "not-installed"] } };
+    assert.deepEqual(moduleRegistry.resolveActiveModuleIds(status), ["rechnung"]);
+    assert.deepEqual(moduleRegistry.resolveActiveModuleIds({ valid: false, license: { modules: ["rechnung"] } }), []);
+    const navigation = read("src/renderer/app/modules/moduleNavigation.js");
+    assert.match(navigation, /getCachedActiveModuleCatalog/);
+    assert.match(navigation, /deriveModuleNavigationByScope/);
+  });
+
+  await run("Paket 8 / Gate B: Modulrechte und Service-Capabilities bleiben kanonisch getrennt", () => {
+    for (const moduleId of moduleRegistry.getModuleIds()) {
+      assert.match(moduleRegistry.getModuleLicenseKey(moduleId), /^module:/);
+      for (const capability of moduleRegistry.getModuleDefinition(moduleId).requiredCapabilities) {
+        assert.match(moduleRegistry.getCapabilityLicenseKey(capability), /^service:/);
+      }
+    }
+    assert.equal(moduleRegistry.getCapabilityLicenseKey("pdf"), "service:pdf");
+    assert.notEqual(moduleRegistry.getCapabilityLicenseKey("pdf"), moduleRegistry.getModuleLicenseKey("protokoll"));
+  });
+
+  await run("Paket 8 / Gate B: nur aktive Fachmodule registrieren Fach-IPCs", () => {
+    const { registerActiveModuleIpcs } = require(path.join(process.cwd(), "src/main/moduleIpcRegistry.js"));
+    const calls = [];
+    const registrar = ({ moduleId }) => calls.push(moduleId);
+    const registrars = { protokoll: registrar, restarbeiten: registrar, rechnung: registrar };
+    const registered = registerActiveModuleIpcs({
+      licenseStatus: { valid: true, license: { modules: ["restarbeiten"] } },
+      getLicenseStatus: () => ({ valid: true, license: { modules: ["restarbeiten"] } }),
+      ipcMain: { handle() {} },
+      registrars,
+    });
+    assert.deepEqual(registered, {
+      activeModuleIds: ["restarbeiten"],
+      registeredModuleIds: ["restarbeiten"],
+    });
+    assert.deepEqual(calls, ["restarbeiten"]);
+  });
+
+  await run("Paket 8 / Gate B: Fachmigrationen laufen modular in einer Bestands-DB", () => withDatabase((db) => {
+    db.prepare("INSERT INTO projects (id, name) VALUES ('existing', 'Bestand')").run();
+    const { ensureSchema } = require(path.join(process.cwd(), "src/main/db/database.js"));
+    assert.deepEqual(ensureSchema(db, { moduleIds: ["rechnung"] }), ["rechnung"]);
+    assert.ok(db.prepare("SELECT name FROM projects WHERE id = 'existing'").get());
+    assert.ok(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='invoices'").get());
+    assert.equal(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='meetings'").get(), undefined);
+  }));
+
+  await run("Paket 8 / Gate B: Core-DB funktioniert ohne Protokolltabellen und Fachlogik", () => withDatabase((db) => {
+    const { ensureSchema } = require(path.join(process.cwd(), "src/main/db/database.js"));
+    assert.deepEqual(ensureSchema(db, { moduleIds: [] }), []);
+    for (const table of ["meetings", "tops", "meeting_tops", "restarbeiten_items", "invoices"]) {
+      assert.equal(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table), undefined, table);
+    }
+    assert.ok(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='firms'").get());
+  }));
+
+  await run("Paket 8 / Gate B: PDF, Mail und Export sind fuer mehrere Module fachneutral anschliessbar", () => {
+    const { PROVIDER_KINDS, PdfDocumentProvider, MailPayloadProvider, ExportProvider, createModuleServiceProviderRegistry } = require(path.join(process.cwd(), "src/main/moduleServiceProviders.js"));
+    const registry = createModuleServiceProviderRegistry();
+    registry.register(PdfDocumentProvider({ moduleId: "protokoll", type: "protocol", provide: ({ input }) => input }));
+    registry.register(PdfDocumentProvider({ moduleId: "rechnung", type: "invoice", provide: ({ input }) => input }));
+    registry.register(MailPayloadProvider({ moduleId: "rechnung", type: "invoice", provide: ({ input }) => input }));
+    registry.register(ExportProvider({ moduleId: "restarbeiten", type: "list", provide: ({ input }) => input }));
+    assert.equal(registry.list({ kind: PROVIDER_KINDS.PDF_DOCUMENT }).length, 2);
+    assert.deepEqual(registry.provide({ kind: PROVIDER_KINDS.PDF_DOCUMENT, moduleId: "rechnung", type: "invoice", input: { invoiceId: "i1" } }), { invoiceId: "i1" });
+  });
+
+  await run("Paket 8 / Gate B: OwnOrganization bleibt vom LicenseSubject getrennt", () => {
+    const { createOwnOrganization } = require(path.join(process.cwd(), "src/shared/identity/ownOrganization.cjs"));
+    const own = createOwnOrganization({ legalName: "Eigene GmbH", customerName: "Lizenzkunde AG", licenseId: "LIC-8" });
+    assert.equal(own.legalName, "Eigene GmbH");
+    assert.equal(Object.hasOwn(own, "customerName"), false);
+    assert.equal(Object.hasOwn(own, "licenseId"), false);
+  });
+}
+
+module.exports = { runGateBRegressionTests };


### PR DESCRIPTION
## Paket 8 – Gate-B-Gesamtregression

Bezug: #271, verbindlicher Gesamtplan #277

### Ergebnis
Alle acht Gate-B-Kriterien aus #277 sind vollständig nachgewiesen. Zusätzlich ist `LicenseSubject != OwnOrganization` abgesichert. **Gate B ist erfüllt**, vorbehaltlich keiner neuen Fehlerklasse – eine solche ist weder lokal noch in der Gesamtregression aufgetreten.

### Kriterien
- Module ohne Core-Sonderfall registrierbar
- globale und projektbezogene Module generisch öffnbar
- Modulnavigation aus aktivem Modulset; nicht lizenzierte Rechnung inaktiv
- Modulrechte und Service-Capabilities kanonisch getrennt
- Fach-IPCs modular registriert
- Fachmigrationen modular in gemeinsamer SQLite-Datei
- Core ohne Protokolltabellen/-fachlogik
- PDF/Mail/Export für mehrere Module fachneutral anschließbar

### Tests
- `gateBRegression.test.cjs`: 9/9
- Paketprüfungen 4–7: 25/25
- Restarbeiten-Datenmodell, Rechnungskunden, FirmDirectory, Projektfirmen-Core: 37/37
- Routing-/Navigation und Modulvertrag: alle Gate-relevanten Prüfungen grün
- Vollregression `npm test`: 0/10 Gruppen wie dokumentierte Baseline, keine neue Fehlerklasse
- ESLint: 0 Fehler
- `git diff --check`: grün

### Baseline
Exakt neun bekannte rote Einzeltests: DB-Mock/`db.transaction`, drei Popup-Standards, `moduleAccessState`/fehlendes `ui-editor-kit`, historischer Lizenzalias, FeatureGuard, Diagnostic-Modulliste und MainHeader-Kennzeichnung. Weitere Gruppenabbrüche stammen aus fehlenden `ui-editor-kit`-Artefakten.

Keine SiGeKo-Fachentwicklung, keine Rechnungsfachlogikerweiterung und keine fachlichen Umbauten außerhalb des Core-Nachweises.