### PR TITLE
Restarbeiten #273 Paket 2: Haupt-Ladefehler behandeln

### DIFF
--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -47,6 +47,7 @@ const TEST_GROUPS = Object.freeze([
     id: "restarbeiten-module",
     label: "Restarbeiten-Modul",
     suites: Object.freeze([
+      ["restarbeitenLoadError.test.cjs", "runRestarbeitenLoadErrorTests"],
       ["restarbeitenPhotoUi.test.cjs", "runRestarbeitenPhotoUiTests"],
       ["restarbeitenModule.test.cjs", "runRestarbeitenModuleTests"],
     ]),

--- a/scripts/tests/restarbeitenLoadError.test.cjs
+++ b/scripts/tests/restarbeitenLoadError.test.cjs
@@ -1,0 +1,34 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+async function runRestarbeitenLoadErrorTests(run) {
+  const source = fs.readFileSync(
+    path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"),
+    "utf8"
+  );
+  const loadStart = source.indexOf("  async load(");
+  const bindStart = source.indexOf("\n  _bindTextLimitSettings()", loadStart);
+  const loadSource = source.slice(loadStart, bindStart);
+
+  await run("Restarbeiten Laden: Hauptfehler wird sichtbar abgefangen", () => {
+    assert.ok(loadStart >= 0 && bindStart > loadStart, "load()-Methode nicht eindeutig gefunden");
+    assert.equal(loadSource.includes("listRestarbeitenByProject(this.projectId)"), true);
+    assert.equal(loadSource.includes("} catch (error) {"), true);
+    assert.equal(loadSource.includes("Restarbeiten konnten nicht geladen werden:"), true);
+    assert.equal(loadSource.includes('this.error = detail'), true);
+  });
+
+  await run("Restarbeiten Laden: Ladezustand wird auch im Fehlerfall beendet", () => {
+    const catchIndex = loadSource.indexOf("} catch (error) {");
+    const finallyIndex = loadSource.indexOf("} finally {", catchIndex);
+    const loadingResetIndex = loadSource.indexOf("this.isLoading = false;", finallyIndex);
+    const renderIndex = loadSource.indexOf("this._renderShell();", loadingResetIndex);
+    assert.ok(catchIndex >= 0, "catch fehlt");
+    assert.ok(finallyIndex > catchIndex, "finally fehlt nach catch");
+    assert.ok(loadingResetIndex > finallyIndex, "isLoading wird im finally nicht zurückgesetzt");
+    assert.ok(renderIndex > loadingResetIndex, "Fehlerzustand wird nach dem Reset nicht gerendert");
+  });
+}
+
+module.exports = { runRestarbeitenLoadErrorTests };

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -234,6 +234,11 @@ export default class RestarbeitenScreen {
         this.draft = prepareDraft();
       }
       this.error = null;
+    } catch (error) {
+      const detail = normalizeText(error?.message || error);
+      this.error = detail
+        ? `Restarbeiten konnten nicht geladen werden: ${detail}`
+        : "Restarbeiten konnten nicht geladen werden.";
     } finally {
       this.isLoading = false;
       this._renderShell();


### PR DESCRIPTION
## Scope

Zweites strikt abgegrenztes Paket aus #273: Der Haupt-Ladevorgang der Restarbeitenliste fängt Fehler jetzt ab, zeigt eine klare Meldung und setzt den Ladezustand im bestehenden `finally` sicher zurück.

Keine Änderung an CRUD, Fotoverwaltung, PDF, Notizdruck, Protokoll, Rechnung, SiGeKo oder Mobil.

## Tests

- `restarbeitenLoadError.test.cjs`: 2/2 grün
- Paket-1-Fototests: 2/2 grün
- ESLint: grün
- `git diff --check`: grün
- vollständiges `npm test`: bekannte Baseline unverändert (0/10 Gruppen; neun dokumentierte Einzelfehler und bekannte Ladeabbrüche durch fehlendes `ui-editor-kit`), keine neue Fehlerklasse

#273 wird paketweise fortgeführt.