### PR TITLE
Restarbeiten #273 Paket 3: toten Preview-State entfernen

### DIFF
--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -47,6 +47,7 @@ const TEST_GROUPS = Object.freeze([
     id: "restarbeiten-module",
     label: "Restarbeiten-Modul",
     suites: Object.freeze([
+      ["restarbeitenPreviewState.test.cjs", "runRestarbeitenPreviewStateTests"],
       ["restarbeitenLoadError.test.cjs", "runRestarbeitenLoadErrorTests"],
       ["restarbeitenPhotoUi.test.cjs", "runRestarbeitenPhotoUiTests"],
       ["restarbeitenModule.test.cjs", "runRestarbeitenModuleTests"],

--- a/scripts/tests/restarbeitenPreviewState.test.cjs
+++ b/scripts/tests/restarbeitenPreviewState.test.cjs
@@ -1,0 +1,30 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+async function runRestarbeitenPreviewStateTests(run) {
+  const screen = fs.readFileSync(
+    path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"),
+    "utf8"
+  );
+  const styles = fs.readFileSync(
+    path.join(__dirname, "../../src/renderer/modules/restarbeiten/styles/restarbeiten.css"),
+    "utf8"
+  );
+
+  await run("Restarbeiten Preview: lokaler Preview-State ist entfernt", () => {
+    assert.equal(screen.includes("outputPreviewOpen"), false);
+    assert.equal(screen.includes("closeRestarbeitenPreview"), false);
+    assert.equal(screen.includes("data-output-preview"), false);
+    assert.equal(styles.includes('data-output-preview="true"'), false);
+  });
+
+  await run("Restarbeiten Preview: gemeinsamer interner Druckweg bleibt aktiv", () => {
+    assert.equal(screen.includes("window?.bbmPrint?.printPdfAndPreviewInternal"), true);
+    assert.equal(screen.includes("await printPdfAndPreviewInternal(this._buildRestarbeitenPdfPayload())"), true);
+    assert.equal(screen.includes('mode: "restarbeiten"'), true);
+    assert.equal(screen.includes("buildRestarbeitenOutputPreview"), false);
+  });
+}
+
+module.exports = { runRestarbeitenPreviewStateTests };

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -195,7 +195,6 @@ export default class RestarbeitenScreen {
     };
     this._lastRestarbeitNotePrint = null;
     this.quicklanePinned = false;
-    this.outputPreviewOpen = false;
   }
 
   render() {
@@ -313,11 +312,6 @@ export default class RestarbeitenScreen {
   async openRestarbeitenOutput({ mode = "print" } = {}) {
     if (mode !== "print") return { ok: false, error: `Ausgabeart ${String(mode)} ist nicht verfügbar.` };
     return this.openRestarbeitenPreview();
-  }
-
-  closeRestarbeitenPreview() {
-    this.outputPreviewOpen = false;
-    this._renderShell();
   }
 
   async openRestarbeitPhotos(restarbeitId = this.selectedId) {
@@ -807,7 +801,6 @@ export default class RestarbeitenScreen {
     this.root.replaceChildren();
     const filteredRows = this._getFilteredItems();
     this.viewItems = toRestarbeitenListItems(filteredRows);
-    this.root.setAttribute("data-output-preview", this.outputPreviewOpen ? "true" : "false");
     const responsibleOptions = this.responsibleFirms
       .map((firm) => ({
         value: normalizeText(firm.key || `${firm.kind}:${firm.id}`),
@@ -852,38 +845,36 @@ export default class RestarbeitenScreen {
     this.root.append(header);
     this._mountQuicklane(quicklane);
 
-    if (!this.outputPreviewOpen) {
-      const main = buildRestarbeitenMainBody({
-        items: this.viewItems,
-        selectedId: this.selectedId,
-        showAmpel: this.showAmpelInList,
-        showLongtext: this.showLongtextInList,
-        onSelect: (id) => this._selectItem(id),
-        onPhotos: (id) => this.openRestarbeitPhotos(id),
-      });
-      const editbox = buildRestarbeitenEditbox({
-        settings: this.settings,
-        textLimits: this.textLimits,
-        draft: this.draft,
-        showAmpel: this.showAmpelInList,
-        responsibleOptions,
-        onNew: () => this._newDraft(),
-        onDraftChange: (patch, options) => this._updateDraft(patch, options),
-        onDelete: () => this._deleteDraft().catch((err) => this._setStubMessage(err?.message || String(err))),
-        onNote: () => this._openNotesPopup().catch((err) => this._setStubMessage(err?.message || String(err))),
-        onAutoSave: () => this._autoSaveDraft().catch((err) => this._setStubMessage(err?.message || String(err))),
-      });
-      const workspace = document.createElement("div");
-      workspace.className = "bbm-restarbeiten-workspace";
-      const listPane = document.createElement("div");
-      listPane.className = "bbm-restarbeiten-workspace__list";
-      const editPane = document.createElement("div");
-      editPane.className = "bbm-restarbeiten-workspace__edit";
-      listPane.appendChild(main);
-      editPane.appendChild(editbox);
-      workspace.append(listPane, editPane);
-      this.root.appendChild(workspace);
-    }
+    const main = buildRestarbeitenMainBody({
+      items: this.viewItems,
+      selectedId: this.selectedId,
+      showAmpel: this.showAmpelInList,
+      showLongtext: this.showLongtextInList,
+      onSelect: (id) => this._selectItem(id),
+      onPhotos: (id) => this.openRestarbeitPhotos(id),
+    });
+    const editbox = buildRestarbeitenEditbox({
+      settings: this.settings,
+      textLimits: this.textLimits,
+      draft: this.draft,
+      showAmpel: this.showAmpelInList,
+      responsibleOptions,
+      onNew: () => this._newDraft(),
+      onDraftChange: (patch, options) => this._updateDraft(patch, options),
+      onDelete: () => this._deleteDraft().catch((err) => this._setStubMessage(err?.message || String(err))),
+      onNote: () => this._openNotesPopup().catch((err) => this._setStubMessage(err?.message || String(err))),
+      onAutoSave: () => this._autoSaveDraft().catch((err) => this._setStubMessage(err?.message || String(err))),
+    });
+    const workspace = document.createElement("div");
+    workspace.className = "bbm-restarbeiten-workspace";
+    const listPane = document.createElement("div");
+    listPane.className = "bbm-restarbeiten-workspace__list";
+    const editPane = document.createElement("div");
+    editPane.className = "bbm-restarbeiten-workspace__edit";
+    listPane.appendChild(main);
+    editPane.appendChild(editbox);
+    workspace.append(listPane, editPane);
+    this.root.appendChild(workspace);
 
     if (this.isLoading || this.error) {
       const status = document.createElement("div");

--- a/src/renderer/modules/restarbeiten/styles/restarbeiten.css
+++ b/src/renderer/modules/restarbeiten/styles/restarbeiten.css
@@ -93,10 +93,6 @@
   height: 100%;
 }
 
-.bbm-restarbeiten-screen[data-output-preview="true"] {
-  grid-template-rows: auto minmax(0, 1fr);
-}
-
 .bbm-restarbeiten-screen,
 .bbm-restarbeiten-screen * {
   box-sizing: border-box;


### PR DESCRIPTION
## Scope

Drittes strikt abgegrenztes Paket aus #273: Entfernt ausschließlich den ungenutzten lokalen `outputPreviewOpen`-State, dessen Close-Methode, DOM-Gating und tote CSS-Regel.

Der produktive gemeinsame PDF-/Preview-Weg über `printPdfAndPreviewInternal` bleibt unverändert. `RestarbeitenOutputPreview.js` wird bewusst noch nicht entfernt; dessen Referenznachweis ist Paket 4.

## Tests

- `restarbeitenPreviewState.test.cjs`: 2/2 grün
- Paket-1-/Paket-2-Tests: 4/4 grün
- ESLint und `git diff --check`: grün
- vollständiges `npm test`: bekannte #271-Baseline unverändert; keine neue Fehlerklasse
