### PR TITLE
Restarbeiten #273 Paket 5: Notizdruck ehrlich kennzeichnen

### DIFF
--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -47,6 +47,7 @@ const TEST_GROUPS = Object.freeze([
     id: "restarbeiten-module",
     label: "Restarbeiten-Modul",
     suites: Object.freeze([
+      ["restarbeitenNotePrint.test.cjs", "runRestarbeitenNotePrintTests"],
       ["restarbeitenPreviewArtifact.test.cjs", "runRestarbeitenPreviewArtifactTests"],
       ["restarbeitenPreviewState.test.cjs", "runRestarbeitenPreviewStateTests"],
       ["restarbeitenLoadError.test.cjs", "runRestarbeitenLoadErrorTests"],

--- a/scripts/tests/restarbeitenModule.test.cjs
+++ b/scripts/tests/restarbeitenModule.test.cjs
@@ -1257,7 +1257,7 @@ async function runRestarbeitenModuleTests(run) {
     }
   });
 
-  await run("Restarbeiten: Notiz-Popup oeffnet, fuegt Notiz hinzu, bleibt offen und bereitet Druck vor", async () => {
+  await run("Restarbeiten: Notiz-Popup bleibt offen und kennzeichnet nicht verfügbaren Druck ehrlich", async () => {
     const mod = await importEsmFromFile(
       path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js")
     );
@@ -1328,11 +1328,9 @@ async function runRestarbeitenModuleTests(run) {
       assert.equal(collectText(doc.body).includes("Erste Notiz zur Restarbeit"), true);
       assert.equal(Boolean(screen.notesOverlay), true);
 
-      findByData(doc.body, "data-bbm-restarbeiten-note-action", "print").click();
-      assert.equal(screen._lastRestarbeitNotePrint.status, "prepared");
-      assert.equal(screen._lastRestarbeitNotePrint.mode, "restarbeit-note-history");
-      assert.equal(screen._lastRestarbeitNotePrint.restarbeitId, "ra-1");
-      assert.equal(collectText(doc.body).includes("Druck vorbereitet."), true);
+      assert.equal(findByData(doc.body, "data-bbm-restarbeiten-note-action", "print"), null);
+      assert.equal(collectText(doc.body).includes("Notizdruck ist derzeit nicht verfügbar."), true);
+      assert.equal(collectText(doc.body).includes("Druck vorbereitet."), false);
 
       findByData(doc.body, "data-bbm-restarbeiten-note-action", "close").click();
       assert.equal(screen.notesOverlay, null);

--- a/scripts/tests/restarbeitenNotePrint.test.cjs
+++ b/scripts/tests/restarbeitenNotePrint.test.cjs
@@ -1,0 +1,24 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+async function runRestarbeitenNotePrintTests(run) {
+  const screen = fs.readFileSync(
+    path.join(__dirname, "../../src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js"),
+    "utf8"
+  );
+
+  await run("Restarbeiten Notizen: UI bietet keinen vorgetäuschten Druck an", () => {
+    assert.equal(screen.includes('data-bbm-restarbeiten-note-action\", \"print'), false);
+    assert.equal(screen.includes("printRestarbeitNoteHistory"), false);
+    assert.equal(screen.includes('mode: "restarbeit-note-history"'), false);
+    assert.equal(screen.includes("Druck vorbereitet."), false);
+  });
+
+  await run("Restarbeiten Notizen: fehlender Druckweg wird ehrlich angezeigt", () => {
+    assert.equal(screen.includes("Notizdruck ist derzeit nicht verfügbar."), true);
+    assert.equal(screen.includes('printAvailability.className = "bbm-restarbeiten-notes-popup__print-availability"'), true);
+  });
+}
+
+module.exports = { runRestarbeitenNotePrintTests };

--- a/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
+++ b/src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js
@@ -191,9 +191,7 @@ export default class RestarbeitenScreen {
       noteText: "",
       isLoading: false,
       error: "",
-      printStatus: "",
     };
-    this._lastRestarbeitNotePrint = null;
     this.quicklanePinned = false;
   }
 
@@ -624,7 +622,6 @@ export default class RestarbeitenScreen {
       noteText: "",
       isLoading: true,
       error: "",
-      printStatus: "",
     };
     this._renderNotesPopup();
     try {
@@ -653,7 +650,6 @@ export default class RestarbeitenScreen {
     const restarbeitId = normalizeText(this.notesPopup.restarbeitId);
     if (!restarbeitId || !text) return;
     this.notesPopup.error = "";
-    this.notesPopup.printStatus = "";
     try {
       await createRestarbeitNote(restarbeitId, text);
       this.notesPopup.noteText = "";
@@ -661,25 +657,6 @@ export default class RestarbeitenScreen {
     } catch (err) {
       this.notesPopup.error = err?.message || String(err);
     }
-    this._renderNotesPopup();
-  }
-
-  printRestarbeitNoteHistory(restarbeitId = this.notesPopup.restarbeitId) {
-    const id = normalizeText(restarbeitId);
-    const result = {
-      ok: Boolean(id),
-      status: id ? "prepared" : "missing-restarbeit",
-      mode: "restarbeit-note-history",
-      restarbeitId: id,
-      notes: Array.isArray(this.notesPopup.notes) ? [...this.notesPopup.notes] : [],
-    };
-    this._lastRestarbeitNotePrint = result;
-    return result;
-  }
-
-  _printRestarbeitNoteHistory() {
-    const result = this.printRestarbeitNoteHistory();
-    this.notesPopup.printStatus = result.ok ? "Druck vorbereitet." : "Kein Datensatz ausgewählt.";
     this._renderNotesPopup();
   }
 
@@ -765,22 +742,15 @@ export default class RestarbeitenScreen {
       addBtn.disabled = !normalizeText(input.value);
     });
     addBtn.addEventListener("click", () => this._addNoteFromPopup(input.value));
+    actions.appendChild(addBtn);
 
-    const printBtn = document.createElement("button");
-    printBtn.type = "button";
-    applyPopupButtonStyle(printBtn);
-    printBtn.textContent = "Drucken";
-    printBtn.setAttribute("data-bbm-restarbeiten-note-action", "print");
-    printBtn.addEventListener("click", () => this._printRestarbeitNoteHistory());
-    actions.append(addBtn, printBtn);
-
-    const status = document.createElement("div");
-    status.className = "bbm-restarbeiten-notes-popup__status";
-    status.textContent = this.notesPopup.printStatus || "";
+    const printAvailability = document.createElement("div");
+    printAvailability.className = "bbm-restarbeiten-notes-popup__print-availability";
+    printAvailability.textContent = "Notizdruck ist derzeit nicht verfügbar.";
 
     const footer = document.createElement("div");
     footer.className = "bbm-restarbeiten-notes-popup__footer bbm-popup-footer";
-    footer.append(status, actions);
+    footer.append(printAvailability, actions);
 
     body.append(summary, history, input);
     card.append(header, body, footer);

--- a/src/renderer/modules/restarbeiten/styles/restarbeiten.css
+++ b/src/renderer/modules/restarbeiten/styles/restarbeiten.css
@@ -1166,7 +1166,8 @@
 }
 
 .bbm-restarbeiten-notes-popup__empty,
-.bbm-restarbeiten-notes-popup__status {
+.bbm-restarbeiten-notes-popup__status,
+.bbm-restarbeiten-notes-popup__print-availability {
   color: var(--bbm-muted);
 }
 


### PR DESCRIPTION
## Scope

Fünftes strikt abgegrenztes Paket aus #273. Da der gemeinsame Druckweg keinen eigenständigen Notizverlauf unterstützt und ein neuer Fachrenderer außerhalb des Scopes läge, wird die bisher funktionslose Druckaktion nicht mehr angeboten.

- Fake-Payload `restarbeit-note-history` und Status „Druck vorbereitet“ entfernt
- Druckschaltfläche entfernt
- sichtbar ehrlicher Hinweis: „Notizdruck ist derzeit nicht verfügbar.“
- Notizladen und -speichern bleiben unverändert

## Tests

- `restarbeitenNotePrint.test.cjs`: 2/2 grün
- frühere Pakettests: 9/9 grün
- bestehender Notiz-Popup-Test auf ehrliches Verhalten aktualisiert
- ESLint und `git diff --check`: grün
- vollständiges `npm test`: bekannte #271-Baseline unverändert, keine neue Fehlerklasse
