### PR TITLE
Restarbeiten #273 Paket 6: V2-Bestand belastbar bewerten

### DIFF
--- a/docs/RESTARBEITEN_V2_REVISION_273_BEWERTUNG.md
+++ b/docs/RESTARBEITEN_V2_REVISION_273_BEWERTUNG.md
@@ -1,0 +1,51 @@
+# Restarbeiten V2 – Bewertung in Revision #273
+
+## Ergebnis
+
+`src/renderer/modules/restarbeitenV2/` ist kein aktiver Produkt- oder UI-Laufzeitpfad.
+Der Bestand wird nicht pauschal gelöscht, sondern als inaktive, testgestützte
+Read-only-Grenze beibehalten.
+
+## Importnachweis
+
+- Der Ordner enthält nur DataSource, Mapper, ReadOnly-Adapter, Legacy-Lesebridge
+  und ReadOnly-DataSource-Factory.
+- Die Dateien importieren ausschließlich untereinander.
+- Außerhalb dieses Ordners importiert kein Produktionsmodul einen V2-Baustein.
+- Es existiert kein `RestarbeitenV2Screen` und kein V2-Modulindex.
+
+## Runtime-Nachweis
+
+- `Router.js` erzeugt und öffnet keinen Restarbeiten-V2-Screen.
+- `moduleNavigation.js` enthält keinen Restarbeiten-V2-Eintrag.
+- `MainHeader.js` erzeugt keinen V2-Button. Verbliebene Felder und Methoden sind
+  deaktivierte Altspuren; sie bilden keinen erreichbaren Einstieg.
+- Der produktive Restarbeiten-Einstieg bleibt das bestehende Modul `restarbeiten`.
+
+## Testnachweis
+
+Folgende eigenständige Nachweise laufen grün:
+
+- Datenvertrag
+- DataSource-Stub
+- Mapper
+- ReadOnly-Adapter
+- Legacy-Lesebridge
+- Lesewege-Inventar
+- Leseweg-Entscheidung
+- ReadOnly-DataSource-Factory
+- DEV-/Runtime-Zugriffsgrenze
+
+Der DEV-/Runtime-Zugriffstest liest die Navigationsquelle direkt. Dadurch hängt
+die Klassifikation nicht von dem bekannten, fehlenden `ui-editor-kit`-Artefakt ab.
+
+## Verbindliche Klassifikation
+
+- produktiv aktiv: **nein**
+- UI-/Router-erreichbar: **nein**
+- schreibend: **nein**
+- isoliert importierbar und getestet: **ja**
+- in Revision #273 zu löschen: **nein**
+
+Eine spätere Aktivierung, Schreibanbindung oder Entfernung benötigt einen eigenen
+Scope und einen neuen Runtime-/Import-/Regressionnachweis.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -104,6 +104,7 @@ const TEST_GROUPS = Object.freeze([
     id: "restarbeiten-v2",
     label: "Restarbeiten-V2 und Einstellungen",
     suites: Object.freeze([
+      ["restarbeitenV2Revision273.test.cjs", "runRestarbeitenV2Revision273Tests"],
       ["restarbeitenV2DevAccess.test.cjs", "runRestarbeitenV2DevAccessTests"],
       ["restarbeitenV2DataContract.test.cjs", "runRestarbeitenV2DataContractTests"],
       ["restarbeitenV2DataSource.test.cjs", "runRestarbeitenV2DataSourceTests"],

--- a/scripts/tests/restarbeitenV2Revision273.test.cjs
+++ b/scripts/tests/restarbeitenV2Revision273.test.cjs
@@ -1,0 +1,39 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function walkFiles(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(directory, entry.name);
+    return entry.isDirectory() ? walkFiles(fullPath) : [fullPath];
+  });
+}
+
+async function runRestarbeitenV2Revision273Tests(run) {
+  const root = path.join(__dirname, "../..");
+  const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+  await run("Restarbeiten V2 #273: kein produktiver Import- oder Runtime-Einstieg", () => {
+    const router = read("src/renderer/app/Router.js");
+    const navigation = read("src/renderer/app/modules/moduleNavigation.js");
+    const v2Directory = path.join(root, "src/renderer/modules/restarbeitenV2");
+    const externalImports = walkFiles(path.join(root, "src"))
+      .filter((file) => /\.(?:c?js|mjs)$/u.test(file) && !file.startsWith(`${v2Directory}${path.sep}`))
+      .filter((file) => /\b(?:from\s+|import\s*\(|require\s*\()\s*["'][^"']*restarbeitenV2\//u.test(fs.readFileSync(file, "utf8")));
+    assert.equal(router.includes("RestarbeitenV2Screen"), false);
+    assert.equal(router.includes("showRestarbeitenV2"), false);
+    assert.equal(navigation.toLowerCase().includes("restarbeitenv2"), false);
+    assert.deepEqual(externalImports, []);
+    assert.equal(fs.existsSync(path.join(v2Directory, "RestarbeitenV2Screen.js")), false);
+  });
+
+  await run("Restarbeiten V2 #273: Bestand ist read-only klassifiziert und bleibt erhalten", () => {
+    const assessment = read("docs/RESTARBEITEN_V2_REVISION_273_BEWERTUNG.md");
+    assert.equal(assessment.includes("produktiv aktiv: **nein**"), true);
+    assert.equal(assessment.includes("isoliert importierbar und getestet: **ja**"), true);
+    assert.equal(assessment.includes("in Revision #273 zu löschen: **nein**"), true);
+    assert.equal(assessment.includes("schreibend: **nein**"), true);
+  });
+}
+
+module.exports = { runRestarbeitenV2Revision273Tests };


### PR DESCRIPTION
## Scope

Sechstes strikt abgegrenztes Paket aus #273: `restarbeitenV2` wird erst nach Import-, Runtime- und Testnachweis klassifiziert. Keine Produktivaktivierung, kein UI-Umbau und keine Massenlöschung.

## Ergebnis

- kein produktiver Import außerhalb des V2-Ordners
- kein Screen, Router-Einstieg oder Modulnavigationseintrag
- nur intern gekoppelte DataSource-/Mapper-/ReadOnly-Adapter-/Bridge-Bausteine
- nicht schreibend
- isoliert importierbar und testgestützt
- Klassifikation: inaktiv, read-only, behalten; spätere Aktivierung oder Entfernung nur in eigenem Scope

## Tests

- neue #273 Import-/Runtime-/Klassifikationstests: 2/2 grün
- acht vorhandene V2-Bausteintests einzeln: 8/8 grün
- vollständiges `npm test`: bekannte #271-Baseline unverändert (neun Einzelfehler und bekannte `ui-editor-kit`-Abbrüche), keine neue Fehlerklasse
