### PR TITLE
Restarbeiten #273 Paket 7: Gesamtregression

### DIFF
--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -47,6 +47,7 @@ const TEST_GROUPS = Object.freeze([
     id: "restarbeiten-module",
     label: "Restarbeiten-Modul",
     suites: Object.freeze([
+      ["restarbeitenRevision273Regression.test.cjs", "runRestarbeitenRevision273RegressionTests"],
       ["restarbeitenNotePrint.test.cjs", "runRestarbeitenNotePrintTests"],
       ["restarbeitenPreviewArtifact.test.cjs", "runRestarbeitenPreviewArtifactTests"],
       ["restarbeitenPreviewState.test.cjs", "runRestarbeitenPreviewStateTests"],

--- a/scripts/tests/restarbeitenRevision273Regression.test.cjs
+++ b/scripts/tests/restarbeitenRevision273Regression.test.cjs
@@ -1,0 +1,61 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+async function runRestarbeitenRevision273RegressionTests(run) {
+  const screen = read("src/renderer/modules/restarbeiten/screens/RestarbeitenScreen.js");
+  const groups = read("scripts/testGroups.cjs");
+
+  await run("Restarbeiten #273 Regression: Foto-UI nutzt bestehende Attachment-API", () => {
+    for (const api of [
+      "listRestarbeitAttachments",
+      "importRestarbeitAttachments",
+      "setPrimaryRestarbeitAttachment",
+      "deleteRestarbeitAttachment",
+    ]) assert.equal(screen.includes(`${api}(`), true, api);
+    assert.equal(screen.includes("Fotos folgen in einem späteren Paket."), false);
+  });
+
+  await run("Restarbeiten #273 Regression: Haupt-Ladefehler ist sichtbar und abgeschlossen", () => {
+    const load = screen.slice(screen.indexOf("  async load("), screen.indexOf("\n  _bindTextLimitSettings()"));
+    assert.match(load, /catch \(error\)[\s\S]*Restarbeiten konnten nicht geladen werden/);
+    assert.match(load, /finally[\s\S]*this\.isLoading = false;[\s\S]*this\._renderShell\(\)/);
+  });
+
+  await run("Restarbeiten #273 Regression: nur gemeinsamer Preview-Weg bleibt", () => {
+    assert.equal(screen.includes("outputPreviewOpen"), false);
+    assert.equal(screen.includes("data-output-preview"), false);
+    assert.equal(screen.includes("printPdfAndPreviewInternal(this._buildRestarbeitenPdfPayload())"), true);
+    assert.equal(fs.existsSync(path.join(process.cwd(), "src/renderer/modules/restarbeiten/RestarbeitenOutputPreview.js")), false);
+  });
+
+  await run("Restarbeiten #273 Regression: Notizdruck wird nicht vorgetäuscht", () => {
+    assert.equal(screen.includes('mode: "restarbeit-note-history"'), false);
+    assert.equal(screen.includes("Druck vorbereitet."), false);
+    assert.equal(screen.includes("Notizdruck ist derzeit nicht verfügbar."), true);
+  });
+
+  await run("Restarbeiten #273 Regression: V2 bleibt inaktiv und testgestützt erhalten", () => {
+    const assessment = read("docs/RESTARBEITEN_V2_REVISION_273_BEWERTUNG.md");
+    assert.equal(assessment.includes("produktiv aktiv: **nein**"), true);
+    assert.equal(assessment.includes("isoliert importierbar und getestet: **ja**"), true);
+    assert.equal(assessment.includes("in Revision #273 zu löschen: **nein**"), true);
+  });
+
+  await run("Restarbeiten #273 Regression: alle Paketnachweise bleiben registriert", () => {
+    for (const suite of [
+      "restarbeitenPhotoUi.test.cjs",
+      "restarbeitenLoadError.test.cjs",
+      "restarbeitenPreviewState.test.cjs",
+      "restarbeitenPreviewArtifact.test.cjs",
+      "restarbeitenNotePrint.test.cjs",
+      "restarbeitenV2Revision273.test.cjs",
+    ]) assert.equal(groups.includes(suite), true, suite);
+  });
+}
+
+module.exports = { runRestarbeitenRevision273RegressionTests };


### PR DESCRIPTION
## Scope

Siebtes und letztes Paket aus #273: dauerhafter Gesamt-Gate-Test für alle Restarbeiten-Revisionskriterien. Kein Produktcode.

## Nachweis

- #273-Gate: 6/6 grün
- Paket-Einzeltests: 11/11 grün
- Restarbeiten-Datenmodell unter Electron-ABI: 16/16 grün
- Restarbeiten-Regeln: 4/4 grün
- V2-Bausteine: 8/8 grün
- Restarbeiten-Editorgrenzen: 20/20 grün
- PDF-Satzvertrag: ausschließlich durch bekannten fehlenden `ui-editor-kit` blockiert
- vollständiges `npm test`: exakt neun bekannte #271-Einzelfehler und bekannte `ui-editor-kit`-Gruppenabbrüche; keine neue Fehlerklasse

## Gate-Inhalte

- Foto-UI nutzt bestehende Attachment-API
- Haupt-Ladefehler sichtbar und Ladezustand beendet
- lokaler Preview-State und tote Preview-Datei entfernt; gemeinsamer Druckweg erhalten
- Notizdruck wird nicht vorgetäuscht
- V2 bleibt inaktiv, read-only, testgestützt und erhalten
- sämtliche Paketnachweise registriert
