### PR TITLE
Protokoll #272 Paket 1: kanonischen Produktivpfad nachweisen

### DIFF
--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -4,6 +4,7 @@ const TEST_GROUPS = Object.freeze([
     label: "Kern, Protokoll und Projektfirmen",
     includeStoragePathTests: true,
     suites: Object.freeze([
+      ["protokollRevision272Path.test.cjs", "runProtokollRevision272PathTests"],
       ["gateBRegression.test.cjs", "runGateBRegressionTests"],
       ["ownOrganizationBoundary.test.cjs", "runOwnOrganizationBoundaryTests"],
       ["moduleServiceProviders.test.cjs", "runModuleServiceProviderTests"],
@@ -24,7 +25,6 @@ const TEST_GROUPS = Object.freeze([
       ["firmDirectoryIpc.test.cjs", "runFirmDirectoryIpcTests"],
       ["projectTransferFirmLogic.test.cjs", "runProjectTransferFirmLogicTests"],
       ["projectFirmsLayout.test.cjs", "runProjectFirmsLayoutTests"],
-      ["protokollRevision272Path.test.cjs", "runProtokollRevision272PathTests"],
       ["protokollRouterFallback.test.cjs", "runProtokollRouterFallbackTests"],
       ["protokollProjectEntryRouting.test.cjs", "runProtokollProjectEntryRoutingTests"],
       ["protokollUiEditorElements.test.cjs", "runProtokollUiEditorElementsTests"],

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -24,6 +24,7 @@ const TEST_GROUPS = Object.freeze([
       ["firmDirectoryIpc.test.cjs", "runFirmDirectoryIpcTests"],
       ["projectTransferFirmLogic.test.cjs", "runProjectTransferFirmLogicTests"],
       ["projectFirmsLayout.test.cjs", "runProjectFirmsLayoutTests"],
+      ["protokollRevision272Path.test.cjs", "runProtokollRevision272PathTests"],
       ["protokollRouterFallback.test.cjs", "runProtokollRouterFallbackTests"],
       ["protokollProjectEntryRouting.test.cjs", "runProtokollProjectEntryRoutingTests"],
       ["protokollUiEditorElements.test.cjs", "runProtokollUiEditorElementsTests"],

--- a/scripts/tests/protokollRevision272Path.test.cjs
+++ b/scripts/tests/protokollRevision272Path.test.cjs
@@ -1,0 +1,45 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+async function runProtokollRevision272PathTests(run) {
+  const moduleCatalog = read("src/renderer/app/modules/moduleCatalog.js");
+  const router = read("src/renderer/app/Router.js");
+  const moduleIndex = read("src/renderer/modules/protokoll/index.js");
+  const integrationView = read(
+    "src/renderer/modules/protokoll/screens/TopsScreenIntegrationView.js"
+  );
+  const compatibilityView = read("src/renderer/views/TopsScreen.js");
+
+  await run("Protokoll #272: Modulkatalog und Router nutzen genau den Moduleinstieg", () => {
+    assert.equal(moduleCatalog.includes('from "../../modules/protokoll/index.js"'), true);
+    assert.equal(router.includes('from "../modules/protokoll/index.js"'), true);
+    assert.equal(moduleCatalog.includes("views/TopsScreen.js"), false);
+    assert.equal(router.includes("views/TopsScreen.js"), false);
+  });
+
+  await run("Protokoll #272: Moduleinstieg fuehrt zum modulnahen Arbeitsscreen", () => {
+    assert.equal(
+      moduleIndex.includes('import TopsScreen from "./screens/TopsScreenIntegrationView.js"'),
+      true
+    );
+    assert.equal(integrationView.includes('import TopsScreen from "./TopsScreen.js"'), true);
+    assert.equal(integrationView.includes("extends TopsScreen"), true);
+  });
+
+  await run("Protokoll #272: views/TopsScreen bleibt reiner Kompatibilitaetspfad", () => {
+    assert.equal(
+      compatibilityView.includes(
+        'export { default } from "../modules/protokoll/screens/TopsScreen.js"'
+      ),
+      true
+    );
+    assert.equal(compatibilityView.includes("class TopsScreen"), false);
+  });
+}
+
+module.exports = { runProtokollRevision272PathTests };

--- a/src/renderer/modules/protokoll/README.md
+++ b/src/renderer/modules/protokoll/README.md
@@ -2,10 +2,23 @@
 
 Diese Struktur ist die technische Heimat fuer das Fachmodul `Protokoll`.
 
-Aktuell ist nur ein kleiner Einstieg angelegt:
+Der produktive Einstieg ist eindeutig:
 
-- `index.js` als kleiner Modul-Einstieg mit Modulkennung, Arbeitsscreen und Sicht auf bereits umgezogenen Modulbestand
-- `screens/` mit einem konservativen Einstieg auf den heutigen `TopsScreen`
+- `app/modules/moduleCatalog.js` registriert ausschliesslich `modules/protokoll/index.js`.
+- `app/Router.js` bezieht den Arbeitsscreen ausschliesslich aus diesem Moduleinstieg.
+- `index.js` registriert `screens/TopsScreenIntegrationView.js` als Arbeitsscreen.
+- `screens/TopsScreenIntegrationView.js` ergaenzt den modulnahen `screens/TopsScreen.js`
+  nur um die Shell-Integration.
+- `views/TopsScreen.js` ist ausschliesslich ein Kompatibilitaets-Re-Export fuer Altimporte und
+  kein produktiver Router- oder Modulkatalog-Einstieg.
+- `renderer/tops/` ist der noch nicht vollstaendig umgezogene, modulinterne Unterbau. Der Ordner
+  ist kein konkurrierender produktiver Moduleinstieg und wird nur nach gesondertem
+  Import-/Runtime-/Testnachweis bereinigt.
+
+Der aktuelle Modulbestand umfasst ausserdem:
+
+- `index.js` mit Modulkennung, Routen, Navigation und Arbeitsscreen
+- `screens/` mit dem produktiven Protokoll-Screen und seiner Shell-Integration
 - `viewmodel/` mit den ersten real umgezogenen Protokoll-ViewModels
 - `SharedEditboxCore.js` als modulinterner Kern fuer den generischen Editbox-Aufbau und die Value-/Read-only-Synchronisation
 - `WorkbenchMetaColumn.js` als modulinterner Kern fuer die Workbench-Meta-Spalte
@@ -17,8 +30,6 @@ sind absichtlich schon angelegt, damit spaetere Umzuege dort sauber anschliessen
 
 Wichtig:
 
-- Noch kein Vollumzug des bestehenden Tops-Unterbaus
-- Noch kein Router-Umbau
-- Noch keine globale Modulregistrierung
-- Noch keine modulbasierte Plattformmechanik
+- Kein kosmetischer Vollumzug des bestehenden Tops-Unterbaus
+- Keine zweite Router- oder Modulregistrierung neben `modules/protokoll/index.js`
 - Gemeinsame Kernbausteine bleiben ausserhalb dieses Moduls


### PR DESCRIPTION
## Scope

Erstes, ausschließlich auf #272 begrenztes Paket: kanonischen produktiven Protokollpfad nachweisen und dauerhaft absichern.

- Modulkatalog und Router verwenden `modules/protokoll/index.js`.
- Der Moduleinstieg führt über `TopsScreenIntegrationView` zum modulnahen `TopsScreen`.
- `views/TopsScreen.js` ist nur Kompatibilitäts-Re-Export.
- `renderer/tops/` wird als noch benötigter modulinterner Unterbau dokumentiert; keine vorzeitige Bereinigung oder Verschiebung.

## Tests

- `protokollRevision272Path.test.cjs`: 3/3 grün.
- Bestehender `protokollRouterFallback.test.cjs`: Paketnachweise grün; eine unveränderte Quicklane-Assertion scheitert identisch auf `main`.
- Relevante Projektpfadtests: bestehende statische Tests grün, bekannte Baselinefehler unverändert.
- `npm test`: weiterhin 0/10 Gruppen; keine neue Fehlerklasse gegenüber der dokumentierten Baseline (#271/#273). Lokale Importtests bleiben durch das fehlende `ui-editor-kit` blockiert.

Closes keinen Gesamt-Issue; #272 bleibt bis Abschluss aller Pakete offen.