### PR TITLE
Protokoll #272 Paket 3: PDF-Dienstgrenze festigen

### DIFF
--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -6,6 +6,7 @@ const TEST_GROUPS = Object.freeze([
     suites: Object.freeze([
       ["protokollRevision272Path.test.cjs", "runProtokollRevision272PathTests"],
       ["protokollSettingsOwnership.test.cjs", "runProtokollSettingsOwnershipTests"],
+      ["protokollPdfServiceBoundary.test.cjs", "runProtokollPdfServiceBoundaryTests"],
       ["gateBRegression.test.cjs", "runGateBRegressionTests"],
       ["ownOrganizationBoundary.test.cjs", "runOwnOrganizationBoundaryTests"],
       ["moduleServiceProviders.test.cjs", "runModuleServiceProviderTests"],

--- a/scripts/tests/protokollPdfServiceBoundary.test.cjs
+++ b/scripts/tests/protokollPdfServiceBoundary.test.cjs
@@ -1,0 +1,68 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+async function runProtokollPdfServiceBoundaryTests(run) {
+  const { PdfDocumentService } = await importEsmFromFile(
+    path.join(process.cwd(), "src/renderer/features/output/PdfDocumentService.js")
+  );
+
+  await run("#272 PDF: gemeinsamer Dienst fuehrt eine gelieferte Router-Operation technisch aus", async () => {
+    const calls = [];
+    const router = {
+      async createDocument(payload) {
+        calls.push(payload);
+        return { ok: true, filePath: "C:/tmp/result.pdf" };
+      },
+    };
+    const service = new PdfDocumentService({ router });
+    const result = await service.create({
+      operation: "createDocument",
+      payload: { projectId: "p1", documentId: "d1" },
+    });
+
+    assert.deepEqual(calls, [{ projectId: "p1", documentId: "d1" }]);
+    assert.deepEqual(result, { ok: true, filePath: "C:/tmp/result.pdf" });
+  });
+
+  await run("#272 PDF: gemeinsamer Dienst bleibt ohne Protokoll-Fachwissen", () => {
+    const source = read("src/renderer/features/output/PdfDocumentService.js");
+    for (const forbidden of [
+      "protokoll",
+      "meetingId",
+      "printClosedMeetingDirect",
+      "printFirmsDirect",
+      "printTodoDirect",
+      "printTopListAllDirect",
+      "layoutRules",
+      "fileName",
+    ]) {
+      assert.equal(source.toLowerCase().includes(forbidden.toLowerCase()), false, forbidden);
+    }
+  });
+
+  await run("#272 PDF: Protokoll-Abschluss nutzt die gemeinsame Dienstgrenze", () => {
+    const source = read("src/renderer/tops/domain/TopsCloseFlow.js");
+    assert.match(source, /new PdfDocumentService\(\{ router: this\.router \}\)/);
+    assert.match(source, /this\.pdfDocumentService\.create\(\{/);
+    assert.doesNotMatch(source, /this\.router\?\.printClosedMeetingDirect/);
+    assert.doesNotMatch(source, /this\.router\?\.printFirmsDirect/);
+    assert.doesNotMatch(source, /this\.router\?\.printTodoDirect/);
+    assert.doesNotMatch(source, /this\.router\?\.printTopListAllDirect/);
+  });
+
+  await run("#272 PDF: fehlende technische Operation faellt kontrolliert geschlossen aus", async () => {
+    const service = new PdfDocumentService({ router: {} });
+    const result = await service.create({ operation: "missing", payload: { id: "x" } });
+    assert.equal(result.ok, false);
+    assert.equal(result.skipped, true);
+    assert.match(result.error, /nicht verfuegbar/);
+  });
+}
+
+module.exports = { runProtokollPdfServiceBoundaryTests };

--- a/src/renderer/features/output/PdfDocumentService.js
+++ b/src/renderer/features/output/PdfDocumentService.js
@@ -1,0 +1,21 @@
+// Gemeinsame technische PDF-/Print-Dienstgrenze.
+// Fachmodule liefern Operation und Payload; der Dienst kennt weder Dokumentarten
+// noch fachliche ViewModels, Layoutregeln oder Dateinamen.
+export class PdfDocumentService {
+  constructor({ router } = {}) {
+    this.router = router || null;
+  }
+
+  async create({ operation, payload } = {}) {
+    const methodName = String(operation || "").trim();
+    const method = methodName ? this.router?.[methodName] : null;
+    if (typeof method !== "function") {
+      return {
+        ok: false,
+        skipped: true,
+        error: methodName ? `PDF-Dienst ${methodName} ist nicht verfuegbar.` : "PDF-Dienst fehlt.",
+      };
+    }
+    return await method.call(this.router, payload || {});
+  }
+}

--- a/src/renderer/modules/protokoll/README.md
+++ b/src/renderer/modules/protokoll/README.md
@@ -37,6 +37,15 @@ Projektformular delegiert an `ProtocolSettingsModal.js`. Der projektbezogene Set
 nur ueber den Protokoll-IPC-Registrar aktiviert. Die vorerst noch vorhandenen, nicht mehr
 aufgerufenen Dialogimplementierungen werden erst im gesonderten Legacy-Paket bewertet.
 
+## PDF-/Print-Grenze
+
+Der Protokoll-Abschluss bestimmt weiterhin fachlich, welche Dokumente in welcher Reihenfolge
+erzeugt werden. `renderer/tops/domain/TopsCloseFlow.js` liefert dazu ausschliesslich Operation
+und Projekt-/Besprechungskontext an `features/output/PdfDocumentService.js`. Dieser gemeinsame
+technische Dienst fuehrt die bereits vorhandenen Router-/`PrintModal`-Operationen aus und kennt
+keine Protokoll-Dokumentart, kein Fach-ViewModel, keine Layoutregel und keinen Dateinamen.
+Renderer, Satzweg, Preview, Speicherung und Druck bleiben unveraendert.
+
 Die Ordner `components/`, `domain/`, `data/`, `state/`, `viewmodel/`, `dialogs/` und `rules/`
 sind absichtlich schon angelegt, damit spaetere Umzuege dort sauber anschliessen koennen.
 

--- a/src/renderer/tops/domain/TopsCloseFlow.js
+++ b/src/renderer/tops/domain/TopsCloseFlow.js
@@ -1,4 +1,16 @@
 import { MailFlow } from "../../features/mail/MailFlow.js";
+import { PdfDocumentService } from "../../features/output/PdfDocumentService.js";
+
+const CLOSE_PDF_OUTPUTS = Object.freeze([
+  Object.freeze({
+    key: "protocol",
+    operation: "printClosedMeetingDirect",
+    errorLabel: "Protokoll-PDF",
+  }),
+  Object.freeze({ key: "firms", operation: "printFirmsDirect", errorLabel: "Firmenliste-PDF" }),
+  Object.freeze({ key: "todo", operation: "printTodoDirect", errorLabel: "ToDo-PDF" }),
+  Object.freeze({ key: "tops", operation: "printTopListAllDirect", errorLabel: "Top-Liste-PDF" }),
+]);
 
 // Fachmodul `Protokoll`:
 // Abschluss- und Ausgabeablauf des Protokolls; Mail/Print bleiben gemeinsame Dienste.
@@ -11,6 +23,8 @@ export class TopsCloseFlow {
     this.isReadOnly = false;
     this.showAmpelInList = true;
     this._lastClosedMeetingForEmail = null;
+    this.pdfDocumentService =
+      options.pdfDocumentService || new PdfDocumentService({ router: this.router });
 
     this._mailViewAdapter = {
       get projectId() {
@@ -110,8 +124,8 @@ export class TopsCloseFlow {
   }
 
   async _printAllOutputs({ projectId, meetingId }) {
-    // Gemeinsame Dienste / Addons:
-    // PDF-/Print-Erzeugung bleibt technisch im Router/PrintModal und nicht im Modul-Unterbau selbst.
+    // Das Fachmodul bestimmt Dokumente, Reihenfolge und Fehlertexte. Die technische
+    // Ausfuehrung bleibt hinter PdfDocumentService -> Router/PrintModal gemeinsam.
     const printResults = {
       protocol: { ok: false, filePath: "" },
       firms: { ok: false, filePath: "" },
@@ -119,48 +133,18 @@ export class TopsCloseFlow {
       tops: { ok: false, filePath: "" },
     };
 
-    try {
-      if (typeof this.router?.printClosedMeetingDirect === "function") {
-        const r = await this.router.printClosedMeetingDirect({ projectId, meetingId });
-        printResults.protocol.ok = r?.ok !== false;
-        printResults.protocol.filePath = r?.filePath || r?.path || "";
+    for (const output of CLOSE_PDF_OUTPUTS) {
+      try {
+        const result = await this.pdfDocumentService.create({
+          operation: output.operation,
+          payload: { projectId, meetingId },
+        });
+        printResults[output.key].ok = result?.ok !== false;
+        printResults[output.key].filePath = result?.filePath || result?.path || "";
+      } catch (err) {
+        console.warn(`[tops-v2] ${output.errorLabel} nach Schliessen fehlgeschlagen:`, err);
+        alert(`${output.errorLabel} konnte nach dem Schliessen nicht erzeugt werden.`);
       }
-    } catch (err) {
-      console.warn("[tops-v2] Protokoll-PDF nach Schliessen fehlgeschlagen:", err);
-      alert("Protokoll-PDF konnte nach dem Schliessen nicht erzeugt werden.");
-    }
-
-    try {
-      if (typeof this.router?.printFirmsDirect === "function") {
-        const r = await this.router.printFirmsDirect({ projectId, meetingId });
-        printResults.firms.ok = r?.ok !== false;
-        printResults.firms.filePath = r?.filePath || r?.path || "";
-      }
-    } catch (err) {
-      console.warn("[tops-v2] Firmenliste-PDF nach Schliessen fehlgeschlagen:", err);
-      alert("Firmenliste-PDF konnte nach dem Schliessen nicht erzeugt werden.");
-    }
-
-    try {
-      if (typeof this.router?.printTodoDirect === "function") {
-        const r = await this.router.printTodoDirect({ projectId, meetingId });
-        printResults.todo.ok = r?.ok !== false;
-        printResults.todo.filePath = r?.filePath || r?.path || "";
-      }
-    } catch (err) {
-      console.warn("[tops-v2] ToDo-PDF nach Schliessen fehlgeschlagen:", err);
-      alert("ToDo-PDF konnte nach dem Schliessen nicht erzeugt werden.");
-    }
-
-    try {
-      if (typeof this.router?.printTopListAllDirect === "function") {
-        const r = await this.router.printTopListAllDirect({ projectId, meetingId });
-        printResults.tops.ok = r?.ok !== false;
-        printResults.tops.filePath = r?.filePath || r?.path || "";
-      }
-    } catch (err) {
-      console.warn("[tops-v2] Top-Liste-PDF nach Schliessen fehlgeschlagen:", err);
-      alert("Top-Liste-PDF konnte nach dem Schliessen nicht erzeugt werden.");
     }
 
     return printResults;


### PR DESCRIPTION
## Scope
- ausschließlich #272 Paket 3: bestehende Protokoll-PDF-Erzeugung über eine gemeinsame technische Dienstgrenze führen
- Protokoll bestimmt weiterhin Dokumentauswahl, Reihenfolge, Kontext und Fehlertexte
- Router/PrintModal bleiben bestehender technischer Renderer-/Speicher-/Druckweg
- keine Änderung an PDF-Layout, Satz, Preview, Dateinamen oder Fachlogik

## Tests
- Pakettest `protokollPdfServiceBoundary.test.cjs`: 4/4 grün
- `topsCloseFlow.test.cjs`: 2/2 grün
- `moduleServiceProviders.test.cjs`: 6/6 grün
- gezielter ESLint + `git diff --check`: grün
- `npm test`: 0/10 Gruppen; ausschließlich bekannte Baselineklassen aus #271/#273, keine neue Fehlerklasse

## Baselineabgrenzung
- bekannt: DB-Mock ohne `transaction` in `meetingTopsRepo`/Rechnungsmigration
- bekannt: fehlende `ui-editor-kit`-Artefakte
- bekannt: drei Popup-Standard-Erwartungen
- bekannt: alte Lizenzalias-, FeatureGuard- und Development-Build-Erwartungen

Closes keinen Gesamt-Scope; #272 bleibt bis zur vollständigen Paketfolge offen.