### PR TITLE
Protokoll #272 Paket 4b: Mailpayload fachlich besitzen

### DIFF
--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -8,6 +8,7 @@ const TEST_GROUPS = Object.freeze([
       ["protokollSettingsOwnership.test.cjs", "runProtokollSettingsOwnershipTests"],
       ["protokollPdfServiceBoundary.test.cjs", "runProtokollPdfServiceBoundaryTests"],
       ["protokollMailTransportBoundary.test.cjs", "runProtokollMailTransportBoundaryTests"],
+      ["protokollMailPayloadOwnership.test.cjs", "runProtokollMailPayloadOwnershipTests"],
       ["gateBRegression.test.cjs", "runGateBRegressionTests"],
       ["ownOrganizationBoundary.test.cjs", "runOwnOrganizationBoundaryTests"],
       ["moduleServiceProviders.test.cjs", "runModuleServiceProviderTests"],

--- a/scripts/tests/protokollMailPayloadOwnership.test.cjs
+++ b/scripts/tests/protokollMailPayloadOwnership.test.cjs
@@ -1,0 +1,124 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+async function runProtokollMailPayloadOwnershipTests(run) {
+  const { ProtokollMailPayloadService } = await importEsmFromFile(
+    path.join(
+      process.cwd(),
+      "src/renderer/modules/protokoll/mail/ProtokollMailPayloadService.js"
+    )
+  );
+
+  await run("#272 Mail 4b: Teilnehmer-Verteiler liefert fachliche Empfaengerauswahl", async () => {
+    const originalWindow = global.window;
+    global.window = {
+      bbmDb: {
+        meetingParticipantsList: async () => ({
+          ok: true,
+          items: [
+            { email: "alle@example.test", is_in_distribution: 0 },
+            { person_email: "verteiler@example.test", is_in_distribution: 1 },
+            { email: "VERTEILER@example.test", is_in_distribution: 1 },
+          ],
+        }),
+      },
+    };
+    try {
+      const service = new ProtokollMailPayloadService({ router: {} });
+      const options = await service.getMeetingRecipientOptions("m1");
+      assert.deepEqual(options, {
+        distribution: ["verteiler@example.test"],
+        all: ["alle@example.test", "verteiler@example.test"],
+        anyDistributionField: true,
+      });
+      assert.deepEqual(service.buildInitialRecipientSelection(options), ["verteiler@example.test"]);
+    } finally {
+      global.window = originalWindow;
+    }
+  });
+
+  await run("#272 Mail 4b: Betreff und Text bleiben protokollspezifisch aufgebaut", async () => {
+    const originalWindow = global.window;
+    global.window = {
+      bbmDb: {
+        projectsList: async () => ({
+          ok: true,
+          list: [{ id: "p1", project_number: "4711", short: "Nord" }],
+        }),
+        projectSettingsGetMany: async () => ({
+          ok: true,
+          data: { "pdf.protocolTitle": "Jour fixe" },
+        }),
+        appSettingsGetMany: async () => ({
+          ok: true,
+          data: {
+            email_subject: "{projectNumber} | {protocolTitle} #{meetingIndex} - {meetingDate}",
+            email_body: "Bitte beachten.",
+          },
+        }),
+      },
+    };
+    try {
+      const service = new ProtokollMailPayloadService({ router: { currentProjectId: "p1" } });
+      const draft = await service.buildDraft({
+        projectId: "p1",
+        meeting: { meeting_index: 17, meeting_date: "2026-09-06" },
+      });
+      assert.equal(draft.subject, "4711  |  Jour fixe #17 - 06.09.2026");
+      assert.equal(draft.body, "Bitte beachten.");
+    } finally {
+      global.window = originalWindow;
+    }
+  });
+
+  await run("#272 Mail 4b: Protokoll-PDF-Suche behaelt bestehende Dateinamenskandidaten", async () => {
+    const originalWindow = global.window;
+    global.window = {
+      bbmDb: {
+        projectsList: async () => ({
+          ok: true,
+          list: [{ id: "p1", project_number: "47/11", short: "Nord" }],
+        }),
+        appSettingsGetMany: async () => ({
+          ok: true,
+          data: { "pdf.protocolsDir": "C:/BBM", "pdf.protocolTitle": "Baubesprechung" },
+        }),
+      },
+    };
+    try {
+      const service = new ProtokollMailPayloadService({ router: {} });
+      const lookup = await service.buildProtocolPdfLookupPayload(
+        { meeting_index: 17, meeting_date: "2026-09-06" },
+        "p1"
+      );
+      assert.equal(lookup.baseDir, "C:/BBM");
+      assert.deepEqual(lookup.expectedFileNames, [
+        "47 11_Baubesprechung_#17-2026-09-06.pdf",
+        "47 11_Nord_Baubesprechung_#17 - 06.09.2026.pdf",
+      ]);
+    } finally {
+      global.window = originalWindow;
+    }
+  });
+
+  await run("#272 Mail 4b: aktiver Flow und Header delegieren an den Modulservice", () => {
+    const flow = read("src/renderer/modules/protokoll/mail/ProtokollMailFlow.js");
+    const header = read("src/renderer/ui/MainHeader.js");
+    assert.match(flow, /new ProtokollMailPayloadService\(\{ router: this\.router \}\)/);
+    assert.match(flow, /payloadService\.getMeetingRecipientOptions/);
+    assert.match(flow, /payloadService\.buildDraft/);
+    assert.match(flow, /payloadService\.buildProtocolPdfLookupPayload/);
+    assert.match(header, /_getProtokollMailPayloadService\(\)/);
+    assert.match(header, /\.getMeetingRecipientOptions\(meetingId\)/);
+    assert.match(header, /\.buildDraft\(\{/);
+    assert.match(header, /\.buildProtocolPdfLookupPayload\(/);
+  });
+}
+
+module.exports = { runProtokollMailPayloadOwnershipTests };

--- a/src/renderer/modules/protokoll/README.md
+++ b/src/renderer/modules/protokoll/README.md
@@ -54,6 +54,10 @@ Payload uebergibt der bestehende Header-Adapter an `features/mail/MailTransportS
 dort bleiben Outlook/mailto, Attachment-Fehlerbehandlung und technische Transportnormalisierung
 fachneutral gemeinsam. Der
 historische Pfad `features/mail/MailFlow.js` ist nur noch ein Kompatibilitaets-Re-Export.
+`mail/ProtokollMailPayloadService.js` besitzt die aktiven Regeln fuer Projekt-/Besprechungskontext,
+Empfaenger aus dem fachlichen Verteiler, Protokoll-Betreff/-Text, Anhangsliste und die Suche nach
+dem gespeicherten Protokoll-PDF. `MainHeader` behaelt seine bisherigen Methodennamen nur als
+Delegationspunkte fuer bestehende Aufrufer.
 
 Die Ordner `components/`, `domain/`, `data/`, `state/`, `viewmodel/`, `dialogs/` und `rules/`
 sind absichtlich schon angelegt, damit spaetere Umzuege dort sauber anschliessen koennen.

--- a/src/renderer/modules/protokoll/mail/ProtokollMailFlow.js
+++ b/src/renderer/modules/protokoll/mail/ProtokollMailFlow.js
@@ -1,5 +1,6 @@
 import { applyPopupButtonStyle } from "../../../ui/popupButtonStyles.js";
 import { cleanupPopupHandlers, createPopupOverlay } from "../../../ui/popupCommon.js";
+import { ProtokollMailPayloadService } from "./ProtokollMailPayloadService.js";
 
 export class ProtokollMailFlow {
   constructor({ view, router }) {
@@ -14,6 +15,7 @@ export class ProtokollMailFlow {
   async openSendMailAfterClose({ printResults, meeting }) {
     const MainHeader = (await import("../../../ui/MainHeader.js")).default;
     const headerHelper = new MainHeader({ router: this.router });
+    const payloadService = new ProtokollMailPayloadService({ router: this.router });
     const meetingRef =
       meeting ||
       (typeof this.view.getSelectedClosedMeetingForEmail === "function"
@@ -21,17 +23,17 @@ export class ProtokollMailFlow {
         : null) || { id: this.view.meetingId };
     const meetingId = meetingRef?.id || this.view.meetingId || null;
 
-    const recOptions = await headerHelper._getMeetingRecipientOptions(meetingId);
+    const recOptions = await payloadService.getMeetingRecipientOptions(meetingId);
     const allRecipients = recOptions.all || [];
-    let selectedRecipients = headerHelper._buildInitialRecipientSelection(recOptions);
+    let selectedRecipients = payloadService.buildInitialRecipientSelection(recOptions);
 
-    const draft = await headerHelper._buildMeetingMailDraft({
+    const draft = await payloadService.buildDraft({
       projectId: this.view.projectId || this.router?.currentProjectId,
       meeting: meetingRef,
       mailType: "",
     });
 
-    const attachments = headerHelper._buildMailAttachmentEntries({
+    const attachments = payloadService.buildAttachmentEntries({
       protocol: printResults?.protocol?.filePath || "",
       firms: printResults?.firms?.filePath || "",
       todo: printResults?.todo?.filePath || "",
@@ -40,7 +42,7 @@ export class ProtokollMailFlow {
 
     if (!attachments[0].path) {
       try {
-        const lookup = await headerHelper._buildProtocolPdfLookupPayload(
+        const lookup = await payloadService.buildProtocolPdfLookupPayload(
           meetingRef,
           this.view.projectId || this.router?.currentProjectId
         );

--- a/src/renderer/modules/protokoll/mail/ProtokollMailPayloadService.js
+++ b/src/renderer/modules/protokoll/mail/ProtokollMailPayloadService.js
@@ -1,0 +1,374 @@
+export class ProtokollMailPayloadService {
+  constructor({ router, getActiveProjectLabel } = {}) {
+    this.router = router || null;
+    this.getActiveProjectLabel =
+      typeof getActiveProjectLabel === "function" ? getActiveProjectLabel : () => "";
+  }
+
+  async getCurrentProjectContext() {
+    const projectId = this.router?.currentProjectId || null;
+    const clean = (value) => String(value || "").trim();
+    const splitProjectLabel = (label) => {
+      const raw = clean(label);
+      if (!raw) return { projectNumber: "", projectShortName: "" };
+      const parts = raw.split(" - ");
+      if (parts.length >= 2) {
+        return {
+          projectNumber: clean(parts.shift()),
+          projectShortName: clean(parts.join(" - ")),
+        };
+      }
+      return { projectNumber: "", projectShortName: raw };
+    };
+
+    if (!projectId) return splitProjectLabel(this.router?.context?.projectLabel || "");
+
+    const api = window.bbmDb || {};
+    if (typeof api.projectsList === "function") {
+      try {
+        const result = await api.projectsList();
+        if (result?.ok && Array.isArray(result.list)) {
+          const project = result.list.find((item) => item && item.id === projectId) || null;
+          if (project) {
+            const projectNumber = clean(project.project_number ?? project.projectNumber ?? "");
+            const projectShortName = clean(
+              project.short ?? project.short_name ?? project.projectShortName ?? ""
+            );
+            if (projectNumber || projectShortName) return { projectNumber, projectShortName };
+          }
+        }
+      } catch (err) {
+        console.warn("[protokoll-mail] project context fallback used:", err);
+      }
+    }
+
+    const fallbackLabel =
+      this.getActiveProjectLabel(projectId) || this.router?.context?.projectLabel || "";
+    return splitProjectLabel(fallbackLabel);
+  }
+
+  formatDate(value) {
+    const raw = String(value || "").trim();
+    if (!raw) return "";
+    const direct = raw.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (direct) return `${direct[3]}.${direct[2]}.${direct[1]}`;
+    const date = new Date(raw);
+    if (Number.isNaN(date.getTime())) return "";
+    const dd = String(date.getDate()).padStart(2, "0");
+    const mm = String(date.getMonth() + 1).padStart(2, "0");
+    return `${dd}.${mm}.${date.getFullYear()}`;
+  }
+
+  async resolveProtocolTitle(projectId = null) {
+    const api = window.bbmDb || {};
+    try {
+      if (projectId && typeof api.projectSettingsGetMany === "function") {
+        const result = await api.projectSettingsGetMany({
+          projectId,
+          keys: ["pdf.protocolTitle"],
+        });
+        const value = String(result?.data?.["pdf.protocolTitle"] || "").trim();
+        if (result?.ok && value) return value;
+      }
+    } catch (_err) {
+      // Bestehender Fallback auf globale Einstellung.
+    }
+    try {
+      if (typeof api.appSettingsGetMany === "function") {
+        const result = await api.appSettingsGetMany(["pdf.protocolTitle"]);
+        const value = String(result?.data?.["pdf.protocolTitle"] || "").trim();
+        if (result?.ok && value) return value;
+      }
+    } catch (_err) {
+      // Bestehender Fallback auf Standardtitel.
+    }
+    return "Baubesprechung";
+  }
+
+  async getStoredTemplate() {
+    const api = window.bbmDb || {};
+    const template = { subject: "", body: "" };
+    if (typeof api.appSettingsGetMany !== "function") return template;
+    try {
+      const result = await api.appSettingsGetMany(["email_subject", "email_body"]);
+      if (!result?.ok) return template;
+      template.subject = String(result.data?.email_subject || "");
+      template.body = String(result.data?.email_body || "");
+    } catch (_err) {
+      // Bestehender Fallback auf leere Vorlage.
+    }
+    return template;
+  }
+
+  buildTemplateContext({ projectNumber, projectShortName, protocolTitle, meeting } = {}) {
+    const clean = (value) => String(value || "").trim();
+    const meetingIndex = clean(
+      meeting?.meeting_index ?? meeting?.meetingIndex ?? meeting?.index ?? meeting?.number ?? ""
+    );
+    const meetingDate = this.formatDate(
+      meeting?.meeting_date ||
+        meeting?.meetingDate ||
+        meeting?.date ||
+        meeting?.created_at ||
+        meeting?.createdAt ||
+        ""
+    );
+    return {
+      projectNumber: clean(projectNumber),
+      projectShortName: clean(projectShortName),
+      protocolTitle: clean(protocolTitle) || "Protokoll",
+      meetingIndex,
+      meetingDate,
+    };
+  }
+
+  defaultSubject(context = {}) {
+    const clean = (value) => String(value || "").trim();
+    const left = [clean(context.projectNumber), clean(context.projectShortName)]
+      .filter(Boolean)
+      .join(" - ");
+    let right = clean(context.protocolTitle) || "Protokoll";
+    if (clean(context.meetingIndex)) right += ` #${clean(context.meetingIndex)}`;
+    if (clean(context.meetingDate)) right += ` - ${clean(context.meetingDate)}`;
+    if (left && right) return `${left}  |  ${right}`;
+    return left || right;
+  }
+
+  applySubjectTemplate(template, context = {}) {
+    const raw = String(template || "");
+    if (!raw.trim()) return this.defaultSubject(context);
+    const replacements = {
+      "{projectNumber}": String(context.projectNumber || ""),
+      "{projectShortName}": String(context.projectShortName || ""),
+      "{protocolTitle}": String(context.protocolTitle || ""),
+      "{meetingIndex}": String(context.meetingIndex || ""),
+      "{meetingDate}": String(context.meetingDate || ""),
+    };
+    let output = raw;
+    Object.entries(replacements).forEach(([token, value]) => {
+      output = output.split(token).join(value);
+    });
+    output = output
+      .replace(/\s+\|\s+\|\s+/g, "  |  ")
+      .replace(/\s*\|\s*/g, "  |  ")
+      .replace(/\s{3,}/g, "  ")
+      .replace(/\s+-\s+-\s+/g, " - ")
+      .replace(/\s+#\s+-/g, " -")
+      .replace(/\|\s*$/g, "")
+      .trim();
+    return output || this.defaultSubject(context);
+  }
+
+  buildFallbackSubject({ projectNumber, projectShortName, mailType } = {}) {
+    const clean = (value) => String(value || "").trim();
+    const base = [clean(projectNumber), clean(projectShortName)].filter(Boolean).join(" - ");
+    const type = clean(mailType);
+    if (!type) return base;
+    return base ? `${base} - ${type}` : type;
+  }
+
+  getDefaultBody() {
+    return (
+      "Sehr geehrte Damen und Herren,\n\n" +
+      "anbei erhalten Sie das neue Protokoll für das oben genannte Projekt mit der Bitte um Beachtung und Veranlassung."
+    );
+  }
+
+  buildInitialRecipientSelection(options = {}) {
+    const all = Array.isArray(options?.all) ? options.all : [];
+    const distribution = Array.isArray(options?.distribution) ? options.distribution : [];
+    if (options?.anyDistributionField && distribution.length) return [...distribution];
+    return [...all];
+  }
+
+  buildAttachmentEntries(attachmentsByKey = {}) {
+    return [
+      { key: "protocol", label: "Protokoll", path: String(attachmentsByKey?.protocol || "").trim(), selected: true },
+      { key: "firms", label: "Firmenliste", path: String(attachmentsByKey?.firms || "").trim(), selected: true },
+      { key: "todo", label: "ToDo-Liste", path: String(attachmentsByKey?.todo || "").trim(), selected: true },
+      { key: "tops", label: "Top-Liste", path: String(attachmentsByKey?.tops || "").trim(), selected: true },
+    ];
+  }
+
+  async buildDraft({ projectId = null, meeting = null, mailType = "", subject = "", body } = {}) {
+    const { projectNumber, projectShortName } = await this.getCurrentProjectContext();
+    const protocolTitle = await this.resolveProtocolTitle(projectId);
+    const emailTemplate = await this.getStoredTemplate();
+    const templateContext = this.buildTemplateContext({
+      projectNumber,
+      projectShortName,
+      protocolTitle,
+      meeting,
+    });
+    const nextSubject =
+      String(subject || "").trim() ||
+      this.applySubjectTemplate(emailTemplate.subject || "", templateContext) ||
+      this.buildFallbackSubject({ projectNumber, projectShortName, mailType }) ||
+      this.defaultSubject(templateContext) ||
+      "Protokoll";
+    let nextBody = typeof body === "string" ? body : String(emailTemplate.body || "");
+    if (!nextBody.trim()) nextBody = this.getDefaultBody();
+    return { subject: nextSubject, body: nextBody, templateContext };
+  }
+
+  async getMeetingRecipientOptions(meetingId = null) {
+    const selectedMeeting =
+      this.router?.activeView?.getSelectedClosedMeetingForEmail?.() ||
+      this.router?.activeView?.getSelectedClosedMeeting?.() ||
+      null;
+    const effectiveMeetingId = meetingId || selectedMeeting?.id || null;
+    if (!effectiveMeetingId) return { distribution: [], all: [], anyDistributionField: false };
+    const api = window.bbmDb || {};
+    if (typeof api.meetingParticipantsList !== "function") {
+      return { distribution: [], all: [], anyDistributionField: false };
+    }
+
+    const readEmail = (item) =>
+      String(
+        item?.email ??
+          item?.email_raw ??
+          item?.mail ??
+          item?.e_mail ??
+          item?.person_email ??
+          item?.personEmail ??
+          item?.participant_email ??
+          item?.participantEmail ??
+          ""
+      ).trim();
+    const distributionKeys = [
+      "isInDistribution",
+      "is_in_distribution",
+      "inDistribution",
+      "in_distribution",
+      "send_email",
+      "sendEmail",
+      "email_enabled",
+      "emailEnabled",
+    ];
+    const hasDistributionField = (item) =>
+      !!item && distributionKeys.some((key) => Object.prototype.hasOwnProperty.call(item, key));
+    const inDistribution = (item) =>
+      Number(
+        distributionKeys
+          .map((key) => item?.[key])
+          .find((value) => value !== undefined && value !== null) ?? 0
+      ) === 1;
+    const uniqueEmails = (items) => {
+      const seen = new Set();
+      const output = [];
+      for (const item of items) {
+        const email = readEmail(item);
+        const key = email.toLowerCase();
+        if (!email || seen.has(key)) continue;
+        seen.add(key);
+        output.push(email);
+      }
+      return output;
+    };
+
+    try {
+      const result = await api.meetingParticipantsList({ meetingId: effectiveMeetingId });
+      const rows = Array.isArray(result?.items)
+        ? result.items
+        : Array.isArray(result?.list)
+          ? result.list
+          : [];
+      if (!result?.ok || !rows.length) {
+        return { distribution: [], all: [], anyDistributionField: false };
+      }
+      const anyDistributionField = rows.some(hasDistributionField);
+      const all = uniqueEmails(rows);
+      if (!anyDistributionField) return { distribution: [...all], all, anyDistributionField: false };
+      return {
+        distribution: uniqueEmails(rows.filter(inDistribution)),
+        all,
+        anyDistributionField: true,
+      };
+    } catch (err) {
+      console.warn("[protokoll-mail] recipients lookup failed:", err);
+      return { distribution: [], all: [], anyDistributionField: false };
+    }
+  }
+
+  async getSelectedMeetingRecipients() {
+    const options = await this.getMeetingRecipientOptions();
+    if (options.anyDistributionField && options.distribution.length) return options.distribution;
+    return options.all.length ? options.all : [];
+  }
+
+  async buildProtocolPdfLookupPayload(selectedMeeting, projectId) {
+    if (!selectedMeeting || !projectId) return null;
+    const api = window.bbmDb || {};
+    if (typeof api.projectsList !== "function" || typeof api.appSettingsGetMany !== "function") {
+      return null;
+    }
+    try {
+      const [projectsResult, settingsResult] = await Promise.all([
+        api.projectsList(),
+        api.appSettingsGetMany(["pdf.protocolsDir", "pdf.protocolTitle"]),
+      ]);
+      if (!projectsResult?.ok || !Array.isArray(projectsResult.list) || !settingsResult?.ok) {
+        return null;
+      }
+      const project = projectsResult.list.find((item) => item && item.id === projectId) || null;
+      const baseDir = String(settingsResult.data?.["pdf.protocolsDir"] || "").trim();
+      const protocolTitle =
+        String(settingsResult.data?.["pdf.protocolTitle"] || "").trim() || "Baubesprechung";
+      if (!project || !baseDir) return null;
+      const cleanPart = (value) =>
+        String(value || "")
+          .replace(/[<>:"/\\|?*]/g, " ")
+          .replace(/\s+/g, " ")
+          .trim();
+      const date = new Date(
+        selectedMeeting?.meeting_date ||
+          selectedMeeting?.meetingDate ||
+          selectedMeeting?.date ||
+          selectedMeeting?.created_at ||
+          selectedMeeting?.createdAt ||
+          selectedMeeting?.updated_at ||
+          selectedMeeting?.updatedAt ||
+          ""
+      );
+      const dateParts = Number.isNaN(date.getTime())
+        ? { dot: "", iso: "" }
+        : {
+            dot: `${String(date.getDate()).padStart(2, "0")}.${String(date.getMonth() + 1).padStart(2, "0")}.${date.getFullYear()}`,
+            iso: `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`,
+          };
+      const meetingIndex =
+        selectedMeeting?.meeting_index ??
+        selectedMeeting?.meetingIndex ??
+        selectedMeeting?.index ??
+        selectedMeeting?.number ??
+        "";
+      const numberPart = cleanPart(
+        project?.project_number ?? project?.projectNumber ?? project?.number ?? ""
+      );
+      const shortPart = cleanPart(project?.short || project?.name || "");
+      const titlePart = cleanPart(protocolTitle);
+      const expectedFileNames = [];
+      if (numberPart && titlePart && meetingIndex && dateParts.iso) {
+        expectedFileNames.push(`${numberPart}_${titlePart}_#${meetingIndex}-${dateParts.iso}.pdf`);
+      }
+      if (numberPart && shortPart && titlePart && meetingIndex && dateParts.dot) {
+        expectedFileNames.push(
+          `${numberPart}_${shortPart}_${titlePart}_#${meetingIndex} - ${dateParts.dot}.pdf`
+        );
+      }
+      return {
+        baseDir,
+        project: {
+          project_number: project?.project_number ?? project?.projectNumber ?? project?.number ?? "",
+          short: project?.short || "",
+          name: project?.name || "",
+        },
+        expectedFileNames,
+        meetingIndex: String(meetingIndex || "").trim(),
+      };
+    } catch (err) {
+      console.warn("[protokoll-mail] protocol pdf lookup payload failed:", err);
+      return null;
+    }
+  }
+}

--- a/src/renderer/ui/MainHeader.js
+++ b/src/renderer/ui/MainHeader.js
@@ -9,6 +9,7 @@ import {
   MailTransportService,
   normalizeMailTransportPayload,
 } from "../features/mail/MailTransportService.js";
+import { ProtokollMailPayloadService } from "../modules/protokoll/mail/ProtokollMailPayloadService.js";
 import { openClosedProtocolSelector } from "./react/ClosedProtocolSelector.js";
 import { resolveProtocolsDir } from "../utils/pdfProtocolsDir.js";
 import { PROTOKOLL_MODULE_ID } from "../app/modules/index.js";
@@ -1874,50 +1875,16 @@ export default class MainHeader {
     this.setStickyNotice(stickyFromContext);
   }
 
+  _getProtokollMailPayloadService() {
+    return new ProtokollMailPayloadService({
+      router: this.router,
+      getActiveProjectLabel: (projectId) =>
+        this._activeLabelForProjectId === projectId ? this._activeLabel : "",
+    });
+  }
+
   async _getCurrentProjectMailContext() {
-    const projectId = this.router?.currentProjectId || null;
-    const clean = (v) => String(v || "").trim();
-    const splitProjectLabel = (label) => {
-      const raw = clean(label);
-      if (!raw) return { projectNumber: "", projectShortName: "" };
-      const parts = raw.split(" - ");
-      if (parts.length >= 2) {
-        return {
-          projectNumber: clean(parts.shift()),
-          projectShortName: clean(parts.join(" - ")),
-        };
-      }
-      return { projectNumber: "", projectShortName: raw };
-    };
-
-    if (!projectId) {
-      return splitProjectLabel(this.router?.context?.projectLabel || "");
-    }
-
-    const api = window.bbmDb || {};
-    if (typeof api.projectsList === "function") {
-      try {
-        const res = await api.projectsList();
-        if (res?.ok && Array.isArray(res.list)) {
-          const project = res.list.find((x) => x && x.id === projectId) || null;
-          if (project) {
-            const projectNumber = clean(project.project_number ?? project.projectNumber ?? "");
-            const projectShortName = clean(project.short ?? project.short_name ?? project.projectShortName ?? "");
-            if (projectNumber || projectShortName) {
-              return { projectNumber, projectShortName };
-            }
-          }
-        }
-      } catch (err) {
-        console.warn("[header] project mail context fallback used:", err);
-      }
-    }
-
-    const fallbackLabel =
-      (this._activeLabelForProjectId === projectId && this._activeLabel) ||
-      this.router?.context?.projectLabel ||
-      "";
-    return splitProjectLabel(fallbackLabel);
+    return await this._getProtokollMailPayloadService().getCurrentProjectContext();
   }
 
   _buildEmailSubject({ projectNumber, projectShortName, mailType } = {}) {
@@ -1932,187 +1899,63 @@ export default class MainHeader {
 
 
 _formatEmailDate(value) {
-  const raw = String(value || "").trim();
-  if (!raw) return "";
-  const direct = raw.match(/^(\d{4})-(\d{2})-(\d{2})/);
-  if (direct) return `${direct[3]}.${direct[2]}.${direct[1]}`;
-  const d = new Date(raw);
-  if (Number.isNaN(d.getTime())) return "";
-  const dd = String(d.getDate()).padStart(2, "0");
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const yyyy = String(d.getFullYear());
-  return `${dd}.${mm}.${yyyy}`;
+  return this._getProtokollMailPayloadService().formatDate(value);
 }
 
 async _resolveProtocolTitleForEmail(projectId = null) {
-  const api = window.bbmDb || {};
-
-  try {
-    if (projectId && typeof api.projectSettingsGetMany === "function") {
-      const res = await api.projectSettingsGetMany({
-        projectId,
-        keys: ["pdf.protocolTitle"],
-      });
-      const value = String(res?.data?.["pdf.protocolTitle"] || "").trim();
-      if (res?.ok && value) return value;
-    }
-  } catch (_err) {
-    // ignore
-  }
-
-  try {
-    if (typeof api.appSettingsGetMany === "function") {
-      const res = await api.appSettingsGetMany(["pdf.protocolTitle"]);
-      const value = String(res?.data?.["pdf.protocolTitle"] || "").trim();
-      if (res?.ok && value) return value;
-    }
-  } catch (_err) {
-    // ignore
-  }
-
-  return "Baubesprechung";
+  return await this._getProtokollMailPayloadService().resolveProtocolTitle(projectId);
 }
 
   async _getStoredEmailTemplate() {
-    const api = window.bbmDb || {};
-    const out = { subject: "", body: "" };
-    if (typeof api.appSettingsGetMany !== "function") return out;
-
-  try {
-    const res = await api.appSettingsGetMany(["email_subject", "email_body"]);
-    if (!res?.ok) return out;
-    const data = res.data || {};
-    out.subject = String(data.email_subject || "");
-    out.body = String(data.email_body || "");
-  } catch (_err) {
-    // ignore
-  }
-
-  return out;
+    return await this._getProtokollMailPayloadService().getStoredTemplate();
 }
 
 _buildEmailTemplateContext({ projectNumber, projectShortName, protocolTitle, meeting } = {}) {
-  const clean = (v) => String(v || "").trim();
-  const idxRaw = meeting?.meeting_index ?? meeting?.meetingIndex ?? meeting?.index ?? meeting?.number ?? "";
-  const idx = clean(idxRaw);
-  const dateRaw =
-    meeting?.meeting_date ||
-    meeting?.meetingDate ||
-    meeting?.date ||
-    meeting?.created_at ||
-    meeting?.createdAt ||
-    "";
-  const date = this._formatEmailDate(dateRaw);
-  return {
-    projectNumber: clean(projectNumber),
-    projectShortName: clean(projectShortName),
-    protocolTitle: clean(protocolTitle) || "Protokoll",
-    meetingIndex: idx,
-    meetingDate: date,
-  };
+  return this._getProtokollMailPayloadService().buildTemplateContext({
+    projectNumber,
+    projectShortName,
+    protocolTitle,
+    meeting,
+  });
 }
 
 _defaultMeetingEmailSubject(context = {}) {
-  const clean = (v) => String(v || "").trim();
-  const left = [clean(context.projectNumber), clean(context.projectShortName)].filter(Boolean).join(" - ");
-  let right = clean(context.protocolTitle) || "Protokoll";
-  if (clean(context.meetingIndex)) right += ` #${clean(context.meetingIndex)}`;
-  if (clean(context.meetingDate)) right += ` - ${clean(context.meetingDate)}`;
-  if (left && right) return `${left}  |  ${right}`;
-  return left || right;
+  return this._getProtokollMailPayloadService().defaultSubject(context);
 }
 
 _applyEmailSubjectTemplate(template, context = {}) {
-  const raw = String(template || "");
-  if (!raw.trim()) return this._defaultMeetingEmailSubject(context);
-  const replacements = {
-    "{projectNumber}": String(context.projectNumber || ""),
-    "{projectShortName}": String(context.projectShortName || ""),
-    "{protocolTitle}": String(context.protocolTitle || ""),
-    "{meetingIndex}": String(context.meetingIndex || ""),
-    "{meetingDate}": String(context.meetingDate || ""),
-  };
-  let out = raw;
-  Object.entries(replacements).forEach(([token, value]) => {
-    out = out.split(token).join(value);
-  });
-  out = out
-    .replace(/\s+\|\s+\|\s+/g, "  |  ")
-    .replace(/\s*\|\s*/g, "  |  ")
-    .replace(/\s{3,}/g, "  ")
-    .replace(/\s+-\s+-\s+/g, " - ")
-    .replace(/\s+#\s+-/g, " -")
-    .replace(/\|\s*$/g, "")
-    .trim();
-  return out || this._defaultMeetingEmailSubject(context);
+  return this._getProtokollMailPayloadService().applySubjectTemplate(template, context);
 }
 
 _buildFallbackEmailSubject({ projectNumber, projectShortName, mailType } = {}) {
-  const clean = (v) => String(v || "").trim();
-  const numberPart = clean(projectNumber);
-  const shortNamePart = clean(projectShortName);
-  const typePart = clean(mailType);
-  const base = [numberPart, shortNamePart].filter(Boolean).join(" - ");
-  if (!typePart) return base;
-  return base ? `${base} - ${typePart}` : typePart;
+  return this._getProtokollMailPayloadService().buildFallbackSubject({
+    projectNumber,
+    projectShortName,
+    mailType,
+  });
 }
 
-  // Fachlicher Mailaufbau:
-  // Projekt-/Protokollbezug, Betreff-Templates und Standardtexte
-  // bleiben hier in der nutzenden Schicht und sind noch kein technischer Versanddienst.
+  // Kompatible Delegationspunkte; die Fachregeln besitzt das Protokollmodul.
   _getDefaultMailBody() {
-    return (
-      "Sehr geehrte Damen und Herren,\n\n" +
-      "anbei erhalten Sie das neue Protokoll für das oben genannte Projekt mit der Bitte um Beachtung und Veranlassung."
-    );
+    return this._getProtokollMailPayloadService().getDefaultBody();
   }
 
   _buildInitialRecipientSelection(recOptions = {}) {
-    const allRecipients = Array.isArray(recOptions?.all) ? recOptions.all : [];
-    const distributionRecipients = Array.isArray(recOptions?.distribution) ? recOptions.distribution : [];
-    if (recOptions?.anyDistributionField && distributionRecipients.length) {
-      return [...distributionRecipients];
-    }
-    return [...allRecipients];
+    return this._getProtokollMailPayloadService().buildInitialRecipientSelection(recOptions);
   }
 
   _buildMailAttachmentEntries(attachmentsByKey = {}) {
-    return [
-      { key: "protocol", label: "Protokoll", path: String(attachmentsByKey?.protocol || "").trim(), selected: true },
-      { key: "firms", label: "Firmenliste", path: String(attachmentsByKey?.firms || "").trim(), selected: true },
-      { key: "todo", label: "ToDo-Liste", path: String(attachmentsByKey?.todo || "").trim(), selected: true },
-      { key: "tops", label: "Top-Liste", path: String(attachmentsByKey?.tops || "").trim(), selected: true },
-    ];
+    return this._getProtokollMailPayloadService().buildAttachmentEntries(attachmentsByKey);
   }
 
   async _buildMeetingMailDraft({ projectId = null, meeting = null, mailType = "", subject = "", body } = {}) {
-    const { projectNumber, projectShortName } = await this._getCurrentProjectMailContext();
-    const protocolTitle = await this._resolveProtocolTitleForEmail(projectId);
-    const emailTemplate = await this._getStoredEmailTemplate();
-    const templateContext = this._buildEmailTemplateContext({
-      projectNumber,
-      projectShortName,
-      protocolTitle,
+    return await this._getProtokollMailPayloadService().buildDraft({
+      projectId,
       meeting,
+      mailType,
+      subject,
+      body,
     });
-
-    let nextSubject = String(subject || "").trim();
-    if (!nextSubject) {
-      nextSubject =
-        this._applyEmailSubjectTemplate(emailTemplate.subject || "", templateContext) ||
-        this._buildFallbackEmailSubject({ projectNumber, projectShortName, mailType }) ||
-        this._defaultMeetingEmailSubject(templateContext) ||
-        "Protokoll";
-    }
-
-    let nextBody = typeof body === "string" ? body : String(emailTemplate.body || "");
-    if (!nextBody.trim()) nextBody = this._getDefaultMailBody();
-
-    return {
-      subject: nextSubject,
-      body: nextBody,
-      templateContext,
-    };
   }
 
   // Technischer Versanddienst:
@@ -2169,187 +2012,18 @@ _buildFallbackEmailSubject({ projectNumber, projectShortName, mailType } = {}) {
   }
 
   async _getMeetingRecipientOptions(meetingId = null) {
-    const selectedMeeting =
-      this.router?.activeView?.getSelectedClosedMeetingForEmail?.() ||
-      this.router?.activeView?.getSelectedClosedMeeting?.() ||
-      null;
-    const mid = meetingId || selectedMeeting?.id || null;
-    if (!mid) return { distribution: [], all: [], anyDistributionField: false };
-
-    const api = window.bbmDb || {};
-    if (typeof api.meetingParticipantsList !== "function") {
-      return { distribution: [], all: [], anyDistributionField: false };
-    }
-
-    const getRows = (res) =>
-      Array.isArray(res?.items) ? res.items : Array.isArray(res?.list) ? res.list : [];
-
-    const readEmail = (item) =>
-      String(
-        item?.email ??
-          item?.email_raw ??
-          item?.mail ??
-          item?.e_mail ??
-          item?.person_email ??
-          item?.personEmail ??
-          item?.participant_email ??
-          item?.participantEmail ??
-          ""
-      ).trim();
-
-    const hasDistributionField = (item) =>
-      item &&
-      (Object.prototype.hasOwnProperty.call(item, "isInDistribution") ||
-        Object.prototype.hasOwnProperty.call(item, "is_in_distribution") ||
-        Object.prototype.hasOwnProperty.call(item, "inDistribution") ||
-        Object.prototype.hasOwnProperty.call(item, "in_distribution") ||
-        Object.prototype.hasOwnProperty.call(item, "send_email") ||
-        Object.prototype.hasOwnProperty.call(item, "sendEmail") ||
-        Object.prototype.hasOwnProperty.call(item, "email_enabled") ||
-        Object.prototype.hasOwnProperty.call(item, "emailEnabled"));
-
-    const inDistribution = (item) =>
-      Number(
-        item?.isInDistribution ??
-          item?.is_in_distribution ??
-          item?.inDistribution ??
-          item?.in_distribution ??
-          item?.send_email ??
-          item?.sendEmail ??
-          item?.email_enabled ??
-          item?.emailEnabled ??
-          0
-      ) === 1;
-
-    try {
-      const res = await api.meetingParticipantsList({ meetingId: mid });
-      const rows = getRows(res);
-      if (!res?.ok || !rows.length) return { distribution: [], all: [], anyDistributionField: false };
-
-      const anyDistributionField = rows.some((item) => hasDistributionField(item));
-      const seenAll = new Set();
-      const all = [];
-      for (const item of rows) {
-        const email = readEmail(item);
-        if (!email) continue;
-        const key = email.toLowerCase();
-        if (seenAll.has(key)) continue;
-        seenAll.add(key);
-        all.push(email);
-      }
-
-      if (!anyDistributionField) {
-        return { distribution: [...all], all, anyDistributionField: false };
-      }
-
-      const dist = [];
-      const seenDist = new Set();
-      for (const item of rows) {
-        if (!inDistribution(item)) continue;
-        const email = readEmail(item);
-        if (!email) continue;
-        const key = email.toLowerCase();
-        if (seenDist.has(key)) continue;
-        seenDist.add(key);
-        dist.push(email);
-      }
-
-      return { distribution: dist, all, anyDistributionField: true };
-    } catch (err) {
-      console.warn("[header] recipients lookup failed:", err);
-      return { distribution: [], all: [], anyDistributionField: false };
-    }
+    return await this._getProtokollMailPayloadService().getMeetingRecipientOptions(meetingId);
   }
 
   async _getSelectedMeetingRecipients() {
-    const opt = await this._getMeetingRecipientOptions();
-    if (opt.anyDistributionField && opt.distribution.length) return opt.distribution;
-    if (opt.all.length) return opt.all;
-    return [];
+    return await this._getProtokollMailPayloadService().getSelectedMeetingRecipients();
   }
 
 async _buildProtocolPdfLookupPayload(selectedMeeting, projectId) {
-  if (!selectedMeeting || !projectId) return null;
-
-  const api = window.bbmDb || {};
-  if (typeof api.projectsList !== "function" || typeof api.appSettingsGetMany !== "function") return null;
-
-  try {
-    const [projectsRes, settingsRes] = await Promise.all([
-      api.projectsList(),
-      api.appSettingsGetMany(["pdf.protocolsDir", "pdf.protocolTitle"]),
-    ]);
-
-    if (!projectsRes?.ok || !Array.isArray(projectsRes.list) || !settingsRes?.ok) return null;
-
-    const project = projectsRes.list.find((x) => x && x.id === projectId) || null;
-    const baseDir = String(settingsRes?.data?.["pdf.protocolsDir"] || "").trim();
-    const protocolTitle =
-      String(settingsRes?.data?.["pdf.protocolTitle"] || "").trim() || "Baubesprechung";
-
-    if (!project || !baseDir) return null;
-
-    const cleanPart = (v) =>
-      String(v || "")
-        .replace(/[<>:"/\\|?*]/g, " ")
-        .replace(/\s+/g, " ")
-        .trim();
-
-    const formatDateParts = (value) => {
-      const d = value instanceof Date ? value : new Date(value);
-      if (Number.isNaN(d.getTime())) return { dot: "", iso: "" };
-      const dd = String(d.getDate()).padStart(2, "0");
-      const mm = String(d.getMonth() + 1).padStart(2, "0");
-      const yyyy = d.getFullYear();
-      return { dot: `${dd}.${mm}.${yyyy}`, iso: `${yyyy}-${mm}-${dd}` };
-    };
-
-    const meetingIndex =
-      selectedMeeting?.meeting_index ??
-      selectedMeeting?.meetingIndex ??
-      selectedMeeting?.index ??
-      selectedMeeting?.number ??
-      "";
-
-    const dateParts = formatDateParts(
-      selectedMeeting?.meeting_date ||
-        selectedMeeting?.meetingDate ||
-        selectedMeeting?.date ||
-        selectedMeeting?.created_at ||
-        selectedMeeting?.createdAt ||
-        selectedMeeting?.updated_at ||
-        selectedMeeting?.updatedAt ||
-        ""
-    );
-
-    const expectedFileNames = [];
-    const numberPart = cleanPart(project?.project_number ?? project?.projectNumber ?? project?.number ?? "");
-    const shortPart = cleanPart(project?.short || project?.name || "");
-    const titlePart = cleanPart(protocolTitle);
-
-    if (numberPart && titlePart && meetingIndex && dateParts.iso) {
-      expectedFileNames.push(`${numberPart}_${titlePart}_#${meetingIndex}-${dateParts.iso}.pdf`);
-    }
-    if (numberPart && shortPart && titlePart && meetingIndex && dateParts.dot) {
-      expectedFileNames.push(
-        `${numberPart}_${shortPart}_${titlePart}_#${meetingIndex} - ${dateParts.dot}.pdf`
-      );
-    }
-
-    return {
-      baseDir,
-      project: {
-        project_number: project?.project_number ?? project?.projectNumber ?? project?.number ?? "",
-        short: project?.short || "",
-        name: project?.name || "",
-      },
-      expectedFileNames,
-      meetingIndex: String(meetingIndex || "").trim(),
-    };
-  } catch (err) {
-    console.warn("[header] protocol pdf lookup payload failed:", err);
-    return null;
-  }
+  return await this._getProtokollMailPayloadService().buildProtocolPdfLookupPayload(
+    selectedMeeting,
+    projectId
+  );
   }
 
 


### PR DESCRIPTION
## Scope
- Teilpaket 4b / Abschluss des Mail-Schritts aus #272
- aktive Regeln für Projekt-/Besprechungskontext, Verteilerempfänger, Betreff/Text, Anhangsliste und Protokoll-PDF-Suche in `ProtokollMailPayloadService` besitzen
- `MainHeader`-Methodennamen als kompatible Delegationspunkte erhalten
- produktiver Abschluss-Mailflow nutzt den Modulservice direkt
- gemeinsamer Outlook/mailto-Transport aus 4a unverändert

## Tests
- `protokollMailPayloadOwnership.test.cjs`: 4/4 grün
- `protokollMailTransportBoundary.test.cjs`: 5/5 grün
- `topsCloseFlow.test.cjs`: 2/2 grün
- neue Dateien ESLint sauber; `git diff --check` grün
- Vollregression: unverändert 0/10 Gruppen, keine neue Fehlerklasse

## Baseline
- ausschließlich bekannte Klassen aus #271/#273: DB-Mock, fehlendes UI-Editor-Kit, drei Popup-Erwartungen, Lizenz-/FeatureGuard-/Development-Erwartungen.