### PR TITLE
Protokoll #272 Paket 5: Teilnehmergrenze trennen

### DIFF
--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -9,6 +9,7 @@ const TEST_GROUPS = Object.freeze([
       ["protokollPdfServiceBoundary.test.cjs", "runProtokollPdfServiceBoundaryTests"],
       ["protokollMailTransportBoundary.test.cjs", "runProtokollMailTransportBoundaryTests"],
       ["protokollMailPayloadOwnership.test.cjs", "runProtokollMailPayloadOwnershipTests"],
+      ["protokollParticipantOwnership.test.cjs", "runProtokollParticipantOwnershipTests"],
       ["gateBRegression.test.cjs", "runGateBRegressionTests"],
       ["ownOrganizationBoundary.test.cjs", "runOwnOrganizationBoundaryTests"],
       ["moduleServiceProviders.test.cjs", "runModuleServiceProviderTests"],

--- a/scripts/tests/moduleIpcRegistration.test.cjs
+++ b/scripts/tests/moduleIpcRegistration.test.cjs
@@ -79,6 +79,7 @@ async function runModuleIpcRegistrationTests(run) {
     const main = read("src/main/main.js");
     assert.equal(main.includes('require("./ipc/meetingsIpc")'), false);
     assert.equal(main.includes('require("./ipc/topsIpc")'), false);
+    assert.match(main, /registerProjectParticipantsIpc\(\)/);
     assert.equal(main.includes('require("./ipc/restarbeitenIpc")'), false);
     assert.equal(main.includes('require("./ipc/rechnungIpc")'), false);
     assert.equal(main.includes("registerRechnungIpc({ ipcMain })"), false);

--- a/scripts/tests/moduleMigrationRegistration.test.cjs
+++ b/scripts/tests/moduleMigrationRegistration.test.cjs
@@ -36,6 +36,8 @@ async function runModuleMigrationRegistrationTests(run) {
     assert.equal(tables.includes("meetings"), false);
     assert.equal(tables.includes("tops"), false);
     assert.equal(tables.includes("meeting_tops"), false);
+    assert.equal(tables.includes("project_candidates"), true);
+    assert.equal(tables.includes("meeting_participants"), false);
     assert.equal(tables.includes("restarbeiten_items"), false);
     assert.equal(tables.includes("invoices"), false);
     db.prepare("INSERT INTO projects (id, name) VALUES (?, ?)").run("core-1", "Core ohne Protokoll");
@@ -61,6 +63,8 @@ async function runModuleMigrationRegistrationTests(run) {
     assert.deepEqual(migrated, ["protokoll", "restarbeiten", "rechnung"]);
     assert.ok(tables.includes("meetings"));
     assert.ok(tables.includes("tops"));
+    assert.ok(tables.includes("project_candidates"));
+    assert.ok(tables.includes("meeting_participants"));
     assert.ok(tables.includes("restarbeiten_items"));
     assert.ok(tables.includes("invoices"));
   }));

--- a/scripts/tests/protokollParticipantOwnership.test.cjs
+++ b/scripts/tests/protokollParticipantOwnership.test.cjs
@@ -1,0 +1,126 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Database = require("better-sqlite3");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+function withDatabase(callback) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-272-participants-"));
+  const db = new Database(path.join(directory, "app.db"));
+  try {
+    db.pragma("foreign_keys = ON");
+    db.exec("CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL)");
+    return callback(db);
+  } finally {
+    db.close();
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function hasTable(db, name) {
+  return !!db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(name);
+}
+
+async function runProtokollParticipantOwnershipTests(run) {
+  await run("#272 Teilnehmer: Core besitzt Stammdaten und Projektpool, aber keine Besprechungsteilnahme", () =>
+    withDatabase((db) => {
+      const { ensureSchema } = require(path.join(process.cwd(), "src/main/db/database.js"));
+      ensureSchema(db, { moduleIds: [] });
+      assert.equal(hasTable(db, "firms"), true);
+      assert.equal(hasTable(db, "persons"), true);
+      assert.equal(hasTable(db, "project_firms"), true);
+      assert.equal(hasTable(db, "project_persons"), true);
+      assert.equal(hasTable(db, "project_candidates"), true);
+      assert.equal(hasTable(db, "meeting_participants"), false);
+    })
+  );
+
+  await run("#272 Teilnehmer: Protokollmigration besitzt Teilnahme, Anwesenheit und Verteiler", () =>
+    withDatabase((db) => {
+      const { ensureSchema } = require(path.join(process.cwd(), "src/main/db/database.js"));
+      ensureSchema(db, { moduleIds: ["protokoll"] });
+      assert.equal(hasTable(db, "project_candidates"), true);
+      assert.equal(hasTable(db, "meeting_participants"), true);
+      const columns = new Set(
+        db.prepare("PRAGMA table_info(meeting_participants)").all().map((column) => column.name)
+      );
+      for (const column of ["meeting_id", "kind", "person_id", "is_present", "is_in_distribution"]) {
+        assert.equal(columns.has(column), true, column);
+      }
+    })
+  );
+
+  await run("#272 Teilnehmer: Meeting-IPC wird nur mit aktivem Protokoll registriert", () => {
+    const { registerActiveModuleIpcs } = require(path.join(
+      process.cwd(),
+      "src/main/moduleIpcRegistry.js"
+    ));
+    const registrars = require(path.join(process.cwd(), "src/main/moduleIpcRegistrars.js"));
+    const handlers = new Map();
+    const ipcMain = { handle: (channel, listener) => handlers.set(channel, listener) };
+    const activeStatus = { valid: true, license: { modules: ["protokoll"] } };
+    registerActiveModuleIpcs({
+      licenseStatus: activeStatus,
+      getLicenseStatus: () => activeStatus,
+      ipcMain,
+      registrars,
+    });
+    for (const channel of ["meetingParticipants:list", "meetingParticipants:set"]) {
+      assert.equal(handlers.has(channel), true, channel);
+    }
+    assert.equal(handlers.has("projectCandidates:list"), false);
+
+    const inactiveHandlers = new Map();
+    registerActiveModuleIpcs({
+      licenseStatus: { valid: true, license: { modules: [] } },
+      ipcMain: { handle: (channel, listener) => inactiveHandlers.set(channel, listener) },
+      registrars,
+    });
+    assert.equal(inactiveHandlers.size, 0);
+  });
+
+  await run("#272 Teilnehmer: Projektpool bleibt als Core-Projektbeziehung verfügbar", () => {
+    const { registerProjectParticipantsIpc } = require(path.join(
+      process.cwd(),
+      "src/main/ipc/participantsIpc.js"
+    ));
+    const handlers = new Map();
+    registerProjectParticipantsIpc({
+      ipcMain: { handle: (channel, listener) => handlers.set(channel, listener) },
+    });
+    assert.deepEqual([...handlers.keys()], [
+      "projectParticipants:pool",
+      "projectCandidates:list",
+      "projectCandidates:set",
+      "projectCandidates:setActive",
+    ]);
+    const source = read("src/main/ipc/participantsIpc.js");
+    assert.match(source, /tableExists\(db, "meetings"\)/);
+    assert.match(source, /tableExists\(db, "meeting_participants"\)/);
+  });
+
+  await run("#272 Teilnehmer: Main und Protokoll registrieren getrennte IPC-Anteile", () => {
+    const main = read("src/main/main.js");
+    const registrar = read("src/main/modules/protokoll/registerIpc.js");
+    assert.match(main, /registerProjectParticipantsIpc\(\)/);
+    assert.equal(main.includes("registerMeetingParticipantsIpc()"), false);
+    assert.match(registrar, /registerMeetingParticipantsIpc\(\{ ipcMain \}\)/);
+  });
+
+  await run("#272 Teilnehmer: Preload bleibt kompatibel ohne ungeguardeten Handler", () => {
+    const preload = read("src/main/preload.js");
+    assert.match(preload, /meetingParticipantsList/);
+    assert.match(preload, /meetingParticipantsSet/);
+    assert.match(preload, /projectCandidatesList/);
+    const registry = read("src/main/moduleIpcRegistry.js");
+    assert.match(registry, /MODULE_NOT_ACTIVE/);
+  });
+}
+
+module.exports = { runProtokollParticipantOwnershipTests };

--- a/src/main/ipc/participantsIpc.js
+++ b/src/main/ipc/participantsIpc.js
@@ -1,5 +1,5 @@
 // src/main/ipc/participantsIpc.js
-const { ipcMain } = require("electron");
+const { ipcMain: electronIpcMain } = require("electron");
 const { initDatabase } = require("../db/database");
 
 function normalizeKind(kind) {
@@ -22,8 +22,15 @@ function normalizeActive(value, fallback = 1) {
   return Number(fallback) ? 1 : 0;
 }
 
+function tableExists(dbConn, tableName) {
+  return !!dbConn
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName);
+}
+
 function removePersonFromOpenMeetings(dbConn, { projectId, kind, personId }) {
   if (!projectId || !kind || !personId) return 0;
+  if (!tableExists(dbConn, "meetings") || !tableExists(dbConn, "meeting_participants")) return 0;
   const info = dbConn
     .prepare(
       `
@@ -145,6 +152,21 @@ function ensureMeetingParticipantsDefaults(dbConn, meetingId) {
 }
 
 function listProjectCandidatesEnriched(dbConn, projectId) {
+  const removalBlockedSelect =
+    tableExists(dbConn, "meetings") && tableExists(dbConn, "meeting_participants")
+      ? `CASE
+          WHEN EXISTS (
+            SELECT 1
+            FROM meetings m
+            INNER JOIN meeting_participants mp ON mp.meeting_id = m.id
+            WHERE m.project_id = pc.project_id
+              AND m.is_closed = 0
+              AND mp.kind = pc.kind
+              AND mp.person_id = pc.person_id
+          ) THEN 1
+          ELSE 0
+        END AS isRemovalBlocked`
+      : "0 AS isRemovalBlocked";
   return dbConn
     .prepare(
       `
@@ -168,18 +190,7 @@ function listProjectCandidatesEnriched(dbConn, projectId) {
           ELSE COALESCE(f.short, f.name, '')
         END AS firm,
 
-        CASE
-          WHEN EXISTS (
-            SELECT 1
-            FROM meetings m
-            INNER JOIN meeting_participants mp ON mp.meeting_id = m.id
-            WHERE m.project_id = pc.project_id
-              AND m.is_closed = 0
-              AND mp.kind = pc.kind
-              AND mp.person_id = pc.person_id
-          ) THEN 1
-          ELSE 0
-        END AS isRemovalBlocked
+        ${removalBlockedSelect}
 
       FROM project_candidates pc
       LEFT JOIN project_persons pp
@@ -353,7 +364,12 @@ function listProjectParticipantsPool(dbConn, projectId) {
     .all(projectId, projectId);
 }
 
-function registerParticipantsIpc() {
+function registerParticipantsIpc({
+  ipcMain = electronIpcMain,
+  includeProject = true,
+  includeMeeting = true,
+} = {}) {
+  if (includeProject) {
   // ============================================================
   // Pool / Lookup
   // ============================================================
@@ -430,8 +446,9 @@ function registerParticipantsIpc() {
       const removed = existing.filter((x) => !newKeys.has(keyOf(x.kind, x.personId)));
 
       // KRITISCHE REGEL: Entfernen blockiert, wenn Person Teilnehmer in irgendeiner offenen Besprechung ist.
-      const checkOpen = db.prepare(
-        `
+      const checkOpen =
+        tableExists(db, "meetings") && tableExists(db, "meeting_participants")
+          ? db.prepare(`
         SELECT m.id, m.meeting_index
         FROM meetings m
         INNER JOIN meeting_participants mp ON mp.meeting_id = m.id
@@ -440,11 +457,11 @@ function registerParticipantsIpc() {
           AND mp.kind = ?
           AND mp.person_id = ?
         LIMIT 1
-      `
-      );
+      `)
+          : null;
 
       for (const r of removed) {
-        const hit = checkOpen.get(projectId, r.kind, r.personId);
+        const hit = checkOpen?.get(projectId, r.kind, r.personId);
         if (hit) {
           return {
             ok: false,
@@ -565,9 +582,12 @@ function registerParticipantsIpc() {
     }
   });
 
+  }
+
   // ============================================================
   // Teilnehmer (Meeting)
   // ============================================================
+  if (includeMeeting) {
   ipcMain.handle("meetingParticipants:list", (event, data) => {
     try {
       const meetingId = data?.meetingId;
@@ -659,6 +679,19 @@ function registerParticipantsIpc() {
       return { ok: false, error: err?.message || String(err) };
     }
   });
+  }
 }
 
-module.exports = { registerParticipantsIpc };
+function registerProjectParticipantsIpc(options = {}) {
+  return registerParticipantsIpc({ ...options, includeProject: true, includeMeeting: false });
+}
+
+function registerMeetingParticipantsIpc(options = {}) {
+  return registerParticipantsIpc({ ...options, includeProject: false, includeMeeting: true });
+}
+
+module.exports = {
+  registerParticipantsIpc,
+  registerProjectParticipantsIpc,
+  registerMeetingParticipantsIpc,
+};

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -38,7 +38,7 @@ if (uiEditorAcceptanceProfile.enabled) {
 const { registerProjectsIpc } = require("./ipc/projectsIpc");
 const { registerCoreProjectFirmsIpc } = require("./core/projectFirmsCore");
 const { registerFirmDirectoryIpc } = require("./ipc/firmDirectoryIpc");
-const { registerParticipantsIpc } = require("./ipc/participantsIpc");
+const { registerProjectParticipantsIpc } = require("./ipc/participantsIpc");
 const { registerPrintIpc } = require("./ipc/printIpc");
 const { registerTableLayoutsIpc } = require("./ipc/tableLayoutsIpc");
 const { registerSettingsIpc } = require("./ipc/settingsIpc");
@@ -578,7 +578,7 @@ app.whenReady().then(async () => {
   registerProjectsIpc();
   registerCoreProjectFirmsIpc();
   registerFirmDirectoryIpc();
-  registerParticipantsIpc();
+  registerProjectParticipantsIpc();
   registerPrintIpc();
   registerTableLayoutsIpc();
   registerSettingsIpc();

--- a/src/main/modules/protokoll/registerIpc.js
+++ b/src/main/modules/protokoll/registerIpc.js
@@ -1,11 +1,13 @@
 const { registerMeetingsIpc } = require("../../ipc/meetingsIpc");
 const { registerTopsIpc } = require("../../ipc/topsIpc");
 const { registerProjectSettingsIpc } = require("../../ipc/projectSettingsIpc");
+const { registerMeetingParticipantsIpc } = require("../../ipc/participantsIpc");
 
 function registerIpc({ ipcMain } = {}) {
   registerMeetingsIpc({ ipcMain });
   registerTopsIpc({ ipcMain });
   registerProjectSettingsIpc({ ipcMain });
+  registerMeetingParticipantsIpc({ ipcMain });
 }
 
 module.exports = Object.freeze({ registerIpc });

--- a/src/renderer/modules/protokoll/README.md
+++ b/src/renderer/modules/protokoll/README.md
@@ -59,6 +59,16 @@ Empfaenger aus dem fachlichen Verteiler, Protokoll-Betreff/-Text, Anhangsliste u
 dem gespeicherten Protokoll-PDF. `MainHeader` behaelt seine bisherigen Methodennamen nur als
 Delegationspunkte fuer bestehende Aufrufer.
 
+## Teilnehmer-/Stammdatengrenze
+
+Globale `firms`/`persons`, allgemeine Projektzuordnungen und `project_candidates` bleiben
+Core-Stammdaten bzw. Core-Projektbeziehungen. Das Protokoll referenziert diese Identitaeten nur.
+`meeting_participants` besitzt Teilnahme, Anwesenheit und Verteiler einer konkreten Besprechung
+und wird ausschließlich mit der Protokollmigration erzeugt. Der bisher kombinierte IPC-Bestand
+ist entlang derselben Grenze registriert: Projektpool/-kandidaten im Core,
+`meetingParticipants:*` ausschließlich über den guarded Protokoll-Registrar. Die statischen
+Preload-Funktionen bleiben kompatibel.
+
 Die Ordner `components/`, `domain/`, `data/`, `state/`, `viewmodel/`, `dialogs/` und `rules/`
 sind absichtlich schon angelegt, damit spaetere Umzuege dort sauber anschliessen koennen.
 


### PR DESCRIPTION
## Scope
- globale Firmen/Personen, Projektzuordnungen und `project_candidates` bleiben Core
- `meeting_participants` bleibt Protokollschema
- kombinierte Teilnehmer-IPC selektiv registrieren: Projektpool/-kandidaten Core, `meetingParticipants:*` guarded Protokoll
- Core-Projektpool prüft optionale Besprechungsreferenzen nur, wenn Protokolltabellen existieren
- Preload und produktive Datenformen unverändert

## Tests
- `protokollParticipantOwnership.test.cjs`: 6/6 grün
- `moduleIpcRegistration.test.cjs`: 7/7 grün
- `moduleMigrationRegistration.test.cjs`: 7/7 grün
- ESLint 0 neue Fehler; `git diff --check` grün
- Vollregression unverändert 0/10 Gruppen, keine neue Klasse

## Besondere Abgrenzung
Eine zunächst erwogene Verschiebung von `project_candidates` wurde vor Commit verworfen, weil dies die Core-Projektbeziehung und Projektfirmenoperationen beeinträchtigt hätte. Der PR enthält ausschließlich die korrigierte Grenzziehung.