### PR TITLE
Protokoll #272 Paket 7: Abschlussregression dokumentieren

### DIFF
--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -118,7 +118,7 @@ Der aktuell sinnvolle Hauptfokus liegt auf **Achse B und Achse C**, flankiert vo
 - kleine Nachweise und Konsolidierungen mitziehen, wo sie den Umbau direkt belegen
 - der erreichte Screen-Stand in `Protokoll` bleibt dabei sichtbar abgesichert
 - M21-Einordnung: `Restarbeiten` ist erreichbar, aber fachlich/funktional unfertig und fuer den UI-Editor nur Pilot-Scope.
-- M21-Einordnung: `Protokoll` ist noch nicht fertig bereinigt und wird fuer UI-Editor-Themen defensiv/read-only behandelt.
+- M21-Einordnung: Die Besitzgrenzen der Protokoll-Revision #272 sind abgeschlossen; fuer UI-Editor-Themen wird der produktive Bestand weiterhin defensiv/read-only behandelt.
 - M21-Einordnung: BBM-Produktiv ist Beispiel-/Pilot-Zielapp fuer das generische UI-Editor-kit; die Ziel-App liefert die ElementRegistry, der Editor liest ausschliesslich diese Registry.
 - Keine Selbstuntersuchung der Ziel-App-Oberflaeche, keine automatische UI-Erkennung, kein UI-Scanning, kein DOM-Scan und keine automatische Registry-Befuellung.
 - M80.2 ist `[A]` abgenommen: tatsächlicher Restarbeiten-Header und stabiler Editbox-Root sind direkt größenfähig, der alte Splitpfad ist gesperrt und die Hauptliste als flexibler Scrollbereich gesichert. M80.2a stabilisiert ausschließlich Testharness und Node-/Electron-ABI-Wechsel. M81 und M81.1 sind abgenommen; M81.1 trennt alte/beschädigte Benutzerprofile vom gültigen Electron-Handshake und archiviert sie vor einem Baselinestart byte-identisch. M82 ist als deklarative App-Starterpaket-Bestandsreferenz `[A]` abgenommen. M82.1 ergänzt ausschließlich Start-Restore, Direktauswahl und begrenzte Layoutwirkung und ist nach vollständiger sichtbarer Abnahme `[A]` abgenommen. M82.2 bindet ausschließlich den gemeinsamen Geführt-/Frei-Geometrierisikovertrag an dieselben Registry-, Pipe-, HostAdapter- und Profilwege an und ist nach vollständiger sichtbarer UI-/PDF-Abnahme mit kontrolliertem Diagnostic-Build `[A]` abgenommen. Der Fachausbau bleibt offen.
@@ -158,7 +158,7 @@ Wenn der reale Repo-Stand einen kleineren und ehrlicheren naechsten Schritt zeig
 - weitere kleine Kernstellen fuer den aktiven Modulumfang sind noch moeglich
 
 ### 6.2 Container 4 – Fachmodul `Protokoll`
-**Status:** weit vorbereitet, Uebergangscontainer aktiv
+**Status:** Revision #272 abgeschlossen; erhaltener Unterbau aktiv
 
 **Erreicht**
 - sichtbare Modulheimat
@@ -173,11 +173,16 @@ Wenn der reale Repo-Stand einen kleineren und ehrlicheren naechsten Schritt zeig
 - ein kleiner Nachweis fuer den entmischten Screen-Stand ist vorhanden
 - die Diktat-Buttons nutzen jetzt die vorhandenen SVG-Assets und sitzen direkt neben der Restzeichenanzeige in der echten Tops-Editbox
 - Protokoll-Popups verwenden die gemeinsame, an der realen Header-Unterkante ausgerichtete Popup-Flaeche; Projekt und Mail sind ohne fachliche Aenderung an dieselbe Basis angeschlossen
+- kanonischer produktiver Moduleinstieg und reine `views/TopsScreen.js`-Kompatibilitaet sind nachgewiesen
+- protokollspezifische Settings besitzen einen gemeinsamen Modulvertrag und modulare IPC-Grenze
+- PDF und Mail laufen ueber gemeinsame technische Dienste; Fachpayload und Abschlussregeln bleiben Protokollbesitz
+- Besprechungsteilnahme, Anwesenheit und Verteiler sind von Core-Stammdaten und Projektpool getrennt
+- nachweislich tote Parallel- und Settings-Legacypfade sind entfernt; notwendige Kompatibilitaets-Re-Exports bleiben erhalten
+- der vollstaendige Kriterien- und Baselinebericht steht in `docs/PROTOKOLL_REVISION_272.md`
 
 **Noch offen**
-- grosser Unterbau liegt weiter unter `src/renderer/tops/`
-- tieferer Unterbau und weitere Restentmischung in `Protokoll` bleiben offen
-- weitere direkte `tops/`-Altpfade sind fuer spaetere Minischritte noch vorhanden
+- der grosse Unterbau unter `src/renderer/tops/` bleibt bewusst erhalten und ist kein konkurrierender Moduleinstieg
+- tiefere Router-/Strukturkonsolidierung bleibt gemaess #272 eine spaetere, bedarfsgetriebene Arbeit
 
 ### 6.3 Container 5 – Fachmodul `weitere Module`
 **Status:** sichtbar, klein, kontrolliert ausbaufaehig

--- a/docs/PROTOKOLL_REVISION_272.md
+++ b/docs/PROTOKOLL_REVISION_272.md
@@ -1,0 +1,57 @@
+# Protokoll-Revision #272
+
+Stand: 2026-09-06, aufbauend auf Gesamtplan #277, abgeschlossenem Core #271 / Gate B
+und abgeschlossener Restarbeiten-Stabilisierung #273.
+
+## Ergebnis
+
+**Revision #272 ist damit erfuellt.** Die vorhandene produktive Protokoll-Fachlogik bleibt
+erhalten; ihre Besitzgrenzen zu Core und gemeinsamen technischen Diensten sind nachgewiesen.
+
+| Revisionspunkt | Ergebnis | Integrierter Nachweis |
+| --- | --- | --- |
+| Produktiver Pfad | `modules/protokoll/index.js` ist der kanonische Einstieg; `renderer/tops/` bleibt erhaltener modulinterner Unterbau | PR #301, `db82d90` |
+| Settings | globale und projektbezogene Protokollsettings besitzen einen gemeinsamen Modulvertrag und modulare IPC-Registrierung | PR #302, `269eafd` |
+| PDF / Print | Fachflow bestimmt Dokumente und Kontext; `PdfDocumentService` führt nur gelieferte technische Operationen aus | PR #303, `0b5ec87` |
+| Mailtransport | Outlook/mailto, Transportnormalisierung und technische Fehler liegen im gemeinsamen `MailTransportService` | PR #304, `280acba` |
+| Mailpayload | Verteiler, Betreff/Text, Anhänge und Protokoll-PDF-Suche liegen im `ProtokollMailPayloadService` | PR #305, `e6bbb4f` |
+| Teilnehmer / Verteiler | Core besitzt Stammdaten und Projektpool; Protokoll besitzt Besprechungsteilnahme, Anwesenheit und Verteiler | PR #306, `36759e8` |
+| Legacy-Close-Flow | nur der import- und runtime-seitig unreferenzierte Parallelbestand wurde entfernt; nötige Re-Exports bleiben | PR #307, `51e023a` |
+| Legacy-Settings | zwei aufruflose Altimplementierungen wurden entfernt; die produktiven Moduldelegationen bleiben | PR #308, `4e72710` |
+
+## Kanonischer Runtime-Pfad
+
+Modulkatalog und Router öffnen den Protokoll-Moduleinstieg. Dieser registriert den modulnahen
+`TopsScreenIntegrationView`, der den erhaltenen produktiven TopsScreen erweitert.
+`src/renderer/views/TopsScreen.js` ist ausschließlich ein Kompatibilitäts-Re-Export. Der tiefere
+Bestand unter `src/renderer/tops/` ist kein konkurrierendes Fachmodul und wurde ohne funktionalen
+Anlass nicht kosmetisch verschoben.
+
+## Abschlussregression
+
+- `protokollRevision272Regression.test.cjs`: 7/7 Kriterien grün.
+- Sämtliche Paketnachweise zu Pfad, Settings, PDF, Mail, Teilnehmern und Legacy bleiben in der
+  Gruppe `core-protokoll` registriert.
+- Fachregressionen für Store, Selectors, Commands, CloseFlow, TOP-Hierarchie, ActionPolicy,
+  Screen-Integration und den realen Protokoll-Acceptance-Pfad bleiben Bestandteil derselben Gruppe.
+- Die vollständige Regression `npm test` endet weiterhin mit 0/10 grünen Gruppen, aber ohne neue
+  Fehlerklasse gegenüber der vor #272 dokumentierten Baseline.
+
+## Baselineabgrenzung
+
+Unverändert bekannt sind:
+
+1. `meetingTopsRepo`: Test-DB-Mock ohne `db.transaction` über die bestehende Rechnungs-Migrationsinitialisierung.
+2. Fehlende `ui-editor-kit`-Artefakte bzw. -Module in mehreren Testgruppen.
+3. Drei bestehende Popup-Standard-Erwartungen.
+4. Historische Lizenz-/Alias-/FeatureGuard-Erwartungen.
+5. Development-License-Modulliste und MainHeader-Kennzeichnung.
+
+Diese Fehler wurden durch die Protokollpakete nicht erzeugt und nicht als Protokollfehler umklassifiziert.
+
+## Scopegrenze
+
+Nicht vorgezogen wurden Rechnungs-, SiGeKo- oder Mobil-Arbeiten. Es gab keinen Neuaufbau des
+Protokolls, keine neue PDF- oder Mailengine, keine fachliche Änderung bestätigter TOP- oder
+Besprechungsregeln und keine ungeprüfte Massenlöschung. Die in #272 als **SPÄTER** klassifizierte
+tiefe Router- oder Strukturkonsolidierung bleibt ausdrücklich außerhalb dieses Abschlusses.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -4,6 +4,7 @@ const TEST_GROUPS = Object.freeze([
     label: "Kern, Protokoll und Projektfirmen",
     includeStoragePathTests: true,
     suites: Object.freeze([
+      ["protokollRevision272Regression.test.cjs", "runProtokollRevision272RegressionTests"],
       ["protokollRevision272Path.test.cjs", "runProtokollRevision272PathTests"],
       ["protokollSettingsOwnership.test.cjs", "runProtokollSettingsOwnershipTests"],
       ["protokollPdfServiceBoundary.test.cjs", "runProtokollPdfServiceBoundaryTests"],

--- a/scripts/tests/protokollRevision272Regression.test.cjs
+++ b/scripts/tests/protokollRevision272Regression.test.cjs
@@ -1,0 +1,72 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+async function runProtokollRevision272RegressionTests(run) {
+  const groups = read("scripts/testGroups.cjs");
+
+  await run("Protokoll #272 Regression: kanonischer Moduleinstieg bleibt produktiv", () => {
+    const catalog = read("src/renderer/app/modules/moduleCatalog.js");
+    const moduleIndex = read("src/renderer/modules/protokoll/index.js");
+    assert.match(catalog, /modules\/protokoll\/index\.js/);
+    assert.match(moduleIndex, /TopsScreenIntegrationView\.js/);
+    assert.equal(catalog.includes("views/TopsScreen.js"), false);
+  });
+
+  await run("Protokoll #272 Regression: Settings bleiben Modulbesitz", () => {
+    const settings = read("src/renderer/views/SettingsView.js");
+    const project = read("src/renderer/modules/projektverwaltung/screens/ProjectFormScreen.js");
+    assert.match(settings, /openGlobalProtocolSettings\(\{ host: this \}\)/);
+    assert.match(project, /openProtocolSettingsModal\(\{ projectId: this\.projectId \}\)/);
+    assert.equal(settings.includes("_createLegacyProtocolContent"), false);
+    assert.equal(project.includes("_openLegacyProjectSettingsModal"), false);
+    assert.match(read("src/main/modules/protokoll/registerIpc.js"), /registerProjectSettingsIpc/);
+  });
+
+  await run("Protokoll #272 Regression: PDF und Mail nutzen gemeinsame Dienstgrenzen", () => {
+    const closeFlow = read("src/renderer/tops/domain/TopsCloseFlow.js");
+    const mailFlow = read("src/renderer/modules/protokoll/mail/ProtokollMailFlow.js");
+    assert.match(closeFlow, /PdfDocumentService/);
+    assert.match(closeFlow, /ProtokollMailFlow/);
+    assert.match(mailFlow, /ProtokollMailPayloadService/);
+    assert.match(read("src/renderer/ui/MainHeader.js"), /MailTransportService/);
+  });
+
+  await run("Protokoll #272 Regression: Besprechungsteilnahme bleibt vom Core-Pool getrennt", () => {
+    const main = read("src/main/main.js");
+    const registrar = read("src/main/modules/protokoll/registerIpc.js");
+    assert.match(main, /registerProjectParticipantsIpc\(\)/);
+    assert.equal(main.includes("registerMeetingParticipantsIpc"), false);
+    assert.match(registrar, /registerMeetingParticipantsIpc\(\{ ipcMain \}\)/);
+  });
+
+  await run("Protokoll #272 Regression: nur nachgewiesenes Legacy ist entfernt", () => {
+    assert.equal(fs.existsSync(path.join(process.cwd(), "src/renderer/features/output/CloseMeetingOutputFlow.js")), false);
+    assert.match(read("src/renderer/views/TopsScreen.js"), /modules\/protokoll\/screens\/TopsScreen/);
+    assert.match(read("src/renderer/features/mail/MailFlow.js"), /ProtokollMailFlow as MailFlow/);
+  });
+
+  await run("Protokoll #272 Regression: Fachlogik-Nachweise bleiben im relevanten Lauf", () => {
+    for (const suite of [
+      "topsStore.test.cjs", "topsSelectors.test.cjs", "topsCommands.test.cjs",
+      "topsCloseFlow.test.cjs", "topServiceHierarchy.test.cjs", "topsActionPolicy.test.cjs",
+      "topsScreen.integration.test.cjs", "m86-2-2ProtokollAcceptanceSeeder.test.cjs",
+    ]) assert.equal(groups.includes(suite), true, suite);
+  });
+
+  await run("Protokoll #272 Regression: alle Revisionspakete sind dauerhaft registriert", () => {
+    for (const suite of [
+      "protokollRevision272Path.test.cjs", "protokollSettingsOwnership.test.cjs",
+      "protokollPdfServiceBoundary.test.cjs", "protokollMailTransportBoundary.test.cjs",
+      "protokollMailPayloadOwnership.test.cjs", "protokollParticipantOwnership.test.cjs",
+      "protokollLegacyProof.test.cjs",
+    ]) assert.equal(groups.includes(suite), true, suite);
+    assert.match(read("docs/PROTOKOLL_REVISION_272.md"), /Revision #272 ist damit erfuellt/);
+  });
+}
+
+module.exports = { runProtokollRevision272RegressionTests };


### PR DESCRIPTION
## Scope
Bündelt ausschließlich den Abschlussnachweis der Protokoll-Revision #272:
- 7 dauerhafte Revisionskriterien im Testharness
- konsistenter Kriterien-/Baselinebericht
- Statuspflege im bestehenden Modularisierungsplan

Keine produktive Fach-, UI-, DB-, PDF-, Mail- oder Routerlogik wird geändert.

## Nachweise
- alle #272-Pakettests einschließlich Abschlusskriterien: 38/38 grün
- Abschlusskriterien: 7/7 grün
- relevante Protokoll-Fachregression: 24/25; ausschließlich bekannte `meetingTopsRepo`-Mockbaseline
- vollständiger `npm test`: 0/10 Gruppen, exakt bekannte Baselineklassen
- ESLint des neuen Tests: 0 Fehler
- `git diff --check`: grün

## Baseline
Unverändert: `meetingTopsRepo`-Mock ohne `db.transaction`, fehlendes `ui-editor-kit`, drei Popup-Standard-Erwartungen sowie bekannte Lizenz-/Alias-/Development-Erwartungen. Keine neue Fehlerklasse.

## Bewertung
Der Bericht bewertet ausschließlich den in #272 definierten Protokoll-Scope. Tiefe Router-/Strukturkonsolidierung bleibt gemäß #272 **SPÄTER**; Rechnungs-, SiGeKo- und Mobil-Arbeiten wurden nicht vorgezogen.