### PR TITLE
Rechnung #275 Paket 1: Bestandsbergung festlegen

### DIFF
--- a/docs/RECHNUNG_REVISION_275.md
+++ b/docs/RECHNUNG_REVISION_275.md
@@ -1,0 +1,68 @@
+# Rechnung – Revision #275
+
+Stand: 2026-09-06, Paket 1 / R2 Bestandsbergung.
+
+## Integrationsbasis
+
+`main` bleibt die einzige Integrationsbasis. Der Rechnungsbestand wird nicht neu
+aufgebaut und kein historischer Branch wird pauschal gemergt.
+
+Geprüfte Stände:
+
+| Stand | Ergebnis |
+| --- | --- |
+| `rechnung-integration` | vollständig Vorfahr von `main` |
+| `rechnung-r2-i1-integration` | vollständig Vorfahr von `main` |
+| `rechnung-r2-i2-integration` | vollständig Vorfahr von `main` |
+| `backup/rechnung-entwicklung-vor-bereinigung-2026-08-16` | historische Quelle; der relevante Fachbestand ist auf `main` in neuerer Form vorhanden |
+| `rechnung-entwicklung` | abgezweigter Plan-/Entwicklungsstand; produktive Fachänderungen sind auf `main` weitergeführt, gemeinsame Altinfrastruktur wird nicht übernommen |
+
+## Auf `main` geborgener Zielbestand
+
+- Fachmodul und UI unter `src/renderer/modules/rechnungen/`
+- kanonischer hybrider Moduldeskriptor `rechnung`
+- modulare IPC- und Migrationsregistrare
+- `InvoiceService`, `InvoiceRepository` und Rechnungsfachmigration
+- gemeinsame Firmenbasis mit fachlicher Verwendung `invoice_customer`
+- freie und projektbezogene Rechnung
+- Rechnungsarten, Leistungszeitraum, Zahlungsziel und Fälligkeit
+- Entwurf, Vorschau, Buchung und Nummernkreis
+- Positionshierarchie, EP/GP sowie Netto/MwSt./Brutto
+- Rechnungs-PDF-V2 über die bestehende gemeinsame Printpipeline
+- rechnungseigene Shared-Regeln und UI-Editor-Registrierung
+- bestehende Rechnungsregressionen in der Testgruppe `rechnungen-design`
+
+## Nicht übernehmen
+
+- alte Core-, Router-, Lizenz- oder Navigationsteile
+- alte direkte IPC-/Migrationsverdrahtungen außerhalb der Modulregistrare
+- zweite Firmen-, Projekt- oder SQLite-Struktur
+- zweite PDF-, Mail-, Export- oder Speicherengine
+- ältere UI-/Editorstände, welche den aktuellen `main`-Stand zurücksetzen würden
+- historische Arbeitsaufträge als neue technische Wahrheit
+
+## Offene Reihenfolge ab Paket 2
+
+1. Eigenständiges `InvoiceIssuerProfile` auf Basis, aber nicht als Teil, von
+   `OwnOrganization` einführen und auf Bestands-DB migrieren.
+2. Empfänger- und Aussteller-Snapshots sowie Buchungsimmutabilität vollständig
+   gegen Stammdatenänderungen sichern; Nummernkreis und rechtlich relevante
+   Belegdaten prüfen.
+3. Freie Rechnung und Auftrags-LV einschließlich Nachträgen stabilisieren.
+4. Abschlag, Schluss, Stundenlohn sowie Steuer-/Zahlungslogik stabilisieren.
+5. PDF, Mail und Export an die gemeinsamen Providerverträge anschließen.
+6. Erst nach stabilem Fachkern E-Rechnung/ZUGFeRD und danach GAEB bearbeiten.
+7. Abschließende Modul-, Bestands-DB- und Mehrmodulregression durchführen.
+
+## Aktuell belegte R3-Lücke
+
+Der bestehende Aussteller-Snapshot wird noch direkt aus `user_profile`
+gebildet. Damit fehlt das in #275 geforderte eigenständige
+`InvoiceIssuerProfile`. Diese Lücke wird nicht in Paket 1 verdeckt oder durch
+eine Branchübernahme umgangen, sondern ist Gegenstand des nächsten Pakets.
+
+## Paket-1-Scope
+
+Paket 1 verändert keinen Produktcode, keine UI und keine PDF-Ausgabe. Es hält
+den geborgenen Bestand, ausgeschlossene Altinfrastruktur und die nächste
+fachliche Lücke reproduzierbar fest.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -68,6 +68,7 @@ const TEST_GROUPS = Object.freeze([
     id: "rechnungen-design",
     label: "Rechnungen UI-Designreferenz",
     suites: Object.freeze([
+      ["rechnungRevision275Inventory.test.cjs", "runRechnungRevision275InventoryTests"],
       ["rechnungenDesignModule.test.cjs", "runRechnungenDesignModuleTests"],
       ["rechnungHeaderRules.test.cjs", "runRechnungHeaderRulesTests"],
       ["rechnungBooking.test.cjs", "runRechnungBookingTests"],

--- a/scripts/tests/rechnungRevision275Inventory.test.cjs
+++ b/scripts/tests/rechnungRevision275Inventory.test.cjs
@@ -1,0 +1,76 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.resolve(__dirname, "../..");
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+async function runRechnungRevision275InventoryTests(run) {
+  await run("Rechnung #275 R2: geborgene Fachbasis ist auf main vollständig vorhanden", () => {
+    const requiredFiles = [
+      "src/main/db/invoiceMigrations.js",
+      "src/main/db/invoiceRepository.js",
+      "src/main/domain/rechnung/InvoiceService.js",
+      "src/main/domain/rechnung/InvoicePdfFinalizer.js",
+      "src/main/ipc/rechnungIpc.js",
+      "src/main/modules/rechnung/registerIpc.js",
+      "src/main/modules/rechnung/registerMigrations.js",
+      "src/renderer/modules/rechnungen/screens/RechnungScreen.js",
+      "src/renderer/modules/rechnungen/print/InvoicePrintContent.js",
+      "src/shared/rechnung/invoiceHeaderRules.mjs",
+      "src/shared/rechnung/rechnungPositions.mjs",
+    ];
+    requiredFiles.forEach((relativePath) => {
+      assert.equal(fs.existsSync(path.join(root, relativePath)), true, relativePath);
+    });
+  });
+
+  await run("Rechnung #275 R2: Modul nutzt kanonische Registrare und gemeinsame Dienste", () => {
+    const moduleEntry = read("src/renderer/modules/rechnungen/index.js");
+    assert.match(moduleEntry, /RECHNUNG_MODULE_ID = "rechnung"/);
+    assert.match(moduleEntry, /moduleType: "hybrid"/);
+    assert.match(moduleEntry, /ipcRegistrar: "rechnung"/);
+    assert.match(moduleEntry, /migrationRegistrar: "rechnung"/);
+    for (const capability of ["pdf", "mail", "export", "file-storage", "ui-editor"]) {
+      assert.equal(moduleEntry.includes(`"${capability}"`), true, capability);
+    }
+  });
+
+  await run("Rechnung #275 R2: keine zweite Rechnungsdatenbank wird eingeführt", () => {
+    const sourceFiles = [
+      "src/main/db/invoiceMigrations.js",
+      "src/main/db/invoiceRepository.js",
+      "src/main/domain/rechnung/InvoiceService.js",
+      "src/main/ipc/rechnungIpc.js",
+    ];
+    const combined = sourceFiles.map(read).join("\n");
+    assert.doesNotMatch(combined, /rechnung\.db|invoice\.db/i);
+    assert.match(read("src/main/modules/rechnung/registerMigrations.js"), /migrations\.ensureInvoiceSchema\(db\)/);
+  });
+
+  await run("Rechnung #275 R2: nächste Identitätslücke ist ehrlich dokumentiert", () => {
+    const report = read("docs/RECHNUNG_REVISION_275.md");
+    assert.match(report, /`main` bleibt die einzige Integrationsbasis/);
+    assert.match(report, /Nicht übernehmen/);
+    assert.match(report, /eigenständige[s\n ]+`InvoiceIssuerProfile`/);
+    assert.match(read("src/main/db/invoiceRepository.js"), /SELECT \* FROM user_profile WHERE id = 1/);
+  });
+}
+
+module.exports = { runRechnungRevision275InventoryTests };
+
+if (require.main === module) {
+  let failures = 0;
+  runRechnungRevision275InventoryTests(async (name, test) => {
+    try {
+      await test();
+      console.log(`ok - ${name}`);
+    } catch (error) {
+      failures += 1;
+      console.error(`not ok - ${name}`);
+      console.error(error?.stack || error);
+    }
+  }).then(() => {
+    process.exitCode = failures ? 1 : 0;
+  });
+}


### PR DESCRIPTION
## Paket
R2 – vorhandenen Rechnungsbestand bergen und Integrationsbasis festlegen.

## Enthalten
- geprüfte Rechnungsbranches und bereits integrierten Fachbestand dokumentiert
- `main` als alleinige Integrationsbasis festgelegt
- ausgeschlossene alte Core-/Router-/Lizenz-/PDF-/Mail-Infrastruktur festgehalten
- nächste belastbare Lücke (`InvoiceIssuerProfile`) ausdrücklich benannt
- vier reproduzierbare Inventar-/Grenztests in der Rechnungsgruppe registriert

## Nicht enthalten
Keine Änderung an Produktcode, UI, PDF, Identitäten, Buchung, Fachworkflow, Core oder anderen Fachmodulen.

## Tests
- Pakettest 4/4 grün
- `git diff --check` grün
- unabhängige Rechnungsfachtests bis zu bekannten/verdeckt vorhandenen Baselinefehlern grün
- Volltest unverändert in den dokumentierten #271-Fehlerklassen; keine neue Regression

Refs #275