### PR TITLE
Rechnung #275 Paket 2: Ausstellerprofil trennen

### DIFF
--- a/docs/RECHNUNG_REVISION_275.md
+++ b/docs/RECHNUNG_REVISION_275.md
@@ -66,3 +66,15 @@ eine Branchübernahme umgangen, sondern ist Gegenstand des nächsten Pakets.
 Paket 1 verändert keinen Produktcode, keine UI und keine PDF-Ausgabe. Es hält
 den geborgenen Bestand, ausgeschlossene Altinfrastruktur und die nächste
 fachliche Lücke reproduzierbar fest.
+
+## Paket 2 / R3 – InvoiceIssuerProfile
+
+Das Rechnungsmodul besitzt ein eigenständiges `InvoiceIssuerProfile`. Die
+additive Fachmigration legt das Profil in derselben BBM-SQLite-Datei an und
+initialisiert es genau einmal aus dem bestehenden `user_profile`-Stand der
+`OwnOrganization`. Danach sind beide Identitäten unabhängig änderbar. Eine
+Lizenzidentität wird weder gelesen noch als Rechnungsteller interpretiert.
+
+Die Buchung verwendet bis zum getrennten Snapshot-Paket weiterhin den
+bestehenden Pfad. Damit werden Einführung der Identität und Umstellung der
+rechtlich wirksamen Buchung nicht in einem unprüfbaren Mischpaket verbunden.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -69,6 +69,7 @@ const TEST_GROUPS = Object.freeze([
     label: "Rechnungen UI-Designreferenz",
     suites: Object.freeze([
       ["rechnungRevision275Inventory.test.cjs", "runRechnungRevision275InventoryTests"],
+      ["rechnungIssuerProfile.test.cjs", "runRechnungIssuerProfileTests"],
       ["rechnungenDesignModule.test.cjs", "runRechnungenDesignModuleTests"],
       ["rechnungHeaderRules.test.cjs", "runRechnungHeaderRulesTests"],
       ["rechnungBooking.test.cjs", "runRechnungBookingTests"],

--- a/scripts/tests/rechnungIssuerProfile.test.cjs
+++ b/scripts/tests/rechnungIssuerProfile.test.cjs
@@ -1,0 +1,54 @@
+const assert = require("node:assert/strict");
+const Database = require("better-sqlite3");
+const { ensureInvoiceSchema } = require("../../src/main/db/invoiceMigrations");
+const { InvoiceIssuerProfileRepository } = require("../../src/main/db/invoiceIssuerProfileRepo");
+
+function database() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE projects (id TEXT PRIMARY KEY);
+    CREATE TABLE firms (id TEXT PRIMARY KEY, removed_at TEXT, is_trashed INTEGER);
+    CREATE TABLE user_profile (
+      id INTEGER PRIMARY KEY, name1 TEXT, name2 TEXT, street TEXT, zip TEXT,
+      city TEXT, country TEXT, phone TEXT, email TEXT, website TEXT, logo_path TEXT,
+      tax_number TEXT, vat_id TEXT, iban TEXT, bic TEXT, bank_name TEXT,
+      commercial_register TEXT, register_number TEXT, managing_director TEXT, legal_notice TEXT
+    );
+  `);
+  return db;
+}
+
+async function runRechnungIssuerProfileTests(run) {
+  await run("Rechnung #275 R3: Migration initialisiert eigenständiges Ausstellerprofil einmalig aus OwnOrganization", () => {
+    const db = database();
+    try {
+      db.prepare("INSERT INTO user_profile (id, name1, street, zip, city, iban) VALUES (1, 'Betrieb Alt', 'Altweg 1', '12345', 'Altstadt', 'DE001')").run();
+      ensureInvoiceSchema(db);
+      const repo = new InvoiceIssuerProfileRepository({ dbProvider: () => db, clock: () => "2026-09-06T12:00:00.000Z" });
+      assert.deepEqual([repo.get().identityType, repo.get().legalName, repo.get().iban], ["invoice-issuer-profile", "Betrieb Alt", "DE001"]);
+      db.prepare("UPDATE user_profile SET name1 = 'Betrieb Neu', iban = 'DE999' WHERE id = 1").run();
+      ensureInvoiceSchema(db);
+      assert.deepEqual([repo.get().legalName, repo.get().iban], ["Betrieb Alt", "DE001"]);
+    } finally { db.close(); }
+  });
+
+  await run("Rechnung #275 R3: Ausstellerprofil ist unabhängig bearbeitbar", () => {
+    const db = database();
+    try {
+      ensureInvoiceSchema(db);
+      const repo = new InvoiceIssuerProfileRepository({ dbProvider: () => db, clock: () => "2026-09-06T12:00:00.000Z" });
+      const updated = repo.upsert({ legalName: "Rechnung GmbH", street: "Rechnungsweg 2", zip: "54321", city: "Rechnungsstadt", vatId: "DE123", iban: "DE002" });
+      assert.deepEqual([updated.legalName, updated.street, updated.vatId, updated.iban], ["Rechnung GmbH", "Rechnungsweg 2", "DE123", "DE002"]);
+      assert.equal(db.prepare("SELECT name1 FROM user_profile WHERE id = 1").get(), undefined);
+    } finally { db.close(); }
+  });
+
+  await run("Rechnung #275 R3: Ausstellerprofil bleibt fachlich außerhalb des Core-Vertrags", () => {
+    const ownOrganization = require("../../src/shared/identity/ownOrganization.cjs");
+    const issuer = require("../../src/shared/rechnung/invoiceIssuerProfile.cjs");
+    assert.notEqual(issuer.INVOICE_ISSUER_PROFILE_ID, ownOrganization.OWN_ORGANIZATION_ID);
+    assert.equal(issuer.createInvoiceIssuerProfile({ customerName: "Lizenzkunde" }).legalName, "");
+  });
+}
+
+module.exports = { runRechnungIssuerProfileTests };

--- a/src/main/db/invoiceIssuerProfileRepo.js
+++ b/src/main/db/invoiceIssuerProfileRepo.js
@@ -1,0 +1,57 @@
+const {
+  INVOICE_ISSUER_PROFILE_ID,
+  createInvoiceIssuerProfile,
+} = require("../../shared/rechnung/invoiceIssuerProfile.cjs");
+const { initDatabase } = require("./database");
+
+const PROFILE_COLUMNS = Object.freeze([
+  "legal_name", "additional_name", "street", "zip", "city", "country",
+  "phone", "email", "website", "logo_path", "tax_number", "vat_id",
+  "iban", "bic", "bank_name", "commercial_register", "register_number",
+  "managing_director", "legal_notice",
+]);
+
+class InvoiceIssuerProfileRepository {
+  constructor({ dbProvider = initDatabase, clock = () => new Date().toISOString() } = {}) {
+    this.dbProvider = dbProvider;
+    this.clock = clock;
+  }
+
+  get() {
+    const row = this.dbProvider().prepare(
+      `SELECT * FROM invoice_issuer_profiles WHERE id = ?`
+    ).get(INVOICE_ISSUER_PROFILE_ID);
+    return row ? createInvoiceIssuerProfile(row) : null;
+  }
+
+  upsert(input = {}) {
+    const current = this.get();
+    const profile = createInvoiceIssuerProfile({ ...(current || {}), ...input });
+    const now = this.clock();
+    const values = Object.fromEntries(PROFILE_COLUMNS.map((column) => {
+      const camel = column.replace(/_([a-z])/g, (_match, letter) => letter.toUpperCase());
+      return [column, profile[camel] ?? ""];
+    }));
+    this.dbProvider().prepare(`
+      INSERT INTO invoice_issuer_profiles (
+        id, ${PROFILE_COLUMNS.join(", ")}, initialized_from_own_organization_at,
+        created_at, updated_at
+      ) VALUES (
+        @id, ${PROFILE_COLUMNS.map((column) => `@${column}`).join(", ")},
+        @initialized_from_own_organization_at, @created_at, @updated_at
+      )
+      ON CONFLICT(id) DO UPDATE SET
+        ${PROFILE_COLUMNS.map((column) => `${column} = excluded.${column}`).join(", ")},
+        updated_at = excluded.updated_at
+    `).run({
+      id: INVOICE_ISSUER_PROFILE_ID,
+      ...values,
+      initialized_from_own_organization_at: current?.initializedFromOwnOrganizationAt || now,
+      created_at: current?.createdAt || now,
+      updated_at: now,
+    });
+    return this.get();
+  }
+}
+
+module.exports = { InvoiceIssuerProfileRepository, PROFILE_COLUMNS };

--- a/src/main/db/invoiceMigrations.js
+++ b/src/main/db/invoiceMigrations.js
@@ -40,6 +40,34 @@ const CURRENT_INVOICE_COLUMN_SET = new Set(CURRENT_INVOICE_COLUMN_NAMES);
 const LEGACY_REQUIRED_COLUMNS = Object.freeze(["customer_firm_id", "issuer_snapshot_json", "recipient_snapshot_json"]);
 const LEGACY_MIGRATION_TABLE = "invoices_current_migration";
 
+const CREATE_INVOICE_ISSUER_PROFILES_SQL = `
+  CREATE TABLE IF NOT EXISTS invoice_issuer_profiles (
+    id TEXT PRIMARY KEY,
+    legal_name TEXT NOT NULL DEFAULT '',
+    additional_name TEXT NOT NULL DEFAULT '',
+    street TEXT NOT NULL DEFAULT '',
+    zip TEXT NOT NULL DEFAULT '',
+    city TEXT NOT NULL DEFAULT '',
+    country TEXT NOT NULL DEFAULT '',
+    phone TEXT NOT NULL DEFAULT '',
+    email TEXT NOT NULL DEFAULT '',
+    website TEXT NOT NULL DEFAULT '',
+    logo_path TEXT NOT NULL DEFAULT '',
+    tax_number TEXT NOT NULL DEFAULT '',
+    vat_id TEXT NOT NULL DEFAULT '',
+    iban TEXT NOT NULL DEFAULT '',
+    bic TEXT NOT NULL DEFAULT '',
+    bank_name TEXT NOT NULL DEFAULT '',
+    commercial_register TEXT NOT NULL DEFAULT '',
+    register_number TEXT NOT NULL DEFAULT '',
+    managing_director TEXT NOT NULL DEFAULT '',
+    legal_notice TEXT NOT NULL DEFAULT '',
+    initialized_from_own_organization_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )
+`;
+
 const CREATE_INVOICES_SQL = `
   CREATE TABLE IF NOT EXISTS invoices (
     id TEXT PRIMARY KEY,
@@ -351,6 +379,39 @@ function migrateDraftCustomerRefs(db) {
   return { globalRolesAdded, projectRefsMigrated, unresolvedProjectRefs };
 }
 
+function ensureInvoiceIssuerProfile(db) {
+  db.exec(CREATE_INVOICE_ISSUER_PROFILES_SQL);
+  const existing = db.prepare("SELECT 1 FROM invoice_issuer_profiles WHERE id = 'default'").get();
+  if (existing) return { initialized: false };
+  const source = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'user_profile'").get()
+    ? db.prepare("SELECT * FROM user_profile WHERE id = 1").get()
+    : null;
+  const now = new Date().toISOString();
+  db.prepare(`
+    INSERT INTO invoice_issuer_profiles (
+      id, legal_name, additional_name, street, zip, city, country, phone, email,
+      website, logo_path, tax_number, vat_id, iban, bic, bank_name,
+      commercial_register, register_number, managing_director, legal_notice,
+      initialized_from_own_organization_at, created_at, updated_at
+    ) VALUES (
+      'default', @name1, @name2, @street, @zip, @city, @country, @phone, @email,
+      @website, @logo_path, @tax_number, @vat_id, @iban, @bic, @bank_name,
+      @commercial_register, @register_number, @managing_director, @legal_notice,
+      @now, @now, @now
+    )
+  `).run({
+    name1: source?.name1 || "", name2: source?.name2 || "", street: source?.street || "",
+    zip: source?.zip || "", city: source?.city || "", country: source?.country || "",
+    phone: source?.phone || "", email: source?.email || "", website: source?.website || "",
+    logo_path: source?.logo_path || "", tax_number: source?.tax_number || "",
+    vat_id: source?.vat_id || "", iban: source?.iban || "", bic: source?.bic || "",
+    bank_name: source?.bank_name || "", commercial_register: source?.commercial_register || "",
+    register_number: source?.register_number || "", managing_director: source?.managing_director || "",
+    legal_notice: source?.legal_notice || "", now,
+  });
+  return { initialized: true };
+}
+
 function ensureInvoiceSchema(db) {
   if (!db) throw new Error("db required");
   let customerMigration = null;
@@ -418,6 +479,7 @@ function ensureInvoiceSchema(db) {
             AND f.is_final = 1
         );
     `);
+    ensureInvoiceIssuerProfile(db);
     customerMigration = migrateDraftCustomerRefs(db);
   };
   if (db.inTransaction) migrate();
@@ -425,4 +487,4 @@ function ensureInvoiceSchema(db) {
   return { customerMigration };
 }
 
-module.exports = { ensureInvoiceSchema, migrateDraftCustomerRefs };
+module.exports = { ensureInvoiceSchema, migrateDraftCustomerRefs, ensureInvoiceIssuerProfile };

--- a/src/shared/rechnung/invoiceIssuerProfile.cjs
+++ b/src/shared/rechnung/invoiceIssuerProfile.cjs
@@ -1,0 +1,36 @@
+const INVOICE_ISSUER_PROFILE_ID = "default";
+
+function text(value) {
+  return String(value ?? "").trim();
+}
+
+function createInvoiceIssuerProfile(source = {}) {
+  return Object.freeze({
+    identityType: "invoice-issuer-profile",
+    id: text(source.id) || INVOICE_ISSUER_PROFILE_ID,
+    legalName: text(source.legalName ?? source.legal_name ?? source.name1),
+    additionalName: text(source.additionalName ?? source.additional_name ?? source.name2),
+    street: text(source.street),
+    zip: text(source.zip),
+    city: text(source.city),
+    country: text(source.country),
+    phone: text(source.phone),
+    email: text(source.email),
+    website: text(source.website),
+    logoPath: text(source.logoPath ?? source.logo_path),
+    taxNumber: text(source.taxNumber ?? source.tax_number),
+    vatId: text(source.vatId ?? source.vat_id),
+    iban: text(source.iban),
+    bic: text(source.bic),
+    bankName: text(source.bankName ?? source.bank_name),
+    commercialRegister: text(source.commercialRegister ?? source.commercial_register),
+    registerNumber: text(source.registerNumber ?? source.register_number),
+    managingDirector: text(source.managingDirector ?? source.managing_director),
+    legalNotice: text(source.legalNotice ?? source.legal_notice),
+    initializedFromOwnOrganizationAt: text(source.initializedFromOwnOrganizationAt ?? source.initialized_from_own_organization_at),
+    createdAt: text(source.createdAt ?? source.created_at),
+    updatedAt: text(source.updatedAt ?? source.updated_at),
+  });
+}
+
+module.exports = Object.freeze({ INVOICE_ISSUER_PROFILE_ID, createInvoiceIssuerProfile });


### PR DESCRIPTION
## Paket
R3a – eigenständiges `InvoiceIssuerProfile` einführen.

## Enthalten
- rechnungseigener Profilvertrag
- rechnungseigenes Repository mit gemeinsamem DB-Provider
- additive Tabelle in der bestehenden BBM-SQLite-Datei
- einmalige Initialisierung aus dem vorhandenen OwnOrganization-/`user_profile`-Stand
- danach unabhängige Bearbeitung ohne Rückwirkung auf OwnOrganization

## Nicht enthalten
Keine Umschaltung der Buchung/Snapshots, keine UI/PDF-, Core-, Workflow- oder Fremdmoduländerung.

## Tests
- Pakettests 3/3 grün
- R2-Inventar 4/4 grün
- relevante Migration/Identität/Rechnung 33/34; nur dokumentierte alte Quellvertragserwartung rot
- Volltest unverändert mit neun #271-Baselinefehlern und bekannten `ui-editor-kit`-Abbrüchen
- Repository-Lint unverändert rot an sechs paketfremden Baselinefehlern; keine neue Paketmeldung

Refs #275