### PR TITLE
Rechnung #275 Paket 3: Snapshots härten

### DIFF
--- a/docs/RECHNUNG_REVISION_275.md
+++ b/docs/RECHNUNG_REVISION_275.md
@@ -78,3 +78,13 @@ Lizenzidentität wird weder gelesen noch als Rechnungsteller interpretiert.
 Die Buchung verwendet bis zum getrennten Snapshot-Paket weiterhin den
 bestehenden Pfad. Damit werden Einführung der Identität und Umstellung der
 rechtlich wirksamen Buchung nicht in einem unprüfbaren Mischpaket verbunden.
+
+## Paket 3 / R3 – Snapshots und Buchungsimmutabilität
+
+Vorschau und Buchung bilden den Aussteller ausschließlich aus dem
+`InvoiceIssuerProfile`; `user_profile`, `OwnOrganization` und Lizenzdaten sind
+keine Live-Quelle des Rechnungsbelegs mehr. Der Snapshot enthält die
+rechtlich relevanten Adress-, Steuer-, Bank-, Register- und Kontaktdaten sowie
+die Profil-ID. Der Empfänger wird weiterhin aus der zentralen Firmenbasis
+gesnapshottet. Nach der Buchung verändern weder Firmenstamm, Betreiberprofil
+noch Rechnungstellerprofil den gespeicherten Beleg.

--- a/scripts/tests/rechnungBooking.test.cjs
+++ b/scripts/tests/rechnungBooking.test.cjs
@@ -192,10 +192,12 @@ async function runRechnungBookingTests(run) {
       assert.equal(booked.status, "BOOKED"); assert.equal(booked.invoice_number, "2026-0001"); assert.ok(booked.booked_at);
       assert.equal(booked.customer_snapshot.companyName, "Kunde Alt"); assert.equal(booked.issuer_snapshot.companyName, "BBM Betrieb");
       env.db.prepare("UPDATE firms SET name='Kunde Neu', street='Neuweg 9' WHERE id='f1'").run();
-      env.db.prepare("UPDATE user_profile SET name1='Betrieb Neu', iban='DE999' WHERE id=1").run();
+      env.db.prepare("UPDATE user_profile SET name1='Betreiber Neu', iban='DE998' WHERE id=1").run();
+      env.db.prepare("UPDATE invoice_issuer_profiles SET legal_name='Betrieb Neu', iban='DE999' WHERE id='default'").run();
       const restored = env.service.get(draft.id);
       assert.equal(restored.customer_snapshot.companyName, "Kunde Alt"); assert.equal(restored.customer_snapshot.street, "Altweg 1");
       assert.equal(restored.issuer_snapshot.companyName, "BBM Betrieb"); assert.equal(restored.issuer_snapshot.iban, "DE001");
+      assert.equal(restored.issuer_snapshot.profileId, "default");
       assert.equal(restored.positions[0].short_text, "Montage");
       await assert.rejects(() => env.service.updateDraft(draft.id, { invoice_date: "2026-08-16" }), /nicht geändert/);
       assert.throws(() => env.service.deleteDraft(draft.id), /nicht gelöscht/);

--- a/scripts/tests/rechnungCentralCustomers.test.cjs
+++ b/scripts/tests/rechnungCentralCustomers.test.cjs
@@ -221,7 +221,8 @@ async function runRechnungCentralCustomersTests(run) {
         env.db.prepare("SELECT use_customer FROM firms WHERE id = 'customer'").get().use_customer,
         0
       );
-      env.db.prepare("UPDATE user_profile SET name1 = 'BBM Neu' WHERE id = 1").run();
+      env.db.prepare("UPDATE user_profile SET name1 = 'Betreiber Neu' WHERE id = 1").run();
+      env.db.prepare("UPDATE invoice_issuer_profiles SET legal_name = 'BBM Neu' WHERE id = 'default'").run();
 
       const restored = env.service.get(draft.id);
       assert.equal(restored.customer_snapshot.companyName, "Kunde Vorher");

--- a/scripts/tests/rechnungIssuerProfile.test.cjs
+++ b/scripts/tests/rechnungIssuerProfile.test.cjs
@@ -43,11 +43,31 @@ async function runRechnungIssuerProfileTests(run) {
     } finally { db.close(); }
   });
 
+  await run("Rechnung #275 R3: leere Erstmigration wartet auf verwertbare OwnOrganization", () => {
+    const db = database();
+    try {
+      ensureInvoiceSchema(db);
+      assert.equal(db.prepare("SELECT COUNT(*) AS count FROM invoice_issuer_profiles").get().count, 0);
+      db.prepare("INSERT INTO user_profile (id, name1, street, zip, city) VALUES (1, 'Später GmbH', 'Weg 3', '20000', 'Hamburg')").run();
+      ensureInvoiceSchema(db);
+      assert.equal(db.prepare("SELECT legal_name FROM invoice_issuer_profiles WHERE id = 'default'").get().legal_name, "Später GmbH");
+    } finally { db.close(); }
+  });
+
   await run("Rechnung #275 R3: Ausstellerprofil bleibt fachlich außerhalb des Core-Vertrags", () => {
     const ownOrganization = require("../../src/shared/identity/ownOrganization.cjs");
     const issuer = require("../../src/shared/rechnung/invoiceIssuerProfile.cjs");
     assert.notEqual(issuer.INVOICE_ISSUER_PROFILE_ID, ownOrganization.OWN_ORGANIZATION_ID);
     assert.equal(issuer.createInvoiceIssuerProfile({ customerName: "Lizenzkunde" }).legalName, "");
+  });
+
+  await run("Rechnung #275 R3: Snapshot enthält rechtlich relevante Profildaten ohne Live-Referenz", () => {
+    const { toInvoiceIssuerSnapshot } = require("../../src/shared/rechnung/invoiceIssuerProfile.cjs");
+    const source = { id: "default", legal_name: "Rechnung GmbH", street: "Weg 1", zip: "12345", city: "Ort", tax_number: "T-1", vat_id: "DE1", iban: "DE001" };
+    const snapshot = toInvoiceIssuerSnapshot(source);
+    source.legal_name = "Geändert";
+    assert.deepEqual([snapshot.profileId, snapshot.companyName, snapshot.taxNumber, snapshot.vatId, snapshot.iban], ["default", "Rechnung GmbH", "T-1", "DE1", "DE001"]);
+    assert.equal(Object.isFrozen(snapshot), true);
   });
 }
 

--- a/scripts/tests/rechnungRevision275Inventory.test.cjs
+++ b/scripts/tests/rechnungRevision275Inventory.test.cjs
@@ -53,7 +53,7 @@ async function runRechnungRevision275InventoryTests(run) {
     assert.match(report, /`main` bleibt die einzige Integrationsbasis/);
     assert.match(report, /Nicht übernehmen/);
     assert.match(report, /eigenständige[s\n ]+`InvoiceIssuerProfile`/);
-    assert.match(read("src/main/db/invoiceRepository.js"), /SELECT \* FROM user_profile WHERE id = 1/);
+    assert.match(read("src/main/db/invoiceRepository.js"), /invoice_issuer_profiles/);
   });
 }
 

--- a/scripts/tests/rechnungStammdaten.test.cjs
+++ b/scripts/tests/rechnungStammdaten.test.cjs
@@ -3,7 +3,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 async function runRechnungStammdatenTests(run) {
-  await run("Rechnung Stammdaten: user_profile bleibt einzige Rechnungsstellerquelle", () => {
+  await run("Rechnung Stammdaten: OwnOrganization und Rechnungstellerprofil bleiben getrennt", () => {
     const database = fs.readFileSync(path.join(process.cwd(), "src/main/db/database.js"), "utf8");
     const repository = fs.readFileSync(path.join(process.cwd(), "src/main/db/userProfileRepo.js"), "utf8");
     const invoiceRepository = fs.readFileSync(path.join(process.cwd(), "src/main/db/invoiceRepository.js"), "utf8");
@@ -11,8 +11,9 @@ async function runRechnungStammdatenTests(run) {
       assert.equal(database.includes(`\"${field}\"`) || database.includes(`${field} TEXT`), true, field);
       assert.equal(repository.includes(`\"${field}\"`), true, field);
     }
-    assert.equal(invoiceRepository.includes("FROM user_profile WHERE id = 1"), true);
-    assert.equal(fs.existsSync(path.join(process.cwd(), "src/main/db/invoiceIssuerProfileRepo.js")), false);
+    assert.equal(invoiceRepository.includes("FROM user_profile WHERE id = 1"), false);
+    assert.equal(invoiceRepository.includes("FROM invoice_issuer_profiles WHERE id = 'default'"), true);
+    assert.equal(fs.existsSync(path.join(process.cwd(), "src/main/db/invoiceIssuerProfileRepo.js")), true);
   });
   await run("Rechnung Stammdaten: gemeinsamer Firmeneditor bietet Pflichtangaben", () => {
     const settings = fs.readFileSync(path.join(process.cwd(), "src/renderer/views/SettingsView.js"), "utf8");

--- a/src/main/db/invoiceMigrations.js
+++ b/src/main/db/invoiceMigrations.js
@@ -386,6 +386,7 @@ function ensureInvoiceIssuerProfile(db) {
   const source = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'user_profile'").get()
     ? db.prepare("SELECT * FROM user_profile WHERE id = 1").get()
     : null;
+  if (!source) return { initialized: false };
   const now = new Date().toISOString();
   db.prepare(`
     INSERT INTO invoice_issuer_profiles (

--- a/src/main/db/invoiceRepository.js
+++ b/src/main/db/invoiceRepository.js
@@ -2,6 +2,8 @@
 
 const { randomUUID } = require("crypto");
 const { initDatabase } = require("./database");
+const { toInvoiceIssuerSnapshot } = require("../../shared/rechnung/invoiceIssuerProfile.cjs");
+const { ensureInvoiceIssuerProfile } = require("./invoiceMigrations");
 
 const HEADER_COLUMNS = Object.freeze([
   "source_type", "document_type", "installment_number", "invoice_date",
@@ -188,25 +190,12 @@ class InvoiceRepository {
   }
 
   _issuerSnapshot(db) {
-    const row = db.prepare("SELECT * FROM user_profile WHERE id = 1").get();
-    if (!row || !String(row.name1 || "").trim() || !String(row.street || "").trim() || !String(row.zip || "").trim() || !String(row.city || "").trim()) {
-      throw new Error("Eigene Unternehmensdaten sind für die Buchung unvollständig.");
+    ensureInvoiceIssuerProfile(db);
+    const row = db.prepare("SELECT * FROM invoice_issuer_profiles WHERE id = 'default'").get();
+    if (!row || !String(row.legal_name || "").trim() || !String(row.street || "").trim() || !String(row.zip || "").trim() || !String(row.city || "").trim()) {
+      throw new Error("Das Rechnungstellerprofil ist für die Buchung unvollständig.");
     }
-    return {
-      companyName: row.name1 || null,
-      companyName2: row.name2 || null,
-      street: row.street || null,
-      zip: row.zip || null,
-      city: row.city || null,
-      country: row.country || null,
-      phone: row.phone || null,
-      email: row.email || null,
-      taxNumber: row.tax_number || null,
-      vatId: row.vat_id || null,
-      iban: row.iban || null,
-      bic: row.bic || null,
-      bankName: row.bank_name || null,
-    };
+    return toInvoiceIssuerSnapshot(row);
   }
 
   buildPreviewSnapshots(header) {

--- a/src/shared/rechnung/invoiceIssuerProfile.cjs
+++ b/src/shared/rechnung/invoiceIssuerProfile.cjs
@@ -33,4 +33,30 @@ function createInvoiceIssuerProfile(source = {}) {
   });
 }
 
-module.exports = Object.freeze({ INVOICE_ISSUER_PROFILE_ID, createInvoiceIssuerProfile });
+function toInvoiceIssuerSnapshot(source = {}) {
+  const profile = createInvoiceIssuerProfile(source);
+  return Object.freeze({
+    profileId: profile.id,
+    companyName: profile.legalName || null,
+    companyName2: profile.additionalName || null,
+    street: profile.street || null,
+    zip: profile.zip || null,
+    city: profile.city || null,
+    country: profile.country || null,
+    phone: profile.phone || null,
+    email: profile.email || null,
+    website: profile.website || null,
+    logoPath: profile.logoPath || null,
+    taxNumber: profile.taxNumber || null,
+    vatId: profile.vatId || null,
+    iban: profile.iban || null,
+    bic: profile.bic || null,
+    bankName: profile.bankName || null,
+    commercialRegister: profile.commercialRegister || null,
+    registerNumber: profile.registerNumber || null,
+    managingDirector: profile.managingDirector || null,
+    legalNotice: profile.legalNotice || null,
+  });
+}
+
+module.exports = Object.freeze({ INVOICE_ISSUER_PROFILE_ID, createInvoiceIssuerProfile, toInvoiceIssuerSnapshot });


### PR DESCRIPTION
## Paket
R3b – Empfänger-/Aussteller-Snapshots und Buchungsimmutabilität.

## Enthalten
- Ausstellersnapshot ausschließlich aus `InvoiceIssuerProfile`
- rechtlich relevante Adress-, Steuer-, Bank-, Register- und Kontaktdaten eingefroren
- Profil-ID im Snapshot
- einmalige Profilinitialisierung wartet bei leerer Erstmigration auf verwertbare OwnOrganization
- Firmenstamm, OwnOrganization und InvoiceIssuerProfile verändern gebuchte Belege nicht

## Nicht enthalten
Keine UI-/PDF-, Nummernkreis-, Fachworkflow-, Provider-, Core- oder Fremdmoduländerung.

## Tests
- relevante Rechnung/Identität 25/26; nur dokumentierte alte Text-Erwartung rot
- Volltest exakt neun #271-Baselinefehler plus bekannte `ui-editor-kit`-Abbrüche
- keine neue Regression

Refs #275