### PR TITLE
Rechnung #275 Paket 4a: Auftrags-LV-Persistenz

### DIFF
--- a/docs/RECHNUNG_REVISION_275.md
+++ b/docs/RECHNUNG_REVISION_275.md
@@ -1,6 +1,6 @@
 # Rechnung – Revision #275
 
-Stand: 2026-09-06, Paket 1 / R2 Bestandsbergung.
+Stand: 2026-09-06, Paket 4a / R4 Auftrags-LV-Persistenz.
 
 ## Integrationsbasis
 
@@ -88,3 +88,31 @@ rechtlich relevanten Adress-, Steuer-, Bank-, Register- und Kontaktdaten sowie
 die Profil-ID. Der Empfänger wird weiterhin aus der zentralen Firmenbasis
 gesnapshottet. Nach der Buchung verändern weder Firmenstamm, Betreiberprofil
 noch Rechnungstellerprofil den gespeicherten Beleg.
+
+## Paket 4a / R4 – Auftrags-LV-Persistenz und Bestandsmigration
+
+Die in #275 festgelegte minimale Auftrags-LV-Basis wird ausschließlich als
+Rechnungsfachpersistenz vorbereitet:
+
+- `billing_orders` besitzt stabile UUIDs, gemeinsamen Firmen-/optionalen
+  Projektbezug und einen bestätigbaren Auftragskopf.
+- `billing_order_positions` bewahrt sichtbare Vertragsnummern und einen
+  expliziten `sort_index`; die freie Rechnungsnummerierung wird nicht verwendet.
+- `billing_order_amendments` ist mit stabiler Ursprungsreferenz sowie Feldern,
+  Format- und Eindeutigkeitsregeln für `N 01`, `N 02` usw. vorbereitet. Die
+  operative Nummernvergabe bleibt Paket 4d.
+- Datenbanktrigger schützen IDs sowie bestätigte Auftrags-, LV- und
+  Nachtragsdaten auch unterhalb eines späteren Service-/IPC-Pfads.
+- Die additive Rechnungsfachmigration ordnet freien Bestand als
+  `NOT_APPLICABLE`, alte gebuchte Auftragsbelege als `LEGACY_SNAPSHOT` und alte
+  bzw. noch nicht gebundene Auftragsentwürfe als `LEGACY_UNRESOLVED` ein.
+- Es wird kein Auftrag aus Auftragsnummer, Positionstext, Positionsnummer oder
+  Listenreihenfolge rekonstruiert. Historisches `positions_json` bleibt
+  byte-inhaltlich unverändert.
+
+Neue `LEGACY_UNRESOLVED`-Entwürfe können vor Paket 4c nicht gebucht werden.
+Vorhandene gebuchte Auftragsbelege bleiben als historische Snapshots lesbar.
+
+Nicht enthalten sind die 4b-Anwendungs-/IPC-Grenze, eine UI, die Erzeugung
+eines Rechnungsentwurfs aus Auftrag, Nachtragsbedienung, PDF oder andere
+Provider. Der Core enthält weiterhin keine Auftrags-/LV-/Nachtragsfachlogik.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -70,6 +70,7 @@ const TEST_GROUPS = Object.freeze([
     suites: Object.freeze([
       ["rechnungRevision275Inventory.test.cjs", "runRechnungRevision275InventoryTests"],
       ["rechnungIssuerProfile.test.cjs", "runRechnungIssuerProfileTests"],
+      ["rechnungBillingOrderPersistence.test.cjs", "runRechnungBillingOrderPersistenceTests"],
       ["rechnungenDesignModule.test.cjs", "runRechnungenDesignModuleTests"],
       ["rechnungHeaderRules.test.cjs", "runRechnungHeaderRulesTests"],
       ["rechnungBooking.test.cjs", "runRechnungBookingTests"],

--- a/scripts/tests/rechnungBillingOrderPersistence.test.cjs
+++ b/scripts/tests/rechnungBillingOrderPersistence.test.cjs
@@ -1,0 +1,213 @@
+const assert = require("node:assert/strict");
+const Database = require("better-sqlite3");
+const { ensureInvoiceSchema } = require("../../src/main/db/invoiceMigrations");
+const { BillingOrderRepository } = require("../../src/main/db/billingOrderRepository");
+
+const UUID = Object.freeze({
+  order: "11111111-1111-4111-8111-111111111111",
+  heading: "22222222-2222-4222-8222-222222222222",
+  service: "33333333-3333-4333-8333-333333333333",
+  service2: "44444444-4444-4444-8444-444444444444",
+  amendment1: "55555555-5555-4555-8555-555555555555",
+  amendment2: "66666666-6666-4666-8666-666666666666",
+  amendment3: "77777777-7777-4777-8777-777777777777",
+});
+
+function database() {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE projects (id TEXT PRIMARY KEY);
+    CREATE TABLE firms (id TEXT PRIMARY KEY, removed_at TEXT, is_trashed INTEGER);
+    INSERT INTO projects (id) VALUES ('project-1');
+    INSERT INTO firms (id, removed_at, is_trashed) VALUES ('firm-1', NULL, 0);
+  `);
+  ensureInvoiceSchema(db);
+  return db;
+}
+
+function legacyDatabase() {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE unrelated_data (id TEXT PRIMARY KEY, value TEXT NOT NULL);
+    INSERT INTO unrelated_data (id, value) VALUES ('keep', 'unverändert');
+    CREATE TABLE invoices (
+      id TEXT PRIMARY KEY,
+      status TEXT,
+      source_type TEXT,
+      source_order_id TEXT,
+      source_order_number TEXT,
+      source_order_date TEXT,
+      positions_json TEXT
+    );
+    INSERT INTO invoices VALUES ('free-draft', 'DRAFT', 'FREE', NULL, NULL, NULL, '[]');
+    INSERT INTO invoices VALUES ('order-draft', 'DRAFT', 'FROM_ORDER', 'legacy-order', 'A-25', '2025-01-10', '[{"position_number":"25"}]');
+    INSERT INTO invoices VALUES ('order-booked', 'BOOKED', 'FROM_ORDER', 'legacy-booked', 'A-24', '2024-03-01', '[{"position_number":"10"}]');
+  `);
+  return db;
+}
+
+function repository(db) {
+  let tick = 0;
+  return new BillingOrderRepository({
+    dbProvider: () => db,
+    clock: () => `2026-09-06T14:10:${String(tick++).padStart(2, "0")}.000Z`,
+  });
+}
+
+function createOrder(repo, input = {}) {
+  return repo.createDraft({
+    id: UUID.order,
+    order_number: "A-25",
+    order_date: "2025-01-10",
+    customer_firm_id: "firm-1",
+    project_id: "project-1",
+    service_reference: "Umbau Musterstraße",
+    ...input,
+  });
+}
+
+async function runRechnungBillingOrderPersistenceTests(run) {
+  await run("Rechnung #275 Paket 4a: Fachmigration legt nur additive Auftrags-LV-Tabellen und Indizes an", () => {
+    const db = database();
+    try {
+      const tables = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all().map(({ name }) => name);
+      for (const name of ["billing_orders", "billing_order_positions", "billing_order_amendments"]) {
+        assert.equal(tables.includes(name), true, name);
+      }
+      const coreSource = require("node:fs").readFileSync(require("node:path").join(process.cwd(), "src/main/db/database.js"), "utf8");
+      assert.doesNotMatch(coreSource, /billing_orders|billing_order_positions|billing_order_amendments|LEGACY_UNRESOLVED/);
+    } finally { db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4a: stabile UUIDs, sichtbare Nummern und Vertragsreihenfolge bleiben erhalten", () => {
+    const db = database();
+    try {
+      const repo = repository(db);
+      const order = createOrder(repo);
+      assert.equal(order.id, UUID.order);
+      repo.addPosition(order.id, {
+        id: UUID.heading, type: "heading", position_number: "10", sort_index: 10,
+        short_text: "Titel Rohbau",
+      });
+      repo.addPosition(order.id, {
+        id: UUID.service, parent_position_id: UUID.heading, type: "service",
+        position_number: "25", sort_index: 20, short_text: "Mauerwerk",
+        quantity: "12.5", unit: "m2", unit_price_cents: 12345,
+        vat_rate_percent: 19, price_input_mode: "NET",
+      });
+      const persisted = repo.get(order.id);
+      assert.deepEqual(persisted.positions.map((position) => [position.id, position.position_number, position.sort_index]), [
+        [UUID.heading, "10", 10],
+        [UUID.service, "25", 20],
+      ]);
+      assert.throws(
+        () => db.prepare("UPDATE billing_order_positions SET id = ? WHERE id = ?").run(UUID.service2, UUID.service),
+        /billing_order_position_identity_immutable/
+      );
+      assert.throws(
+        () => repo.addPosition(order.id, { id: UUID.service2, type: "service", position_number: "25", sort_index: 30, short_text: "Doppelt" }),
+        /UNIQUE constraint failed/
+      );
+    } finally { db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4a: bestätigter Auftragskopf und Vertrags-LV sind auch auf DB-Ebene unveränderlich", () => {
+    const db = database();
+    try {
+      const repo = repository(db);
+      createOrder(repo);
+      repo.addPosition(UUID.order, { id: UUID.service, type: "service", position_number: "25", sort_index: 10, short_text: "Mauerwerk" });
+      const confirmed = repo.confirmOrder(UUID.order);
+      assert.deepEqual([confirmed.status, confirmed.positions[0].position_number, confirmed.positions[0].sort_index], ["CONFIRMED", "25", 10]);
+      assert.throws(() => db.prepare("UPDATE billing_orders SET order_number = 'NEU' WHERE id = ?").run(UUID.order), /billing_order_confirmed_immutable/);
+      assert.throws(() => db.prepare("UPDATE billing_order_positions SET position_number = '26' WHERE id = ?").run(UUID.service), /billing_order_positions_confirmed_immutable/);
+      assert.throws(() => db.prepare("UPDATE billing_order_positions SET sort_index = 20 WHERE id = ?").run(UUID.service), /billing_order_positions_confirmed_immutable/);
+      assert.throws(() => db.prepare("DELETE FROM billing_order_positions WHERE id = ?").run(UUID.service), /billing_order_positions_confirmed_immutable/);
+      assert.throws(() => db.prepare("DELETE FROM billing_orders WHERE id = ?").run(UUID.order), /billing_order_confirmed_immutable/);
+    } finally { db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4a: Nachtragsschema bereitet Referenz und N 01/N 02 vor, ohne Paket-4d-Workflow", () => {
+    const db = database();
+    try {
+      const repo = repository(db);
+      createOrder(repo);
+      repo.addPosition(UUID.order, { id: UUID.heading, type: "heading", position_number: "10", sort_index: 10, short_text: "Titel" });
+      repo.addPosition(UUID.order, { id: UUID.service, type: "service", position_number: "25", sort_index: 20, short_text: "Mauerwerk" });
+      repo.confirmOrder(UUID.order);
+      assert.throws(
+        () => repo.createDraftAmendment(UUID.order, { id: UUID.amendment1, relates_to_order_position_id: UUID.heading, short_text: "Ungültig" }),
+        /billing_order_amendment_origin_invalid/
+      );
+      const firstDraft = repo.createDraftAmendment(UUID.order, {
+        id: UUID.amendment1, relates_to_order_position_id: UUID.service, short_text: "Zusatzöffnung",
+      });
+      assert.deepEqual([firstDraft.status, firstDraft.sequence_no, firstDraft.amendment_number], ["DRAFT", null, null]);
+      const insertConfirmed = db.prepare(`
+        INSERT INTO billing_order_amendments (
+          id, order_id, sequence_no, amendment_number, relates_to_order_position_id,
+          short_text, status, confirmed_at, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, 'CONFIRMED', 'confirmed', 'created', 'updated')
+      `);
+      insertConfirmed.run(UUID.amendment2, UUID.order, 1, "N 01", UUID.service, "Zusatzsturz");
+      insertConfirmed.run(UUID.amendment3, UUID.order, 2, "N 02", UUID.service, "Zusatzöffnung 2");
+      assert.deepEqual(
+        db.prepare("SELECT sequence_no, amendment_number FROM billing_order_amendments WHERE status = 'CONFIRMED' ORDER BY sequence_no").all(),
+        [{ sequence_no: 1, amendment_number: "N 01" }, { sequence_no: 2, amendment_number: "N 02" }]
+      );
+      assert.throws(
+        () => db.prepare("UPDATE billing_order_amendments SET amendment_number = 'N 03' WHERE id = ?").run(UUID.amendment2),
+        /billing_order_amendment_confirmed_immutable/
+      );
+      assert.throws(() => db.prepare("DELETE FROM billing_order_amendments WHERE id = ?").run(UUID.amendment2), /billing_order_amendment_confirmed_immutable/);
+      assert.equal(typeof repo.confirmAmendment, "undefined");
+    } finally { db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4a: Bestandsmigration klassifiziert Legacy-Fälle ohne unsichere Zuordnung", () => {
+    const db = legacyDatabase();
+    try {
+      ensureInvoiceSchema(db);
+      const states = db.prepare("SELECT id, order_binding_state FROM invoices ORDER BY id").all();
+      assert.deepEqual(states, [
+        { id: "free-draft", order_binding_state: "NOT_APPLICABLE" },
+        { id: "order-booked", order_binding_state: "LEGACY_SNAPSHOT" },
+        { id: "order-draft", order_binding_state: "LEGACY_UNRESOLVED" },
+      ]);
+      assert.equal(db.prepare("SELECT value FROM unrelated_data WHERE id = 'keep'").get().value, "unverändert");
+      assert.equal(db.prepare("SELECT COUNT(*) AS count FROM billing_orders").get().count, 0);
+      assert.throws(
+        () => db.prepare("UPDATE invoices SET status = 'BOOKED' WHERE id = 'order-draft'").run(),
+        /invoice_order_binding_legacy_unresolved/
+      );
+      ensureInvoiceSchema(db);
+      assert.deepEqual(db.prepare("SELECT source_order_id, source_order_number, positions_json, order_binding_state FROM invoices WHERE id = 'order-draft'").get(), {
+        source_order_id: "legacy-order",
+        source_order_number: "A-25",
+        positions_json: '[{"position_number":"25"}]',
+        order_binding_state: "LEGACY_UNRESOLVED",
+      });
+      assert.equal(db.prepare("SELECT COUNT(*) AS count FROM billing_orders").get().count, 0);
+    } finally { db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4a: neue FROM_ORDER-Entwürfe bleiben bis Paket 4c ungelöst und nicht buchbar", () => {
+    const db = database();
+    try {
+      db.prepare(`
+        INSERT INTO invoices (
+          id, status, source_type, document_type, invoice_date, positions_json,
+          payment_term_days, due_date, created_at, updated_at
+        ) VALUES ('new-order-draft', 'DRAFT', 'FROM_ORDER', 'INVOICE', '2026-09-06', '[]', 8, '2026-09-14', 'now', 'now')
+      `).run();
+      assert.equal(db.prepare("SELECT order_binding_state FROM invoices WHERE id = 'new-order-draft'").get().order_binding_state, "LEGACY_UNRESOLVED");
+      assert.throws(
+        () => db.prepare("UPDATE invoices SET status = 'BOOKED' WHERE id = 'new-order-draft'").run(),
+        /invoice_order_binding_legacy_unresolved/
+      );
+    } finally { db.close(); }
+  });
+}
+
+module.exports = { runRechnungBillingOrderPersistenceTests };

--- a/src/main/db/billingOrderRepository.js
+++ b/src/main/db/billingOrderRepository.js
@@ -1,0 +1,194 @@
+"use strict";
+
+const { randomUUID } = require("crypto");
+const { initDatabase } = require("./database");
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function requiredText(value, errorCode) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) throw new Error(errorCode);
+  return normalized;
+}
+
+function stableUuid(value, errorCode) {
+  const id = value == null || value === "" ? randomUUID() : String(value).trim();
+  if (!UUID_PATTERN.test(id)) throw new Error(errorCode);
+  return id;
+}
+
+function isoDate(value) {
+  const normalized = requiredText(value, "billing_order_date_required");
+  if (!ISO_DATE_PATTERN.test(normalized)) throw new Error("billing_order_date_invalid");
+  const parsed = new Date(`${normalized}T00:00:00.000Z`);
+  if (!Number.isFinite(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== normalized) {
+    throw new Error("billing_order_date_invalid");
+  }
+  return normalized;
+}
+
+function nullableText(value) {
+  const normalized = String(value ?? "").trim();
+  return normalized || null;
+}
+
+function positionValues(input, { id, orderId, now }) {
+  return {
+    id,
+    order_id: orderId,
+    parent_position_id: nullableText(input.parent_position_id),
+    type: requiredText(input.type, "billing_order_position_type_required").toLowerCase(),
+    position_number: requiredText(input.position_number, "billing_order_position_number_required"),
+    sort_index: Number(input.sort_index),
+    short_text: requiredText(input.short_text, "billing_order_position_short_text_required"),
+    long_text: String(input.long_text ?? ""),
+    quantity: nullableText(input.quantity),
+    unit: nullableText(input.unit),
+    unit_price_cents: input.unit_price_cents ?? null,
+    is_nep: input.is_nep ? 1 : 0,
+    vat_rate_percent: input.vat_rate_percent ?? null,
+    price_input_mode: nullableText(input.price_input_mode)?.toUpperCase() || null,
+    price_input_cents: input.price_input_cents ?? null,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+function amendmentValues(input, { id, orderId, now }) {
+  return {
+    id,
+    order_id: orderId,
+    relates_to_order_position_id: stableUuid(
+      input.relates_to_order_position_id,
+      "billing_order_amendment_origin_id_invalid"
+    ),
+    short_text: requiredText(input.short_text, "billing_order_amendment_short_text_required"),
+    long_text: String(input.long_text ?? ""),
+    quantity: nullableText(input.quantity),
+    unit: nullableText(input.unit),
+    unit_price_cents: input.unit_price_cents ?? null,
+    is_nep: input.is_nep ? 1 : 0,
+    vat_rate_percent: input.vat_rate_percent ?? null,
+    price_input_mode: nullableText(input.price_input_mode)?.toUpperCase() || null,
+    price_input_cents: input.price_input_cents ?? null,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+class BillingOrderRepository {
+  constructor({ dbProvider = initDatabase, clock = () => new Date().toISOString() } = {}) {
+    this.dbProvider = dbProvider;
+    this.clock = clock;
+  }
+
+  _db() {
+    return this.dbProvider();
+  }
+
+  get(id) {
+    const db = this._db();
+    const order = db.prepare("SELECT * FROM billing_orders WHERE id = ?").get(String(id || ""));
+    if (!order) return null;
+    return {
+      ...order,
+      positions: db
+        .prepare("SELECT * FROM billing_order_positions WHERE order_id = ? ORDER BY sort_index, id")
+        .all(order.id),
+      amendments: db
+        .prepare(`
+          SELECT * FROM billing_order_amendments
+          WHERE order_id = ?
+          ORDER BY CASE WHEN sequence_no IS NULL THEN 1 ELSE 0 END, sequence_no, created_at, id
+        `)
+        .all(order.id),
+    };
+  }
+
+  createDraft(input = {}) {
+    const db = this._db();
+    const now = this.clock();
+    const id = stableUuid(input.id, "billing_order_id_invalid");
+    db.prepare(`
+      INSERT INTO billing_orders (
+        id, order_number, order_date, customer_firm_id, project_id,
+        service_reference, status, confirmed_at, created_at, updated_at
+      ) VALUES (
+        @id, @order_number, @order_date, @customer_firm_id, @project_id,
+        @service_reference, 'DRAFT', NULL, @created_at, @updated_at
+      )
+    `).run({
+      id,
+      order_number: requiredText(input.order_number, "billing_order_number_required"),
+      order_date: isoDate(input.order_date),
+      customer_firm_id: requiredText(input.customer_firm_id, "billing_order_customer_required"),
+      project_id: nullableText(input.project_id),
+      service_reference: requiredText(input.service_reference, "billing_order_service_reference_required"),
+      created_at: now,
+      updated_at: now,
+    });
+    return this.get(id);
+  }
+
+  addPosition(orderId, input = {}) {
+    const db = this._db();
+    const now = this.clock();
+    const normalizedOrderId = stableUuid(orderId, "billing_order_id_invalid");
+    const id = stableUuid(input.id, "billing_order_position_id_invalid");
+    const values = positionValues(input, { id, orderId: normalizedOrderId, now });
+    db.prepare(`
+      INSERT INTO billing_order_positions (
+        id, order_id, parent_position_id, type, position_number, sort_index,
+        short_text, long_text, quantity, unit, unit_price_cents, is_nep,
+        vat_rate_percent, price_input_mode, price_input_cents, created_at, updated_at
+      ) VALUES (
+        @id, @order_id, @parent_position_id, @type, @position_number, @sort_index,
+        @short_text, @long_text, @quantity, @unit, @unit_price_cents, @is_nep,
+        @vat_rate_percent, @price_input_mode, @price_input_cents, @created_at, @updated_at
+      )
+    `).run(values);
+    return db.prepare("SELECT * FROM billing_order_positions WHERE id = ?").get(id);
+  }
+
+  confirmOrder(id) {
+    const db = this._db();
+    const orderId = stableUuid(id, "billing_order_id_invalid");
+    const confirmedAt = this.clock();
+    const transaction = db.transaction(() => {
+      const result = db.prepare(`
+        UPDATE billing_orders
+        SET status = 'CONFIRMED', confirmed_at = @confirmed_at, updated_at = @confirmed_at
+        WHERE id = @id AND status = 'DRAFT'
+      `).run({ id: orderId, confirmed_at: confirmedAt });
+      if (result.changes !== 1) throw new Error("billing_order_not_confirmable");
+    });
+    transaction.immediate();
+    return this.get(orderId);
+  }
+
+  createDraftAmendment(orderId, input = {}) {
+    const db = this._db();
+    const now = this.clock();
+    const normalizedOrderId = stableUuid(orderId, "billing_order_id_invalid");
+    const id = stableUuid(input.id, "billing_order_amendment_id_invalid");
+    const values = amendmentValues(input, { id, orderId: normalizedOrderId, now });
+    db.prepare(`
+      INSERT INTO billing_order_amendments (
+        id, order_id, sequence_no, amendment_number, relates_to_order_position_id,
+        short_text, long_text, quantity, unit, unit_price_cents, is_nep,
+        vat_rate_percent, price_input_mode, price_input_cents, status,
+        confirmed_at, created_at, updated_at
+      ) VALUES (
+        @id, @order_id, NULL, NULL, @relates_to_order_position_id,
+        @short_text, @long_text, @quantity, @unit, @unit_price_cents, @is_nep,
+        @vat_rate_percent, @price_input_mode, @price_input_cents, 'DRAFT',
+        NULL, @created_at, @updated_at
+      )
+    `).run(values);
+    return db.prepare("SELECT * FROM billing_order_amendments WHERE id = ?").get(id);
+  }
+
+}
+
+module.exports = { BillingOrderRepository };

--- a/src/main/db/invoiceMigrations.js
+++ b/src/main/db/invoiceMigrations.js
@@ -21,6 +21,7 @@ const CURRENT_INVOICE_COLUMN_DEFINITIONS = Object.freeze([
   ["source_order_id", "TEXT"],
   ["source_order_number", "TEXT"],
   ["source_order_date", "TEXT"],
+  ["order_binding_state", "TEXT NOT NULL DEFAULT 'NOT_APPLICABLE' CHECK (order_binding_state IN ('NOT_APPLICABLE', 'LEGACY_UNRESOLVED', 'LEGACY_SNAPSHOT', 'BOUND'))"],
   ["service_reference", "TEXT"],
   ["construction_project", "TEXT"],
   ["intro_text", "TEXT"],
@@ -89,6 +90,7 @@ const CREATE_INVOICES_SQL = `
     source_order_id TEXT,
     source_order_number TEXT,
     source_order_date TEXT,
+    order_binding_state TEXT NOT NULL DEFAULT 'NOT_APPLICABLE' CHECK (order_binding_state IN ('NOT_APPLICABLE', 'LEGACY_UNRESOLVED', 'LEGACY_SNAPSHOT', 'BOUND')),
     service_reference TEXT,
     construction_project TEXT,
     intro_text TEXT,
@@ -125,7 +127,7 @@ function addMissingInvoiceColumns(db, columns) {
   }
 }
 
-function applySafeLegacyDefaults(db) {
+function applySafeLegacyDefaults(db, { initializeOrderBindingState = false } = {}) {
   db.exec(`
     UPDATE invoices SET source_type = 'FREE' WHERE source_type IS NULL;
     UPDATE invoices SET document_type = 'INVOICE' WHERE document_type IS NULL;
@@ -134,6 +136,16 @@ function applySafeLegacyDefaults(db) {
     UPDATE invoices SET status = 'DRAFT' WHERE status IS NULL;
     UPDATE invoices SET pdf_finalization_status = 'NONE' WHERE pdf_finalization_status IS NULL;
   `);
+  if (initializeOrderBindingState) {
+    db.exec(`
+      UPDATE invoices
+      SET order_binding_state = CASE
+        WHEN source_type = 'FREE' THEN 'NOT_APPLICABLE'
+        WHEN status = 'DRAFT' THEN 'LEGACY_UNRESOLVED'
+        ELSE 'LEGACY_SNAPSHOT'
+      END
+    `);
+  }
 }
 
 function needsLegacyCompatibilityRebuild(columns, createSql) {
@@ -197,6 +209,7 @@ function rebuildIncompatibleLegacyInvoices(db, columns) {
       source_order_id TEXT,
       source_order_number TEXT,
       source_order_date TEXT,
+      order_binding_state TEXT NOT NULL DEFAULT 'NOT_APPLICABLE',
       service_reference TEXT,
       construction_project TEXT,
       intro_text TEXT,
@@ -239,6 +252,234 @@ function rebuildIncompatibleLegacyInvoices(db, columns) {
     DROP TABLE invoices;
     ALTER TABLE ${quoteIdentifier(LEGACY_MIGRATION_TABLE)} RENAME TO invoices;
   `);
+}
+
+const CREATE_BILLING_ORDER_SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS billing_orders (
+    id TEXT PRIMARY KEY CHECK (
+      length(id) = 36 AND substr(id, 9, 1) = '-' AND substr(id, 14, 1) = '-'
+      AND substr(id, 19, 1) = '-' AND substr(id, 24, 1) = '-'
+    ),
+    order_number TEXT NOT NULL UNIQUE CHECK (length(trim(order_number)) > 0),
+    order_date TEXT NOT NULL CHECK (length(order_date) = 10),
+    customer_firm_id TEXT NOT NULL,
+    project_id TEXT,
+    service_reference TEXT NOT NULL CHECK (length(trim(service_reference)) > 0),
+    status TEXT NOT NULL DEFAULT 'DRAFT' CHECK (status IN ('DRAFT', 'CONFIRMED', 'CANCELLED')),
+    confirmed_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    CHECK ((status = 'DRAFT' AND confirmed_at IS NULL) OR (status IN ('CONFIRMED', 'CANCELLED') AND confirmed_at IS NOT NULL)),
+    FOREIGN KEY (customer_firm_id) REFERENCES firms(id) ON DELETE RESTRICT,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE RESTRICT
+  );
+
+  CREATE TABLE IF NOT EXISTS billing_order_positions (
+    id TEXT PRIMARY KEY CHECK (
+      length(id) = 36 AND substr(id, 9, 1) = '-' AND substr(id, 14, 1) = '-'
+      AND substr(id, 19, 1) = '-' AND substr(id, 24, 1) = '-'
+    ),
+    order_id TEXT NOT NULL,
+    parent_position_id TEXT,
+    type TEXT NOT NULL CHECK (type IN ('heading', 'service', 'note')),
+    position_number TEXT NOT NULL CHECK (length(trim(position_number)) > 0),
+    sort_index INTEGER NOT NULL CHECK (sort_index >= 0),
+    short_text TEXT NOT NULL CHECK (length(trim(short_text)) > 0),
+    long_text TEXT NOT NULL DEFAULT '',
+    quantity TEXT,
+    unit TEXT,
+    unit_price_cents INTEGER CHECK (unit_price_cents IS NULL OR unit_price_cents >= 0),
+    is_nep INTEGER NOT NULL DEFAULT 0 CHECK (is_nep IN (0, 1)),
+    vat_rate_percent INTEGER CHECK (vat_rate_percent IS NULL OR vat_rate_percent BETWEEN 0 AND 100),
+    price_input_mode TEXT CHECK (price_input_mode IS NULL OR price_input_mode IN ('NET', 'GROSS')),
+    price_input_cents INTEGER CHECK (price_input_cents IS NULL OR price_input_cents >= 0),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (order_id, id),
+    UNIQUE (order_id, position_number),
+    UNIQUE (order_id, sort_index),
+    FOREIGN KEY (order_id) REFERENCES billing_orders(id) ON DELETE CASCADE,
+    FOREIGN KEY (order_id, parent_position_id) REFERENCES billing_order_positions(order_id, id) ON DELETE RESTRICT
+  );
+
+  CREATE TABLE IF NOT EXISTS billing_order_amendments (
+    id TEXT PRIMARY KEY CHECK (
+      length(id) = 36 AND substr(id, 9, 1) = '-' AND substr(id, 14, 1) = '-'
+      AND substr(id, 19, 1) = '-' AND substr(id, 24, 1) = '-'
+    ),
+    order_id TEXT NOT NULL,
+    sequence_no INTEGER,
+    amendment_number TEXT,
+    relates_to_order_position_id TEXT NOT NULL,
+    short_text TEXT NOT NULL CHECK (length(trim(short_text)) > 0),
+    long_text TEXT NOT NULL DEFAULT '',
+    quantity TEXT,
+    unit TEXT,
+    unit_price_cents INTEGER CHECK (unit_price_cents IS NULL OR unit_price_cents >= 0),
+    is_nep INTEGER NOT NULL DEFAULT 0 CHECK (is_nep IN (0, 1)),
+    vat_rate_percent INTEGER CHECK (vat_rate_percent IS NULL OR vat_rate_percent BETWEEN 0 AND 100),
+    price_input_mode TEXT CHECK (price_input_mode IS NULL OR price_input_mode IN ('NET', 'GROSS')),
+    price_input_cents INTEGER CHECK (price_input_cents IS NULL OR price_input_cents >= 0),
+    status TEXT NOT NULL DEFAULT 'DRAFT' CHECK (status IN ('DRAFT', 'CONFIRMED', 'CANCELLED')),
+    confirmed_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (order_id, sequence_no),
+    UNIQUE (order_id, amendment_number),
+    CHECK (
+      (status = 'DRAFT' AND sequence_no IS NULL AND amendment_number IS NULL AND confirmed_at IS NULL)
+      OR
+      (status IN ('CONFIRMED', 'CANCELLED') AND sequence_no > 0 AND amendment_number = printf('N %02d', sequence_no) AND confirmed_at IS NOT NULL)
+    ),
+    FOREIGN KEY (order_id) REFERENCES billing_orders(id) ON DELETE RESTRICT,
+    FOREIGN KEY (order_id, relates_to_order_position_id) REFERENCES billing_order_positions(order_id, id) ON DELETE RESTRICT
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_billing_orders_customer ON billing_orders(customer_firm_id, order_date DESC);
+  CREATE INDEX IF NOT EXISTS idx_billing_orders_project ON billing_orders(project_id, order_date DESC);
+  CREATE INDEX IF NOT EXISTS idx_billing_order_positions_order ON billing_order_positions(order_id, sort_index);
+  CREATE INDEX IF NOT EXISTS idx_billing_order_amendments_order ON billing_order_amendments(order_id, sequence_no);
+
+  CREATE TRIGGER IF NOT EXISTS trg_billing_orders_stable_id
+  BEFORE UPDATE OF id ON billing_orders
+  WHEN NEW.id IS NOT OLD.id
+  BEGIN
+    SELECT RAISE(ABORT, 'billing_order_id_immutable');
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_billing_orders_confirmed_immutable
+  BEFORE UPDATE ON billing_orders
+  WHEN OLD.status IN ('CONFIRMED', 'CANCELLED') AND (
+    NEW.order_number IS NOT OLD.order_number OR NEW.order_date IS NOT OLD.order_date
+    OR NEW.customer_firm_id IS NOT OLD.customer_firm_id OR NEW.project_id IS NOT OLD.project_id
+    OR NEW.service_reference IS NOT OLD.service_reference OR NEW.confirmed_at IS NOT OLD.confirmed_at
+    OR (OLD.status = 'CONFIRMED' AND NEW.status NOT IN ('CONFIRMED', 'CANCELLED'))
+    OR (OLD.status = 'CANCELLED' AND NEW.status IS NOT OLD.status)
+  )
+  BEGIN
+    SELECT RAISE(ABORT, 'billing_order_confirmed_immutable');
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_billing_orders_confirmed_no_delete
+  BEFORE DELETE ON billing_orders
+  WHEN OLD.status IN ('CONFIRMED', 'CANCELLED')
+  BEGIN
+    SELECT RAISE(ABORT, 'billing_order_confirmed_immutable');
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_billing_order_positions_draft_insert
+  BEFORE INSERT ON billing_order_positions
+  WHEN NOT EXISTS (SELECT 1 FROM billing_orders WHERE id = NEW.order_id AND status = 'DRAFT')
+  BEGIN
+    SELECT RAISE(ABORT, 'billing_order_positions_require_draft_order');
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_billing_order_positions_stable_identity
+  BEFORE UPDATE OF id, order_id ON billing_order_positions
+  WHEN NEW.id IS NOT OLD.id OR NEW.order_id IS NOT OLD.order_id
+  BEGIN
+    SELECT RAISE(ABORT, 'billing_order_position_identity_immutable');
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_billing_order_positions_draft_update
+  BEFORE UPDATE ON billing_order_positions
+  WHEN NOT EXISTS (SELECT 1 FROM billing_orders WHERE id = OLD.order_id AND status = 'DRAFT')
+  BEGIN
+    SELECT RAISE(ABORT, 'billing_order_positions_confirmed_immutable');
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_billing_order_positions_draft_delete
+  BEFORE DELETE ON billing_order_positions
+  WHEN NOT EXISTS (SELECT 1 FROM billing_orders WHERE id = OLD.order_id AND status = 'DRAFT')
+  BEGIN
+    SELECT RAISE(ABORT, 'billing_order_positions_confirmed_immutable');
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_billing_order_amendments_confirmed_order_insert
+  BEFORE INSERT ON billing_order_amendments
+  WHEN NOT EXISTS (SELECT 1 FROM billing_orders WHERE id = NEW.order_id AND status = 'CONFIRMED')
+  BEGIN
+    SELECT RAISE(ABORT, 'billing_order_amendments_require_confirmed_order');
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_billing_order_amendments_stable_identity
+  BEFORE UPDATE OF id, order_id ON billing_order_amendments
+  WHEN NEW.id IS NOT OLD.id OR NEW.order_id IS NOT OLD.order_id
+  BEGIN
+    SELECT RAISE(ABORT, 'billing_order_amendment_identity_immutable');
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_billing_order_amendments_valid_origin_insert
+  BEFORE INSERT ON billing_order_amendments
+  WHEN NOT EXISTS (
+    SELECT 1 FROM billing_order_positions
+    WHERE order_id = NEW.order_id AND id = NEW.relates_to_order_position_id AND type = 'service'
+  )
+  BEGIN
+    SELECT RAISE(ABORT, 'billing_order_amendment_origin_invalid');
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_billing_order_amendments_valid_origin_update
+  BEFORE UPDATE OF order_id, relates_to_order_position_id ON billing_order_amendments
+  WHEN NOT EXISTS (
+    SELECT 1 FROM billing_order_positions
+    WHERE order_id = NEW.order_id AND id = NEW.relates_to_order_position_id AND type = 'service'
+  )
+  BEGIN
+    SELECT RAISE(ABORT, 'billing_order_amendment_origin_invalid');
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_billing_order_amendments_confirmed_immutable
+  BEFORE UPDATE ON billing_order_amendments
+  WHEN OLD.status IN ('CONFIRMED', 'CANCELLED') AND (
+    NEW.id IS NOT OLD.id OR NEW.order_id IS NOT OLD.order_id
+    OR NEW.sequence_no IS NOT OLD.sequence_no OR NEW.amendment_number IS NOT OLD.amendment_number
+    OR NEW.relates_to_order_position_id IS NOT OLD.relates_to_order_position_id
+    OR NEW.short_text IS NOT OLD.short_text OR NEW.long_text IS NOT OLD.long_text
+    OR NEW.quantity IS NOT OLD.quantity OR NEW.unit IS NOT OLD.unit
+    OR NEW.unit_price_cents IS NOT OLD.unit_price_cents OR NEW.is_nep IS NOT OLD.is_nep
+    OR NEW.vat_rate_percent IS NOT OLD.vat_rate_percent OR NEW.price_input_mode IS NOT OLD.price_input_mode
+    OR NEW.price_input_cents IS NOT OLD.price_input_cents OR NEW.confirmed_at IS NOT OLD.confirmed_at
+    OR (OLD.status = 'CONFIRMED' AND NEW.status NOT IN ('CONFIRMED', 'CANCELLED'))
+    OR (OLD.status = 'CANCELLED' AND NEW.status IS NOT OLD.status)
+  )
+  BEGIN
+    SELECT RAISE(ABORT, 'billing_order_amendment_confirmed_immutable');
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_billing_order_amendments_confirmed_no_delete
+  BEFORE DELETE ON billing_order_amendments
+  WHEN OLD.status IN ('CONFIRMED', 'CANCELLED')
+  BEGIN
+    SELECT RAISE(ABORT, 'billing_order_amendment_confirmed_immutable');
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_invoices_order_binding_insert
+  AFTER INSERT ON invoices
+  WHEN NEW.source_type = 'FROM_ORDER' AND NEW.order_binding_state = 'NOT_APPLICABLE'
+  BEGIN
+    UPDATE invoices SET order_binding_state = 'LEGACY_UNRESOLVED' WHERE id = NEW.id;
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_invoices_order_binding_source_change
+  AFTER UPDATE OF source_type ON invoices
+  WHEN NEW.status = 'DRAFT' AND NEW.source_type IS NOT OLD.source_type
+  BEGIN
+    UPDATE invoices
+    SET order_binding_state = CASE WHEN NEW.source_type = 'FREE' THEN 'NOT_APPLICABLE' ELSE 'LEGACY_UNRESOLVED' END
+    WHERE id = NEW.id;
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS trg_invoices_legacy_unresolved_no_booking
+  BEFORE UPDATE OF status ON invoices
+  WHEN OLD.order_binding_state = 'LEGACY_UNRESOLVED' AND NEW.status = 'BOOKED'
+  BEGIN
+    SELECT RAISE(ABORT, 'invoice_order_binding_legacy_unresolved');
+  END;
+`;
+
+function ensureBillingOrderSchema(db) {
+  db.exec(CREATE_BILLING_ORDER_SCHEMA_SQL);
 }
 
 function hasUniqueInvoiceNumberIndex(db) {
@@ -419,14 +660,16 @@ function ensureInvoiceSchema(db) {
   const migrate = () => {
     db.exec(CREATE_INVOICES_SQL);
     const originalColumns = invoiceColumns(db);
+    const hadOrderBindingState = originalColumns.some((column) => column.name === "order_binding_state");
     const createSql = db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'invoices'").get()?.sql || "";
     addMissingInvoiceColumns(db, originalColumns);
-    applySafeLegacyDefaults(db);
+    applySafeLegacyDefaults(db, { initializeOrderBindingState: !hadOrderBindingState });
     const currentColumns = invoiceColumns(db);
     if (needsLegacyCompatibilityRebuild(originalColumns, createSql)) {
       rebuildIncompatibleLegacyInvoices(db, currentColumns);
     }
     ensureInvoiceIndexes(db);
+    ensureBillingOrderSchema(db);
     db.exec(`
       CREATE TABLE IF NOT EXISTS invoice_number_sequences (
         sequence_key TEXT PRIMARY KEY,
@@ -488,4 +731,4 @@ function ensureInvoiceSchema(db) {
   return { customerMigration };
 }
 
-module.exports = { ensureInvoiceSchema, migrateDraftCustomerRefs, ensureInvoiceIssuerProfile };
+module.exports = { ensureInvoiceSchema, migrateDraftCustomerRefs, ensureInvoiceIssuerProfile, ensureBillingOrderSchema };


### PR DESCRIPTION
## Scope

Setzt ausschließlich Paket 4a aus #275 um:

- additive Persistenz für `BillingOrder`, `BillingOrderPosition` und `BillingOrderAmendment`
- stabile UUID-/Identitäts- und DB-Unveränderlichkeitsregeln
- sichtbare Vertragsnummern und explizite Reihenfolge ohne Neuberechnung
- `LEGACY_UNRESOLVED` / `LEGACY_SNAPSHOT` ohne heuristische Altbestandszuordnung
- Nachtragsschema für spätere Pakete vorbereitet

Nicht enthalten: Paket 4b-Service/IPC, UI, Auftragssnapshot in Rechnung, Nachtragsworkflow/Nummernvergabe, PDF/Mail/Export, Core-Fachlogik.

## Prüfung

- 6/6 neue Pakettests grün
- 59 relevante Migrations-/Gate-B-/Rechnungsnachweise grün
- `git diff --check` und Syntaxprüfungen grün
- Volltest: exakt bekannte neun Baseline-Einzelfehler und fehlende `ui-editor-kit`-Artefakte
- isoliert zusätzlich der bereits bekannte alte Screen-Textvertrag `Rechnungspositionen`
- keine neue Fehlerklasse

Closes keinen Gesamt-Scope; #275 bleibt offen.