### PR TITLE
Rechnung #275: Paket 4d – Nachträge und atomare Nummernvergabe

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,3 +1,14 @@
+## Rechnung #275 – Paket 4d (2026-09-06)
+
+Auf main-Basis 62bf2fb (PR #313–#315) Nachtragsanlage und atomare Bestätigung
+über bestehenden Auftragsservice ergänzt. 8/8 Pakettests einschließlich echter
+Prozesskonkurrenz, Ursprungs-/Lizenzguards und Rechnungssnapshot-Erhalt grün.
+Relevante Regression: 100 grün / eine bekannte Screen-Baseline rot. Volltest:
+463 grün / dieselben neun Baselinefehler und ui-editor-kit-Abbrüche. Keine neue
+Regression; keine Schema-/UI-/Core-Änderung. Details: docs/RECHNUNG_REVISION_275.md.
+PR, CI und Main-Commit werden in #275 nach Integration dokumentiert.
+Paket 4e nicht begonnen; #275 bleibt offen.
+
 # STATUS.md â€” BBM-Produktiv
 
 ## 2026-09-06 – Rechnung #275 Paket 4c-fix

--- a/docs/MODULARISIERUNGSPLAN.md
+++ b/docs/MODULARISIERUNGSPLAN.md
@@ -18,6 +18,18 @@ Diese Datei ist **kein** Architekturpapier und **kein** Codex-Ausfuehrungsmanual
 
 ## 1. Operative Arbeitsgrundsaetze
 
+### Rechnung #275 – Paket 4d (2026-09-06)
+
+Container 5: Nachtragsentwurf und Bestätigung über den bestehenden BillingOrderService.
+Atomare Nummernfolge pro Auftrag, stabile Ursprungs-Serviceposition, unverändertes
+Vertrags-LV und unveränderte 4c-Snapshots. Vorhandene 4a-Persistenz und DB-Guards
+bleiben bestehen; keine Schema-/UI-/Core-Änderung. Acht Pakettests einschließlich
+konkurrierender SQLite-Prozesse grün; relevante Regression 100 grün / bekannte
+Screen-Baseline rot. Volltest 463 grün / unveränderte neun Baselinefehler.
+Detailnachweis in `docs/RECHNUNG_REVISION_275.md` und #275.
+Kurzfahrplan: 4d integrieren/dokumentieren; 4e nur nach gesondertem Auftrag;
+weiterer Rechnungsfachscope anschließend gemäß #275. 4e nicht begonnen.
+
 ### Rechnung #275 – Paket 4c-fix (2026-09-06)
 
 Container 5: angehaltenen 4c-Snapshotbestand geprüft und dessen DB-Blocker

--- a/docs/RECHNUNG_REVISION_275.md
+++ b/docs/RECHNUNG_REVISION_275.md
@@ -1,6 +1,101 @@
 # Rechnung – Revision #275
 
-Stand: 2026-09-06, Paket 4c mit Korrekturpaket 4c-fix.
+Stand: 2026-09-06, Paket 4d – Nachträge und Ursprungsreferenzen.
+
+## Paket 4d – Nachtragszugang am bestätigten Auftrag
+
+Basis: main `62bf2fb99a61a0bbd6b39a10f0aba7fd8d38285b`; PR #313, #314 und
+#315 sind enthalten. Container 5, ausschließlich Rechnungsfachlogik. Der aktuelle
+4d-Auftrag begrenzt den älteren Gesamtvertrag: Nachtragsübernahme in Rechnungen
+und sichtbare Darstellung sind hier ausdrücklich nicht enthalten.
+
+### Anwendungsgrenze
+
+Der bestehende `BillingOrderService` bleibt der einzige produktive Importeur des
+`BillingOrderRepository`. Zwei Operationen ergänzen die vorhandene Auftragsgrenze:
+
+| Operation | Payload | Ergebnis |
+| --- | --- | --- |
+| `createDraftAmendment` | `{ id, amendment }` | DRAFT mit serverseitiger UUID; Nummer, Sequenz und Bestätigungszeitpunkt NULL |
+| `confirmAmendment` | `{ id, amendment_id }` | bestätigter Nachtrag mit atomar vergebener Nummer und Zeitstempel |
+
+`id` bezeichnet immer die Auftrags-UUID. `amendment` enthält ausschließlich
+`relates_to_order_position_id`, Kurz-/Langtext und die bereits vorhandenen Mengen-/
+Preis-/Steuer-/NEP-Felder. Client-IDs, Nummern, Sequenzen, Status, Zeitstempel,
+Vertragsnummern und Sortierungsfelder werden nicht akzeptiert. Gemeinsame
+Fachwerte verwenden dieselbe bestehende Validierung wie Vertragspositionen.
+
+Vor Anlage und Bestätigung werden Auftrag und Referenz innerhalb einer
+Schreibtransaktion geprüft: nur CONFIRMED, nur eine ursprüngliche service-Position
+dieses Auftrags. Titel, Notizen, Nachtrags-IDs, fremde Aufträge, fehlende IDs und
+LEGACY_UNRESOLVED-Payloads werden abgewiesen. Bestätigung prüft gespeicherte
+Fachwerte erneut; ein ungültiger Altentwurf bleibt unverändert DRAFT.
+
+Der bestehende Rechnungs-IPC-Registrar erhält die Kanäle
+`rechnung:order:amendment:createDraft` und `rechnung:order:amendment:confirm`.
+Preload bietet `rechnungOrderAmendmentCreateDraft(id, amendment)` und
+`rechnungOrderAmendmentConfirm(id, amendment_id)`. Beide Zugriffe unterliegen
+modularer Aktivierung und aktueller fachlicher Lizenzprüfung. Kein UI-Neubau.
+
+### Atomare Nummernvergabe und Bestand
+
+Die bestehende SQLite-IMMEDIATE-Transaktionshülle umfasst Serviceprüfung,
+Ermittlung von MAX(sequence_no) + 1 pro Auftrag und abschließendes UPDATE.
+`sequence_no`, `amendment_number` per `printf('N %02d', sequence_no)`, Status und
+Zeitstempel werden gemeinsam geschrieben. Erst dann wird committed. Zwei
+Verbindungen können denselben Höchstwert nicht parallel reservieren. Die
+vorhandenen UNIQUE-Regeln sichern Auftrag/Sequenz und Auftrag/Kennung zusätzlich.
+
+Unbestätigte Entwürfe verbrauchen keine Nummer. Abgewiesene oder zurückgerollte
+Bestätigungen ebenfalls nicht. Erneute Bestätigung desselben Entwurfs wird
+abgewiesen. Bereits vergebene Nummern, auch aus bestehendem CANCELLED-Bestand,
+bleiben belegt. Es gibt keine automatische Neunummerierung historischen Bestands.
+
+Keine Schemaänderung, keine zweite Persistenz, keine neue DB-Datei. Bestehende
+4a-Trigger schützen UUIDs, Ursprungsreferenzen und bestätigte Nachtragsinhalte.
+Ein Änderungs-/Lösch-/Stornierungsservice ist nicht Bestandteil dieser Grenze.
+
+Das Vertrags-LV bleibt in `positions` vollständig unverändert. Nachträge stehen
+separat in `amendments`, bestätigte in sequence_no-Reihenfolge, unnummerierte
+Entwürfe danach. Sie sind fachlich der nachgelagerte LV-Teil und erhalten keinen
+Vertrags-sort_index. Die Ursprungsnummer bleibt über die stabile UUID der
+unveränderlichen Vertragsposition nachvollziehbar. Eine zusammengeführte UI-
+oder Rechnungsliste wird in diesem Paket nicht erzeugt.
+
+4c bleibt unverändert: Rechnungssnapshots werden weder nachträglich aktualisiert
+noch um Nachträge ergänzt. Auch eine neue Rechnung übernimmt in diesem Paket
+weiterhin ausschließlich das Vertrags-LV. Der umfassendere Nachtrags-Snapshot-
+Vertrag benötigt einen gesondert freigegebenen Anschlussauftrag.
+
+### Tests / Abgrenzung
+
+- 8/8 neue Fach-/Persistenz-/IPC-/Guard-Prüfungen grün.
+- Echter Konkurrenznachweis: vier getrennte Electron-Prozesse mit unabhängigen
+  SQLite-Verbindungen auf derselben Datei konkurrieren um die Schreibsperre;
+  danach N 01 bis N 04 ohne Duplikat oder Lücke. Zwei weitere Prozesse bestätigen
+  denselben Entwurf: genau einer erfolgreich (N 05), der zweite abgewiesen;
+  anschließender Entwurf erhält N 06.
+- Injizierter Write-Abbruch: kompletter Rollback, nächster Erfolg erhält N 01.
+- Bestandsnachweis: vorhandene N 01/N 02 bleiben erhalten; nächste Vergabe N 03;
+  wiederholte Migration bewahrt bestätigte und unbestätigte Nachtragsdaten.
+- Vertrags-LV und vorhandene reale 4c-Rechnungszeile bleiben vollständig identisch.
+- Bestehende 4c-Prüfungen 9/9 und 4c-fix-Prüfungen 3/3 unverändert grün.
+- Relevante Rechnungs-/Migrations-/Core-Gruppe: 100 grün, nur die bekannte
+  historische Screen-Text-Erwartung `Rechnungspositionen` rot.
+- Frische main-Baseline: 455 grüne Einzelprüfungen / 9 bekannte Fehler.
+- Volltest nach Änderung: 463 grün / identische 9 Fehler. Fehlertitel und
+  ui-editor-kit-Ladeabbrüche maschinell identisch verglichen; 0/10 Gesamtgruppen.
+- Keine neue Regression. Keine visuellen UI- oder Windows-Buildtests behauptet.
+
+Die alten 4a/4b-Assertions zur ausdrücklichen Abwesenheit der erst für 4d
+vorgesehenen Operationen wurden dem beauftragten Funktionsausbau angepasst.
+Die ursprünglichen Persistenz-/Fachguards bleiben geprüft. Ein erster Testaufbau
+verwendete doppelte Auftragsnummern und wurde im Fixture korrigiert; kein
+Produktfehler. PR-/CI-/Main-Commit-Nachweis folgt nach Integration in #275.
+
+Paket 4e ist nicht begonnen. Das Gesamtissue #275 bleibt offen.
+
+Die folgenden Abschnitte dokumentieren die damaligen Einzelpaketstände.
 
 ## Paket 4c-fix – konsistente Snapshotspalten
 

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -74,6 +74,7 @@ const TEST_GROUPS = Object.freeze([
       ["rechnungBillingOrderService.test.cjs", "runRechnungBillingOrderServiceTests"],
       ["rechnungOrderSnapshot.test.cjs", "runRechnungOrderSnapshotTests"],
       ["rechnungOrderSnapshotMigration.test.cjs", "runRechnungOrderSnapshotMigrationTests"],
+      ["rechnungOrderAmendment.test.cjs", "runRechnungOrderAmendmentTests"],
       ["rechnungenDesignModule.test.cjs", "runRechnungenDesignModuleTests"],
       ["rechnungHeaderRules.test.cjs", "runRechnungHeaderRulesTests"],
       ["rechnungBooking.test.cjs", "runRechnungBookingTests"],

--- a/scripts/tests/rechnungBillingOrderPersistence.test.cjs
+++ b/scripts/tests/rechnungBillingOrderPersistence.test.cjs
@@ -128,7 +128,7 @@ async function runRechnungBillingOrderPersistenceTests(run) {
     } finally { db.close(); }
   });
 
-  await run("Rechnung #275 Paket 4a: Nachtragsschema bereitet Referenz und N 01/N 02 vor, ohne Paket-4d-Workflow", () => {
+  await run("Rechnung #275 Paket 4a/4d: Nachtragsbestand bewahrt Referenz und N 01/N 02 bei fortgesetzter Nummernvergabe", () => {
     const db = database();
     try {
       const repo = repository(db);
@@ -161,7 +161,8 @@ async function runRechnungBillingOrderPersistenceTests(run) {
         /billing_order_amendment_confirmed_immutable/
       );
       assert.throws(() => db.prepare("DELETE FROM billing_order_amendments WHERE id = ?").run(UUID.amendment2), /billing_order_amendment_confirmed_immutable/);
-      assert.equal(typeof repo.confirmAmendment, "undefined");
+      const confirmed = repo.confirmAmendment(UUID.order, firstDraft.id);
+      assert.deepEqual([confirmed.id, confirmed.sequence_no, confirmed.amendment_number], [firstDraft.id, 3, "N 03"]);
     } finally { db.close(); }
   });
 

--- a/scripts/tests/rechnungBillingOrderService.test.cjs
+++ b/scripts/tests/rechnungBillingOrderService.test.cjs
@@ -41,7 +41,7 @@ async function runRechnungBillingOrderServiceTests(run) {
       assert.equal(service.repository, undefined);
       assert.equal(db.prepare("SELECT COUNT(*) AS n FROM invoices").get().n, 0);
       assert.equal(db.prepare("SELECT COUNT(*) AS n FROM billing_order_amendments").get().n, 0);
-      assert.equal(service.createDraftAmendment, undefined);
+      // Nachtragsoperationen ergänzt in Paket 4d; der unveränderte Auftrag hat keine Nachträge.
     } finally { db.close(); }
   });
 
@@ -161,7 +161,7 @@ async function runRechnungBillingOrderServiceTests(run) {
         assert.equal(name, "electron");
         return { contextBridge: { exposeInMainWorld: (key, value) => { if (key === "bbmDb") api = value; } }, ipcRenderer: { invoke: (channel, payload) => handlers.get(channel)({}, payload), on() {} } };
       }, console, process: { env: {} } });
-      assert.deepEqual([...handlers.keys()].filter(k => k.startsWith("rechnung:order:")), ["rechnung:order:get", "rechnung:order:createDraft", "rechnung:order:addPosition", "rechnung:order:confirm"]);
+      assert.deepEqual([...handlers.keys()].filter(k => k.startsWith("rechnung:order:")), ["rechnung:order:get", "rechnung:order:createDraft", "rechnung:order:addPosition", "rechnung:order:confirm", "rechnung:order:amendment:createDraft", "rechnung:order:amendment:confirm"]);
       const created = await api.rechnungOrderCreateDraft(header());
       assert.equal(created.ok, true);
       const { id } = created.data;

--- a/scripts/tests/rechnungOrderAmendment.test.cjs
+++ b/scripts/tests/rechnungOrderAmendment.test.cjs
@@ -1,0 +1,254 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const vm = require("node:vm");
+const { spawn } = require("node:child_process");
+const { randomUUID } = require("node:crypto");
+const Database = require("better-sqlite3");
+const { ensureInvoiceSchema } = require("../../src/main/db/invoiceMigrations");
+const { BillingOrderRepository } = require("../../src/main/db/billingOrderRepository");
+const { BillingOrderService } = require("../../src/main/domain/rechnung/BillingOrderService");
+const { InvoiceRepository } = require("../../src/main/db/invoiceRepository");
+const { InvoiceService } = require("../../src/main/domain/rechnung/InvoiceService");
+
+function fixture(filename = ":memory:") {
+  const db = new Database(filename);
+  db.pragma("foreign_keys = ON");
+  db.exec(`CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE firms (id TEXT PRIMARY KEY, name TEXT, name2 TEXT, street TEXT, zip TEXT, city TEXT, country TEXT, phone TEXT, email TEXT, use_customer INTEGER, removed_at TEXT, is_trashed INTEGER);
+    CREATE TABLE project_firms (id TEXT PRIMARY KEY, project_id TEXT, name TEXT, name2 TEXT, street TEXT, zip TEXT, city TEXT, country TEXT, phone TEXT, email TEXT, use_customer INTEGER, removed_at TEXT, is_active INTEGER);
+    CREATE TABLE user_profile (id INTEGER PRIMARY KEY, name1 TEXT, name2 TEXT, street TEXT, zip TEXT, city TEXT, country TEXT, phone TEXT, email TEXT, tax_number TEXT, vat_id TEXT, iban TEXT, bic TEXT, bank_name TEXT);
+    INSERT INTO firms (id, name, street, zip, city, use_customer, is_trashed) VALUES ('customer', 'Bau GmbH', 'Bauweg 1', '20000', 'Hamburg', 1, 0);
+    INSERT INTO user_profile (id, name1, street, zip, city) VALUES (1, 'Aussteller', 'Weg 1', '20000', 'Hamburg');`);
+  ensureInvoiceSchema(db);
+  const repository = new BillingOrderRepository({ dbProvider: () => db });
+  let allowed = true;
+  const service = new BillingOrderService({ repository, authorize: () => { if (!allowed) throw new Error("FEATURE_NOT_ALLOWED:rechnung"); } });
+  let orderCount = 0;
+  const order = (confirm = true) => {
+    const draft = service.createDraft({ order_number: `A-${++orderCount}`, order_date: "2026-09-06", customer_firm_id: "customer", service_reference: "Sanierung" });
+    for (const [type, number, sort] of [["heading", "10", 10], ["service", "25", 30], ["note", "40.01", 50]]) {
+      service.addPosition({ id: draft.id, position: { type, position_number: number, sort_index: sort, short_text: type } });
+    }
+    return confirm ? service.confirmOrder({ id: draft.id }) : service.get({ id: draft.id });
+  };
+  return { db, repository, service, order, deny: () => { allowed = false; } };
+}
+const values = (order, patch = {}) => ({ relates_to_order_position_id: order.positions[1].id, short_text: "Zusatzleistung", long_text: "Nachtrag Mauerwerk", quantity: "12.5000", unit: "m2", unit_price_cents: 12345, vat_rate_percent: 19, price_input_mode: "NET", ...patch });
+const create = (e, order, patch) => e.service.createDraftAmendment({ id: order.id, amendment: values(order, patch) });
+const confirm = (e, order, draft) => e.service.confirmAmendment({ id: order.id, amendment_id: draft.id });
+
+// Separate Electron/SQLite connections really contend for the same file write lock.
+async function compete(e, filename, order, drafts) {
+  const children = [];
+  let timer;
+  e.db.exec("BEGIN IMMEDIATE");
+  try {
+    return await new Promise((resolve, reject) => {
+      let waiting = 0;
+      const results = [];
+      timer = setTimeout(() => reject(new Error("amendment_race_timeout")), 15000);
+      drafts.forEach((draft, index) => {
+        const child = spawn(process.execPath, [__filename, "--race-worker", filename, order.id, draft.id], { env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" }, stdio: ["ignore", "pipe", "pipe"] });
+        children.push(child);
+        let buffer = "", errors = "";
+        child.stderr.on("data", data => { errors += data; });
+        child.on("error", reject);
+        child.stdout.on("data", data => {
+          buffer += data;
+          let end;
+          while ((end = buffer.indexOf("\n")) !== -1) {
+            const line = buffer.slice(0, end); buffer = buffer.slice(end + 1);
+            if (line === "WAITING") {
+              if (++waiting === drafts.length) e.db.exec("COMMIT");
+            } else if (line.startsWith("RESULT ")) results[index] = JSON.parse(line.slice(7));
+          }
+        });
+        child.on("close", code => {
+          if (code !== 0 || !results[index]) return reject(new Error(`race_worker_failed:${code}:${errors}`));
+          if (children.every(entry => entry.exitCode !== null) && results.filter(Boolean).length === drafts.length) resolve(results);
+        });
+      });
+    });
+  } finally {
+    clearTimeout(timer);
+    if (e.db.inTransaction) e.db.exec("ROLLBACK");
+    await Promise.all(children.map(child => child.exitCode !== null ? Promise.resolve() : new Promise(resolve => { child.once("close", resolve); child.kill(); })));
+  }
+}
+
+async function runRechnungOrderAmendmentTests(run) {
+  await run("Rechnung #275 Paket 4d: Entwürfe ohne Nummer, lückenlose Bestätigung je Auftrag und stabile UUIDs", () => {
+    const e = fixture();
+    try {
+      const order = e.order();
+      const first = create(e, order), second = create(e, order), unused = create(e, order);
+      for (const draft of [first, second, unused]) {
+        assert.match(draft.id, /^[0-9a-f-]{36}$/);
+        assert.equal(draft.sequence_no, null); assert.equal(draft.amendment_number, null); assert.equal(draft.confirmed_at, null);
+      }
+      const a = confirm(e, order, second), b = confirm(e, order, first);
+      assert.deepEqual([a.id, a.sequence_no, a.amendment_number, a.status], [second.id, 1, "N 01", "CONFIRMED"]);
+      assert.deepEqual([b.id, b.sequence_no, b.amendment_number], [first.id, 2, "N 02"]);
+      assert.ok(a.confirmed_at);
+      assert.equal(a.quantity, "12.5000");
+      const other = e.order();
+      assert.equal(confirm(e, other, create(e, other)).amendment_number, "N 01");
+      assert.equal(confirm(e, order, create(e, order)).amendment_number, "N 03");
+      const loaded = e.service.get({ id: order.id });
+      assert.deepEqual(loaded.positions, order.positions);
+      assert.deepEqual(loaded.amendments.map(a => a.sequence_no), [1, 2, 3, null]);
+      assert.equal(loaded.amendments[0].relates_to_order_position_id, order.positions[1].id);
+      assert.equal(loaded.positions.find(p => p.id === a.relates_to_order_position_id).position_number, "25");
+    } finally { e.db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4d: Ursprungs- und Auftragsguards weisen fremde Titel, Notizen, Nachträge und Legacy ab", () => {
+    const e = fixture();
+    try {
+      const order = e.order(), other = e.order(), draftOrder = e.order(false);
+      const amendment = create(e, order);
+      for (const origin of [order.positions[0].id, order.positions[2].id, other.positions[1].id, amendment.id, randomUUID(), "25", null]) {
+        assert.throws(() => create(e, order, { relates_to_order_position_id: origin }), /billing_order_/);
+      }
+      assert.throws(() => create(e, draftOrder), /require_confirmed_order/);
+      assert.throws(() => confirm(e, other, amendment), /amendment_not_found/);
+      assert.throws(() => e.service.createDraftAmendment({ id: order.id, amendment: values(order), order_binding_state: "LEGACY_UNRESOLVED" }), /legacy_unresolved/);
+      e.db.prepare("UPDATE billing_orders SET status = 'CANCELLED' WHERE id = ?").run(order.id);
+      assert.throws(() => create(e, order), /require_confirmed_order/);
+      assert.throws(() => confirm(e, order, amendment), /require_confirmed_order/);
+      assert.equal(e.service.get({ id: order.id }).amendments[0].status, "DRAFT");
+    } finally { e.db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4d: strikte Fachwerte und Clientfelder, fehlerhafter Altentwurf verbraucht keine Nummer", () => {
+    const e = fixture();
+    try {
+      const order = e.order();
+      for (const patch of [{ id: randomUUID() }, { order_id: order.id }, { sequence_no: 1 }, { amendment_number: "N 01" }, { status: "CONFIRMED" }, { sort_index: 15 }, { position_number: "11" }, { short_text: "" }, { quantity: "1,5" }, { quantity: {} }, { unit_price_cents: 0.5 }, { vat_rate_percent: 101 }, { is_nep: "true" }, { price_input_mode: "other" }, { long_text: {} }]) {
+        assert.throws(() => create(e, order, patch), /billing_order_/);
+      }
+      assert.equal(e.service.get({ id: order.id }).amendments.length, 0);
+      const bad = e.repository.createDraftAmendment(order.id, values(order, { quantity: "historisch unklar" }));
+      assert.throws(() => confirm(e, order, bad), /quantity_invalid/);
+      assert.equal(e.service.get({ id: order.id }).amendments[0].sequence_no, null);
+      const good = create(e, order);
+      assert.throws(() => e.service.confirmAmendment({ id: order.id, amendment_id: good.id, sequence_no: 99 }), /field_not_allowed/);
+      assert.equal(confirm(e, order, good).amendment_number, "N 01");
+    } finally { e.db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4d: Persistenz schützt bestätigte Nachträge, Vertrags-LV und vergebene Nummern", () => {
+    const e = fixture();
+    try {
+      const order = e.order(), draft = create(e, order), a = confirm(e, order, draft);
+      assert.throws(() => confirm(e, order, draft), /not_confirmable/);
+      for (const [field, value] of [["short_text", "Manipulation"], ["quantity", "99"], ["relates_to_order_position_id", order.positions[0].id], ["sequence_no", 20], ["amendment_number", "N 20"], ["status", "DRAFT"], ["id", randomUUID()]]) {
+        assert.throws(() => e.db.prepare(`UPDATE billing_order_amendments SET ${field} = ? WHERE id = ?`).run(value, a.id));
+      }
+      assert.throws(() => e.db.prepare("DELETE FROM billing_order_amendments WHERE id = ?").run(a.id), /immutable/);
+      assert.throws(() => e.db.prepare("UPDATE billing_order_positions SET sort_index = 1 WHERE id = ?").run(order.positions[1].id), /immutable/);
+      assert.deepEqual(e.service.get({ id: order.id }).positions, order.positions);
+      assert.deepEqual(e.service.get({ id: order.id }).amendments[0], a);
+      // Existing 4a cancellation storage retains its number; no cancellation API added.
+      e.db.prepare("UPDATE billing_order_amendments SET status = 'CANCELLED' WHERE id = ?").run(a.id);
+      assert.equal(confirm(e, order, create(e, order)).amendment_number, "N 02");
+      const before = e.service.get({ id: order.id });
+      ensureInvoiceSchema(e.db); ensureInvoiceSchema(e.db);
+      assert.deepEqual(e.service.get({ id: order.id }), before);
+    } finally { e.db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4d: fehlgeschlagener Bestätigungswrite rollt Nummer und Status vollständig zurück", () => {
+    const e = fixture();
+    try {
+      const order = e.order(), draft = create(e, order);
+      e.db.exec("CREATE TRIGGER fail_confirm AFTER UPDATE ON billing_order_amendments BEGIN SELECT RAISE(ABORT, 'injected_write_failure'); END;");
+      assert.throws(() => confirm(e, order, draft), /injected_write_failure/);
+      assert.deepEqual(e.service.get({ id: order.id }).amendments[0], draft);
+      assert.equal(e.db.inTransaction, false);
+      e.db.exec("DROP TRIGGER fail_confirm");
+      assert.equal(confirm(e, order, draft).amendment_number, "N 01");
+    } finally { e.db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4d: reale konkurrierende Verbindungen vergeben lückenlos und bestätigen denselben Entwurf nur einmal", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-amendment-race-"));
+    const filename = path.join(dir, "bbm.sqlite");
+    const e = fixture(filename);
+    try {
+      const order = e.order();
+      const drafts = Array.from({ length: 4 }, () => create(e, order));
+      const results = await compete(e, filename, order, drafts);
+      assert.ok(results.every(result => result.ok), JSON.stringify(results));
+      assert.deepEqual(results.map(r => r.data.sequence_no).sort((a, b) => a - b), [1, 2, 3, 4]);
+      const same = create(e, order);
+      const repeated = await compete(e, filename, order, [same, same]);
+      assert.equal(repeated.filter(r => r.ok).length, 1);
+      assert.match(repeated.find(r => !r.ok).error, /not_confirmable/);
+      assert.equal(confirm(e, order, create(e, order)).amendment_number, "N 06");
+      assert.deepEqual(e.service.get({ id: order.id }).amendments.map(a => a.amendment_number), ["N 01", "N 02", "N 03", "N 04", "N 05", "N 06"]);
+    } finally { e.db.close(); fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  await run("Rechnung #275 Paket 4d: Nachtragsanlage und Bestätigung verändern keine vorhandenen Rechnungssnapshots", async () => {
+    const e = fixture();
+    try {
+      const order = e.order();
+      const invoices = new InvoiceRepository({ dbProvider: () => e.db });
+      const service = new InvoiceService({ repository: invoices, billingOrderService: e.service, settingsGetMany: () => ({}), today: () => "2026-09-06" });
+      const draft = await service.createDraftFromOrder({ source_order_id: order.id, service_period_type: "SINGLE_DATE", service_date: "2026-09-01" });
+      const before = e.db.prepare("SELECT * FROM invoices WHERE id = ?").get(draft.id);
+      confirm(e, order, create(e, order));
+      confirm(e, order, create(e, order));
+      assert.deepEqual(e.db.prepare("SELECT * FROM invoices WHERE id = ?").get(draft.id), before);
+      assert.deepEqual(e.service.get({ id: order.id }).positions, order.positions);
+    } finally { e.db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4d: echter Preload-IPC-Service-Zugang mit dynamischen Modul- und Fachguards", async () => {
+    const e = fixture();
+    try {
+      const { registerRechnungIpc } = require("../../src/main/ipc/rechnungIpc");
+      const { registerActiveModuleIpcs } = require("../../src/main/moduleIpcRegistry");
+      const handlers = new Map();
+      let status = { valid: true, license: { modules: ["rechnung"] } };
+      const options = { ipcMain: { handle: (key, handler) => handlers.set(key, handler) }, licenseStatus: status, getLicenseStatus: () => status,
+        registrars: { rechnung: ({ ipcMain }) => registerRechnungIpc({ ipcMain, billingOrderService: e.service, service: {}, firmDirectory: {}, projectRepository: {}, pdfFinalizer: {} }) } };
+      registerActiveModuleIpcs(options);
+      let api;
+      vm.runInNewContext(fs.readFileSync(path.join(__dirname, "../../src/main/preload.js"), "utf8"), { require: () => ({ contextBridge: { exposeInMainWorld: (key, value) => { if (key === "bbmDb") api = value; } }, ipcRenderer: { invoke: (key, payload) => handlers.get(key)({}, payload), on() {} } }), console, process: { env: {} } });
+      const order = e.order();
+      const draft = await api.rechnungOrderAmendmentCreateDraft(order.id, values(order));
+      assert.equal(draft.ok, true); assert.equal(draft.data.amendment_number, null);
+      assert.equal((await api.rechnungOrderAmendmentConfirm(order.id, draft.data.id)).data.amendment_number, "N 01");
+      assert.equal((await api.rechnungOrderAmendmentConfirm(order.id, draft.data.id)).code, "billing_order_amendment_not_confirmable");
+      assert.equal((await api.rechnungOrderAmendmentCreateDraft(order.id, values(order, { sequence_no: 2 }))).ok, false);
+      const unconfirmed = create(e, order);
+      e.deny();
+      assert.equal((await api.rechnungOrderAmendmentCreateDraft(order.id, values(order))).ok, false);
+      assert.equal((await api.rechnungOrderAmendmentConfirm(order.id, unconfirmed.id)).ok, false);
+      status = { valid: true, license: { modules: [] } };
+      assert.throws(() => api.rechnungOrderAmendmentCreateDraft(order.id, values(order)), /MODULE_NOT_ACTIVE/);
+      assert.throws(() => api.rechnungOrderAmendmentConfirm(order.id, unconfirmed.id), /MODULE_NOT_ACTIVE/);
+      handlers.clear(); registerActiveModuleIpcs({ ...options, licenseStatus: status });
+      assert.equal(handlers.size, 0);
+    } finally { e.db.close(); }
+  });
+}
+
+if (require.main === module && process.argv[2] === "--race-worker") {
+  const db = new Database(process.argv[3], { timeout: 10000 });
+  db.pragma("foreign_keys = ON");
+  const service = new BillingOrderService({ repository: new BillingOrderRepository({ dbProvider: () => db }), authorize: () => {} });
+  process.stdout.write("WAITING\n", () => {
+    let result;
+    try { result = { ok: true, data: service.confirmAmendment({ id: process.argv[4], amendment_id: process.argv[5] }) }; }
+    catch (error) { result = { ok: false, error: error.message }; }
+    finally { db.close(); }
+    process.stdout.write(`RESULT ${JSON.stringify(result)}\n`);
+  });
+}
+
+module.exports = { runRechnungOrderAmendmentTests };

--- a/src/main/db/billingOrderRepository.js
+++ b/src/main/db/billingOrderRepository.js
@@ -194,6 +194,25 @@ class BillingOrderRepository {
     return db.prepare("SELECT * FROM billing_order_amendments WHERE id = ?").get(id);
   }
 
+  confirmAmendment(orderId, amendmentId) {
+    const db = this._db();
+    return this.withTransaction(() => {
+      // Acquire the write lock before reading the sequence, including cancelled numbers.
+      const { next } = db.prepare("SELECT COALESCE(MAX(sequence_no), 0) + 1 AS next FROM billing_order_amendments WHERE order_id = ?").get(orderId);
+      if (!Number.isSafeInteger(next) || next < 1) throw new Error("billing_order_amendment_sequence_invalid");
+      const now = this.clock();
+      const result = db.prepare(`
+        UPDATE billing_order_amendments
+        SET sequence_no = @sequence, amendment_number = printf('N %02d', @sequence),
+            status = 'CONFIRMED', confirmed_at = @now, updated_at = @now
+        WHERE id = @id AND order_id = @order_id AND status = 'DRAFT'
+          AND EXISTS (SELECT 1 FROM billing_orders WHERE id = @order_id AND status = 'CONFIRMED')
+      `).run({ id: amendmentId, order_id: orderId, sequence: next, now });
+      if (result.changes !== 1) throw new Error("billing_order_amendment_not_confirmable");
+      return db.prepare("SELECT * FROM billing_order_amendments WHERE id = ?").get(amendmentId);
+    });
+  }
+
 }
 
 module.exports = { BillingOrderRepository };

--- a/src/main/domain/rechnung/BillingOrderService.js
+++ b/src/main/domain/rechnung/BillingOrderService.js
@@ -5,6 +5,7 @@ const { BillingOrderRepository } = require("../../db/billingOrderRepository");
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const HEADER_FIELDS = ["order_number", "order_date", "customer_firm_id", "project_id", "service_reference"];
 const POSITION_FIELDS = ["parent_position_id", "type", "position_number", "sort_index", "short_text", "long_text", "quantity", "unit", "unit_price_cents", "is_nep", "vat_rate_percent", "price_input_mode", "price_input_cents"];
+const AMENDMENT_FIELDS = ["relates_to_order_position_id", "short_text", "long_text", "quantity", "unit", "unit_price_cents", "is_nep", "vat_rate_percent", "price_input_mode", "price_input_cents"];
 
 function fail(code) {
   const error = new Error(code);
@@ -48,6 +49,11 @@ function position(input) {
   if (!["heading", "service", "note"].includes(result.type)) fail("billing_order_position_type_invalid");
   if (!Number.isSafeInteger(input.sort_index) || input.sort_index < 0) fail("billing_order_sort_index_invalid");
   if (input.parent_position_id != null) id(input.parent_position_id);
+  validateValues(input);
+  return result;
+}
+
+function validateValues(input) {
   if (input.long_text != null && typeof input.long_text !== "string") fail("billing_order_long_text_invalid");
   if (input.quantity != null && (typeof input.quantity !== "string" || !/^\d+(?:\.\d+)?$/.test(input.quantity) || !Number.isFinite(Number(input.quantity)))) fail("billing_order_quantity_invalid");
   if (input.unit != null) text(input.unit, "unit");
@@ -57,7 +63,11 @@ function position(input) {
   if (input.vat_rate_percent > 100) fail("billing_order_vat_rate_percent_invalid");
   if (input.is_nep != null && ![true, false, 0, 1].includes(input.is_nep)) fail("billing_order_is_nep_invalid");
   if (input.price_input_mode != null && !["NET", "GROSS"].includes(input.price_input_mode)) fail("billing_order_price_input_mode_invalid");
-  return result;
+}
+
+function amendment(input) {
+  validateValues(input);
+  return { ...input, short_text: text(input.short_text, "short_text"), relates_to_order_position_id: id(input.relates_to_order_position_id) };
 }
 
 function validateLv(positions) {
@@ -130,6 +140,40 @@ class BillingOrderService {
       validateLv(order.positions);
       if (!order.positions.some((entry) => entry.type === "service")) fail("billing_order_service_position_required");
       return this.#repository.confirmOrder(order.id);
+    });
+  }
+
+  #amendable(orderId, originId) {
+    const order = this.#load(orderId);
+    if (order.status !== "CONFIRMED") fail("billing_order_amendments_require_confirmed_order");
+    if (!order.positions.some((entry) => entry.id === originId && entry.type === "service")) {
+      fail("billing_order_amendment_origin_invalid");
+    }
+    return order;
+  }
+
+  createDraftAmendment(input) {
+    this.#authorize();
+    const command = inputObject(input, ["id", "amendment"]);
+    const values = amendment(inputObject(command.amendment, AMENDMENT_FIELDS));
+    return this.#repository.withTransaction(() => {
+      const order = this.#amendable(command.id, values.relates_to_order_position_id);
+      return this.#repository.createDraftAmendment(order.id, values);
+    });
+  }
+
+  confirmAmendment(input) {
+    this.#authorize();
+    const command = inputObject(input, ["id", "amendment_id"]);
+    const amendmentId = id(command.amendment_id);
+    return this.#repository.withTransaction(() => {
+      const order = this.#load(command.id);
+      const draft = order.amendments.find((entry) => entry.id === amendmentId);
+      if (!draft) fail("billing_order_amendment_not_found");
+      if (draft.status !== "DRAFT") fail("billing_order_amendment_not_confirmable");
+      const values = amendment(draft);
+      this.#amendable(order.id, values.relates_to_order_position_id);
+      return this.#repository.confirmAmendment(order.id, draft.id);
     });
   }
 }

--- a/src/main/ipc/rechnungIpc.js
+++ b/src/main/ipc/rechnungIpc.js
@@ -38,6 +38,8 @@ function registerRechnungIpc({
   handle("rechnung:order:createDraft", (data) => billingOrderService.createDraft(data));
   handle("rechnung:order:addPosition", (data) => billingOrderService.addPosition(data));
   handle("rechnung:order:confirm", (data) => billingOrderService.confirmOrder(data));
+  handle("rechnung:order:amendment:createDraft", (data) => billingOrderService.createDraftAmendment(data));
+  handle("rechnung:order:amendment:confirm", (data) => billingOrderService.confirmAmendment(data));
   handle("rechnung:list", () => service.list(), "list");
   handle("rechnung:get", (data) => service.get(data.id));
   handle("rechnung:createDraft", (data) => service.createDraft(data));

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -103,6 +103,8 @@ contextBridge.exposeInMainWorld("bbmDb", {
   rechnungOrderCreateDraft: (header) => ipcRenderer.invoke("rechnung:order:createDraft", header),
   rechnungOrderAddPosition: (id, position) => ipcRenderer.invoke("rechnung:order:addPosition", { id, position }),
   rechnungOrderConfirm: (id) => ipcRenderer.invoke("rechnung:order:confirm", { id }),
+  rechnungOrderAmendmentCreateDraft: (id, amendment) => ipcRenderer.invoke("rechnung:order:amendment:createDraft", { id, amendment }),
+  rechnungOrderAmendmentConfirm: (id, amendment_id) => ipcRenderer.invoke("rechnung:order:amendment:confirm", { id, amendment_id }),
   rechnungList: () => ipcRenderer.invoke("rechnung:list"),
   rechnungGet: (id) => ipcRenderer.invoke("rechnung:get", { id }),
   rechnungCreateDraft: (header) => ipcRenderer.invoke("rechnung:createDraft", header),


### PR DESCRIPTION
Bisher war die 4a-Nachtragspersistenz nur vorbereitet. Paket 4d ergänzt den fachlichen Zugang über den bestehenden BillingOrderService: Nachtragsentwurf anlegen und bestätigen.

- Nur bestätigte Aufträge und ursprüngliche service-Positionen desselben Auftrags sind zulässig. UUID-Referenzen werden geprüft; keine Text-/Nummernheuristik.
- Entwürfe bleiben ohne Nummer. IMMEDIATE-Schreibtransaktion umfasst Fachprüfung, MAX(sequence_no)+1 und gemeinsames Schreiben von sequence_no, N 01/N 02…, Status und Zeitstempel.
- Vorhandene vergebene Nummern einschließlich CANCELLED bleiben belegt; gescheiterte Bestätigungen verbrauchen keine Nummer.
- Vorhandene 4a-Tabellen, UNIQUE-Regeln und Immutabilitätsguards bleiben unverändert. Keine neue Migration/Persistenz.
- Zwei neue Rechnungs-IPC-/Preload-Aufrufe transportieren zum einzigen fachlichen Auftragsservice, mit Modul- und Lizenzguards.
- Vertragspositionen bleiben unverändert; Nachträge bleiben separat nach Sequenz geordnet. Keine UI oder Rechnungsübernahme, keine Änderung an 4c-Snapshots, kein 4e.

Prüfbasis: main 62bf2fb99a61a0bbd6b39a10f0aba7fd8d38285b mit PR #313/#314/#315.

Tests:
- 8/8 neue Pakettests grün: Nummernfolge, Ursprungs-/Fachguards, Immutabilität/Bestandsmigration, Rollback, echte Prozesskonkurrenz, Snapshotbestand und tatsächlicher Preload→IPC→Service-Zugang.
- Konkurrenz: vier unabhängige SQLite-Prozesse an derselben Datei vergeben N 01–N 04; zwei Bestätigungen desselben Entwurfs ergeben genau einen Erfolg N 05, danach N 06.
- Bestehende 4c 9/9 und 4c-fix 3/3 unverändert grün.
- Relevante Rechnung/Migration/Core: 100 grün, ausschließlich bekannte Screen-Text-Baseline rot.
- main-Volltest 455 grün /9 bekannte Fehler; Paketvolltest 463 grün /identische 9 Fehler und identische ui-editor-kit-Ladeabbrüche. Weiterhin 0/10 Gruppen; keine neue Regression.
- Alte 4a/4b-Tests zur ausdrücklich fehlenden 4d-Operation und zur Vier-Kanal-Liste gezielt an die beauftragte Erweiterung angepasst; Bestandssperren bleiben geprüft.
- Syntax und git diff --check grün.

Lokaler Commit 386aeca3589d22ca64545a3eb66f3bed45fe743d; veröffentlichter Baum 675b9c0c11dea8d7b24513f981892700997b9e5b exakt identisch. Ergebnis/CI/Main-Commit werden nach Integration in #275 dokumentiert. #275 bleibt offen.