### PR TITLE
Rechnung #275: 4d2-Teststand – manuelle Windows-Abnahme ausstehend

### DIFF
--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -75,6 +75,7 @@ const TEST_GROUPS = Object.freeze([
       ["rechnungOrderSnapshot.test.cjs", "runRechnungOrderSnapshotTests"],
       ["rechnungOrderSnapshotMigration.test.cjs", "runRechnungOrderSnapshotMigrationTests"],
       ["rechnungOrderAmendment.test.cjs", "runRechnungOrderAmendmentTests"],
+      ["rechnungAmendmentSnapshot.test.cjs", "runRechnungAmendmentSnapshotTests"],
       ["rechnungenDesignModule.test.cjs", "runRechnungenDesignModuleTests"],
       ["rechnungHeaderRules.test.cjs", "runRechnungHeaderRulesTests"],
       ["rechnungBooking.test.cjs", "runRechnungBookingTests"],

--- a/scripts/tests/rechnungAmendmentSnapshot.test.cjs
+++ b/scripts/tests/rechnungAmendmentSnapshot.test.cjs
@@ -1,0 +1,157 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { randomUUID } = require("node:crypto");
+const { pathToFileURL } = require("node:url");
+const { orderSnapshotFixture } = require("./rechnungOrderSnapshot.test.cjs");
+const { createOrderSnapshot } = require("../../src/main/domain/rechnung/invoiceOrderSnapshot");
+const { InvoiceService } = require("../../src/main/domain/rechnung/InvoiceService");
+const { ensureInvoiceSchema } = require("../../src/main/db/invoiceMigrations");
+
+function amendment(e, source, confirm = true) {
+  const draft = e.billing.createDraftAmendment({ id: source.id, amendment: {
+    relates_to_order_position_id: source.positions.find(p => p.position_number === "25").id,
+    short_text: "Zusätzliche Öffnung", long_text: "Verstärkung der Laibung", quantity: "2.5000", unit: "m2",
+    unit_price_cents: 12500, is_nep: false, vat_rate_percent: 19, price_input_mode: "NET", price_input_cents: 12500,
+  } });
+  return confirm ? e.billing.confirmAmendment({ id: source.id, amendment_id: draft.id }) : draft;
+}
+const rules = () => import(pathToFileURL(path.join(__dirname, "../../src/shared/rechnung/rechnungPositions.mjs")).href);
+
+// Execute the actual production method both in a minimal DOM test and in Chromium.
+function renderMethodSource() {
+  const source = fs.readFileSync(path.join(__dirname, "../../src/renderer/modules/rechnungen/screens/RechnungScreen.js"), "utf8");
+  const start = source.indexOf("  _renderLvPositions() {");
+  const end = source.indexOf("\n  _syncDerived()", start);
+  assert.ok(start > 0 && end > start);
+  return source.slice(start, end);
+}
+
+async function runRechnungAmendmentSnapshotTests(run) {
+  await run("Rechnung #275 Paket 4d2: mehrere Rechnungen bewahren ihren Anlagezeitpunkt mit nur bestätigten Nachträgen", async () => {
+    const e = orderSnapshotFixture();
+    try {
+      const source = e.confirm();
+      const before = await e.create();
+      const row = id => e.db.prepare("SELECT * FROM invoices WHERE id = ?").get(id);
+      const beforeRow = row(before.id);
+      const n1 = amendment(e, source);
+      const draft = amendment(e, source, false);
+      const withOne = await e.create();
+      const oneRow = row(withOne.id);
+      const n2 = e.billing.confirmAmendment({ id: source.id, amendment_id: draft.id });
+      const ignoredDraft = amendment(e, source, false);
+      const cancelled = amendment(e, source);
+      e.db.prepare("UPDATE billing_order_amendments SET status = 'CANCELLED' WHERE id = ?").run(cancelled.id);
+      const withTwo = await e.create();
+      assert.equal(e.reads(), 3, "ein atomarer Quellenabruf je Rechnung");
+      assert.equal(before.positions.length, source.positions.length);
+      assert.deepEqual(withOne.positions.filter(p => p.position_origin === "AMENDMENT").map(p => p.position_number), ["N 01"]);
+      assert.deepEqual(withTwo.positions.map(p => p.position_number), [...source.positions.map(p => p.position_number), "N 01", "N 02"]);
+      const copied = withTwo.positions.slice(source.positions.length);
+      assert.deepEqual(copied.map(p => p.source_order_amendment_id), [n1.id, n2.id]);
+      assert.ok(!withTwo.positions.some(p => [ignoredDraft.id, cancelled.id].includes(p.source_order_amendment_id)));
+      for (const [i, p] of copied.entries()) {
+        const original = [n1, n2][i];
+        assert.notEqual(p.id, original.id);
+        assert.equal(p.source_order_id, source.id);
+        assert.equal(p.relates_to_order_position_id, original.relates_to_order_position_id);
+        assert.equal(p.relates_to_position_number, "25");
+        assert.equal(p.parent_id, null);
+        assert.ok(p.sort_index > Math.max(...source.positions.map(p => p.sort_index)));
+        for (const field of ["sequence_no", "amendment_number", "short_text", "long_text", "quantity", "unit", "unit_price_cents", "is_nep", "vat_rate_percent", "price_input_mode", "price_input_cents"]) assert.deepEqual(p[field], original[field], field);
+      }
+      assert.notEqual(withOne.positions.at(-1).id, copied[0].id);
+      assert.deepEqual(JSON.parse(withTwo.order_snapshot_json).positions, withTwo.positions);
+      assert.deepEqual(row(before.id), beforeRow);
+      assert.deepEqual(row(withOne.id), oneRow);
+      assert.deepEqual(e.billing.get({ id: source.id }).positions, source.positions);
+      ensureInvoiceSchema(e.db); ensureInvoiceSchema(e.db);
+      assert.deepEqual(row(before.id), beforeRow);
+      assert.deepEqual(row(withOne.id), oneRow);
+      assert.deepEqual(e.invoices.get(withTwo.id), withTwo);
+    } finally { e.db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4d2: Sortierung nur der Nachtragskopien, Vertragsreihenfolge und UUID-Bezug unverändert", async () => {
+    const e = orderSnapshotFixture();
+    try {
+      const source = e.confirm();
+      amendment(e, source); amendment(e, source);
+      const order = e.billing.get({ id: source.id });
+      order.amendments.reverse();
+      const before = structuredClone(order);
+      const snapshot = createOrderSnapshot(order, await rules());
+      assert.deepEqual(order, before);
+      assert.deepEqual(snapshot.positions.map(p => p.position_number), ["10", "40.01", "25", "N 01", "N 02"]);
+      assert.deepEqual(snapshot.positions.slice(0, 3).map(p => [p.source_order_position_id, p.sort_index]), order.positions.map(p => [p.id, p.sort_index]));
+      const changedLabel = structuredClone(order);
+      changedLabel.positions.find(p => p.position_number === "25").position_number = "25.001";
+      const relabelled = createOrderSnapshot(changedLabel, await rules());
+      assert.equal(relabelled.positions.at(-1).relates_to_position_number, "25.001");
+      assert.equal(snapshot.positions.at(-1).relates_to_position_number, "25");
+    } finally { e.db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4d2: ungültiger bestätigter Ursprung, Identität oder Nummer bricht Rechnungsanlage atomar ab", async () => {
+    const e = orderSnapshotFixture();
+    try {
+      const source = e.confirm(); amendment(e, source);
+      const original = e.billing.get({ id: source.id });
+      for (const patch of [
+        { relates_to_order_position_id: original.positions[0].id }, { relates_to_order_position_id: randomUUID() },
+        { relates_to_order_position_id: "25" }, { order_id: randomUUID() }, { sequence_no: 0 },
+        { sequence_no: 1.5 }, { amendment_number: "N01" }, { amendment_number: "N 02" }, { id: "N 01" },
+      ]) {
+        const invalid = structuredClone(original); Object.assign(invalid.amendments[0], patch);
+        const service = new InvoiceService({ repository: e.invoices, billingOrderService: { get: () => invalid }, settingsGetMany: () => ({}), today: () => "2026-09-06" });
+        await assert.rejects(() => service.createDraftFromOrder({ source_order_id: source.id, service_period_type: "SINGLE_DATE", service_date: "2026-09-01" }), /invoice_order_amendment_/);
+        assert.equal(e.db.prepare("SELECT COUNT(*) n FROM invoices").get().n, 0);
+        assert.equal(e.db.inTransaction, false);
+      }
+      const duplicate = structuredClone(original); duplicate.amendments.push({ ...duplicate.amendments[0], id: randomUUID() });
+      const positionRules = await rules();
+      assert.throws(() => createOrderSnapshot(duplicate, positionRules), /invoice_order_amendment_number_invalid/);
+    } finally { e.db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4d2: Nachtragsquellkopie ist bei Speichern, Vorschauen und Buchen gesperrt", async () => {
+    const e = orderSnapshotFixture();
+    try {
+      const source = e.confirm(); amendment(e, source);
+      const draft = await e.create();
+      for (const operation of ["updateDraft", "previewDraft", "bookDraft"]) {
+        for (const field of ["source_order_amendment_id", "relates_to_order_position_id", "relates_to_position_number", "sequence_no", "amendment_number", "position_number", "sort_index", "quantity", "short_text"]) {
+          const positions = structuredClone(draft.positions); positions.at(-1)[field] = "manipuliert";
+          await assert.rejects(() => e.service[operation](draft.id, { positions }), /snapshot_immutable/);
+        }
+        await assert.rejects(() => e.service[operation](draft.id, { positions: draft.positions.slice().reverse() }), /snapshot_immutable/);
+      }
+      assert.deepEqual((await e.service.updateDraft(draft.id, { intro_text: "Begleittext" })).positions, draft.positions);
+      assert.deepEqual((await e.service.previewDraft(draft.id)).positions, draft.positions);
+      assert.equal(e.reads(), 1);
+    } finally { e.db.close(); }
+  });
+
+  await run("Rechnung #275 Paket 4d2: echter LV-Renderer setzt Bezug vor Kurztext und erhält Auswahl ohne freien Umbau", async () => {
+    const e = orderSnapshotFixture();
+    try {
+      const source = e.confirm(); amendment(e, source); amendment(e, source);
+      const draft = await e.create();
+      const node = (tag, className = "", textContent = "") => ({ tag, className, textContent, children: [], append(...children) { this.children.push(...children); }, replaceChildren(...children) { this.children = children; } });
+      const r = await rules();
+      const render = new Function("node", "calculatePositionTotalCents", "calculateInvoiceTotalsCents", "POSITION_TYPES", "formatQuantityForDisplay", "formatEuroCents", "money", `return ({${renderMethodSource()}})._renderLvPositions`)(node, r.calculatePositionTotalCents, r.calculateInvoiceTotalsCents, r.POSITION_TYPES, x => x, x => x, x => x);
+      const screen = { positionsList: node("div"), _orderedPositions: () => draft.positions, _positionDepth: () => 0, positionsTotal: {}, invoiceVatLabel: {}, invoiceVat: {}, invoiceTotal: {}, _handlePositionRowClick: entry => { screen.selectedPositionId = entry.id; } };
+      render.call(screen);
+      const rows = screen.positionsList.children.filter(n => n.tag === "article");
+      assert.deepEqual(rows.map(row => row.children[0].children[0].textContent), draft.positions.map(p => p.position_number));
+      const select = rows.at(-1).children[0], content = select.children[1];
+      assert.deepEqual(content.children.map(n => n.textContent), ["Nachtragspos. zu Pos.: 25", "Zusätzliche Öffnung"]);
+      assert.equal(content.children[0].className, "rechnung-lv-position__origin");
+      select.onclick(); assert.equal(screen.selectedPositionId, draft.positions.at(-1).id);
+      assert.equal(rows[0].children[0].children[1].tag, "strong");
+    } finally { e.db.close(); }
+  });
+}
+
+module.exports = { runRechnungAmendmentSnapshotTests, renderMethodSource, amendment };

--- a/scripts/tests/rechnungOrderSnapshot.test.cjs
+++ b/scripts/tests/rechnungOrderSnapshot.test.cjs
@@ -225,4 +225,4 @@ async function runRechnungOrderSnapshotTests(run) {
   });
 }
 
-module.exports = { runRechnungOrderSnapshotTests };
+module.exports = { runRechnungOrderSnapshotTests, orderSnapshotFixture: fixture };

--- a/src/main/domain/rechnung/invoiceOrderSnapshot.js
+++ b/src/main/domain/rechnung/invoiceOrderSnapshot.js
@@ -55,6 +55,35 @@ function createOrderSnapshot(order, positionRules) {
     if (p.parent_position_id && !entry.parent_id) fail("invoice_order_snapshot_parent_invalid");
     return { ...entry, total_cents: positionRules.calculatePositionTotalCents(entry) };
   });
+  const origins = new Map(order.positions.map(p => [p.id, p]));
+  const confirmed = (order.amendments || []).filter(a => a.status === "CONFIRMED");
+  const sequences = new Set();
+  const amendmentIds = new Set();
+  let sortIndex = order.positions.reduce((max, p) => Math.max(max, p.sort_index), -1);
+  for (const a of [...confirmed].sort((left, right) => left.sequence_no - right.sequence_no)) {
+    const origin = origins.get(a.relates_to_order_position_id);
+    if (a.order_id !== order.id || !origin || origin.order_id !== order.id || origin.type !== "service") fail("invoice_order_amendment_origin_invalid");
+    if (!Number.isSafeInteger(a.sequence_no) || a.sequence_no < 1 || sequences.has(a.sequence_no)
+      || a.amendment_number !== `N ${String(a.sequence_no).padStart(2, "0")}`) fail("invoice_order_amendment_number_invalid");
+    if (typeof a.id !== "string" || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(a.id)
+      || amendmentIds.has(a.id)) fail("invoice_order_amendment_id_invalid");
+    sequences.add(a.sequence_no);
+    amendmentIds.add(a.id);
+    if (!Number.isSafeInteger(++sortIndex)) fail("invoice_order_amendment_sort_invalid");
+    const entry = {
+      id: randomUUID(), position_origin: "AMENDMENT", source_order_id: order.id,
+      source_order_amendment_id: a.id, relates_to_order_position_id: origin.id,
+      relates_to_position_number: origin.position_number,
+      sequence_no: a.sequence_no, amendment_number: a.amendment_number,
+      parent_id: null, type: "service", is_title: false,
+      position_number: a.amendment_number, sort_index: sortIndex,
+      short_text: a.short_text, long_text: a.long_text,
+      quantity: a.quantity, unit: a.unit, unit_price_cents: a.unit_price_cents,
+      is_nep: a.is_nep, vat_rate_percent: a.vat_rate_percent,
+      price_input_mode: a.price_input_mode, price_input_cents: a.price_input_cents,
+    };
+    positions.push({ ...entry, total_cents: positionRules.calculatePositionTotalCents(entry) });
+  }
   const { positions: _positions, amendments: _amendments, ...head } = order;
   return { version: 1, order: head, positions };
 }

--- a/src/renderer/modules/rechnungen/screens/RechnungScreen.js
+++ b/src/renderer/modules/rechnungen/screens/RechnungScreen.js
@@ -375,7 +375,13 @@ export default class RechnungScreen {
       const row = node("article", `rechnung-lv-position${entry.id === this.selectedPositionId ? " is-selected" : ""}${entry.is_title ? " is-title" : ""}${isMoveTarget ? " is-move-target" : ""} is-depth-${Math.min(depth, 4)}`);
       const select = node("button", "rechnung-lv-position__select"); select.type = "button"; select.onclick = () => this._handlePositionRowClick(entry);
       const amount = calculatePositionTotalCents(entry);
-      select.append(node("span", "rechnung-lv-position__number", entry.position_origin === "CONTRACT" ? entry.position_number : entry.type === POSITION_TYPES.NOTE ? "Hinweis" : entry.type === POSITION_TYPES.HEADING && !entry.is_title ? "Text" : entry.position_number || ""), node("strong", "rechnung-lv-position__short", entry.short_text)); row.append(select);
+      const shortText = node("strong", "rechnung-lv-position__short", entry.short_text);
+      let content = shortText;
+      if (entry.position_origin === "AMENDMENT") {
+        content = node("span", "rechnung-lv-position__amendment-content");
+        content.append(node("span", "rechnung-lv-position__origin", `Nachtragspos. zu Pos.: ${entry.relates_to_position_number}`), shortText);
+      }
+      select.append(node("span", "rechnung-lv-position__number", ["CONTRACT", "AMENDMENT"].includes(entry.position_origin) ? entry.position_number : entry.type === POSITION_TYPES.NOTE ? "Hinweis" : entry.type === POSITION_TYPES.HEADING && !entry.is_title ? "Text" : entry.position_number || ""), content); row.append(select);
       if (entry.long_text) row.append(node("p", "rechnung-lv-position__long", entry.long_text));
       if (entry.type === POSITION_TYPES.SERVICE) {
         const quantity = entry.quantity === null || entry.quantity === undefined || entry.quantity === "" ? "" : formatQuantityForDisplay(entry.quantity, this.quantityDecimalPlaces);

--- a/src/renderer/modules/rechnungen/styles/rechnungenDesign.css
+++ b/src/renderer/modules/rechnungen/styles/rechnungenDesign.css
@@ -426,6 +426,8 @@ select.invoice-control { padding-right: 28px; }
 .rechnung-lv-position__select:hover .rechnung-lv-position__short { color: var(--invoice-color-primary); }
 .rechnung-lv-position__number { color: var(--invoice-color-muted); font-variant-numeric: tabular-nums; }
 .rechnung-lv-position__short { font-size: 13px; line-height: 1.4; }
+.rechnung-lv-position__amendment-content { display: grid; gap: 3px; min-width: 0; }
+.rechnung-lv-position__origin { color: var(--invoice-color-muted); font-size: 11px; line-height: 1.4; }
 .rechnung-lv-position__long { margin-left: 52px; color: var(--invoice-color-muted); font-size: 12px; line-height: 1.5; }
 .rechnung-lv-position__long summary { cursor: pointer; color: var(--invoice-color-primary); }
 .rechnung-lv-position__long p { margin: 5px 0 0; white-space: pre-line; }


### PR DESCRIPTION
## Manuelle Windows-Abnahme ausstehend – NICHT MERGEN

Dieser Draft-PR stellt ausschließlich den gesicherten, bereits implementierten 4d2-Arbeitsstand für die manuelle Abnahme bereit. Die Veröffentlichung wurde ausdrücklich freigegeben; eine Integration nach main ist nicht freigegeben.

### Unveränderter Teststand

Basis: main cdfb92a9d890c1037259ea4d1d5246d98bc8aaf3 mit PR #313–#316.
Alle sechs Dateien sind per SHA-256 bytegleich mit dem gesicherten 4d2-Arbeitsstand.
Keine neue Fachänderung, keine neue Testinfrastruktur und keine Dokumentationsänderung im Code-Commit.

Enthalten: bestätigte Nachträge im einmaligen Auftragssnapshot, stabile Ursprungsreferenzen, N-Kennung und Bezugzeile im bestehenden LV-Renderer; fünf zugehörige Tests.

### Vor Veröffentlichung erneut ausgeführt

- 4d2-Pakettests: 5/5 grün.
- Relevante R4-/Migrations-/Rechnungs-/Core-Regression: 105 grün / eine bekannte Screen-Text-Baseline rot.
- Volltest: 468 grüne Einzelprüfungen / neun bekannte Fehler; bekannte ui-editor-kit-Ladeabbrüche. Weiterhin 0/10 Gruppen.
- Fehlertitel und Ladeabbrüche sind maschinell identisch mit der main-Baseline.
- Syntax und git diff --check grün.
- Keine neue Regression in den automatisierten Prüfungen. Praktische UI-Abnahme fehlt weiterhin.

### Manuelle Abnahme unter Windows

Voraussetzung: diesen Testbranch verwenden, nicht bisherigen main. Tatsächliches UI-Editor-kit und funktionsfähige Windows-/Electron-Umgebung erforderlich. Vorhandener isolierter Rechnungseinstieg: node scripts/runIsolatedUiEditorAcceptance.cjs --module=rechnung.

- [ ] Bestätigten Auftrag mit Vertrags-LV sowie N 01 und N 02 verwenden; neue Rechnung anlegen.
- [ ] Vertrags-LV vollständig und unverändert vor allen Nachträgen.
- [ ] N 01/N 02 am Ende, korrekte Reihenfolge und exakte Kennzeichnung.
- [ ] Bezug „Nachtragspos. zu Pos.: <Ursprungsposition>“ oberhalb des Kurztexts.
- [ ] DRAFT-Nachträge erscheinen nicht.
- [ ] Vertragsnummern unverändert; Nachträge nicht wie freie Positionen umnummerier-/verschiebbar.
- [ ] Schmale Fensterdarstellung lesbar und bedienbar.
- [ ] Alte Rechnung erneut öffnen: Snapshot bleibt unverändert.
- [ ] Danach N 03 bestätigen und neue Rechnung erzeugen: nur die neue Rechnung enthält N 03.
- [ ] Ergebnis, ggf. betroffene Punkte und Screenshots dokumentiert.

Der bekannte Work-Umgebungsblocker bleibt bestehen: fehlendes UI-Editor-kit, fehlende grafische Laufzeit und verweigerte lokale Unix-Sockets. Keine bestandene Sichtprüfung behauptet.

Paket 4e wird nicht begonnen. #275 bleibt offen. **Dieser PR darf in diesem Auftrag nicht gemergt werden.**