### PR TITLE
SiGeKo #274 S1.1: technischer Modulanschluss ohne Fachlogik

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4528,3 +4528,12 @@ Wichtig:
 - Guardrails: `rechnungButtonEffectiveGeometry.test.cjs` ist in der Rechnungs-Testgruppe registriert; `rechnungUiEditorUnbounded.test.cjs`, die neue Produktpfad-Abnahme und der korrigierte M86.24-Rechnungslauf sind grün. Messberichte: `output/playwright/rechnung-buttons-product-acceptance/`.
 - Bekannte paketfremde rote Baselines: Der gesamte M86.24-Dreimodullauf verwirft unveränderte Protokoll-/Restarbeiten-Profile wegen bereits ungültiger Registrygeometrien. Die Rechnungs-Testgruppe bleibt an bestehenden PDF-Hash-, Screen-Alias-, Dezimalwert-, Briefkopf-CSS- und Alt-Renderer-Assertions rot; beide neuen Buttonguards sind darin grün.
 - Fachfunktion, PDF/Druck, Navigation, Button-Handler, Registry-IDs und Parentstruktur blieben unverändert. Kein Commit, kein Push.
+# SiGeKo #274 – S1.1 technischer Modulanschluss
+
+- Main-/Renderer-Deskriptor, modularer IPC-/Migrationsregistrar und technische
+  Preload-/Servicegrenze umgesetzt; gemeinsamer Guard berücksichtigt Freigabeentzug.
+- Keine Fachtabellen oder sichtbaren Screens; produktive UI-Freigabe bleibt unverändert.
+- 10/10 Pakettests, 78 relevante Prüfungen grün mit 1 bekannter Baseline;
+  Volltest 473 grün / dieselben 9 Baselinefehler gegenüber 463/9 auf Ausgangs-main.
+- Nachweis: `docs/SIGEKO_S1_1.md`; PR/Integration und Commit werden in #274 dokumentiert.
+- Nächster offener Schritt: S1.2 einschließlich isolierter Windows-Abnahme, nicht begonnen.

--- a/docs/SIGEKO_S1_1.md
+++ b/docs/SIGEKO_S1_1.md
@@ -1,0 +1,69 @@
+# SiGeKo S1.1 – technischer Modulanschluss
+
+Grundlage: #274 / #277. Ausgangs-main: `cdfb92a9d890c1037259ea4d1d5246d98bc8aaf3`.
+
+## Umfang
+
+- `sigeko` ist im vorhandenen Main-Modulregister ein Projektmodul mit den
+  kanonischen Capability-Deklarationen PDF, Mail, File-Storage und UI-Editor.
+- Der Renderer-Katalog kennt den passenden Deskriptor. Screens, Routen und
+  Navigation sind leer; die produktive Standardfreigabe bleibt unverändert.
+  Sichtbarer Einstieg und Windows-Abnahme folgen ausschließlich in S1.2.
+- `bbmDb.sigekoGetModuleInfo()` -> `sigeko:getModuleInfo` -> `SigekoService`.
+  Die Operation liefert nur Modul-ID und Modultyp, keine Fachdaten.
+- Der bestehende modulare IPC-Guard prüft den aktuellen Lizenz-/Modulstatus
+  bei jedem Aufruf. Es gibt keine eigene SiGeKo-Autorisierung.
+- Der Migrationsregistrar ist absichtlich ohne Schemaoperation. Keine neue
+  Tabelle, DB, Projekterweiterung oder fachliche Datenentscheidung.
+- Keine PDF-/Mail-/Speicherimplementierung, kein Protokoll-/TOP-Import,
+  keine Rechnungsänderung und kein vorgezogenes S1.2.
+
+## Prüfung auf dem Paketstand
+
+- Neue S1.1-Suite: **10/10 grün** unter Electron-ABI.
+- Relevanter isolierter Lauf: **78 grün, 1 bekannte Baseline**. Enthalten:
+  S1.1, Modul-IPC (7), Migrationen (7), Provider (6), Gate B (9),
+  Routing/Lizenzvertrag sowie Abschlussnachweise #272 (7) und #273 (6).
+- Volltest vor Änderung: **463 grün, 9 rot**, 0/10 Gruppen erfolgreich.
+- Volltest nach Änderung: **473 grün, dieselben 9 rot**, 0/10 Gruppen erfolgreich.
+- Fehlgeschlagene Testnamen und fehlende Module sind zwischen Ausgangs-main
+  und Paketstand identisch. Keine neue Regression.
+- Gezieltes ESLint und `git diff --check` grün.
+
+Die S1.1-Suite ist in `scripts/testGroups.cjs` registriert und läuft über
+`npm test`. Für einen isolierten Lauf unter der bereits vorbereiteten
+Electron-ABI:
+
+```bash
+ELECTRON_RUN_AS_NODE=1 node_modules/.bin/electron -e 'require("./scripts/tests/sigekoModuleBoundary.test.cjs").runSigekoModuleBoundaryTests(async (name, test) => { await test(); console.log(name); }).catch(error => { console.error(error); process.exitCode = 1; })'
+```
+
+Die Tests führen den tatsächlichen Preload-Code mit einer Electron-Bridge
+im Test aus, rufen den produktiven modularen Registrar/Service auf und prüfen
+Freigabeentzug. Echte SQLite-DBs prüfen Core-only, Bestandsdaten, identisches
+Schema nach wiederholter SiGeKo-Migration und SiGeKo + Restarbeiten ohne Protokoll.
+
+## Baselineabgrenzung
+
+Unverändert vorhanden:
+
+1. `meetingTopsRepo`: historischer Test-DB-Mock ohne `db.transaction`.
+2. Drei bestehende Popup-Standard-Erwartungen.
+3. `moduleAccessState`: fehlendes `ui-editor-kit`.
+4. Historische APP/PDF/MAIL/EXPORT-Alias-Erwartung (auch im isolierten Lauf rot).
+5. Historische FeatureGuard-Erwartung.
+6. Development-License-Diagnostic-Modulliste.
+7. Development-License/MainHeader-Kennzeichnung.
+
+Weitere Gruppen brechen unverändert beim Laden fehlender `ui-editor-kit`-Module ab.
+Diese Abbrüche sind keine erfolgreiche UI-Prüfung. S1.1 verändert keine sichtbare
+UI oder PDF; eine Windows-Bedienabnahme wird hier nicht behauptet.
+
+Der alte IPC-Registrar-Test enthielt eine feste Dreimodul-Verzeichnismap.
+Er folgt jetzt dem vorhandenen Deskriptorfeld `ipcRegistrar` und prüft damit
+auch SiGeKo, ohne seine Assertions abzuschwächen.
+
+## Abschlussgrenze
+
+PR-, Review-, CI- und Main-Commit-Nachweis werden in #274 dokumentiert.
+Nur S1.1 wird abgeschlossen; #274 bleibt für die Folgepakete offen.

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -4,6 +4,7 @@ const TEST_GROUPS = Object.freeze([
     label: "Kern, Protokoll und Projektfirmen",
     includeStoragePathTests: true,
     suites: Object.freeze([
+      ["sigekoModuleBoundary.test.cjs", "runSigekoModuleBoundaryTests"],
       ["protokollRevision272Regression.test.cjs", "runProtokollRevision272RegressionTests"],
       ["protokollRevision272Path.test.cjs", "runProtokollRevision272PathTests"],
       ["protokollSettingsOwnership.test.cjs", "runProtokollSettingsOwnershipTests"],

--- a/scripts/tests/moduleIpcRegistration.test.cjs
+++ b/scripts/tests/moduleIpcRegistration.test.cjs
@@ -89,10 +89,9 @@ async function runModuleIpcRegistrationTests(run) {
   await run("Paket 4: jedes installierte Fachmodul besitzt einen kleinen Registrar", () => {
     const registry = JSON.parse(read("src/main/module-registry.json"));
     const registrarCatalog = require(path.join(process.cwd(), "src/main/moduleIpcRegistrars.js"));
-    const moduleDirs = { protokoll: "protokoll", restarbeiten: "restarbeiten", rechnung: "rechnung" };
-    for (const [moduleId, definition] of Object.entries(registry.modules)) {
+    for (const definition of Object.values(registry.modules)) {
       assert.equal(typeof registrarCatalog[definition.ipcRegistrar], "function");
-      const source = read(`src/main/modules/${moduleDirs[moduleId]}/registerIpc.js`);
+      const source = read(`src/main/modules/${definition.ipcRegistrar}/registerIpc.js`);
       assert.match(source, /function registerIpc/);
       assert.equal(source.includes("ipcMain.handle"), false);
     }

--- a/scripts/tests/sigekoModuleBoundary.test.cjs
+++ b/scripts/tests/sigekoModuleBoundary.test.cjs
@@ -1,0 +1,166 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const Database = require("better-sqlite3");
+const { importEsmFromFile } = require("./_esmLoader.cjs");
+
+const root = path.resolve(__dirname, "../..");
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+const status = (modules, valid = true) => ({ valid, license: { modules } });
+
+function register(initialStatus) {
+  const { registerActiveModuleIpcs } = require("../../src/main/moduleIpcRegistry");
+  const handlers = new Map();
+  let current = initialStatus;
+  const result = registerActiveModuleIpcs({
+    licenseStatus: current,
+    getLicenseStatus: () => current,
+    ipcMain: { handle: (channel, handler) => handlers.set(channel, handler) },
+    registrars: require("../../src/main/moduleIpcRegistrars"),
+  });
+  return { result, handlers, setStatus: (next) => { current = next; } };
+}
+
+async function runSigekoModuleBoundaryTests(run) {
+  await run("S1.1: Main und Renderer deklarieren denselben kanonischen Projektmodulvertrag", async () => {
+    const registry = require("../../src/main/moduleRegistry");
+    const { getSigekoModuleEntry } = await importEsmFromFile(path.join(root, "src/renderer/modules/sigeko/index.js"));
+    const main = registry.getModuleDefinition("sigeko");
+    const renderer = getSigekoModuleEntry();
+    assert.equal(main.kind, "project");
+    assert.equal(renderer.moduleId, "sigeko");
+    assert.equal(renderer.moduleLabel, "SiGeKo");
+    assert.equal(renderer.moduleType, main.kind);
+    for (const key of ["licenseKey", "ipcRegistrar", "migrationRegistrar", "requiredCapabilities"]) {
+      assert.deepEqual(renderer[key], main[key]);
+    }
+    assert.equal(main.licenseKey, "module:sigeko");
+    for (const capability of main.requiredCapabilities) {
+      assert.equal(registry.getCapabilityLicenseKey(capability), `service:${capability}`);
+    }
+    assert.ok(Object.isFrozen(renderer));
+    assert.deepEqual(Object.keys(renderer.screens), []);
+    assert.deepEqual(renderer.routes.project, []);
+    assert.deepEqual(renderer.navigation.project, []);
+  });
+
+  await run("S1.1: Katalog kennt SiGeKo ohne produktive UI-Freigabe oder neue Routerroute", async () => {
+    const catalog = read("src/renderer/app/modules/moduleCatalog.js");
+    assert.match(catalog, /getSigekoModuleEntry[\s\S]*from "\.\.\/\.\.\/modules\/sigeko\/index.js"/);
+    assert.match(catalog, /moduleId: SIGEKO_MODULE_ID,\s*entry: getSigekoModuleEntry\(\)/);
+    const defaults = catalog.split("const DEFAULT_ACTIVE_MODULE_IDS = Object.freeze([")[1].split("]);", 1)[0];
+    assert.doesNotMatch(defaults, /SIGEKO_MODULE_ID/);
+    const { getSigekoModuleEntry } = await importEsmFromFile(path.join(root, "src/renderer/modules/sigeko/index.js"));
+    const runtime = await importEsmFromFile(path.join(root, "src/renderer/app/modules/moduleRouteRuntime.js"));
+    assert.equal(await runtime.openModuleEntry({ moduleEntry: getSigekoModuleEntry(), scope: "project", projectId: "p", show() { assert.fail("S1.2 vorgezogen"); } }), false);
+  });
+
+  await run("S1.1: produktiver IPC-Registrar erreicht SiGeKo-Service ohne Protokoll", () => {
+    const harness = register(status(["sigeko"]));
+    assert.deepEqual(harness.result.registeredModuleIds, ["sigeko"]);
+    assert.deepEqual([...harness.handlers.keys()], ["sigeko:getModuleInfo"]);
+    assert.deepEqual(harness.handlers.get("sigeko:getModuleInfo")({}), {
+      ok: true, module: { moduleId: "sigeko", moduleType: "project" },
+    });
+  });
+
+  await run("S1.1: IPC delegiert ausschliesslich die technische Operation an den Service", () => {
+    const { registerSigekoIpc } = require("../../src/main/ipc/sigekoIpc");
+    let calls = 0;
+    let handler;
+    registerSigekoIpc({
+      ipcMain: { handle: (_channel, fn) => { handler = fn; } },
+      service: { getModuleInfo() { calls += 1; return { marker: "service" }; } },
+    });
+    assert.deepEqual(handler({}, { operation: "createProject", sql: "ignored" }), { ok: true, module: { marker: "service" } });
+    assert.equal(calls, 1);
+  });
+
+  await run("S1.1: Core-only, ungueltige Lizenz und fehlende Modulfreigabe registrieren keinen SiGeKo-IPC", () => {
+    for (const license of [status([]), status(["sigeko"], false), null, status(["unknown"])]) {
+      const harness = register(license);
+      assert.deepEqual(harness.result.registeredModuleIds, []);
+      assert.equal(harness.handlers.size, 0);
+    }
+  });
+
+  await run("S1.1: Freigabeentzug und Lizenzverlust sperren bereits registrierten Handler", () => {
+    const harness = register(status(["sigeko"]));
+    const call = () => harness.handlers.get("sigeko:getModuleInfo")({});
+    assert.equal(call().ok, true);
+    for (const revoked of [status([]), status(["protokoll"]), status(["sigeko"], false), null]) {
+      harness.setStatus(revoked);
+      assert.throws(call, { code: "MODULE_NOT_ACTIVE", message: "MODULE_NOT_ACTIVE:sigeko" });
+    }
+    harness.setStatus(status(["sigeko"]));
+    assert.equal(call().ok, true);
+  });
+
+  await run("S1.1: echter Preload-Aufruf durchlaeuft modularen Guard und Service", async () => {
+    const harness = register(status(["sigeko"]));
+    const exposed = {};
+    vm.runInNewContext(read("src/main/preload.js"), {
+      require(name) {
+        assert.equal(name, "electron");
+        return {
+          contextBridge: { exposeInMainWorld: (name, api) => { exposed[name] = api; } },
+          ipcRenderer: { invoke: async (channel, ...args) => harness.handlers.get(channel)({}, ...args) },
+        };
+      },
+    });
+    assert.deepEqual(Object.keys(exposed.bbmDb).filter((key) => key.startsWith("sigeko")), ["sigekoGetModuleInfo"]);
+    assert.deepEqual(await exposed.bbmDb.sigekoGetModuleInfo(), { ok: true, module: { moduleId: "sigeko", moduleType: "project" } });
+    harness.setStatus(status([]));
+    await assert.rejects(exposed.bbmDb.sigekoGetModuleInfo(), { code: "MODULE_NOT_ACTIVE" });
+  });
+
+  await run("S1.1: Migrationsregistrar ist auf Bestands-DB strikt schema- und daten-neutral", () => {
+    const db = new Database(":memory:");
+    try {
+      db.exec("CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL); INSERT INTO projects VALUES ('p1', 'Bestand');");
+      const { ensureSchema } = require("../../src/main/db/database");
+      ensureSchema(db, { moduleIds: [] });
+      const schema = () => db.prepare("SELECT type, name, sql FROM sqlite_master ORDER BY type, name").all();
+      const before = schema();
+      assert.deepEqual(ensureSchema(db, { moduleIds: ["sigeko"] }), ["sigeko"]);
+      assert.deepEqual(ensureSchema(db, { moduleIds: ["sigeko", "sigeko"] }), ["sigeko"]);
+      assert.deepEqual(schema(), before);
+      assert.equal(db.prepare("SELECT name FROM projects WHERE id = 'p1'").get().name, "Bestand");
+      for (const table of ["meetings", "tops", "invoices", "restarbeiten_items", "sigeko_projects"]) {
+        assert.equal(db.prepare("SELECT name FROM sqlite_master WHERE name = ?").get(table), undefined);
+      }
+    } finally { db.close(); }
+  });
+
+  await run("S1.1: gemeinsame Migration bleibt mit SiGeKo und Restarbeiten ohne Protokoll nutzbar", () => {
+    const db = new Database(":memory:");
+    try {
+      db.exec("CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL)");
+      const { ensureSchema } = require("../../src/main/db/database");
+      assert.deepEqual(ensureSchema(db, { moduleIds: ["sigeko", "restarbeiten"] }), ["sigeko", "restarbeiten"]);
+      assert.ok(db.prepare("SELECT name FROM sqlite_master WHERE name = 'restarbeiten_items'").get());
+      assert.equal(db.prepare("SELECT name FROM sqlite_master WHERE name = 'meetings'").get(), undefined);
+    } finally { db.close(); }
+  });
+
+  await run("S1.1: technische Grenze enthaelt weder Fachdaten noch fremde Fachimporte", () => {
+    for (const file of [
+      "src/main/domain/sigeko/SigekoService.js",
+      "src/main/ipc/sigekoIpc.js",
+      "src/main/modules/sigeko/registerIpc.js",
+      "src/main/modules/sigeko/registerMigrations.js",
+      "src/renderer/modules/sigeko/index.js",
+    ]) {
+      assert.doesNotMatch(read(file), /(?:require\(|from\s*)["'][^"']*(?:protokoll|\/tops|rechnung|restarbeiten|\/db\/|sqlite)/i);
+      assert.doesNotMatch(read(file), /CREATE TABLE|ALTER TABLE|requireFeature|enforceLicensedFeature|new Database/);
+    }
+    const { createSigekoService } = require("../../src/main/domain/sigeko/SigekoService");
+    const service = createSigekoService();
+    assert.deepEqual(Object.keys(service), ["getModuleInfo"]);
+    assert.ok(Object.isFrozen(service));
+    assert.ok(Object.isFrozen(service.getModuleInfo()));
+  });
+}
+
+module.exports = { runSigekoModuleBoundaryTests };

--- a/src/main/domain/sigeko/SigekoService.js
+++ b/src/main/domain/sigeko/SigekoService.js
@@ -1,0 +1,11 @@
+// Technischer Einstieg. Fachoperationen kommen erst mit ihren eigenen Paketen.
+// Autorisierung bleibt am gemeinsamen modularen IPC-Guard.
+function createSigekoService() {
+  return Object.freeze({
+    getModuleInfo() {
+      return Object.freeze({ moduleId: "sigeko", moduleType: "project" });
+    },
+  });
+}
+
+module.exports = Object.freeze({ createSigekoService });

--- a/src/main/ipc/sigekoIpc.js
+++ b/src/main/ipc/sigekoIpc.js
@@ -1,0 +1,10 @@
+const { createSigekoService } = require("../domain/sigeko/SigekoService");
+
+function registerSigekoIpc({ ipcMain, service = createSigekoService() } = {}) {
+  ipcMain.handle("sigeko:getModuleInfo", () => ({
+    ok: true,
+    module: service.getModuleInfo(),
+  }));
+}
+
+module.exports = Object.freeze({ registerSigekoIpc });

--- a/src/main/module-registry.json
+++ b/src/main/module-registry.json
@@ -40,6 +40,19 @@
         "ui-editor"
       ]
     },
+    "sigeko": {
+      "kind": "project",
+      "licenseKey": "module:sigeko",
+      "ipcGroup": "sigeko",
+      "ipcRegistrar": "sigeko",
+      "migrationRegistrar": "sigeko",
+      "requiredCapabilities": [
+        "pdf",
+        "mail",
+        "file-storage",
+        "ui-editor"
+      ]
+    },
     "rechnung": {
       "kind": "hybrid",
       "licenseKey": "module:rechnung",

--- a/src/main/modules/sigeko/registerIpc.js
+++ b/src/main/modules/sigeko/registerIpc.js
@@ -1,0 +1,7 @@
+const { registerSigekoIpc } = require("../../ipc/sigekoIpc");
+
+function registerIpc({ ipcMain } = {}) {
+  return registerSigekoIpc({ ipcMain });
+}
+
+module.exports = Object.freeze({ registerIpc });

--- a/src/main/modules/sigeko/registerMigrations.js
+++ b/src/main/modules/sigeko/registerMigrations.js
@@ -1,0 +1,5 @@
+function registerMigrations() {
+  // S1.1 registriert nur den Anschluss. Keine Fachtabellen vor S2.
+}
+
+module.exports = Object.freeze({ registerMigrations });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -13,6 +13,9 @@ function _wrapIdArg(name, objKey) {
 }
 
 contextBridge.exposeInMainWorld("bbmDb", {
+  // SiGeKo: technische Anwendungsgrenze, noch keine Fachoperationen.
+  sigekoGetModuleInfo: () => ipcRenderer.invoke("sigeko:getModuleInfo"),
+
   // ============================================================
   // Projekte
   // ============================================================

--- a/src/renderer/app/modules/moduleCatalog.js
+++ b/src/renderer/app/modules/moduleCatalog.js
@@ -10,8 +10,16 @@ import {
   getRechnungModuleEntry,
   RECHNUNG_MODULE_ID,
 } from "../../modules/rechnungen/index.js";
+import {
+  getSigekoModuleEntry,
+  SIGEKO_MODULE_ID,
+} from "../../modules/sigeko/index.js";
 
 const AVAILABLE_MODULE_ENTRIES = Object.freeze([
+  Object.freeze({
+    moduleId: SIGEKO_MODULE_ID,
+    entry: getSigekoModuleEntry(),
+  }),
   Object.freeze({
     moduleId: PROTOKOLL_MODULE_ID,
     entry: getProtokollModuleEntry(),

--- a/src/renderer/modules/sigeko/index.js
+++ b/src/renderer/modules/sigeko/index.js
@@ -1,0 +1,20 @@
+import { createModuleDescriptor } from "../../app/modules/moduleDescriptorContract.js";
+
+export const SIGEKO_MODULE_ID = "sigeko";
+export const SIGEKO_MODULE_LABEL = "SiGeKo";
+
+export function getSigekoModuleEntry() {
+  return createModuleDescriptor({
+    moduleId: SIGEKO_MODULE_ID,
+    moduleLabel: SIGEKO_MODULE_LABEL,
+    moduleType: "project",
+    licenseKey: "module:sigeko",
+    // Screens, Navigation und sichtbarer Einstieg folgen in S1.2.
+    screens: Object.freeze({}),
+    routes: Object.freeze({}),
+    navigation: Object.freeze({}),
+    ipcRegistrar: "sigeko",
+    migrationRegistrar: "sigeko",
+    requiredCapabilities: Object.freeze(["pdf", "mail", "file-storage", "ui-editor"]),
+  });
+}


### PR DESCRIPTION
SiGeKo ist bisher nur als kanonische ID bekannt. S1.1 registriert den technischen Anschluss im bestehenden Modulrahmen, damit spätere Fachpakete über eine definierte Servicegrenze aufsetzen können.

Umfang:
- Main- und Renderer-Deskriptor als Projektmodul; vorhandene Capability-IDs.
- Modularer IPC-Registrar und schemafreier Migrationsregistrar.
- bbmDb.sigekoGetModuleInfo → modular geguardeter IPC → SigekoService.
- Screens, Routen und Navigation bleiben leer; produktive Standard-UI-Freigabe unverändert.
- Der bestehende IPC-Registrar-Test folgt dem Deskriptor statt einer Dreimodulliste.

Nachweise:
- S1.1: 10/10 grün, einschließlich ausgeführtem Preload, Freigabeentzug, Core-only und echter SQLite-Bestandsprüfung.
- Relevante Regression: 78 grün, 1 bekannte Lizenz-Alias-Baseline. Gate B 9/9, IPC 7/7, Migrationen 7/7, Provider 6/6, #272 7/7 und #273 6/6 grün.
- npm test vor Änderung: 463 grün / 9 bekannte rote Tests.
- npm test nach Änderung: 473 grün / dieselben 9 roten Tests und dieselben ui-editor-kit-Ladeabbrüche; weiterhin 0/10 Gruppen.
- Gezieltes ESLint und git diff --check grün.
- Ausgangs-main: cdfb92a9d890c1037259ea4d1d5246d98bc8aaf3.
- Remote-Baum d61d544d8a9c53a63ee14df3532f538676ed88b3 entspricht exakt dem lokal geprüften Commit 9aa0545eebd4bf25c3641ec1125b29672264a78c.

Keine neue Regression. Keine Fachtabellen, UI, Grunddaten oder PDF/Mail/Speicheranschlüsse. Rechnung unverändert. Praktische Windows-Abnahme betrifft S1.2 und wird hier nicht behauptet.

Details: docs/SIGEKO_S1_1.md. Teilpaket zu #274; Issue bleibt offen. S1.2 wird nicht begonnen.