### PR TITLE
PDF: fixed-layout-Vertrag durch Registry und Profile erhalten

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,9 +1,11 @@
 ## 2026-09-07 – PDF fixed-layout Vertragspaket vor S1.4a
 
-Fachneutrale Kit-Erweiterung und BBM-Registry-/Profilanschluss vorbereitet.
+Fachneutrale Kit-Erweiterung und BBM-Registry-/Profilanschluss technisch geprüft.
 7/7 neue Integrationstests grün; main 1499/99, Kandidat 1506/99, exakt gleiche
 Fehlernamen und keine fehlenden Tests. Legacy-Descriptor-/Profilhashes bytegleich.
-Native Windows-CI und Veröffentlichung offen (Kit-Push automatisch abgelehnt).
+Native Windows-CI 34160014785: 34/1 -> 42/1, identischer Baselinefehler,
+alle acht neuen Vertragsprüfungen bestanden. Veröffentlichung freigegeben;
+Kit-PR #93 und BBM-PR #321. Mergezuordnung in #274.
 Details: docs/PDF_FIXED_LAYOUT_CONTRACT.md. Kein S1.4a-/S1.5-Fortgang.
 
 ## Rechnung #275 – Paket 4d (2026-09-06)

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,3 +1,11 @@
+## 2026-09-07 – PDF fixed-layout Vertragspaket vor S1.4a
+
+Fachneutrale Kit-Erweiterung und BBM-Registry-/Profilanschluss vorbereitet.
+7/7 neue Integrationstests grün; main 1499/99, Kandidat 1506/99, exakt gleiche
+Fehlernamen und keine fehlenden Tests. Legacy-Descriptor-/Profilhashes bytegleich.
+Native Windows-CI und Veröffentlichung offen (Kit-Push automatisch abgelehnt).
+Details: docs/PDF_FIXED_LAYOUT_CONTRACT.md. Kein S1.4a-/S1.5-Fortgang.
+
 ## Rechnung #275 – Paket 4d (2026-09-06)
 
 Auf main-Basis 62bf2fb (PR #313–#315) Nachtragsanlage und atomare Bestätigung

--- a/docs/PDF_FIXED_LAYOUT_CONTRACT.md
+++ b/docs/PDF_FIXED_LAYOUT_CONTRACT.md
@@ -55,12 +55,41 @@ Kein Print-Renderer und keine V2-Satzregel wird verändert.
 - Der erste während paralleler Änderungen gestartete BBM-Lauf wurde verworfen:
   bestehender unstaged-diff-Guard brach eine Gruppe ab. Maßgeblich sind getrennte
   saubere Basis/Kandidaten mit vollständigem Prüffallvergleich.
-- Native Windows/.NET-10-Vertragsprüfungen sind vorbereitet, lokal mangels .NET
-  nicht ausführbar. Dazu gehört ein CI-Job mit separater Basis-/Head-Prüfung im Kit.
-- Automatische Freigabeprüfung hat den Kit-Push wegen fehlender expliziter
-  Veröffentlichungsfreigabe abgelehnt. Kein Push/PR/Merge als erfolgt behauptet.
+- Native Windows/.NET-10-Vertragsprüfungen wurden nach Freigabe in CI ausgeführt;
+  lokal fehlt .NET. Ergebnis und Baseline stehen im CI-Abschluss unten.
+- Die erste Veröffentlichungsblockade wurde durch ausdrückliche Nutzerfreigabe
+  aufgelöst. Die beiden Prüf-PRs sind veröffentlicht; Nachweise folgen unten.
 
-S1.4/S1.4a bleiben bis zum bestandenen nativen Vertragsnachweis blockiert.
+Historischer Zwischenstand vor der Freigabe: S1.4/S1.4a waren bis zum nativen Vertragsnachweis blockiert.
 Gesicherter alter S1.4a-Arbeitsstand wurde nicht eingespielt. S1.5 nicht begonnen.
 Eine echte Overlay-PDF, Editorbedienung, Windows-Paketierung oder Druckpipeline
 sind kein in diesem Vertragspaket erbrachter Nachweis.
+
+## CI-Abschluss nach Veröffentlichungsfreigabe
+
+Die Veröffentlichung wurde ausdrücklich freigegeben. Über die GitHub-Anbindung
+wurden die lokal geprüften Trees bytegleich übertragen; der direkte Git-CLI-Push
+hatte keine Anmeldung. Prüf-PRs: UI-Editor-kit #93 / BBM-Produktiv #321.
+
+Nativer Nachweis: https://github.com/SteffenBandholt/UI-Editor-kit/actions/runs/34160014785
+- Basis 0240ef8: 34 bestanden / 1 fehlgeschlagen / 0 übersprungen.
+- Kit-Codehead 689ab1f0ba0be94094edeeccba8dc1cb8522c9ae:
+  42 bestanden / 1 fehlgeschlagen / 0 übersprungen, acht neue Tests bestanden.
+- Identischer Fehlername: VisibleUiPdfEndToEndUsesTwoRealProcessesAndCleansArtifacts.
+  In beiden Jobs derselbe Prozess-Exitcode -1073741811; kein neuer Vertragsfehler.
+- Der zunächst gefundene neue Analyzerfehler MSTEST0037 wurde ausschließlich
+  durch Assert.HasCount im Test korrigiert. Der Folgelauf kompiliert erfolgreich.
+- Der vollständige native Prüflauf ist wegen der genannten Baseline weiterhin rot.
+  Sichtbare Windows-Editorbedienung wird nicht als abgenommen behauptet.
+
+Kit-Standard-CI bleibt bei der schon lokal auf Basis reproduzierten M82.3-
+Quelltextassertion rot (erwartetes altes 860/1260-Dreispaltenlayout).
+BBM-Standard-CI #1041 bleibt bei den acht bekannten Popup-/Lizenzfehlern und
+fehlendem ui-editor-kit im vorhandenen CI-Aufbau rot. Maßgeblicher vollständiger
+BBM-Paketvergleich mit echtem Kit bleibt 1499/99 -> 1506/99 ohne neue Fehler und
+mit vollständigem bisherigen Fallinventar.
+
+Das fachneutrale Vertragspaket ist technisch geprüft. PR-/Mergezuordnung wird
+in BBM #274 dokumentiert. Danach kann S1.4a als eigenes Paket fortgesetzt werden.
+S1.4a ist durch dieses Vertragspaket noch nicht implementiert oder abgenommen;
+S1.5 nicht begonnen, Rechnung #275 bleibt eingefroren.

--- a/docs/PDF_FIXED_LAYOUT_CONTRACT.md
+++ b/docs/PDF_FIXED_LAYOUT_CONTRACT.md
@@ -1,0 +1,66 @@
+# PDF-Editorvertrag – fachneutrales Vorpaket zu SiGeKo S1.4a
+
+Basis BBM main: a2ed5f8e7fdcd32116be780418d3cbd89f36e99c (mit beiden PDF-Blankovorlagen).
+Basis UI-Editor-kit main: 0240ef870dda7caaec7e639a6f5bf262b8037bc8.
+Führende Planung: #277 / #274; S1.1–S1.3 abgeschlossen, Rechnung #275 eingefroren.
+
+## Entwurfsentscheidung
+
+Dieses Paket verändert PDF-Vertragsmetadaten, keine sichtbare UI/PDF-Struktur.
+Die bestehende gemeinsame Infrastruktur erhält ein explizites
+`layoutModel: "fixed-layout"`; fehlend oder `"tabular"` bleibt Legacy.
+Die führende fachneutrale Entscheidung liegt im UI-Editor-kit unter
+`docs/PDF_FIXED_LAYOUT_CONTRACT.md` (K16/M81).
+
+Der Host deklariert ausschließlich tatsächlich vorhandene Layoutziele mit IDs,
+Scope, Parent, Kind/Rolle, Ref-/Renderer-Key, Reihenfolge, Baselines/Grenzen und
+Operationen. Root Dokument -> genau eine Seitenvorlage -> Overlay oder bewusst
+registrierter Bereich/Gruppe -> Text/Wert/Bild. Es gibt keine neuen produktiven
+Elemente, Buttons, Felder, Tabellen oder Fachaktionen. Technische Testfixtures
+sind vollständig deklariert und nicht produktiv registriert.
+
+JS- und nativer Vertrag erlauben nichttabellarische Dokumente und explizite
+A0–A6/custom-Millimeterseiten (A2 quer: 594 × 420). Vorhandene Tabellen benötigen
+weiterhin klassifizierte Spalten. Parent-/ID-/Operations-/Fachdatenprüfungen bleiben
+verbindlich. Satzlogik, Seitenzuweisung und `setPageBreakRule` bleiben Hostbesitz.
+Kein Print-Renderer und keine V2-Satzregel wird verändert.
+
+## BBM-Anschluss
+
+- `declarativePdfAdapter.cjs`: fixed-layout-Profilhash erhält denselben Modell-/
+  Format-/Orientierungs-/Maßpräfix wie der native Kit-Profilhash. Legacy bleibt
+  bytegleich. Modell-/Seitenwechsel kann nicht als additive Profilmigration laufen.
+- `pdfDocumentTypeRegistry.cjs`: Kandidat, akzeptierte Registry, aktive Projektion
+  und additive Synchronisation verwenden weiter denselben Kit-Validator.
+  Modellwechsel und fixed-layout-Seitenwechsel sind inkompatibel und ersetzen
+  keinen akzeptierten Bestand stillschweigend.
+- Sieben neue Integrationstests in bestehender Testgruppe. Keine neue Infrastruktur.
+- BBM verwendet weiterhin seine vorhandene `file:../UI-Editor-kit`-Abhängigkeit.
+  Beide Repositories müssen mit diesem zusammengehörigen Vertragspaket vorliegen.
+
+## Abnahme und Stand
+
+- Gezielte BBM-Integration: 7/7 grün.
+- Unverändertes aktuelles main mit altem Kit: 1499 grün / 99 bekannte Fehler.
+- Sauberer Kandidaten-Volltest: 1506 grün / exakt dieselben 99 Fehlernamen.
+  Keine fehlenden bisherigen Tests, sieben neue bestandene Fälle.
+- Protokoll/Restarbeiten/Rechnung: Descriptorbytes, Registryfingerprints und native
+  Profilhashes im Basis-/Kandidatenvergleich identisch; alle drei validieren.
+- Kit: neue Suite 8/8; bestehende M81-Suite grün. Sämtliche npm-Teilbefehle einzeln
+  gegen Basis geprüft: 64/5 vorher, 65/5 danach, dieselben fünf Baselinefehler.
+  `npm test` stoppt bereits auf Basis am lokalen Pipe-EPERM; vier weitere
+  vorhandene Snapshot-/Quelltextassertionen sind unverändert rot.
+  `npm pack --dry-run`, `npm run release:check` und Vertrags-Selbsttest grün.
+- Vollständige Fehlernamen und SHA256-Nachweise: PDF_FIXED_LAYOUT_TESTVERGLEICH.json.
+- Der erste während paralleler Änderungen gestartete BBM-Lauf wurde verworfen:
+  bestehender unstaged-diff-Guard brach eine Gruppe ab. Maßgeblich sind getrennte
+  saubere Basis/Kandidaten mit vollständigem Prüffallvergleich.
+- Native Windows/.NET-10-Vertragsprüfungen sind vorbereitet, lokal mangels .NET
+  nicht ausführbar. Dazu gehört ein CI-Job mit separater Basis-/Head-Prüfung im Kit.
+- Automatische Freigabeprüfung hat den Kit-Push wegen fehlender expliziter
+  Veröffentlichungsfreigabe abgelehnt. Kein Push/PR/Merge als erfolgt behauptet.
+
+S1.4/S1.4a bleiben bis zum bestandenen nativen Vertragsnachweis blockiert.
+Gesicherter alter S1.4a-Arbeitsstand wurde nicht eingespielt. S1.5 nicht begonnen.
+Eine echte Overlay-PDF, Editorbedienung, Windows-Paketierung oder Druckpipeline
+sind kein in diesem Vertragspaket erbrachter Nachweis.

--- a/docs/PDF_FIXED_LAYOUT_TESTVERGLEICH.json
+++ b/docs/PDF_FIXED_LAYOUT_TESTVERGLEICH.json
@@ -199,6 +199,28 @@
       ]
     }
   },
-  "nativeWindowsGate": "Not executed: no local .NET; push auto-review rejected; prepared CI must pass before integration",
-  "publication": "No push, PR or merge; approval pending"
+  "nativeWindowsGate": {
+    "run": "https://github.com/SteffenBandholt/UI-Editor-kit/actions/runs/34160014785",
+    "base": {
+      "passed": 34,
+      "failed": 1,
+      "skipped": 0
+    },
+    "candidate": {
+      "passed": 42,
+      "failed": 1,
+      "skipped": 0
+    },
+    "head": "689ab1f0ba0be94094edeeccba8dc1cb8522c9ae",
+    "sameFailure": "VisibleUiPdfEndToEndUsesTwoRealProcessesAndCleansArtifacts",
+    "sameProcessExitCode": -1073741811,
+    "newTestsPassed": 8,
+    "firstAttemptCorrection": "MSTEST0037: Assert.HasCount replaces count Assert.AreEqual"
+  },
+  "publication": {
+    "authorized": true,
+    "kitPr": "https://github.com/SteffenBandholt/UI-Editor-kit/pull/93",
+    "bbmPr": "https://github.com/SteffenBandholt/BBM-Produktiv/pull/321",
+    "mergeEvidence": "BBM issue #274"
+  }
 }

--- a/docs/PDF_FIXED_LAYOUT_TESTVERGLEICH.json
+++ b/docs/PDF_FIXED_LAYOUT_TESTVERGLEICH.json
@@ -1,0 +1,204 @@
+{
+  "date": "2026-09-07",
+  "bbmBase": "a2ed5f8e7fdcd32116be780418d3cbd89f36e99c",
+  "kitBase": "0240ef870dda7caaec7e639a6f5bf262b8037bc8",
+  "runtime": "Electron 30.5.1 / Node 20.16.0, ELECTRON_RUN_AS_NODE=1, existing grouped runner; native ABI123",
+  "baseline": {
+    "passed": 1499,
+    "failed": 99
+  },
+  "candidate": {
+    "passed": 1506,
+    "failed": 99
+  },
+  "newFailures": [],
+  "missingTests": [],
+  "addedPassingTests": [
+    "Fixed-layout PDF: A2 candidate, accepted snapshot and active registry preserve model without tables",
+    "Fixed-layout PDF: additive acceptance, deactivation and reactivation retain valid parent structure",
+    "Fixed-layout PDF: candidate, projection and merge reject dangling parents",
+    "Fixed-layout PDF: model and fixed page changes cannot silently replace accepted identity",
+    "Fixed-layout PDF: omitted layout model keeps legacy tabular validation and fingerprints",
+    "Fixed-layout PDF: optional tables still require two direct columns at all acceptance stages",
+    "Fixed-layout PDF: saved neutral state restores and additive profile migration retains positions"
+  ],
+  "baselineFailureNames": [
+    "#272 Mail 4b: Protokoll-PDF-Suche behaelt bestehende Dateinamenskandidaten",
+    "meetingTopsRepo: erledigte TOPs werden nur im direkten Folgeprotokoll uebernommen",
+    "ProjectFirmsView: laedt project_firms per IPC und wendet gespeicherte UI-Breiten an",
+    "ProjectFirmsView: fehlender Layout-Payload faellt auf Standardlayout zurueck",
+    "Protokoll Quicklane-Filter sitzt in der screen-eigenen rechten Toolbox",
+    "Protokoll-Projektpfad: Projekt-Einstiege nutzen die Projekt-Protokollauflosung",
+    "Protokoll-Projektpfad: openProjectModule reicht blocked-Payload durch",
+    "Projektverwaltung: Router importiert die Screen-Klassen aus dem Modulpfad",
+    "Projektverwaltung: Legacy-Projekt-Arbeitsbereich bleibt isoliert",
+    "Projektverwaltung: sichtbare Firmenbegriffe sind klarer benannt",
+    "Projektverwaltung: Projektklick startet direkt den Protokollpfad",
+    "Projektverwaltung: blockiertes Protokoll wird beim Hauptklick nicht als Erfolg behandelt",
+    "Projektverwaltung: DEV-Version schaltet Modulfreigabe auf alle aktiven Module frei",
+    "Projektverwaltung: Projektkarte rendert rechte Modul-Aktionsleiste und stoppt Bubble",
+    "Projektverwaltung: coreShellHeaderBridge kapselt die Header-/Router-Bridges",
+    "Projektverwaltung: MainHeader source nutzt den textbasierten Kopfbereich",
+    "M86.13: Protokoll und Restarbeiten erhalten den einen zweizeiligen MainHeader",
+    "Projektverwaltung: MainHeader rendert zwei gemeinsame Zeilen mit Plan und DEV-Marker",
+    "Projektverwaltung: Legacy-Projekt-Arbeitsbereich bleibt isoliert",
+    "Projektverwaltung: Router haelt den Legacy-Projekt-Arbeitsbereich getrennt",
+    "Restarbeiten: generischer UI-Editor-Target-Contract ist erfuellt",
+    "Restarbeiten: Quicklane besitzt echte UI-Editor-Gruppen im DOM",
+    "Restarbeiten: Quicklane-Ampel schaltet auch das Editbox-Ampelsymbol",
+    "Restarbeiten M85.2: Produktvorschau nutzt gefilterte Reihenfolge und internen V2-PDF-Weg",
+    "Restarbeiten: Notiz-Popup bleibt offen und kennzeichnet nicht verfügbaren Druck ehrlich",
+    "Rechnung Step 1.4/2: echter Screen verbindet Belegkopf und Positionsarbeit",
+    "Rechnung Navigation: kanonischer globaler Moduldeskriptor loest den echten Screen auf",
+    "Rechnung Navigation: DRAFT-Eingaben speichern seriell ohne Positionsverlust",
+    "Rechnung Editbox: Inhalt wird nur beim Fokuswechsel vollstaendig markiert",
+    "Rechnung Editbox: Menge bleibt dezimalfaehig, rechtsbuendig und wird durch den 0-bis-4-Stepper begrenzt",
+    "Rechnung Editbox: Gesamtbetrag nutzt die vorhandenen Rechnungssummen dynamisch und formatiert Euro",
+    "Rechnung Preisbedienung: Brutto-Haken rechnet den sichtbaren EP wirtschaftlich gleich um",
+    "Rechnung Briefkopf: Ausstellerdaten bleiben im Kopf schlank, Finanzdaten stehen im Blattfuß",
+    "Rechnung Textlimits: nutzt zentrale Protokoll-Limits, Counter und Settings-Aktualisierung",
+    "Rechnung UI: vertikale Rahmen- und Grenzabstaende sind null",
+    "Rechnung Navigation: normaler Start wartet auf Modulzugriff und nutzt keinen DEV-Pfad",
+    "Rechnung Hierarchie-UI: Anlegekontext, Tiefensperre, Schieben und FROM_ORDER-Sperre folgen dem Protokollprinzip",
+    "Rechnung Navigation: normaler Arbeitsweg rendert das Rechnungsblatt mit Bau-LV und getrennten Anwendungsaktionen",
+    "Rechnungsbuttons: reale Chromium-BoundingBox folgt fuer alle 16 Ziele der angeforderten Breite und Hoehe",
+    "Popup-Standard: aktiviert die freigegebenen Rechnungen- und Produktdialoge",
+    "Popup-Standard: Protokoll-, Firmen- und Teilnehmerdialoge nutzen die zentrale Opt-in-Basis",
+    "Popup-Standard: Import-, Textkorrektur- und Maildialoge nutzen die Opt-in-Basis",
+    "HomeView: zentrales Icon ist sichtbar verkleinert",
+    "HomeView: letzter Projektstart fragt zuerst den Modulstatus ab",
+    "M85 Satzvertrag: alle strukturellen Golden-Snapshots sind reproduzierbar",
+    "M85 Satzvertrag: Tabellenkopf, Reihenfolge, Grenzfall und TOP-Fortsetzung bleiben stabil",
+    "M85 Satzvertrag: Level-1 bleibt mit erstem Inhalt zusammen und Abschluss bleibt als Block zusammen",
+    "M85.2 Restarbeiten: Querformat, 13 Spalten, Filterfolge, Tabellenkopf und Fortsetzungen sind verriegelt",
+    "PDF-V2-INVOICE-002 bis -010: Kopf, Bau-LV, Abschluss und Seitenfooter sind golden verriegelt",
+    "M85 Satzvertrag: Teilnehmerzeilen werden vollständig und mit wiederholtem Tabellenkopf segmentiert",
+    "M85 Satzvertrag: Vorbemerkungen werden wortgenau und sichtbar fortgesetzt",
+    "M85 Satzvertrag: Editor darf Satz- und Fachoperationen nicht freigeben",
+    "M85 Satzvertrag: Editor-Overlay bleibt vor der bestehenden Paginierung",
+    "M85 PDF-Bedienung: Position, Schrift und Seitenwert-Sichtbarkeit wirken im echten Print-DOM",
+    "M85 PDF-Bedienung: innere Spaltengrenze bleibt in Track, Kopf und Daten lueckenlos",
+    "M85 PDF-Readback: Tabellenspalten liefern reale seitenbezogene Track-Geometrie",
+    "M85 PDF-Bedienung: Teilnehmer-Tabelle bleibt bis zur Nutzflaechenkante lueckenlos",
+    "M85 PDF-Meta: Body-Zeilen nutzen die gemeinsame innere Spaltenbreite",
+    "M85 PDF-Bedienung: Tabellenkopf-Text bewegt sich innerhalb der unveraenderten Spalte",
+    "M85 Satzvertrag: Renderer, Paginierung, Profilweg und Altpfade bleiben eindeutig",
+    "Ausgabe: Level-1-Titel reicht vorhandene ToDo- und Beschlusskennzeichnungen in das PDF durch",
+    "Ausgabe: bestehender Outlook-COM-Weg fuegt alle ausgewaehlten Dateien als echte Anhaenge an",
+    "Ausgabe: Abschlusslisten werden pro Protokollstand eindeutig benannt und gespeichert",
+    "Lizenzmodell: APP/PDF/MAIL/EXPORT bleiben als Alias auf Modul Protokoll erlaubt",
+    "FeatureGuard: Standardfeatures mit gueltiger Lizenz erlaubt",
+    "Development-Lizenz: paketierter Diagnostic-Build erhaelt gueltigen internen Status",
+    "Development-Lizenz: sichtbare Kennzeichnung und zentraler Print-Buildkanal sind verdrahtet",
+    "M52/M80 Startpunkt: Navigation enthaelt die separate UI-Editor-Aktion",
+    "M52/M80 echte Navigationskette: UI-Editor-Aktion startet keinen Screen",
+    "M54 Legacy-Isolation: CoreShell startet den alten RuntimeLauncher nicht automatisch parallel",
+    "M80.1 BBM: führende Registry, vollständige Restarbeiten-Refs und gesperrte Restscopes",
+    "M80.2 Registry: Header, Liste und Editbox sind direkt aktiv; Split ist gesperrt",
+    "M80/M83 Registry: nativer ElectronPipeHostAdapter bildet alle Rechnungstypen oeffentlich ab",
+    "M81 BBM-PDF-Registry ist explizit, vollstaendig und deterministisch",
+    "M81 nutzt echten BBM-printToPDF-Pfad und kein ReferenceOrder-Modell",
+    "M82 BBM: Target-Manifest leitet alle aktiven Scope-Zahlen exakt aus Komponentenvertrag und Registry ab",
+    "M82.1 BBM 01: Registryversion bleibt konsistent",
+    "M82.2 BBM 33: docs/licensing.md bleibt hashgleich",
+    "M82.3 BBM 01: Registryversion bleibt konsistent",
+    "M82.3 BBM 24: kompakter UI-Workspace hat Ein-Zwei-Drei-Modus",
+    "M82.3 BBM 31: docs/licensing.md bleibt hashgleich",
+    "M82.6 BBM 44: Protokoll-Feld erlaubt direkte Breite",
+    "M82.7.1 BBM 34: die allgemeine technische Speichergrenze bleibt erhalten",
+    "M82.7.1 BBM 39: mehrere Schritte lassen sich exakt rueckgaengig machen",
+    "M82.7.2/M83.0 BBM: Inventar umfasst alle 187 textResize-Ziele in sieben produktiven Scopes",
+    "M86.6 BBM 28: generische content-box-Breite verwendet die sichtbare aktuelle Breite ohne Richtungsumkehr",
+    "M82.7.4 BBM 28: licensing-Dokumentation hat weiterhin den Schutz-Hash",
+    "M82.7.5 BBM 01: Registryversion kennzeichnet den erweiterten Vertrag",
+    "M82.7.5 BBM 34: licensing-Dokumentation behaelt den Schutz-Hash",
+    "M83.0 BBM 05: Restarbeiten, Protokoll und Rechnung sind vollstaendig gebuendelt",
+    "M83.0 Rechnung 01: echter Rechnungsscreen mountet alle 131 Einzel-Refs mit vollstaendigem DOM-Vertrag",
+    "M83.0 BBM 16: Schutzdatei licensing bleibt bytegenau unveraendert",
+    "M86.12 03: Chromium berechnet im normalen Profil drei getrennte Header- und Zeilenspalten",
+    "M86.15 Rechnung 07: Rechnungs-Textareas unterschreiten 24 und ueberschreiten 720 ohne Ersatzgrenze",
+    "M86.16: vollständige sichtbare Registry reagiert je Modulzyklus im echten Chromium-Renderer",
+    "M86.21: Restarbeiten bleibt im Hauptviewport ohne horizontale Ueberbreite",
+    "M86.23 04: Restarbeiten und Protokoll behalten bestätigte Layouts nach Close und Neustart",
+    "M86.24: echte Minus-Bounds und sichtbarer Save-and-continue-Pfad bleiben nach Close und Neustart erhalten",
+    "Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert"
+  ],
+  "logSha256": {
+    "bbm-baseline.log": "a179a8173e7d5bbb47881cb5359f6de8d1cf76c88e01c302b799197e71a42f22",
+    "bbm-candidate.log": "147a78328242c6b853c50df9abc5aea9d853667cb3db067766769d5c3504ec69"
+  },
+  "legacyRegistries": {
+    "baseline": [
+      {
+        "documentTypeId": "protocol",
+        "valid": true,
+        "fingerprint": "sha256:4a35f5a9dbee9ef83f7ddb3ee9cf98fe81af3b54ef5d02a8159630d99145771c",
+        "nativeFingerprint": "a4505d85f3840c2611215712b773a930f1f15add5e6b1762907ca9b9a3e39a9e",
+        "descriptorSha256": "d589f15799fced72c5aaeff5eac3e41c99eff89a9e056dc6659bc62e977ba146"
+      },
+      {
+        "documentTypeId": "restarbeiten",
+        "valid": true,
+        "fingerprint": "sha256:3e4269a6ae2b5273f95018c51ea54260c041d4caf9a29e4a7b76256abca70325",
+        "nativeFingerprint": "65d0ea228fb6a4f1db0c24326724aa9e7ad42b78af9b94b20dd96fe135db0734",
+        "descriptorSha256": "085678432114a0f970c4a819af347dda23f99f9c8cfd66fcb19f51fa5a4b0e26"
+      },
+      {
+        "documentTypeId": "invoice",
+        "valid": true,
+        "fingerprint": "sha256:06dbf48cbf208ce3395712e8a3ab9b0387f43b713880756498765059af6e2725",
+        "nativeFingerprint": "2a7c6681e3561fd9e8dc4e0ffb919bedb78999e233073e197cfc60ec899e8df5",
+        "descriptorSha256": "90e2f8f1bf2951eb7e5499e6e7854c2ce2c1ee98aae7b8674edd82c481d3120a"
+      }
+    ],
+    "candidate": [
+      {
+        "documentTypeId": "protocol",
+        "valid": true,
+        "fingerprint": "sha256:4a35f5a9dbee9ef83f7ddb3ee9cf98fe81af3b54ef5d02a8159630d99145771c",
+        "nativeFingerprint": "a4505d85f3840c2611215712b773a930f1f15add5e6b1762907ca9b9a3e39a9e",
+        "descriptorSha256": "d589f15799fced72c5aaeff5eac3e41c99eff89a9e056dc6659bc62e977ba146"
+      },
+      {
+        "documentTypeId": "restarbeiten",
+        "valid": true,
+        "fingerprint": "sha256:3e4269a6ae2b5273f95018c51ea54260c041d4caf9a29e4a7b76256abca70325",
+        "nativeFingerprint": "65d0ea228fb6a4f1db0c24326724aa9e7ad42b78af9b94b20dd96fe135db0734",
+        "descriptorSha256": "085678432114a0f970c4a819af347dda23f99f9c8cfd66fcb19f51fa5a4b0e26"
+      },
+      {
+        "documentTypeId": "invoice",
+        "valid": true,
+        "fingerprint": "sha256:06dbf48cbf208ce3395712e8a3ab9b0387f43b713880756498765059af6e2725",
+        "nativeFingerprint": "2a7c6681e3561fd9e8dc4e0ffb919bedb78999e233073e197cfc60ec899e8df5",
+        "descriptorSha256": "90e2f8f1bf2951eb7e5499e6e7854c2ce2c1ee98aae7b8674edd82c481d3120a"
+      }
+    ]
+  },
+  "kitCommandComparison": {
+    "base": {
+      "passed": 64,
+      "failed": 5,
+      "failingCommands": [
+        "node scripts/tests/m80-electron-target.test.cjs",
+        "node scripts/tests/m82-3-spacing-compact-ui.test.cjs",
+        "node scripts/tests/m82-5-simple-editor-mode.test.cjs",
+        "node scripts/tests/m82-7-capability-guided-simple-mode.test.cjs",
+        "node scripts/tests/m82-7-3-text-resize-current-value.test.cjs"
+      ]
+    },
+    "candidate": {
+      "passed": 65,
+      "failed": 5,
+      "failingCommands": [
+        "node scripts/tests/m80-electron-target.test.cjs",
+        "node scripts/tests/m82-3-spacing-compact-ui.test.cjs",
+        "node scripts/tests/m82-5-simple-editor-mode.test.cjs",
+        "node scripts/tests/m82-7-capability-guided-simple-mode.test.cjs",
+        "node scripts/tests/m82-7-3-text-resize-current-value.test.cjs"
+      ]
+    }
+  },
+  "nativeWindowsGate": "Not executed: no local .NET; push auto-review rejected; prepared CI must pass before integration",
+  "publication": "No push, PR or merge; approval pending"
+}

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -205,6 +205,7 @@ const TEST_GROUPS = Object.freeze([
       ["m80-1RegistrationRefresh.test.cjs", "runM801RegistrationRefreshTests"],
       ["m80-2HeaderEditboxLayout.test.cjs", "runM802HeaderEditboxLayoutTests"],
       ["m81BbmPdfAdapter.test.cjs", "runM81BbmPdfAdapterTests"],
+      ["fixedLayoutPdfRegistry.test.cjs", "runFixedLayoutPdfRegistryTests"],
       ["m81-1ProfileRestore.test.cjs", "runM811ProfileRestoreTests"],
       ["m82AppStarterPackage.test.cjs", "runM82AppStarterPackageTests"],
       ["m82-1BbmFeintuning.test.cjs", "runM821BbmFeintuningTests"],

--- a/scripts/tests/fixedLayoutPdfRegistry.test.cjs
+++ b/scripts/tests/fixedLayoutPdfRegistry.test.cjs
@@ -1,0 +1,159 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+function fixture() {
+  const scopeId = "pdf.fixture.overlay";
+  const element = (suffix, kind, parentId, order) => ({
+    id: suffix ? `${scopeId}.${suffix}` : scopeId,
+    scopeId, name: kind, kind, parentId, order, role: "layout", pageArea: kind === "document" ? "document" : "body",
+    visible: true, editable: kind === "value", capabilities: kind === "value" ? ["move"] : [], lockedOps: [],
+    baseline: { x: 10, y: 10, width: 40, height: 12, visible: true },
+    layoutBounds: { minX: 0, maxX: 594, minY: 0, maxY: 420, minWidth: 1, maxWidth: 594, minHeight: 1, maxHeight: 420 },
+    refKey: `fixture.${suffix || "document"}`, rendererKey: `fixture.${suffix || "document"}`,
+  });
+  const registry = {
+    applicationId: "bbm-produktiv", documentTypeId: "fixture-overlay", displayName: "Fixed layout fixture",
+    scopeId, unit: "mm", registryVersion: 1, layoutModel: "fixed-layout",
+    pageSettings: { format: "A2", orientation: "landscape", width: 594, height: 420, margins: { top: 0, right: 0, bottom: 0, left: 0 } },
+    elements: [element("", "document", null, 0), element("page", "page", scopeId, 1), element("area", "area", `${scopeId}.page`, 2), element("value", "value", `${scopeId}.area`, 3)],
+  };
+  const registration = {
+    documentTypeId: registry.documentTypeId, moduleId: "fixture", scopeId, profileStorageKey: "fixture-overlay",
+    contractVersion: "1.0.0", descriptorVersion: 1, displayName: registry.displayName, candidateRegistry: registry,
+  };
+  return { registry, registration, element };
+}
+
+async function runFixedLayoutPdfRegistryTests(run) {
+  const { createPdfRegistryFingerprint } = require("ui-editor-kit");
+  const { validateCandidate, analyzePdfDocumentType, createAcceptedRecord, createEffectiveRegistry, mergeAdditiveRegistry, createPdfDocumentTypeRegistryStore } = require("../../src/main/ui-editor/pdfDocumentTypeRegistry.cjs");
+  const { createDeclarativePdfAdapter, persistedRegistryFingerprint } = require("../../src/main/ui-editor/declarativePdfAdapter.cjs");
+  const adapterFor = (registry) => createDeclarativePdfAdapter({ documentTypeId: registry.documentTypeId, displayName: registry.displayName, registry });
+
+  await run("Fixed-layout PDF: A2 candidate, accepted snapshot and active registry preserve model without tables", () => {
+    const { registry, registration } = fixture();
+    assert.deepEqual(validateCandidate(registration).validationErrors, []);
+    assert.equal(analyzePdfDocumentType(registration).canRegister, true);
+    const accepted = createAcceptedRecord(registration, registry);
+    const analysis = analyzePdfDocumentType(registration, accepted);
+    assert.equal(analysis.status, "available");
+    assert.equal(analysis.effectiveRegistry.layoutModel, "fixed-layout");
+    assert.equal(analysis.effectiveRegistry.registryFingerprint, createPdfRegistryFingerprint(registry));
+    assert.equal(adapterFor(analysis.effectiveRegistry).getPdfRegistry().pageSettings.width, 594);
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-fixed-registry-"));
+    try {
+      const store = createPdfDocumentTypeRegistryStore({ root });
+      store.save(accepted);
+      assert.deepEqual(createEffectiveRegistry(store.get(registry.documentTypeId)), analysis.effectiveRegistry);
+    } finally { fs.rmSync(root, { recursive: true, force: true }); }
+  });
+
+  await run("Fixed-layout PDF: additive acceptance, deactivation and reactivation retain valid parent structure", () => {
+    const { registry, registration, element } = fixture();
+    const accepted = createAcceptedRecord(registration, registry);
+    const added = element("second", "value", `${registry.scopeId}.area`, 4);
+    const next = { ...registry, registryVersion: 2, elements: [...registry.elements, added] };
+    const nextRegistration = { ...registration, descriptorVersion: 2, candidateRegistry: next };
+    const analysis = analyzePdfDocumentType(nextRegistration, accepted);
+    assert.deepEqual(analysis.newElementIds, [added.id]);
+    assert.equal(analysis.canSynchronizeElements, true);
+    const merged = mergeAdditiveRegistry(registry, next, analysis.newElementIds);
+    const record = createAcceptedRecord(nextRegistration, merged, accepted, next.elements.map((entry) => entry.id));
+    assert.equal(createEffectiveRegistry(record).elements.length, 5);
+    const inactive = createAcceptedRecord(registration, merged, record, registry.elements.map((entry) => entry.id));
+    assert.equal(createEffectiveRegistry(inactive).elements.length, 4);
+    assert.deepEqual(analyzePdfDocumentType(nextRegistration, inactive).reactivatedElementIds, [added.id]);
+    assert.equal(merged.layoutModel, "fixed-layout");
+  });
+
+  await run("Fixed-layout PDF: model and fixed page changes cannot silently replace accepted identity", () => {
+    const { registry, registration } = fixture();
+    const accepted = createAcceptedRecord(registration, registry);
+    const variants = [
+      [{ ...registry, layoutModel: "tabular" }, "layoutModel"],
+      [{ ...registry, pageSettings: { ...registry.pageSettings, format: "A4", width: 297, height: 210 } }, "pageSettings"],
+      [{ ...registry, pageSettings: { ...registry.pageSettings, margins: { ...registry.pageSettings.margins, left: 1 } } }, "pageSettings"],
+    ];
+    for (const [candidateRegistry, field] of variants) {
+      const analysis = analyzePdfDocumentType({ ...registration, candidateRegistry }, accepted);
+      assert.equal(analysis.status, "incompatible");
+      assert.ok(analysis.identityErrors.includes(field));
+      assert.equal(analysis.canSynchronizeElements, false);
+      assert.throws(() => mergeAdditiveRegistry(registry, candidateRegistry, []), { code: "pdf_registry_sync_invalid" });
+    }
+  });
+
+  await run("Fixed-layout PDF: candidate, projection and merge reject dangling parents", () => {
+    const { registry, registration, element } = fixture();
+    const invalid = { ...registry, elements: [...registry.elements, element("orphan", "value", "pdf.missing", 4)] };
+    assert.equal(validateCandidate({ ...registration, candidateRegistry: invalid }).ok, false);
+    assert.throws(() => mergeAdditiveRegistry(registry, invalid, [invalid.elements.at(-1).id]), { code: "pdf_registry_sync_invalid" });
+    const record = createAcceptedRecord(registration, registry, null, registry.elements.filter((entry) => entry.kind !== "area").map((entry) => entry.id));
+    assert.throws(() => createEffectiveRegistry(record), { code: "pdf_registry_active_projection_invalid" });
+  });
+
+  await run("Fixed-layout PDF: optional tables still require two direct columns at all acceptance stages", () => {
+    const { registry, registration, element } = fixture();
+    const table = element("table", "table", `${registry.scopeId}.area`, 4);
+    const column = (suffix, order) => ({ ...element(suffix, "tableColumn", table.id, order), columnRole: "contentColumn" });
+    const oneColumn = { ...registry, elements: [...registry.elements, table, column("column-one", 5)] };
+    assert.equal(validateCandidate({ ...registration, candidateRegistry: oneColumn }).ok, false);
+    assert.throws(() => mergeAdditiveRegistry(registry, oneColumn, [table.id, oneColumn.elements.at(-1).id]), { code: "pdf_registry_sync_invalid" });
+    const twoColumns = { ...oneColumn, elements: [...oneColumn.elements, column("column-two", 6)] };
+    assert.equal(validateCandidate({ ...registration, candidateRegistry: twoColumns }).ok, true);
+    const record = createAcceptedRecord(registration, twoColumns, null, oneColumn.elements.map((entry) => entry.id));
+    assert.throws(() => createEffectiveRegistry(record), { code: "pdf_registry_active_projection_invalid" });
+  });
+
+  await run("Fixed-layout PDF: omitted layout model keeps legacy tabular validation and fingerprints", () => {
+    const { getBbmPdfRegistry } = require("../../src/main/ui-editor/bbmPdfAdapter.cjs");
+    const registry = getBbmPdfRegistry();
+    const explicit = { ...registry, layoutModel: "tabular" };
+    assert.equal(createPdfRegistryFingerprint(explicit), createPdfRegistryFingerprint(registry));
+    assert.equal(persistedRegistryFingerprint(explicit), persistedRegistryFingerprint(registry));
+    const registration = { ...fixture().registration, documentTypeId: registry.documentTypeId, scopeId: registry.scopeId, candidateRegistry: explicit };
+    assert.equal(analyzePdfDocumentType(registration, createAcceptedRecord(registration, registry)).status, "available");
+    const fixed = fixture();
+    delete fixed.registry.layoutModel;
+    assert.equal(validateCandidate(fixed.registration).ok, false);
+  });
+
+  await run("Fixed-layout PDF: saved neutral state restores and additive profile migration retains positions", () => {
+    const { registry, element } = fixture();
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-fixed-profile-"));
+    try {
+      const adapter = adapterFor(registry);
+      const filePath = adapter.configureProfileRoot(root);
+      const state = adapter.getCurrentPdfLayoutState();
+      state.elements.find((entry) => entry.elementId.endsWith(".value")).x = 24;
+      const document = { schemaVersion: 1, documentKind: "pdf-layout-profile", applicationId: registry.applicationId, documentType: registry.documentTypeId, profileId: "pdf-standard", scopeId: registry.scopeId, registryFingerprint: persistedRegistryFingerprint(registry), layoutState: state };
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      const legacyModelFingerprint = persistedRegistryFingerprint({ ...registry, layoutModel: "tabular" });
+      assert.notEqual(document.registryFingerprint, legacyModelFingerprint);
+      fs.writeFileSync(filePath, JSON.stringify({ ...document, registryFingerprint: legacyModelFingerprint }));
+      assert.throws(() => adapter.getPersistedPdfLayoutState(), { code: "pdf_layout_incompatible" });
+      fs.writeFileSync(filePath, JSON.stringify(document));
+      assert.equal(adapter.getPersistedPdfLayoutState().elements.at(-1).x, 24);
+      const next = { ...registry, registryVersion: 2, elements: [...registry.elements, element("added", "value", `${registry.scopeId}.area`, 4)] };
+      const nextAdapter = adapterFor(next);
+      nextAdapter.configureProfileRoot(root);
+      assert.equal(nextAdapter.reconcilePersistedProfile(registry).migrated, true);
+      assert.equal(nextAdapter.getPersistedPdfLayoutState().elements.find((entry) => entry.elementId.endsWith(".value")).x, 24);
+      const changedPage = { ...next, pageSettings: { ...next.pageSettings, format: "A4", width: 297, height: 210 } };
+      const incompatible = adapterFor(changedPage);
+      incompatible.configureProfileRoot(root);
+      const before = fs.readFileSync(filePath, "utf8");
+      assert.notEqual(persistedRegistryFingerprint(changedPage), persistedRegistryFingerprint(next));
+      assert.throws(() => incompatible.getPersistedPdfLayoutState(), { code: "pdf_layout_incompatible" });
+      assert.throws(() => incompatible.reconcilePersistedProfile(next), { code: "pdf_layout_incompatible" });
+      assert.throws(() => nextAdapter.reconcilePersistedProfile({ ...next, layoutModel: "tabular" }), { code: "pdf_layout_incompatible" });
+      assert.equal(fs.readFileSync(filePath, "utf8"), before);
+    } finally { fs.rmSync(root, { recursive: true, force: true }); }
+  });
+}
+
+module.exports = { runFixedLayoutPdfRegistryTests };

--- a/src/main/ui-editor/declarativePdfAdapter.cjs
+++ b/src/main/ui-editor/declarativePdfAdapter.cjs
@@ -23,7 +23,11 @@ function persistedRegistryFingerprint(registry) {
     if (operations.has("resize")) { operations.add("resizeWidth"); operations.add("resizeHeight"); }
     return [entry.id, entry.scopeId, entry.parentId || "", kindNames[entry.kind], roleNames[entry.role] || "Content", capabilityNames.filter(([operation]) => operations.has(operation)).map(([, name]) => name).join(","), pageAreaNames[entry.pageArea] || "Body", String(entry.order), entry.boundaryResizePolicy || ""].join("|");
   }).join("\n");
-  return crypto.createHash("sha256").update(canonical, "utf8").digest("hex");
+  // Native PdfRegistryFingerprint uses the same additive prefix. Legacy hashes stay byte-identical.
+  const page = registry.pageSettings;
+  const prefix = registry.layoutModel === "fixed-layout"
+    ? `fixed-layout|${page.format}|${page.orientation}|${page.width}|${page.height}\n` : "";
+  return crypto.createHash("sha256").update(prefix + canonical, "utf8").digest("hex");
 }
 
 function persistedFields(definition) {
@@ -155,6 +159,16 @@ function createDeclarativePdfAdapter({ applicationId = "bbm-produktiv", document
   }
 
   function reconcilePersistedProfile(previousRegistry) {
+    const previousModel = previousRegistry.layoutModel ?? "tabular";
+    const currentModel = normalizedRegistry.layoutModel ?? "tabular";
+    const pageIdentity = (registry) => {
+      const page = registry.pageSettings;
+      return JSON.stringify([page.format, page.orientation, page.width, page.height,
+        ...["top", "right", "bottom", "left"].map((side) => page.margins[side])]);
+    };
+    if (previousModel !== currentModel || currentModel === "fixed-layout" && pageIdentity(previousRegistry) !== pageIdentity(normalizedRegistry)) {
+      throw Object.assign(new Error("PDF-Modell oder Seitenvertrag darf nicht additiv migriert werden."), { code: "pdf_layout_incompatible" });
+    }
     const filePath = getPdfProfilePath();
     if (!filePath || !fs.existsSync(filePath)) return { migrated: false, addedElementIds: [] };
     const document = JSON.parse(fs.readFileSync(filePath, "utf8"));

--- a/src/main/ui-editor/pdfDocumentTypeRegistry.cjs
+++ b/src/main/ui-editor/pdfDocumentTypeRegistry.cjs
@@ -22,6 +22,18 @@ function elementSignature(element) {
   return JSON.stringify(stableValue(element));
 }
 
+function registryLayoutIdentityErrors(acceptedRegistry, candidateRegistry) {
+  const acceptedModel = acceptedRegistry?.layoutModel ?? "tabular";
+  const candidateModel = candidateRegistry?.layoutModel ?? "tabular";
+  const errors = [];
+  if (acceptedModel !== candidateModel) errors.push("layoutModel");
+  if (acceptedModel === "fixed-layout" && candidateModel === "fixed-layout" &&
+      elementSignature(acceptedRegistry?.pageSettings) !== elementSignature(candidateRegistry?.pageSettings)) {
+    errors.push("pageSettings");
+  }
+  return errors;
+}
+
 function identityFromRegistration(registration) {
   return Object.freeze({
     documentTypeId: registration.documentTypeId,
@@ -132,6 +144,7 @@ function analyzePdfDocumentType(registration, acceptedRecord = null) {
 
   const acceptedIdentity = ["documentTypeId", "moduleId", "scopeId", "profileStorageKey", "contractVersion"];
   const identityErrors = acceptedIdentity.filter((key) => acceptedRecord[key] !== identity[key]);
+  identityErrors.push(...registryLayoutIdentityErrors(acceptedRecord.registry, candidate.registry));
   const acceptedElements = new Map((acceptedRecord.registry?.elements || []).map((element) => [element.id, element]));
   const activeElementIds = new Set(activeElementIdsOf(acceptedRecord));
   const candidateElements = new Map((candidate.registry?.elements || []).map((element) => [element.id, element]));
@@ -180,6 +193,13 @@ function analyzePdfDocumentType(registration, acceptedRecord = null) {
 }
 
 function mergeAdditiveRegistry(acceptedRegistry, candidateRegistry, newElementIds) {
+  const identityErrors = registryLayoutIdentityErrors(acceptedRegistry, candidateRegistry);
+  if (identityErrors.length) {
+    throw Object.assign(new TypeError("PDF-Layoutmodell oder feste Seitendefinition ist nicht additiv kompatibel."), {
+      code: "pdf_registry_sync_invalid",
+      validationErrors: identityErrors.map((field) => ({ code: "pdf_registry_identity_incompatible", field })),
+    });
+  }
   const additions = new Set(newElementIds);
   const elements = [
     ...(acceptedRegistry?.elements || []).map(clone),


### PR DESCRIPTION
Dieser PR erhält den neuen fachneutralen fixed-layout-Vertrag durch vorhandene BBM-Registry-/Profilgrenzen. Modell- und Seitenwechsel werden nicht still als additive Migration übernommen. Benötigt SteffenBandholt/UI-Editor-kit#93.

Nachweis:
- Sieben neue Integrationstests grün. Sauberer Volltest mit echtem Kit 1499/99 -> 1506/99: gleiche Fehlernamen, kein fehlender bisheriger Test.
- Protokoll/Restarbeiten/Rechnung: Descriptoren und Registry-/native Profilhashes bytegleich. Keine Renderer-/Druckpipeline-, SiGeKo-Fach- oder Rechnungsänderung.
- Windows-Kit-Regression https://github.com/SteffenBandholt/UI-Editor-kit/actions/runs/34160014785: 34/1 -> 42/1, alle acht neuen Vertragsprüfungen bestanden; identischer vorhandener Prozessfehler.
- Standard-BBM-CI behält acht bekannte Popup-/Lizenzfehler und fehlendes Kit im vorhandenen CI-Aufbau. Nicht als vollständig grün bewertet.
- Finaler Head b549858 ergänzt nur Nachweisdokumentation gegenüber lokal vollständig geprüftem Produktcode.

Details docs/PDF_FIXED_LAYOUT_TESTVERGLEICH.json und docs/PDF_FIXED_LAYOUT_CONTRACT.md. #274 / #277. S1.4a ist damit erst wieder aufnehmbar, noch nicht implementiert; S1.5 nicht begonnen.