### PR TITLE
S1.4a: neutralen PDF-Provider an Druckweg und Editor anschließen

### DIFF
--- a/.github/workflows/sigeko-pdf.yml
+++ b/.github/workflows/sigeko-pdf.yml
@@ -86,3 +86,36 @@ jobs:
             /tmp/bbm-ui-editor-acceptance-*/temp/**/*.pdf
             ${{ runner.temp }}/*-golden.json
             ${{ runner.temp }}/golden-comparison.json
+
+  windows-pdf:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: BBM-Produktiv
+      - uses: actions/checkout@v4
+        with:
+          repository: SteffenBandholt/UI-Editor-kit
+          ref: 5e0d551d93e97c32d169ea6d5107186a44ecd47f
+          path: UI-Editor-kit
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install candidate
+        working-directory: BBM-Produktiv
+        run: npm ci
+      - name: Real Windows PDF, storage, preview and editor regeneration
+        working-directory: BBM-Produktiv
+        run: npm run test:sigeko:s1.4a
+      - name: Preserve Windows acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sigeko-pdf-windows-evidence
+          if-no-files-found: warn
+          path: |
+            ${{ runner.temp }}/bbm-ui-editor-acceptance-*/acceptance-result.json
+            ${{ runner.temp }}/bbm-ui-editor-acceptance-*/internal-preview.png
+            ${{ runner.temp }}/bbm-ui-editor-acceptance-*/Ablage/**/*.pdf
+            ${{ runner.temp }}/bbm-ui-editor-acceptance-*/temp/**/*.pdf

--- a/.github/workflows/sigeko-pdf.yml
+++ b/.github/workflows/sigeko-pdf.yml
@@ -39,9 +39,6 @@ jobs:
           node-version: 20
       - name: Install display support
         run: sudo apt-get update && sudo apt-get install -y xvfb libgtk-3-0 libnss3 libasound2t64
-      - name: Install editor kit
-        working-directory: UI-Editor-kit
-        run: npm ci
       - name: Install candidate
         working-directory: BBM-Produktiv
         run: npm ci
@@ -67,7 +64,7 @@ jobs:
           const assert = require('node:assert/strict');
           const crypto = require('node:crypto');
           const read = name => JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/${name}-golden.json`, 'utf8'));
-          const summarize = run => run.results.map(({id, snapshot}) => ({id, pageCount: snapshot.pageCount,
+          const summarize = run => run.results.map(({id, snapshot}) => ({id, pageCount: snapshot.pages.length,
             sha256: crypto.createHash('sha256').update(JSON.stringify(snapshot)).digest('hex')})).sort((a,b) => a.id.localeCompare(b.id));
           const baseline = summarize(read('base'));
           const candidate = summarize(read('head'));

--- a/.github/workflows/sigeko-pdf.yml
+++ b/.github/workflows/sigeko-pdf.yml
@@ -111,6 +111,9 @@ jobs:
         run: npm ci
       - name: Real Windows PDF, storage, preview and editor regeneration
         working-directory: BBM-Produktiv
+        env:
+          TEMP: ${{ runner.temp }}
+          TMP: ${{ runner.temp }}
         run: npm run test:sigeko:s1.4a
       - name: Preserve Windows acceptance evidence
         if: always()

--- a/.github/workflows/sigeko-pdf.yml
+++ b/.github/workflows/sigeko-pdf.yml
@@ -45,6 +45,10 @@ jobs:
       - name: Install baseline
         working-directory: BBM-base
         run: npm ci
+      - name: Configure Electron sandbox helpers
+        run: |
+          sudo chown root:root BBM-Produktiv/node_modules/electron/dist/chrome-sandbox BBM-base/node_modules/electron/dist/chrome-sandbox
+          sudo chmod 4755 BBM-Produktiv/node_modules/electron/dist/chrome-sandbox BBM-base/node_modules/electron/dist/chrome-sandbox
       - name: Real PDF, storage, internal preview and editor regeneration
         working-directory: BBM-Produktiv
         run: xvfb-run -a npm run test:sigeko:s1.4a

--- a/.github/workflows/sigeko-pdf.yml
+++ b/.github/workflows/sigeko-pdf.yml
@@ -1,0 +1,91 @@
+name: SiGeKo PDF provider acceptance
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/main/print/**'
+      - 'src/main/ipc/printIpc.js'
+      - 'src/main/modulePdfProviders.js'
+      - 'src/main/modules/sigeko/technicalPdfProvider.js'
+      - 'src/main/ui-editor/**'
+      - 'src/renderer/print/**'
+      - 'src/shared/print/**'
+      - 'scripts/runSigekoPdfAcceptance.cjs'
+      - '.github/workflows/sigeko-pdf.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  pdf:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: BBM-Produktiv
+      - uses: actions/checkout@v4
+        with:
+          repository: SteffenBandholt/UI-Editor-kit
+          ref: 5e0d551d93e97c32d169ea6d5107186a44ecd47f
+          path: UI-Editor-kit
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: BBM-base
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install display support
+        run: sudo apt-get update && sudo apt-get install -y xvfb libgtk-3-0 libnss3 libasound2t64
+      - name: Install editor kit
+        working-directory: UI-Editor-kit
+        run: npm ci
+      - name: Install candidate
+        working-directory: BBM-Produktiv
+        run: npm ci
+      - name: Install baseline
+        working-directory: BBM-base
+        run: npm ci
+      - name: Real PDF, storage, internal preview and editor regeneration
+        working-directory: BBM-Produktiv
+        run: xvfb-run -a npm run test:sigeko:s1.4a
+      - name: Generate 49 baseline PDF snapshots
+        if: always()
+        working-directory: BBM-base
+        run: xvfb-run -a node scripts/pdf-v2/runM85PdfFixtures.cjs --output "$RUNNER_TEMP/base-golden.json"
+      - name: Generate 49 candidate PDF snapshots
+        if: always()
+        working-directory: BBM-Produktiv
+        run: xvfb-run -a node scripts/pdf-v2/runM85PdfFixtures.cjs --output "$RUNNER_TEMP/head-golden.json"
+      - name: Compare page counts and complete structural snapshots
+        if: always()
+        run: |
+          node <<'JS'
+          const fs = require('node:fs');
+          const assert = require('node:assert/strict');
+          const crypto = require('node:crypto');
+          const read = name => JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/${name}-golden.json`, 'utf8'));
+          const summarize = run => run.results.map(({id, snapshot}) => ({id, pageCount: snapshot.pageCount,
+            sha256: crypto.createHash('sha256').update(JSON.stringify(snapshot)).digest('hex')})).sort((a,b) => a.id.localeCompare(b.id));
+          const baseline = summarize(read('base'));
+          const candidate = summarize(read('head'));
+          assert.equal(baseline.length, 49);
+          assert.deepEqual(candidate, baseline);
+          fs.writeFileSync(`${process.env.RUNNER_TEMP}/golden-comparison.json`, JSON.stringify({ok:true, fixtures:candidate}, null, 2));
+          console.log('PASS: all 49 page counts and structural snapshots unchanged.');
+          JS
+      - name: Preserve technical acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sigeko-pdf-evidence
+          if-no-files-found: warn
+          path: |
+            /tmp/bbm-ui-editor-acceptance-*/acceptance-result.json
+            /tmp/bbm-ui-editor-acceptance-*/internal-preview.png
+            /tmp/bbm-ui-editor-acceptance-*/Ablage/**/*.pdf
+            /tmp/bbm-ui-editor-acceptance-*/temp/**/*.pdf
+            ${{ runner.temp }}/*-golden.json
+            ${{ runner.temp }}/golden-comparison.json

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,3 +1,22 @@
+## 2026-09-07 – SiGeKo S1.4a: technische PDF-Providerbrücke
+
+S1.4a technisch abgeschlossen, Übergabe über PR #322 gegen main db0ca2f.
+Explizite fachneutrale Providerbrücke, vorhandene PrintShell-Inhaltsslots,
+S1.3-Modulablage und bestehender fixed-layout-Editor-/Regenerationsweg verbunden.
+Kein zweiter PDF-/Editorweg. Technischer A4-Textbeleg; keine SiGeKo-Fachfelder.
+
+Volltest mit echtem Kit: 1506/99 -> 1514/99, exakt gleiche 99 Baselinefehler,
+keine fehlenden Bestandsprüfungen, acht neue Vertragstests grün. GitHub-Lauf
+34162498993 bestätigt Windows/Linux: reale PDF, Speicherung, sichtbare interne
+Vorschau, Wiederöffnen, Schriftwechsel 14->15pt im regenerierten PDF, korrekte
+DOM-Bounds/Refs und Overflow-Abweisung mit Restore. Alle 49 bestehenden
+PDF-Struktursnapshots samt Seitenzahlen auf Basis/Kandidat identisch.
+
+Details und Fehlernamen: docs/SIGEKO_S1_4A_PDF_PROVIDER.md sowie
+docs/SIGEKO_S1_4A_TESTVERGLEICH.json. Native WPF-Editorbedienung nicht manuell
+geprüft; bekannte Standard-CI-/Font-Baseline bleibt dokumentiert. Rechnung #275
+und beide Blankovorlagen unverändert. Nächster Meilenstein S1.4; S1.5 nicht begonnen.
+
 ## 2026-09-07 – PDF fixed-layout Vertragspaket vor S1.4a
 
 Fachneutrale Kit-Erweiterung und BBM-Registry-/Profilanschluss technisch geprüft.

--- a/docs/SIGEKO_S1_4A_PDF_PROVIDER.md
+++ b/docs/SIGEKO_S1_4A_PDF_PROVIDER.md
@@ -77,3 +77,39 @@ Der fokussierte GitHub-Workflow erzeugt zusätzlich alle 49 bestehenden Golden-
 Fixtures auf Basis und Kandidat in derselben Umgebung und vergleicht die kompletten
 Strukturhashes und Seitenzahlen. Ergebnisse und Einschränkungen werden nach dem
 Lauf hier ergänzt; bisherige Baselinefehler sind keine bestandenen Tests.
+
+## Ausgeführte Abnahme / Grenzen (2026-09-07)
+
+- Vollständiger sauberer Electron-ABI-Lauf mit echtem Kit: Basis 1506 grün /
+  99 rot; Kandidat 1514 grün / exakt dieselben 99 Fehlernamen. Kein
+  Bestandsprüffall fehlt. Alle acht neuen Vertragstests bestanden. Namen und
+  Loghashes: `SIGEKO_S1_4A_TESTVERGLEICH.json`.
+- GitHub-Lauf [34162498993](https://github.com/SteffenBandholt/BBM-Produktiv/actions/runs/34162498993):
+  echte PDF-/Ablage-/Preview-/Regenerationsabnahme auf Windows und Linux grün.
+  Titelgröße tatsächlich im PDF von rund 14 auf 15 pt geändert; Text unverändert.
+  Registry-/DOM-Bounds innerhalb 0,3 mm. Alle 49 Bestands-Struktursnapshots und
+  Seitenzahlen exakt gleich zwischen Basis und Kandidat.
+- Die Produkt-PDF wurde zusätzlich mit Poppler gerendert und visuell geprüft:
+  Titel und Text lesbar, keine Überlagerung oder abgeschnittenen Inhalte.
+  Die zunächst zu früh aufgenommene dunkle Vorschauaufnahme wurde korrigiert:
+  Der abschließende Lauf wartet auf zwei stabile Bilder der sichtbaren PDF-Seite.
+  Die Windows-Vorschauaufnahme wurde visuell geprüft; Titel und Text sind sichtbar.
+  Vier gemountete explizite Editor-Refs entsprechen vollständig der Registry.
+  Ein realer 400-mm-Body wird als Overflow abgewiesen; Restore funktioniert und
+  der Test lässt sämtliche erzeugten PDF-Dateien bytegleich.
+- Lokaler GUI-Lauf kann kein BrowserWindow erzeugen; er bleibt ausdrücklich
+  fehlgeschlagen. GitHub-Prüfungen ersetzen hier den fehlenden Display-Runtime.
+  Erste CI-Anläufe scheiterten an einer unnötigen Kit-Installation und nicht
+  eingerichteten Linux-Sandbox-Helpern; die Runner-Konfiguration wurde korrigiert.
+- Vorhandene NotoSans-Fontladewarnungen bleiben sichtbar. Die Fontdateien sind
+  unverändert; der Strukturvergleich verwendet auf beiden Ständen denselben Bestand.
+- Standard-BBM-CI bleibt wegen vorhandener Baselinefehler und fehlender
+  UI-Editor-kit-Installation rot. Keine Baselineassertion wurde abgeschwächt.
+- Kein manueller Bediennachweis der nativen Windows-Editoroberfläche: geprüft
+  sind die echte PDF-Erzeugung, interne Electron-Vorschau, bestehende Registry,
+  Adapteroperation und tatsächliche Editor-Regeneration.
+
+PR: [#322](https://github.com/SteffenBandholt/BBM-Produktiv/pull/322), Basis `main`,
+Arbeitsbranch `codex/sigeko-s1-4a-provider`. Nächster Meilenstein nach technischer
+Abnahme ist S1.4; S1.5 wird nicht vorgezogen. A2-SiGePlan- und Vorankündigungsvorlagen
+bleiben unverändert.

--- a/docs/SIGEKO_S1_4A_PDF_PROVIDER.md
+++ b/docs/SIGEKO_S1_4A_PDF_PROVIDER.md
@@ -1,0 +1,79 @@
+# S1.4a – neutraler PDF-Provideranschluss
+
+Basis: Gesamtplan #277, SiGeKo #274, BBM main db0ca2f und UI-Editor-kit main
+5e0d551 nach dem fachneutralen fixed-layout-Vertrag (#321 / Kit #93).
+
+## Umfang und Entwurfsentscheidung
+
+Ausgabe: PDF, editorfähig. Ein begrenzter technischer A4-Beleg mit Titel und Text
+weist den vorhandenen Print-, Ablage-, Vorschau- und Regenerationsweg nach.
+Keine SiGeKo-Fachfelder, keine Vorlagenüberlagerung und kein S1.5. Rechnung #275
+bleibt eingefroren. Die A2-Querformatvorlage wird in diesem Paket nicht gerendert.
+
+| ID / explizite Ref | Kind / Label | Parent | Editable / allowedOps |
+|---|---|---|---|
+| `pdf.bbm.technical-neutral` / `technical.document` | document / Technisches Dokument | null | false / keine |
+| `pdf.bbm.technical-neutral.page` / `technical.page` | page / Seite | Dokument | false / keine |
+| `pdf.bbm.technical-neutral.title` / `technical.title` | text / Titel | Seite | true / textResize |
+| `pdf.bbm.technical-neutral.body` / `technical.body` | text / Text | Seite | true / textResize |
+
+Refs sind einzelne explizite Ziele in `.printRoot`, `.page`, `.providerTitle` und
+`.providerBody`. Registry und vorhandenes `pdfEditorLayout` stellen stabile IDs,
+Kind, Label, Parent, Rolle, Reihenfolge, Sichtbarkeit, Baseline, Grenzen und
+Operationen bereit. Keine Bestands- oder Fachdatenanalyse erzeugt Editorziele.
+Keine Tabellen, Spalten, Bedienbuttons oder Eingabefelder werden hinzugefügt.
+Satz, Seitenformat, Sichtbarkeit, Positionen, Textinhalt, fachliche IPC-Aktionen,
+Speichern/Anlegen/Löschen/Upload/Import/Export/Autosave bleiben gesperrt.
+
+## Technischer Vertrag
+
+`mode: provider` verlangt einen expliziten `documentTypeId` und `providerRequest`
+mit `moduleId`, `providerId`, `projectId`, `documentId`, `data` und `storage.target`.
+Optionale übergeordnete Projekt-/Dokument-IDs müssen identisch sein. Eine fehlende
+oder widersprüchliche Identität wird abgewiesen; es gibt keinen Protokoll-Fallback.
+
+Die Modulzusammensetzung registriert den technischen SiGeKo-Provider. Die gemeinsame
+Bridge kennt keine Fachimplementierung. Sie prüft Modul-Capability, zentrale Lizenz,
+Projekt und das S1.3-Speicherziel, bevor sie den Provider aufruft. Wiederholte
+Berechtigungs-/Pfadprüfungen erzeugen keine Providerinhalte. Provider können asynchron
+liefern. Text gelangt ausschließlich als Textknoten in den Renderer.
+
+Der Print-Einstieg nutzt weiterhin das vorhandene PrintWindow und genau einen
+`webContents.printToPDF`-Aufruf. `PrintShell.renderPrint` erhält generische
+Inhaltsslots; Kopf, Body, Fußreserve, CSS und PDF-Ausgabe bleiben gemeinsam.
+Der bestehende Editor-Resolver führt denselben Providerkontext zur Regeneration.
+Profile verwenden ausschließlich den vorhandenen deklarativen Adapter/Profilweg.
+
+## Dokumentartspezifische Satzregeln
+
+Gemeinsame Bezugspunkte: `PDF-V2-SATZ-001`, `002`, `005`, `013`. Bestehende
+Protokoll-, Listen-, Restarbeiten- und Rechnungsregeln werden nicht geändert.
+
+- `PDF-PROVIDER-001`: genau eine A4-Hochformatseite, Ränder O/R/U/L 10/12/10/12 mm,
+  vorhandene Global-/FullHeader-Slots und 12-mm-Fußreserve.
+- `PDF-PROVIDER-002`: Titel höchstens 80 Zeichen ohne Zeilenumbruch; Text höchstens
+  600 Zeichen / zehn explizite Zeilen. Keine Tabelle und keine fachlichen Kopfwerte.
+- `PDF-PROVIDER-003`: Titelbox 12/18/186/20 mm bei 14 pt, Textbox 12/61/186/150 mm
+  bei 11 pt; Zeilenabstand 1,35. Nur Schriftgröße 8–16 pt ist editierbar. Die
+  End-DOM-Messung weist Überlauf und Überlagerung vor Druckfreigabe ab.
+- `PDF-PROVIDER-004`: Speichern, Vorschau und Editor-Regeneration verwenden dieselbe
+  Provideridentität und Ablageauflösung. Regeneration schreibt kontrolliert temporär.
+- `PDF-PROVIDER-005`: Schriftänderungen werden atomar geprüft und im bestehenden
+  Arbeitszustand zurückgelesen. Auch Restore und Profilimport prüfen Schriftgrenzen.
+
+## Nachweise
+
+`scripts/tests/sigekoPdfProvider.test.cjs` prüft Guards, Kontext, Datenlimits,
+Operationssperren, Schriftgrenzen, Profilwiederherstellung und Regenerationsrouting.
+Die Suite ist im bestehenden Volltest registriert.
+
+`npm run test:sigeko:s1.4a` erzeugt ein isoliertes Testprofil samt Testprojekt und
+prüft echte PDF-Bytes, Seitenzahl, Text, interne Vorschau, Wiederöffnen und einen
+im PDF messbaren Schriftwechsel über den bestehenden Editor-Resolver. Der Lauf
+ändert keine Produktivdaten. Unter Linux mit Display: `xvfb-run -a npm run
+test:sigeko:s1.4a`. Die native Windows-Editoroberfläche ist damit nicht geprüft.
+
+Der fokussierte GitHub-Workflow erzeugt zusätzlich alle 49 bestehenden Golden-
+Fixtures auf Basis und Kandidat in derselben Umgebung und vergleicht die kompletten
+Strukturhashes und Seitenzahlen. Ergebnisse und Einschränkungen werden nach dem
+Lauf hier ergänzt; bisherige Baselinefehler sind keine bestandenen Tests.

--- a/docs/SIGEKO_S1_4A_TESTVERGLEICH.json
+++ b/docs/SIGEKO_S1_4A_TESTVERGLEICH.json
@@ -1,0 +1,264 @@
+{
+  "baseCommit": "db0ca2fe94a51e9c27ba163a1571bc3bebe6a655",
+  "kitCommit": "5e0d551d93e97c32d169ea6d5107186a44ecd47f",
+  "baseline": {
+    "passed": 1506,
+    "failed": 99
+  },
+  "candidate": {
+    "passed": 1514,
+    "failed": 99
+  },
+  "newFailures": [],
+  "missingTests": [],
+  "newPassingTests": [
+    "S1.4a: bounded technical data rejects missing text and excess single-page input",
+    "S1.4a: common profile restore preserves font size and rejects invalid persisted values",
+    "S1.4a: denied license, missing project and invalid storage reject before provider execution",
+    "S1.4a: explicit provider identity and module guard precede content production",
+    "S1.4a: fixed-layout text operations enforce limits atomically and lock domain changes",
+    "S1.4a: malformed and mismatched provider contexts never fall back to protocol",
+    "S1.4a: print bridge contains no module implementation or second PDF engine",
+    "S1.4a: registered regeneration keeps explicit project, document, provider and storage context"
+  ],
+  "unchangedBaselineFailures": [
+    "#272 Mail 4b: Protokoll-PDF-Suche behaelt bestehende Dateinamenskandidaten",
+    "meetingTopsRepo: erledigte TOPs werden nur im direkten Folgeprotokoll uebernommen",
+    "ProjectFirmsView: laedt project_firms per IPC und wendet gespeicherte UI-Breiten an",
+    "ProjectFirmsView: fehlender Layout-Payload faellt auf Standardlayout zurueck",
+    "Protokoll Quicklane-Filter sitzt in der screen-eigenen rechten Toolbox",
+    "Protokoll-Projektpfad: Projekt-Einstiege nutzen die Projekt-Protokollauflosung",
+    "Protokoll-Projektpfad: openProjectModule reicht blocked-Payload durch",
+    "Projektverwaltung: Router importiert die Screen-Klassen aus dem Modulpfad",
+    "Projektverwaltung: Legacy-Projekt-Arbeitsbereich bleibt isoliert",
+    "Projektverwaltung: sichtbare Firmenbegriffe sind klarer benannt",
+    "Projektverwaltung: Projektklick startet direkt den Protokollpfad",
+    "Projektverwaltung: blockiertes Protokoll wird beim Hauptklick nicht als Erfolg behandelt",
+    "Projektverwaltung: DEV-Version schaltet Modulfreigabe auf alle aktiven Module frei",
+    "Projektverwaltung: Projektkarte rendert rechte Modul-Aktionsleiste und stoppt Bubble",
+    "Projektverwaltung: coreShellHeaderBridge kapselt die Header-/Router-Bridges",
+    "Projektverwaltung: MainHeader source nutzt den textbasierten Kopfbereich",
+    "M86.13: Protokoll und Restarbeiten erhalten den einen zweizeiligen MainHeader",
+    "Projektverwaltung: MainHeader rendert zwei gemeinsame Zeilen mit Plan und DEV-Marker",
+    "Projektverwaltung: Legacy-Projekt-Arbeitsbereich bleibt isoliert",
+    "Projektverwaltung: Router haelt den Legacy-Projekt-Arbeitsbereich getrennt",
+    "Restarbeiten: generischer UI-Editor-Target-Contract ist erfuellt",
+    "Restarbeiten: Quicklane besitzt echte UI-Editor-Gruppen im DOM",
+    "Restarbeiten: Quicklane-Ampel schaltet auch das Editbox-Ampelsymbol",
+    "Restarbeiten M85.2: Produktvorschau nutzt gefilterte Reihenfolge und internen V2-PDF-Weg",
+    "Restarbeiten: Notiz-Popup bleibt offen und kennzeichnet nicht verfügbaren Druck ehrlich",
+    "Rechnung Step 1.4/2: echter Screen verbindet Belegkopf und Positionsarbeit",
+    "Rechnung Navigation: kanonischer globaler Moduldeskriptor loest den echten Screen auf",
+    "Rechnung Navigation: DRAFT-Eingaben speichern seriell ohne Positionsverlust",
+    "Rechnung Editbox: Inhalt wird nur beim Fokuswechsel vollstaendig markiert",
+    "Rechnung Editbox: Menge bleibt dezimalfaehig, rechtsbuendig und wird durch den 0-bis-4-Stepper begrenzt",
+    "Rechnung Editbox: Gesamtbetrag nutzt die vorhandenen Rechnungssummen dynamisch und formatiert Euro",
+    "Rechnung Preisbedienung: Brutto-Haken rechnet den sichtbaren EP wirtschaftlich gleich um",
+    "Rechnung Briefkopf: Ausstellerdaten bleiben im Kopf schlank, Finanzdaten stehen im Blattfuß",
+    "Rechnung Textlimits: nutzt zentrale Protokoll-Limits, Counter und Settings-Aktualisierung",
+    "Rechnung UI: vertikale Rahmen- und Grenzabstaende sind null",
+    "Rechnung Navigation: normaler Start wartet auf Modulzugriff und nutzt keinen DEV-Pfad",
+    "Rechnung Hierarchie-UI: Anlegekontext, Tiefensperre, Schieben und FROM_ORDER-Sperre folgen dem Protokollprinzip",
+    "Rechnung Navigation: normaler Arbeitsweg rendert das Rechnungsblatt mit Bau-LV und getrennten Anwendungsaktionen",
+    "Rechnungsbuttons: reale Chromium-BoundingBox folgt fuer alle 16 Ziele der angeforderten Breite und Hoehe",
+    "Popup-Standard: aktiviert die freigegebenen Rechnungen- und Produktdialoge",
+    "Popup-Standard: Protokoll-, Firmen- und Teilnehmerdialoge nutzen die zentrale Opt-in-Basis",
+    "Popup-Standard: Import-, Textkorrektur- und Maildialoge nutzen die Opt-in-Basis",
+    "HomeView: zentrales Icon ist sichtbar verkleinert",
+    "HomeView: letzter Projektstart fragt zuerst den Modulstatus ab",
+    "M85 Satzvertrag: alle strukturellen Golden-Snapshots sind reproduzierbar",
+    "M85 Satzvertrag: Tabellenkopf, Reihenfolge, Grenzfall und TOP-Fortsetzung bleiben stabil",
+    "M85 Satzvertrag: Level-1 bleibt mit erstem Inhalt zusammen und Abschluss bleibt als Block zusammen",
+    "M85.2 Restarbeiten: Querformat, 13 Spalten, Filterfolge, Tabellenkopf und Fortsetzungen sind verriegelt",
+    "PDF-V2-INVOICE-002 bis -010: Kopf, Bau-LV, Abschluss und Seitenfooter sind golden verriegelt",
+    "M85 Satzvertrag: Teilnehmerzeilen werden vollständig und mit wiederholtem Tabellenkopf segmentiert",
+    "M85 Satzvertrag: Vorbemerkungen werden wortgenau und sichtbar fortgesetzt",
+    "M85 Satzvertrag: Editor darf Satz- und Fachoperationen nicht freigeben",
+    "M85 Satzvertrag: Editor-Overlay bleibt vor der bestehenden Paginierung",
+    "M85 PDF-Bedienung: Position, Schrift und Seitenwert-Sichtbarkeit wirken im echten Print-DOM",
+    "M85 PDF-Bedienung: innere Spaltengrenze bleibt in Track, Kopf und Daten lueckenlos",
+    "M85 PDF-Readback: Tabellenspalten liefern reale seitenbezogene Track-Geometrie",
+    "M85 PDF-Bedienung: Teilnehmer-Tabelle bleibt bis zur Nutzflaechenkante lueckenlos",
+    "M85 PDF-Meta: Body-Zeilen nutzen die gemeinsame innere Spaltenbreite",
+    "M85 PDF-Bedienung: Tabellenkopf-Text bewegt sich innerhalb der unveraenderten Spalte",
+    "M85 Satzvertrag: Renderer, Paginierung, Profilweg und Altpfade bleiben eindeutig",
+    "Ausgabe: Level-1-Titel reicht vorhandene ToDo- und Beschlusskennzeichnungen in das PDF durch",
+    "Ausgabe: bestehender Outlook-COM-Weg fuegt alle ausgewaehlten Dateien als echte Anhaenge an",
+    "Ausgabe: Abschlusslisten werden pro Protokollstand eindeutig benannt und gespeichert",
+    "Lizenzmodell: APP/PDF/MAIL/EXPORT bleiben als Alias auf Modul Protokoll erlaubt",
+    "FeatureGuard: Standardfeatures mit gueltiger Lizenz erlaubt",
+    "Development-Lizenz: paketierter Diagnostic-Build erhaelt gueltigen internen Status",
+    "Development-Lizenz: sichtbare Kennzeichnung und zentraler Print-Buildkanal sind verdrahtet",
+    "M52/M80 Startpunkt: Navigation enthaelt die separate UI-Editor-Aktion",
+    "M52/M80 echte Navigationskette: UI-Editor-Aktion startet keinen Screen",
+    "M54 Legacy-Isolation: CoreShell startet den alten RuntimeLauncher nicht automatisch parallel",
+    "M80.1 BBM: führende Registry, vollständige Restarbeiten-Refs und gesperrte Restscopes",
+    "M80.2 Registry: Header, Liste und Editbox sind direkt aktiv; Split ist gesperrt",
+    "M80/M83 Registry: nativer ElectronPipeHostAdapter bildet alle Rechnungstypen oeffentlich ab",
+    "M81 BBM-PDF-Registry ist explizit, vollstaendig und deterministisch",
+    "M81 nutzt echten BBM-printToPDF-Pfad und kein ReferenceOrder-Modell",
+    "M82 BBM: Target-Manifest leitet alle aktiven Scope-Zahlen exakt aus Komponentenvertrag und Registry ab",
+    "M82.1 BBM 01: Registryversion bleibt konsistent",
+    "M82.2 BBM 33: docs/licensing.md bleibt hashgleich",
+    "M82.3 BBM 01: Registryversion bleibt konsistent",
+    "M82.3 BBM 24: kompakter UI-Workspace hat Ein-Zwei-Drei-Modus",
+    "M82.3 BBM 31: docs/licensing.md bleibt hashgleich",
+    "M82.6 BBM 44: Protokoll-Feld erlaubt direkte Breite",
+    "M82.7.1 BBM 34: die allgemeine technische Speichergrenze bleibt erhalten",
+    "M82.7.1 BBM 39: mehrere Schritte lassen sich exakt rueckgaengig machen",
+    "M82.7.2/M83.0 BBM: Inventar umfasst alle 187 textResize-Ziele in sieben produktiven Scopes",
+    "M86.6 BBM 28: generische content-box-Breite verwendet die sichtbare aktuelle Breite ohne Richtungsumkehr",
+    "M82.7.4 BBM 28: licensing-Dokumentation hat weiterhin den Schutz-Hash",
+    "M82.7.5 BBM 01: Registryversion kennzeichnet den erweiterten Vertrag",
+    "M82.7.5 BBM 34: licensing-Dokumentation behaelt den Schutz-Hash",
+    "M83.0 BBM 05: Restarbeiten, Protokoll und Rechnung sind vollstaendig gebuendelt",
+    "M83.0 Rechnung 01: echter Rechnungsscreen mountet alle 131 Einzel-Refs mit vollstaendigem DOM-Vertrag",
+    "M83.0 BBM 16: Schutzdatei licensing bleibt bytegenau unveraendert",
+    "M86.12 03: Chromium berechnet im normalen Profil drei getrennte Header- und Zeilenspalten",
+    "M86.15 Rechnung 07: Rechnungs-Textareas unterschreiten 24 und ueberschreiten 720 ohne Ersatzgrenze",
+    "M86.16: vollständige sichtbare Registry reagiert je Modulzyklus im echten Chromium-Renderer",
+    "M86.21: Restarbeiten bleibt im Hauptviewport ohne horizontale Ueberbreite",
+    "M86.23 04: Restarbeiten und Protokoll behalten bestätigte Layouts nach Close und Neustart",
+    "M86.24: echte Minus-Bounds und sichtbarer Save-and-continue-Pfad bleiben nach Close und Neustart erhalten",
+    "Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert"
+  ],
+  "logsSha256": {
+    "bbm-candidate.log": "147a78328242c6b853c50df9abc5aea9d853667cb3db067766769d5c3504ec69",
+    "bbm-s14a-final.log": "d81d076246a2673be3894add96a02dda140294d20cc2eb72ec93b07eb36632e5"
+  },
+  "candidateVerifiedCommit": "f1f86f3d0fe456b467b9c78c2a7bd281119b392f",
+  "ci": {
+    "workflowRun": 34162498993,
+    "url": "https://github.com/SteffenBandholt/BBM-Produktiv/actions/runs/34162498993",
+    "testedCommit": "f1f86f3d0fe456b467b9c78c2a7bd281119b392f",
+    "windows": "success",
+    "linux": "success",
+    "fixtureCount": 49,
+    "identicalPageCounts": true,
+    "identicalStructuralSnapshots": true,
+    "nativeWpfEditorUiVerified": false,
+    "standardWorkflow": "known baseline failures plus absent ui-editor-kit installation"
+  },
+  "windowsAcceptance": {
+    "savedPdf": {
+      "bytes": 26931,
+      "sha256": "86172464ba61e4254dfcc60b8493503fe9eb53470b12514dd91cf31f6f744be5",
+      "pageCount": 1,
+      "pageBox": [
+        0,
+        0,
+        595.91998,
+        842.88
+      ]
+    },
+    "previewPaint": {
+      "visible": true,
+      "width": 1008,
+      "height": 681,
+      "whiteFraction": 0.633853151397011,
+      "pageLeft": 305,
+      "pageRight": 986,
+      "inkSamples": 407,
+      "stableFrames": 2,
+      "screenshotSha256": "0c4ec14f1e23f305c2e7a181ddb6dcff3ead834df97fe8176b613d7a0d520606"
+    },
+    "reopenedUnchanged": true,
+    "rendererOverflow": {
+      "errorCode": "PDF_PROVIDER_LAYOUT_OVERFLOW",
+      "beforeHeight": 566.921875,
+      "restoredHeight": 566.921875,
+      "mountedRefs": [
+        {
+          "id": "pdf.bbm.technical-neutral",
+          "kind": "document",
+          "label": "Technisches Dokument",
+          "parent": "",
+          "editable": "false",
+          "ops": "",
+          "connected": true,
+          "matches": 1,
+          "parentContains": true
+        },
+        {
+          "id": "pdf.bbm.technical-neutral.page",
+          "kind": "page",
+          "label": "Seite",
+          "parent": "pdf.bbm.technical-neutral",
+          "editable": "false",
+          "ops": "",
+          "connected": true,
+          "matches": 1,
+          "parentContains": true
+        },
+        {
+          "id": "pdf.bbm.technical-neutral.title",
+          "kind": "text",
+          "label": "Titel",
+          "parent": "pdf.bbm.technical-neutral.page",
+          "editable": "true",
+          "ops": "textResize",
+          "connected": true,
+          "matches": 1,
+          "parentContains": true
+        },
+        {
+          "id": "pdf.bbm.technical-neutral.body",
+          "kind": "text",
+          "label": "Text",
+          "parent": "pdf.bbm.technical-neutral.page",
+          "editable": "true",
+          "ops": "textResize",
+          "connected": true,
+          "matches": 1,
+          "parentContains": true
+        }
+      ],
+      "pdfFilesUnchanged": true
+    },
+    "regeneratedRenderBounds": [
+      {
+        "elementId": "pdf.bbm.technical-neutral",
+        "pageNumber": 1,
+        "box": {
+          "x": 0,
+          "y": 0,
+          "width": 210,
+          "height": 297
+        }
+      },
+      {
+        "elementId": "pdf.bbm.technical-neutral.page",
+        "pageNumber": 1,
+        "box": {
+          "x": 0,
+          "y": 0,
+          "width": 210,
+          "height": 297
+        }
+      },
+      {
+        "elementId": "pdf.bbm.technical-neutral.title",
+        "pageNumber": 1,
+        "box": {
+          "x": 11.997,
+          "y": 17.996,
+          "width": 186.005,
+          "height": 19.997,
+          "fontSize": 15
+        }
+      },
+      {
+        "elementId": "pdf.bbm.technical-neutral.body",
+        "pageNumber": 1,
+        "box": {
+          "x": 11.997,
+          "y": 60.991,
+          "width": 186.005,
+          "height": 149.999,
+          "fontSize": 11
+        }
+      }
+    ],
+    "regeneratedPdfSha256": "449c46571b9c63420e165ca469e9defd54e9a022cf87e8bbad4088ce92e944b5"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "pack:diagnostic": "npm run fix:electron-deps && npm run prepare:ui-editor && node scripts/dist.cjs --diagnostic --dir",
     "dist": "node scripts/dist.cjs",
     "test": "node scripts/runElectronNodeTest.cjs",
+    "test:sigeko:s1.4a": "node scripts/runSigekoPdfAcceptance.cjs",
     "test:sigeko:s1.3:windows": "node scripts/runSigekoStorageAcceptance.cjs",
     "lint": "eslint \"src/**/*.js\"",
     "lint:fix": "eslint \"src/**/*.js\" --fix",

--- a/scripts/runSigekoPdfAcceptance.cjs
+++ b/scripts/runSigekoPdfAcceptance.cjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const crypto = require("node:crypto");
+const { spawn } = require("node:child_process");
+const { pathToFileURL } = require("node:url");
+const { createAcceptanceProfile, createSanitizedEnvironment } = require("./runIsolatedUiEditorAcceptance.cjs");
+const { ACCEPTANCE_SWITCH, configureUiEditorAcceptanceProfile, isPathInside } = require("../src/main/startup/uiEditorAcceptanceProfile");
+
+const ROOT = path.resolve(__dirname, "..");
+const HELP = `SiGeKo S1.4a: realer bestehender Print-/Preview-/Editor-Regenerationsweg.
+  node scripts/runSigekoPdfAcceptance.cjs
+  node scripts/runSigekoPdfAcceptance.cjs --headless
+  xvfb-run -a node scripts/runSigekoPdfAcceptance.cjs
+
+Worker mit einem durch createAcceptanceProfile() erzeugten Temp-Profil:
+  electron scripts/runSigekoPdfAcceptance.cjs --worker ${ACCEPTANCE_SWITCH}<Temp-Profil>
+
+--headless versucht Chromium Ozone ohne Display. Ein nicht unterstuetztes
+Backend ist ein fehlgeschlagener Lauf, kein bestandener PDF-Nachweis.
+Unter Linux als root erhaelt ausschliesslich dieser Abnahmeprozess --no-sandbox.
+PDFs, Screenshot und acceptance-result.json bleiben im isolierten Temp-Profil.
+Die native Windows-Editoroberflaeche ist nicht Teil dieser technischen Abnahme.`;
+
+async function inspectPdf(filePath) {
+  const bytes = fs.readFileSync(filePath);
+  assert.equal(bytes.subarray(0, 5).toString("ascii"), "%PDF-", "Keine echte PDF-Datei");
+  const { getDocument } = await import(pathToFileURL(require.resolve("pdfjs-dist/legacy/build/pdf.mjs")).href);
+  const document = await getDocument({ data: new Uint8Array(bytes), isEvalSupported: false, disableFontFace: true }).promise;
+  try {
+    assert.equal(document.numPages, 1, "Neutraler Technikbeleg muss genau eine Seite besitzen");
+    const page = await document.getPage(1);
+    const content = await page.getTextContent();
+    const textItems = content.items.filter((item) => item.str?.trim()).map((item) => ({ text: item.str, fontSizePoints: Math.hypot(item.transform[2], item.transform[3]) }));
+    return { filePath, bytes: bytes.length, sha256: crypto.createHash("sha256").update(bytes).digest("hex"), pageCount: document.numPages, pageBox: page.view, text: content.items.map((item) => item.str || "").join(" "), textItems };
+  } finally { await document.destroy(); }
+}
+
+async function runWorker() {
+  console.log("[S1.4a] Electron worker gestartet");
+  const { app, BrowserWindow } = require("electron");
+  let profile;
+  let db;
+  const report = { schemaVersion: 1, package: "S1.4a", ok: false, nativeEditorUiVerified: false, checks: {} };
+  try {
+    app.setAppPath(ROOT);
+    // Vor DB-/Lizenz-/Print-Import: vorhandenes validiertes Abnahmeprofil.
+    profile = configureUiEditorAcceptanceProfile({ electronApp: app });
+    assert.equal(profile.enabled, true, "Isoliertes Abnahmeprofil erforderlich");
+    const tempPath = path.join(profile.rootPath, "temp");
+    fs.mkdirSync(tempPath, { recursive: true });
+    app.setPath("temp", tempPath);
+    app.disableHardwareAcceleration();
+    await app.whenReady();
+    console.log("[S1.4a] Electron bereit; isolierte Datenbank und Entwicklungs-Testlizenz");
+    const { getStatus } = require("../src/main/licensing/licenseService");
+    const license = getStatus({ fresh: true });
+    assert.equal(license.valid, true, "Bestehende Entwicklungs-Testlizenz fehlt");
+    assert.ok(license.license.modules.includes("sigeko"));
+    const { configureDatabaseMigrations, initDatabase } = require("../src/main/db/database");
+    configureDatabaseMigrations({ ...license, license: { ...license.license, modules: ["sigeko"] } }, { allowLegacyImport: false });
+    db = initDatabase();
+    assert.ok(isPathInside(profile.rootPath, db.name), "DB muss im Abnahmeprofil liegen");
+    const project = require("../src/main/db/projectsRepo").createProject({ project_number: "S14A", name: "SiGeKo PDF Technikabnahme" });
+    const baseDir = path.join(profile.rootPath, "Ablage");
+    require("../src/main/db/appSettingsRepo").appSettingsSetMany({ "pdf.protocolsDir": baseDir });
+    const { REGISTRY, DOCUMENT_TYPE_ID } = require("../src/main/ui-editor/technicalPdfAdapter.cjs");
+    assert.equal(DOCUMENT_TYPE_ID, "technical-neutral");
+    assert.equal(REGISTRY.layoutModel, "fixed-layout");
+    const { registerPrintIpc, generatePdfForUiEditor } = require("../src/main/ipc/printIpc");
+    registerPrintIpc();
+    const { createPdfEditorAdapterResolver } = require("../src/main/ui-editor/pdfAdapterRegistry.cjs");
+    const uiEditorRoot = path.join(profile.userDataPath, "ui-editor");
+    const resolver = createPdfEditorAdapterResolver({ profileBaseRoot: path.join(uiEditorRoot, "profiles"), registrationRoot: uiEditorRoot, regeneratePdf: generatePdfForUiEditor });
+    const registered = resolver.activateAcceptedDocumentType(DOCUMENT_TYPE_ID);
+    assert.equal(registered.editorAvailable, true, "Technischer PDF-Typ nicht editorfaehig akzeptiert");
+    const payload = {
+      mode: "provider", documentTypeId: DOCUMENT_TYPE_ID, projectId: project.id, documentId: "s14a-proof", silent: true,
+      providerRequest: { moduleId: "sigeko", providerId: "technical-neutral", projectId: project.id, documentId: "s14a-proof",
+        data: { title: "S1.4a Techniknachweis", body: "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg." }, storage: { target: "Unterlagen", baseDir } },
+    };
+    console.log("[S1.4a] Registry akzeptiert; echtes BrowserWindow wird erstellt");
+    const caller = new BrowserWindow({ show: false, webPreferences: { contextIsolation: true, sandbox: false, nodeIntegration: false, preload: path.join(ROOT, "src/main/preload.js") } });
+    console.log("[S1.4a] BrowserWindow erstellt; produktive Preload-/IPC-Bruecke wird geladen");
+    await caller.loadURL("data:text/html;charset=utf-8,<title>S1.4a IPC Abnahme</title>");
+    const invoke = (method) => caller.webContents.executeJavaScript(`window.${method}(${JSON.stringify(payload)})`, true);
+    const saved = await invoke("bbmDb.printHtmlToPdf");
+    assert.equal(saved.ok, true, JSON.stringify(saved));
+    assert.ok(isPathInside(baseDir, saved.filePath), "PDF ausserhalb des festgelegten Test-Ablageziels");
+    const stored = await inspectPdf(saved.filePath);
+    assert.ok(stored.text.includes(payload.providerRequest.data.title), "Titel fehlt im echten PDF");
+    assert.ok(stored.text.includes(payload.providerRequest.data.body), "Text fehlt im echten PDF");
+    report.checks.savedPdf = stored;
+
+    const existingWindows = new Set(BrowserWindow.getAllWindows().map((win) => win.id));
+    const preview = await invoke("bbmPrint.printPdfAndPreviewInternal");
+    assert.equal(preview.ok, true, JSON.stringify(preview));
+    const previewWindow = BrowserWindow.getAllWindows().find((win) => !existingWindows.has(win.id) && win.webContents.getURL() === pathToFileURL(preview.filePath).href);
+    assert.ok(previewWindow, "Bestehende interne PDF-Vorschau wurde nicht geoeffnet");
+    const previewPdf = await inspectPdf(preview.filePath);
+    assert.equal(previewPdf.text, stored.text);
+    // Die bestehende Vorschau laedt dieselbe gespeicherte Datei erneut.
+    await previewWindow.loadURL(pathToFileURL(preview.filePath).href);
+    const reopened = await inspectPdf(preview.filePath);
+    assert.equal(reopened.sha256, previewPdf.sha256, "Wiederoeffnen hat gespeicherten PDF-Inhalt veraendert");
+    const screenshotPath = path.join(profile.rootPath, "internal-preview.png");
+    fs.writeFileSync(screenshotPath, (await previewWindow.webContents.capturePage()).toPNG());
+    report.checks.internalPreview = { filePath: preview.filePath, screenshotPath, reopenedUnchanged: true, pageCount: reopened.pageCount };
+
+    const context = { projectId: project.id, documentId: payload.documentId, documentTypeId: DOCUMENT_TYPE_ID, providerRequest: payload.providerRequest };
+    assert.equal(resolver.setActiveDocumentContext(context).ok, true);
+    resolver.preparePdfEditorSessionBaseline();
+    const editable = resolver.getPdfRegistry().elements.find((element) => element.capabilities?.includes("textResize"));
+    assert.ok(editable, "Neutraler Text muss explizit textResize registrieren");
+    const before = resolver.getCurrentPdfLayoutState().elements.find((entry) => entry.elementId === editable.id);
+    const fontSize = Number(before.fontSize) + 1;
+    const change = resolver.submitPdfChangeRequest({ changeId: "s14a-font-proof", scopeId: REGISTRY.scopeId, elementId: editable.id, operation: "textResize", payload: { text: { fontSize } } });
+    assert.equal(change.success, true, JSON.stringify(change));
+    assert.equal(resolver.getCurrentPdfLayoutState().elements.find((entry) => entry.elementId === editable.id).fontSize, fontSize);
+    const generated = await resolver.regeneratePdfPreview();
+    assert.equal(generated.pageCount, 1, "Echte Render-Metadaten enthalten nicht genau eine Seite");
+    assert.equal(generated.state, "current");
+    const regeneratedPdf = await inspectPdf(generated.controlledOutputPath);
+    assert.equal(regeneratedPdf.text, stored.text, "Layoutaenderung darf Fachtext nicht veraendern");
+    assert.ok(regeneratedPdf.textItems.some((item) => stored.textItems.some((old) => old.text === item.text && item.fontSizePoints > old.fontSizePoints + 0.5)), "Schriftgroessen-Aenderung ist im erzeugten PDF nicht nachweisbar");
+    assert.ok(isPathInside(profile.rootPath, generated.controlledOutputPath));
+    assert.ok(Array.isArray(generated.renderBounds) && generated.renderBounds.some((entry) => entry.elementId === editable.id || entry.id === editable.id), "Bearbeitetes Element fehlt in echten Render-Bounds");
+    report.checks.editorRegeneration = { elementId: editable.id, previousFontSize: before.fontSize, fontSize, metadata: generated, pdf: regeneratedPdf };
+    report.ok = true;
+  } catch (error) {
+    report.error = { message: error?.message || String(error), code: error?.code || null, validationErrors: error?.validationErrors || [], stack: error?.stack || "" };
+    console.error(`[S1.4a] FAIL: ${report.error.stack}`);
+  } finally {
+    for (const win of BrowserWindow.getAllWindows()) win.destroy();
+    if (db?.open) db.close();
+    if (profile) {
+      const reportPath = path.join(profile.rootPath, "acceptance-result.json");
+      fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+      console.log(`[S1.4a] ${report.ok ? "PASS" : "FAIL"}: ${reportPath}`);
+    }
+    app.exit(report.ok ? 0 : 1);
+  }
+}
+
+async function launch() {
+  const profile = createAcceptanceProfile();
+  console.log(`[S1.4a] Isoliertes Profil bleibt erhalten: ${profile.rootPath}`);
+  const args = [];
+  if (process.platform === "linux" && process.getuid?.() === 0) args.push("--no-sandbox");
+  if (process.argv.includes("--headless")) args.push("--ozone-platform=headless");
+  args.push(__filename, "--worker", `${ACCEPTANCE_SWITCH}${profile.rootPath}`);
+  const child = spawn(require("electron"), args, { cwd: ROOT, env: createSanitizedEnvironment(), stdio: "inherit" });
+  const timeout = setTimeout(() => { console.error("[S1.4a] FAIL: Abnahme-Timeout"); child.kill("SIGTERM"); }, 180000);
+  const code = await new Promise((resolve, reject) => { child.once("error", reject); child.once("exit", (exitCode) => resolve(exitCode ?? 1)); }).finally(() => clearTimeout(timeout));
+  const reportPath = path.join(profile.rootPath, "acceptance-result.json");
+  if (!fs.existsSync(reportPath)) {
+    fs.writeFileSync(reportPath, JSON.stringify({ schemaVersion: 1, package: "S1.4a", ok: false, nativeEditorUiVerified: false, checks: {}, error: { code: "ACCEPTANCE_WORKER_ABORTED", message: `Electron endete ohne Abnahmebericht (Exit ${code}); PDF-/Vorschau-Nachweis nicht erbracht.` } }, null, 2));
+    console.error(`[S1.4a] FAIL: ${reportPath}`);
+  }
+  process.exitCode = code || (JSON.parse(fs.readFileSync(reportPath, "utf8")).ok === true ? 0 : 1);
+}
+
+if (process.versions.electron && process.argv.includes("--worker")) void runWorker();
+else if (require.main === module) {
+  if (process.argv.includes("--help")) console.log(HELP);
+  else launch().catch((error) => { console.error(`[S1.4a] FAIL: ${error.stack || error}`); process.exitCode = 1; });
+}
+
+module.exports = { inspectPdf, runWorker, launch };

--- a/scripts/runSigekoPdfAcceptance.cjs
+++ b/scripts/runSigekoPdfAcceptance.cjs
@@ -128,6 +128,14 @@ async function runWorker() {
     assert.ok(regeneratedPdf.textItems.some((item) => stored.textItems.some((old) => old.text === item.text && item.fontSizePoints > old.fontSizePoints + 0.5)), "Schriftgroessen-Aenderung ist im erzeugten PDF nicht nachweisbar");
     assert.ok(isPathInside(profile.rootPath, generated.controlledOutputPath));
     assert.ok(Array.isArray(generated.renderBounds) && generated.renderBounds.some((entry) => entry.elementId === editable.id || entry.id === editable.id), "Bearbeitetes Element fehlt in echten Render-Bounds");
+    for (const definition of REGISTRY.elements.filter((entry) => entry.kind === "text")) {
+      const measured = generated.renderBounds.find((entry) => entry.elementId === definition.id)?.box;
+      assert.ok(measured, `Reale Bounds fehlen: ${definition.id}`);
+      for (const field of ["x", "y", "width", "height"]) {
+        assert.ok(Math.abs(measured[field] - definition.baseline[field]) < 0.3,
+          `Registry-/DOM-Abweichung ${definition.id}.${field}: ${measured[field]} statt ${definition.baseline[field]}`);
+      }
+    }
     report.checks.editorRegeneration = { elementId: editable.id, previousFontSize: before.fontSize, fontSize, metadata: generated, pdf: regeneratedPdf };
     report.ok = true;
   } catch (error) {

--- a/scripts/runSigekoPdfAcceptance.cjs
+++ b/scripts/runSigekoPdfAcceptance.cjs
@@ -39,9 +39,76 @@ async function inspectPdf(filePath) {
   } finally { await document.destroy(); }
 }
 
+function pdfPagePaintEvidence(bitmap, width, height) {
+  const white = (x, y) => {
+    const offset = (y * width + x) * 4;
+    return bitmap[offset] > 240 && bitmap[offset + 1] > 240 && bitmap[offset + 2] > 240;
+  };
+  let whiteSamples = 0;
+  let samples = 0;
+  for (let y = 0; y < height; y += 4) for (let x = 0; x < width; x += 4) {
+    samples += 1;
+    if (white(x, y)) whiteSamples += 1;
+  }
+  const scanY = Math.floor(height * 0.65);
+  let start = 0;
+  let pageLeft = 0;
+  let pageRight = 0;
+  for (let x = 0; x <= width; x += 1) {
+    if (x < width && white(x, scanY)) continue;
+    if (x - start > pageRight - pageLeft) { pageLeft = start; pageRight = x; }
+    start = x + 1;
+  }
+  let inkSamples = 0;
+  for (let y = Math.max(15, Math.floor(height * 0.1)); y < Math.min(height - 15, height * 0.75); y += 2) {
+    for (let x = pageLeft + 12; x < pageRight - 12; x += 2) {
+      const offset = (y * width + x) * 4;
+      if (bitmap[offset] < 100 && bitmap[offset + 1] < 100 && bitmap[offset + 2] < 100 &&
+          white(x, y - 14) && white(x, y + 14)) inkSamples += 1;
+    }
+  }
+  const whiteFraction = whiteSamples / Math.max(samples, 1);
+  return { visible: width > 0 && height > 0 && whiteFraction > 0.2 && whiteFraction < 0.98 &&
+    pageRight - pageLeft > width * 0.3 && inkSamples >= 10, width, height, whiteFraction, pageLeft, pageRight, inkSamples };
+}
+
+async function capturePaintedPdfPreview(window, screenshotPath) {
+  const deadline = Date.now() + 15000;
+  let previousHash = "";
+  let lastImage;
+  let evidence;
+  while (Date.now() < deadline) {
+    lastImage = await window.webContents.capturePage();
+    const { width, height } = lastImage.getSize();
+    evidence = pdfPagePaintEvidence(lastImage.toBitmap(), width, height);
+    const hash = crypto.createHash("sha256").update(lastImage.toPNG()).digest("hex");
+    if (evidence.visible && hash === previousHash) {
+      fs.writeFileSync(screenshotPath, lastImage.toPNG());
+      return { ...evidence, stableFrames: 2, screenshotSha256: hash };
+    }
+    previousHash = evidence.visible ? hash : "";
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  if (lastImage) fs.writeFileSync(screenshotPath, lastImage.toPNG());
+  throw Object.assign(new Error(`Interne PDF-Vorschau zeigt keine stabil gezeichnete Seite mit Text: ${JSON.stringify(evidence)}`), { code: "PDF_PREVIEW_PAINT_TIMEOUT" });
+}
+
+function pdfInventory(directories) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const filePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(filePath);
+      else if (entry.isFile() && /\.pdf$/i.test(entry.name)) files.push({ filePath, sha256: crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex") });
+    }
+  };
+  directories.forEach(visit);
+  return files.sort((left, right) => left.filePath.localeCompare(right.filePath));
+}
+
 async function runWorker() {
   console.log("[S1.4a] Electron worker gestartet");
-  const { app, BrowserWindow } = require("electron");
+  const { app, BrowserWindow, ipcMain } = require("electron");
   let profile;
   let db;
   const report = { schemaVersion: 1, package: "S1.4a", ok: false, nativeEditorUiVerified: false, checks: {} };
@@ -107,8 +174,61 @@ async function runWorker() {
     const reopened = await inspectPdf(preview.filePath);
     assert.equal(reopened.sha256, previewPdf.sha256, "Wiederoeffnen hat gespeicherten PDF-Inhalt veraendert");
     const screenshotPath = path.join(profile.rootPath, "internal-preview.png");
-    fs.writeFileSync(screenshotPath, (await previewWindow.webContents.capturePage()).toPNG());
-    report.checks.internalPreview = { filePath: preview.filePath, screenshotPath, reopenedUnchanged: true, pageCount: reopened.pageCount };
+    const paint = await capturePaintedPdfPreview(previewWindow, screenshotPath);
+    report.checks.internalPreview = { filePath: preview.filePath, screenshotPath, reopenedUnchanged: true, pageCount: reopened.pageCount, paint };
+
+    const beforeOverflowPdfs = pdfInventory([baseDir, tempPath]);
+    const readyMessages = new Map();
+    const onHtmlReady = (event, message) => readyMessages.set(message?.jobId, { sender: event.sender, message });
+    ipcMain.on("print:ready", onHtmlReady);
+    try {
+      const htmlPreview = await invoke("bbmDb.printOpenHtmlPreview");
+      assert.equal(htmlPreview.ok, true, JSON.stringify(htmlPreview));
+      const deadline = Date.now() + 15000;
+      while (!readyMessages.has(htmlPreview.jobId) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 100));
+      const ready = readyMessages.get(htmlPreview.jobId);
+      assert.ok(ready, "Echte HTML-Vorschau meldet kein print:ready");
+      assert.equal(ready.message.ok, true, JSON.stringify(ready.message));
+      const guardUrl = pathToFileURL(path.join(ROOT, "src/renderer/print/layout/ProviderDocument.js")).href;
+      const overflow = await ready.sender.executeJavaScript(`(async () => {
+        const { validateProviderDocumentLayout } = await import(${JSON.stringify(guardUrl)});
+        const definitions = ${JSON.stringify(REGISTRY.elements)};
+        const declaredNodes = new Map(definitions.map((definition) => [definition.id, document.querySelector(definition.rendererKey)]));
+        const mountedRefs = definitions.map((definition) => {
+          const node = declaredNodes.get(definition.id);
+          const parent = declaredNodes.get(definition.parentId);
+          return { id: node?.getAttribute("data-ui-inspector-id"), kind: node?.getAttribute("data-ui-editor-kind"),
+            label: node?.getAttribute("data-ui-editor-label"), parent: node?.getAttribute("data-ui-editor-parent"),
+            editable: node?.getAttribute("data-ui-editor-editable"), ops: node?.getAttribute("data-ui-editor-ops"),
+            connected: node?.isConnected === true, matches: document.querySelectorAll(definition.rendererKey).length,
+            parentContains: definition.parentId === null || Boolean(parent?.contains(node)) };
+        });
+        const root = document.querySelector(".printRoot");
+        const body = root.querySelector(".providerBody");
+        validateProviderDocumentLayout(root);
+        const originalHeight = body.style.height;
+        const beforeHeight = body.getBoundingClientRect().height;
+        let errorCode = null;
+        try {
+          body.style.height = "400mm";
+          try { validateProviderDocumentLayout(root); }
+          catch (error) { errorCode = error.code || error.message; }
+        } finally { body.style.height = originalHeight; }
+        validateProviderDocumentLayout(root);
+        return { errorCode, beforeHeight, restoredHeight: body.getBoundingClientRect().height, mountedRefs };
+      })()`, true);
+      assert.equal(overflow.mountedRefs.length, 4, "Vier explizit deklarierte PDF-Refs erwartet");
+      assert.deepEqual(overflow.mountedRefs, REGISTRY.elements.map((definition) => ({
+        id: definition.id, kind: definition.kind, label: definition.name, parent: definition.parentId || "",
+        editable: String(definition.editable === true), ops: (definition.allowedOps || definition.capabilities || []).join(","),
+        connected: true, matches: 1, parentContains: true,
+      })), "Gemountete explizite PDF-Refs weichen vom Editorvertrag ab");
+      assert.equal(overflow.errorCode, "PDF_PROVIDER_LAYOUT_OVERFLOW");
+      assert.equal(overflow.restoredHeight, overflow.beforeHeight);
+      assert.deepEqual(pdfInventory([baseDir, tempPath]), beforeOverflowPdfs, "HTML-Overflowpruefung hat PDF-Dateien angelegt oder veraendert");
+      report.checks.rendererOverflow = { ...overflow, pdfFilesUnchanged: true };
+      BrowserWindow.fromWebContents(ready.sender)?.close();
+    } finally { ipcMain.removeListener("print:ready", onHtmlReady); }
 
     const context = { projectId: project.id, documentId: payload.documentId, documentTypeId: DOCUMENT_TYPE_ID, providerRequest: payload.providerRequest };
     assert.equal(resolver.setActiveDocumentContext(context).ok, true);
@@ -177,4 +297,4 @@ else if (require.main === module) {
   else launch().catch((error) => { console.error(`[S1.4a] FAIL: ${error.stack || error}`); process.exitCode = 1; });
 }
 
-module.exports = { inspectPdf, runWorker, launch };
+module.exports = { inspectPdf, pdfPagePaintEvidence, runWorker, launch };

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -205,6 +205,7 @@ const TEST_GROUPS = Object.freeze([
       ["m80-1RegistrationRefresh.test.cjs", "runM801RegistrationRefreshTests"],
       ["m80-2HeaderEditboxLayout.test.cjs", "runM802HeaderEditboxLayoutTests"],
       ["m81BbmPdfAdapter.test.cjs", "runM81BbmPdfAdapterTests"],
+      ["sigekoPdfProvider.test.cjs", "runSigekoPdfProviderTests"],
       ["fixedLayoutPdfRegistry.test.cjs", "runFixedLayoutPdfRegistryTests"],
       ["m81-1ProfileRestore.test.cjs", "runM811ProfileRestoreTests"],
       ["m82AppStarterPackage.test.cjs", "runM82AppStarterPackageTests"],

--- a/scripts/tests/sigekoPdfProvider.test.cjs
+++ b/scripts/tests/sigekoPdfProvider.test.cjs
@@ -6,6 +6,7 @@ const path = require("node:path");
 
 async function runSigekoPdfProviderTests(run) {
   const { createPdfProviderBridge, isProviderRequest } = require("../../src/main/print/pdfProviderBridge");
+  const { createProductivePdfProviderRegistry } = require("../../src/main/modulePdfProviders");
   const { createModuleServiceProviderRegistry, PdfDocumentProvider } = require("../../src/main/moduleServiceProviders");
   const { createDeclarativePdfAdapter, persistedRegistryFingerprint } = require("../../src/main/ui-editor/declarativePdfAdapter.cjs");
   const { REGISTRY, DOCUMENT_TYPE_ID, SCOPE_ID } = require("../../src/main/ui-editor/technicalPdfAdapter.cjs");
@@ -20,7 +21,7 @@ async function runSigekoPdfProviderTests(run) {
   const adapterFor = () => createDeclarativePdfAdapter({ documentTypeId: DOCUMENT_TYPE_ID, displayName: REGISTRY.displayName, registry: REGISTRY, documentIdentityFields: ["projectId", "documentId"] });
   await run("S1.4a: explicit provider identity and module guard precede content production", async () => {
     const guards = [];
-    const bridge = createPdfProviderBridge({ storage, enforce: (moduleId) => guards.push(moduleId) });
+    const bridge = createPdfProviderBridge({ registry: createProductivePdfProviderRegistry(), storage, enforce: (moduleId) => guards.push(moduleId) });
     const source = payload();
     const result = await bridge.provide(source);
     assert.deepEqual(guards, ["sigeko"]);
@@ -35,7 +36,7 @@ async function runSigekoPdfProviderTests(run) {
     assert.equal(bridge.outputDirectory(source), "/fixture/SiGeKo/Unterlagen");
   });
   await run("S1.4a: malformed and mismatched provider contexts never fall back to protocol", () => {
-    const bridge = createPdfProviderBridge({ storage, enforce: () => {} });
+    const bridge = createPdfProviderBridge({ registry: createProductivePdfProviderRegistry(), storage, enforce: () => {} });
     const invalid = [ {}, { ...payload(), mode: "protocol" }, { ...payload(), documentTypeId: "protocol" },
       { ...payload(), projectId: "other" }, { ...payload(), documentId: "other" } ];
     for (const field of ["moduleId", "providerId", "projectId", "documentId"]) {
@@ -62,7 +63,7 @@ async function runSigekoPdfProviderTests(run) {
     await bridge.provide(payload()); assert.equal(calls, 1);
   });
   await run("S1.4a: bounded technical data rejects missing text and excess single-page input", async () => {
-    const bridge = createPdfProviderBridge({ storage, enforce: () => {} });
+    const bridge = createPdfProviderBridge({ registry: createProductivePdfProviderRegistry(), storage, enforce: () => {} });
     for (const data of [{}, { title: "a\nb", body: "Text" }, { title: "a".repeat(81), body: "Text" },
       { title: "Titel", body: "x".repeat(601) }, { title: "Titel", body: Array(11).fill("x").join("\n") }]) {
       const source = payload(); source.providerRequest.data = data;
@@ -126,7 +127,7 @@ async function runSigekoPdfProviderTests(run) {
   });
   await run("S1.4a: print bridge contains no module implementation or second PDF engine", () => {
     const bridge = fs.readFileSync(path.join(__dirname, "../../src/main/print/pdfProviderBridge.js"), "utf8");
-    assert.doesNotMatch(bridge, /sigeko|technicalPdfProvider|printToPDF/);
+    assert.doesNotMatch(bridge, /sigeko|technicalPdfProvider|modulePdfProviders|printToPDF/);
     const print = fs.readFileSync(path.join(__dirname, "../../src/main/ipc/printIpc.js"), "utf8");
     assert.equal((print.match(/\.printToPDF\(/g) || []).length, 1);
   });

--- a/scripts/tests/sigekoPdfProvider.test.cjs
+++ b/scripts/tests/sigekoPdfProvider.test.cjs
@@ -40,6 +40,7 @@ async function runSigekoPdfProviderTests(run) {
       { ...payload(), projectId: "other" }, { ...payload(), documentId: "other" } ];
     for (const field of ["moduleId", "providerId", "projectId", "documentId"]) {
       const source = payload(); delete source.providerRequest[field]; invalid.push(source);
+      const empty = payload(); empty.providerRequest[field] = " "; invalid.push(empty);
     }
     for (const source of invalid) assert.throws(() => bridge.resolve(source), { code: "PDF_PROVIDER_REQUEST_INVALID" });
     const unknown = payload(); unknown.providerRequest.providerId = unknown.documentTypeId = "unknown";

--- a/scripts/tests/sigekoPdfProvider.test.cjs
+++ b/scripts/tests/sigekoPdfProvider.test.cjs
@@ -1,0 +1,133 @@
+"use strict";
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+async function runSigekoPdfProviderTests(run) {
+  const { createPdfProviderBridge, isProviderRequest } = require("../../src/main/print/pdfProviderBridge");
+  const { createModuleServiceProviderRegistry, PdfDocumentProvider } = require("../../src/main/moduleServiceProviders");
+  const { createDeclarativePdfAdapter, persistedRegistryFingerprint } = require("../../src/main/ui-editor/declarativePdfAdapter.cjs");
+  const { REGISTRY, DOCUMENT_TYPE_ID, SCOPE_ID } = require("../../src/main/ui-editor/technicalPdfAdapter.cjs");
+  const payload = () => ({ mode: "provider", documentTypeId: DOCUMENT_TYPE_ID, providerRequest: {
+    moduleId: "sigeko", providerId: DOCUMENT_TYPE_ID, projectId: "project-a", documentId: "document-a",
+    data: { title: "Neutraler Titel", body: "Neutraler Inhalt" }, storage: { target: "Unterlagen" },
+  } });
+  const storage = { resolve: ({ projectId }) => {
+    if (projectId !== "project-a") throw Object.assign(new Error("Projekt fehlt"), { code: "PROJECT_NOT_FOUND" });
+    return { targets: { Unterlagen: "/fixture/SiGeKo/Unterlagen" } };
+  } };
+  const adapterFor = () => createDeclarativePdfAdapter({ documentTypeId: DOCUMENT_TYPE_ID, displayName: REGISTRY.displayName, registry: REGISTRY, documentIdentityFields: ["projectId", "documentId"] });
+  await run("S1.4a: explicit provider identity and module guard precede content production", async () => {
+    const guards = [];
+    const bridge = createPdfProviderBridge({ storage, enforce: (moduleId) => guards.push(moduleId) });
+    const source = payload();
+    const result = await bridge.provide(source);
+    assert.deepEqual(guards, ["sigeko"]);
+    assert.equal(result.documentId, "document-a");
+    assert.equal(result.projectId, "project-a");
+    assert.deepEqual(result.providerDocument, source.providerRequest.data);
+    assert.equal(isProviderRequest({ providerRequest: {} }), true);
+    assert.equal(isProviderRequest({ mode: "protocol" }), false);
+    const resolved = bridge.resolve(source);
+    resolved.request.data.title = "Mutation";
+    assert.equal(source.providerRequest.data.title, "Neutraler Titel");
+    assert.equal(bridge.outputDirectory(source), "/fixture/SiGeKo/Unterlagen");
+  });
+  await run("S1.4a: malformed and mismatched provider contexts never fall back to protocol", () => {
+    const bridge = createPdfProviderBridge({ storage, enforce: () => {} });
+    const invalid = [ {}, { ...payload(), mode: "protocol" }, { ...payload(), documentTypeId: "protocol" },
+      { ...payload(), projectId: "other" }, { ...payload(), documentId: "other" } ];
+    for (const field of ["moduleId", "providerId", "projectId", "documentId"]) {
+      const source = payload(); delete source.providerRequest[field]; invalid.push(source);
+    }
+    for (const source of invalid) assert.throws(() => bridge.resolve(source), { code: "PDF_PROVIDER_REQUEST_INVALID" });
+    const unknown = payload(); unknown.providerRequest.providerId = unknown.documentTypeId = "unknown";
+    assert.throws(() => bridge.resolve(unknown), { code: "PDF_PROVIDER_UNKNOWN" });
+  });
+  await run("S1.4a: denied license, missing project and invalid storage reject before provider execution", async () => {
+    let calls = 0;
+    const registry = createModuleServiceProviderRegistry();
+    registry.register(PdfDocumentProvider({ moduleId: "sigeko", type: DOCUMENT_TYPE_ID, provide: () => { calls++; return {}; } }));
+    const denied = createPdfProviderBridge({ registry, storage, enforce: () => { throw Object.assign(new Error("Denied"), { code: "DENIED" }); } });
+    await assert.rejects(() => denied.provide(payload()), { code: "DENIED" });
+    const bridge = createPdfProviderBridge({ registry, storage, enforce: () => {} });
+    const missing = payload(); missing.providerRequest.projectId = "missing";
+    await assert.rejects(() => bridge.provide(missing), { code: "PROJECT_NOT_FOUND" });
+    const invalid = payload(); invalid.providerRequest.storage.target = "../escape";
+    await assert.rejects(() => bridge.provide(invalid), { code: "PDF_STORAGE_TARGET_INVALID" });
+    assert.equal(calls, 0);
+    bridge.resolve(payload()); bridge.outputDirectory(payload()); assert.equal(calls, 0);
+    await bridge.provide(payload()); assert.equal(calls, 1);
+  });
+  await run("S1.4a: bounded technical data rejects missing text and excess single-page input", async () => {
+    const bridge = createPdfProviderBridge({ storage, enforce: () => {} });
+    for (const data of [{}, { title: "a\nb", body: "Text" }, { title: "a".repeat(81), body: "Text" },
+      { title: "Titel", body: "x".repeat(601) }, { title: "Titel", body: Array(11).fill("x").join("\n") }]) {
+      const source = payload(); source.providerRequest.data = data;
+      await assert.rejects(() => bridge.provide(source), { code: "PDF_PROVIDER_DATA_INVALID" });
+    }
+  });
+  await run("S1.4a: fixed-layout text operations enforce limits atomically and lock domain changes", () => {
+    const adapter = adapterFor();
+    assert.equal(REGISTRY.layoutModel, "fixed-layout");
+    assert.equal(REGISTRY.elements.filter((entry) => entry.kind === "table").length, 0);
+    const request = { changeId: "font", scopeId: SCOPE_ID, elementId: `${SCOPE_ID}.title`, operation: "textResize", payload: { text: { fontSize: 15 } } };
+    assert.equal(adapter.submitPdfChangeRequest(request).success, true);
+    const before = adapter.getCurrentPdfLayoutState().elements;
+    assert.equal(before.find((entry) => entry.elementId === request.elementId).fontSize, 15);
+    for (const fontSize of [0, -1, 7, 17, null, "12", NaN, Infinity]) {
+      assert.equal(adapter.submitPdfChangeRequest({ ...request, payload: { text: { fontSize } } }).success, false);
+      assert.deepEqual(adapter.getCurrentPdfLayoutState().elements, before);
+    }
+    for (const operation of ["setPageBreakRule", "move", "setVisibility", "changeText", "modifyDomainData"]) {
+      assert.equal(adapter.submitPdfChangeRequest({ ...request, operation }).success, false);
+    }
+    const invalid = adapter.getCurrentPdfLayoutState(); invalid.elements.at(-1).fontSize = 1000;
+    assert.throws(() => adapter.replaceCurrentPdfLayoutState(invalid), { code: "pdf_layout_incompatible" });
+    assert.deepEqual(adapter.getCurrentPdfLayoutState().elements, before);
+  });
+  await run("S1.4a: common profile restore preserves font size and rejects invalid persisted values", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-s14a-profile-"));
+    try {
+      const adapter = adapterFor(); const filePath = adapter.configureProfileRoot(root);
+      const state = adapter.getCurrentPdfLayoutState(); state.elements.at(-1).fontSize = 13;
+      const document = { schemaVersion: 1, documentKind: "pdf-layout-profile", applicationId: "bbm-produktiv", documentType: DOCUMENT_TYPE_ID,
+        profileId: "pdf-standard", scopeId: SCOPE_ID, registryFingerprint: persistedRegistryFingerprint(REGISTRY), layoutState: state };
+      fs.mkdirSync(path.dirname(filePath), { recursive: true }); fs.writeFileSync(filePath, JSON.stringify(document));
+      const reopened = adapterFor(); reopened.configureProfileRoot(root);
+      assert.equal(reopened.getPersistedPdfLayoutState().elements.at(-1).fontSize, 13);
+      state.elements.at(-1).fontSize = 1000; fs.writeFileSync(filePath, JSON.stringify(document));
+      assert.throws(() => reopened.getPersistedPdfLayoutState(), { code: "pdf_profile_invalid" });
+    } finally { fs.rmSync(root, { recursive: true, force: true }); }
+  });
+  await run("S1.4a: registered regeneration keeps explicit project, document, provider and storage context", async () => {
+    const { createPdfEditorAdapterResolver } = require("../../src/main/ui-editor/pdfAdapterRegistry.cjs");
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-s14a-registry-"));
+    try {
+      let received;
+      const resolver = createPdfEditorAdapterResolver({ profileBaseRoot: path.join(root, "profiles"), registrationRoot: root,
+        regeneratePdf: async (request) => { received = request; return { controlledOutputPath: "/fixture/generated.pdf", pageCount: 1 }; } });
+      resolver.activateAcceptedDocumentType(DOCUMENT_TYPE_ID);
+      assert.equal(resolver.resolvePrintRegistration({ documentTypeId: DOCUMENT_TYPE_ID }).registration.documentTypeId, DOCUMENT_TYPE_ID);
+      assert.equal(resolver.resolvePrintRegistration({ mode: "provider" }), null);
+      const source = payload(); const context = { documentTypeId: DOCUMENT_TYPE_ID, projectId: "project-a", documentId: "document-a", providerRequest: source.providerRequest };
+      assert.equal(resolver.setActiveDocumentContext(context).ok, true);
+      const identity = resolver.getPdfContract().activeDocumentId;
+      await resolver.regeneratePdfPreview();
+      assert.deepEqual(received.providerRequest, source.providerRequest);
+      assert.equal(received.projectId, context.projectId); assert.equal(received.documentId, context.documentId);
+      assert.equal(received.mode, "provider"); assert.equal(received.targetDir, "temp");
+      resolver.setActiveDocumentContext({ ...context, documentId: "other" });
+      assert.notEqual(resolver.getPdfContract().activeDocumentId, identity);
+      await assert.rejects(() => resolver.regeneratePdfPreview(), /Providerkontext/);
+    } finally { fs.rmSync(root, { recursive: true, force: true }); }
+  });
+  await run("S1.4a: print bridge contains no module implementation or second PDF engine", () => {
+    const bridge = fs.readFileSync(path.join(__dirname, "../../src/main/print/pdfProviderBridge.js"), "utf8");
+    assert.doesNotMatch(bridge, /sigeko|technicalPdfProvider|printToPDF/);
+    const print = fs.readFileSync(path.join(__dirname, "../../src/main/ipc/printIpc.js"), "utf8");
+    assert.equal((print.match(/\.printToPDF\(/g) || []).length, 1);
+  });
+}
+module.exports = { runSigekoPdfProviderTests };

--- a/src/main/ipc/printIpc.js
+++ b/src/main/ipc/printIpc.js
@@ -36,6 +36,11 @@ require("../ui-editor/restarbeitenPdfAdapter.cjs");
 require("../ui-editor/invoicePdfAdapter.cjs");
 const { createPdfEditorAdapterResolver } = require("../ui-editor/pdfAdapterRegistry.cjs");
 
+const { isProviderRequest, createPdfProviderBridge } = require("../print/pdfProviderBridge");
+require("../ui-editor/technicalPdfAdapter.cjs");
+let _providerBridge;
+function providerBridge() { return _providerBridge || (_providerBridge = createPdfProviderBridge()); }
+
 let _pdfEditorAdapterResolver = null;
 
 function _getPdfEditorAdapterResolver() {
@@ -414,17 +419,18 @@ async function _printToPdf(payload = {}, includeMetadata = false) {
   if (!mode) {
     throw new Error(`Unbekannter Druckmodus: ${String(payload.mode || "").trim() || "-"}`);
   }
-  const projectId = payload.projectId || null;
+  const providerContext = isProviderRequest(payload) ? providerBridge().resolve(payload).request : null;
+  const projectId = providerContext?.projectId || payload.projectId || null;
   const meetingId = payload.meetingId || null;
   const invoiceId = payload.invoiceId || null;
   const invoicePreview = payload.invoicePreview === true;
-  const orientation = _resolveRequestedOrientation(payload);
+  const orientation = isProviderRequest(payload) ? "portrait" : _resolveRequestedOrientation(payload);
 
   console.log(
     `[print:${jobId}] start mode=${mode} projectId=${projectId} meetingId=${meetingId} invoiceId=${invoiceId} orientation=${orientation}`
   );
 
-  const data = await getPrintData({
+  const data = isProviderRequest(payload) ? await providerBridge().provide(payload) : await getPrintData({
     mode,
     projectId,
     meetingId,
@@ -439,7 +445,13 @@ async function _printToPdf(payload = {}, includeMetadata = false) {
   });
   const projectNumber = data?.project?.project_number || data?.project?.projectNumber || null;
 
-  const outPath = await _buildOutputPath({
+  let providerOutputPath;
+  if (isProviderRequest(payload)) {
+    const dir = payload.targetDir === "temp" ? app.getPath("temp") : providerBridge().outputDirectory(payload);
+    fs.mkdirSync(dir, { recursive: true });
+    providerOutputPath = uniquePath(dir, payload.fileName || "Technisches-Dokument.pdf");
+  }
+  const outPath = providerOutputPath || await _buildOutputPath({
     fileName: payload.fileName || null,
     targetDir: payload.targetDir,
     baseDir: payload.baseDir,
@@ -515,6 +527,7 @@ async function _printToPdf(payload = {}, includeMetadata = false) {
         if (msg?.ok === false) {
           throw new Error(String(msg?.error || "Print-Renderer hat die PDF-Erzeugung abgewiesen."));
         }
+        if (isProviderRequest(payload)) providerBridge().resolve(payload);
         const pdfBuffer = await win.webContents.printToPDF(options);
         fs.writeFileSync(outPath, pdfBuffer);
         console.log(`[print:${jobId}] PDF written -> ${outPath}`);
@@ -541,6 +554,7 @@ async function _printToPdf(payload = {}, includeMetadata = false) {
       console.log(`[print:${jobId}] sending print:init (debug=${debug})`);
       win.webContents.send("print:init", {
         jobId,
+        ...(isProviderRequest(payload) ? { providerRequest: structuredClone(payload.providerRequest), documentId: providerContext.documentId } : {}),
         mode,
         documentTypeId: payload.documentTypeId || null,
         projectId,
@@ -581,9 +595,10 @@ function registerPrintIpc() {
   ipcMain.handle("print:getData", async (_evt, payload) =>
     _runIpcTask(async () => {
       const p = payload || {};
-      _enforceFeature(_featureForPrintMode(p.mode));
+      if (isProviderRequest(p)) providerBridge().resolve(p);
+      else _enforceFeature(_featureForPrintMode(p.mode));
       const orientation = _resolveRequestedOrientation(p);
-      const data = await getPrintData({
+      const data = isProviderRequest(p) ? await providerBridge().provide(p) : await getPrintData({
         mode: p.mode,
         projectId: p.projectId,
         meetingId: p.meetingId,
@@ -596,9 +611,16 @@ function registerPrintIpc() {
         restarbeitenLocationLabels: p.restarbeitenLocationLabels || null,
         showAmpelInList: typeof p.showAmpelInList === "boolean" ? p.showAmpelInList : null,
       });
-      const pdfResolution = _getPdfEditorAdapterResolver().resolvePrintRegistration({ documentTypeId: p.documentTypeId, mode: data.mode });
+      const pdfResolution = _getPdfEditorAdapterResolver().resolvePrintRegistration({ documentTypeId: p.documentTypeId, mode: isProviderRequest(p) ? undefined : data.mode });
       if (pdfResolution) {
         const pdfAdapter = pdfResolution.adapter;
+        if (isProviderRequest(p)) {
+          data.pdfEditorRegistry = pdfAdapter.getPdfRegistry();
+          data.pdfEditorLayoutState = {
+            scopeId: data.pdfEditorRegistry.scopeId,
+            elements: data.pdfEditorRegistry.elements.map((entry) => ({ elementId: entry.id, scopeId: entry.scopeId, ...entry.baseline })),
+          };
+        }
         if (p.pdfEditorPreview === true) {
           data.pdfEditorLayoutState = pdfAdapter.getCurrentPdfLayoutState();
           data.pdfEditorRegistry = pdfAdapter.getPdfRegistry();
@@ -629,7 +651,8 @@ function registerPrintIpc() {
   ipcMain.handle("print:openHtmlPreview", async (_evt, payload) =>
     _runIpcTask(async () => {
       const p = payload || {};
-      _enforceFeature(_featureForPrintMode(p.mode));
+      if (isProviderRequest(p)) providerBridge().resolve(p);
+      else _enforceFeature(_featureForPrintMode(p.mode));
       const orientation = _resolveRequestedOrientation(p);
       const jobId = _randId();
       const win = createPrintWindow({ show: true, devTools: false });
@@ -639,9 +662,10 @@ function registerPrintIpc() {
       win.webContents.once("did-finish-load", () => {
         win.webContents.send("print:init", {
           jobId,
+          ...(isProviderRequest(p) ? { providerRequest: structuredClone(p.providerRequest), documentId: p.providerRequest.documentId } : {}),
           mode: p.mode || "topsAll",
           documentTypeId: p.documentTypeId || null,
-          projectId: p.projectId || null,
+          projectId: p.providerRequest?.projectId || p.projectId || null,
           meetingId: p.meetingId || null,
           invoiceId: p.invoiceId || null,
           invoicePreview: p.invoicePreview === true,
@@ -674,7 +698,8 @@ function registerPrintIpc() {
   ipcMain.handle("print:toPdfAndOpen", async (_evt, payload) =>
     _runIpcTask(async () => {
       const p = payload || {};
-      _enforceFeature(_featureForPrintMode(p.mode));
+      if (isProviderRequest(p)) providerBridge().resolve(p);
+      else _enforceFeature(_featureForPrintMode(p.mode));
       const outPath = await printToPdf(p);
       const openError = await shell.openPath(outPath);
       if (String(openError || "").trim()) {
@@ -688,7 +713,8 @@ function registerPrintIpc() {
   ipcMain.handle("print:toPdfAndPreviewInternal", async (_evt, payload) =>
     _runIpcTask(async () => {
       const p = payload || {};
-      _enforceFeature(_featureForPrintMode(p.mode));
+      if (isProviderRequest(p)) providerBridge().resolve(p);
+      else _enforceFeature(_featureForPrintMode(p.mode));
       const outPath = await printToPdf(p);
       const previewResult = await openInternalPdfPreview({
         filePath: outPath,
@@ -704,7 +730,8 @@ function registerPrintIpc() {
   ipcMain.handle("print:toPdf", async (_evt, payload) =>
     _runIpcTask(async () => {
       const p = payload || {};
-      _enforceFeature(_featureForPrintMode(p.mode));
+      if (isProviderRequest(p)) providerBridge().resolve(p);
+      else _enforceFeature(_featureForPrintMode(p.mode));
       console.log(
         `[PRINT_ACTIVE] handler=print:toPdf payload.mode=${payload?.mode || ""} projectId=${
           payload?.projectId ?? ""
@@ -755,7 +782,8 @@ function registerPrintIpc() {
   ipcMain.handle("print:htmlToPdf", async (_evt, payload) =>
     _runIpcTask(async () => {
       const p = payload || {};
-      _enforceFeature(_featureForPrintMode(p.mode));
+      if (isProviderRequest(p)) providerBridge().resolve(p);
+      else _enforceFeature(_featureForPrintMode(p.mode));
       console.log(
         `[PRINT_ACTIVE] handler=print:htmlToPdf payload.mode=${payload?.mode || ""} projectId=${
           payload?.projectId ?? ""

--- a/src/main/ipc/printIpc.js
+++ b/src/main/ipc/printIpc.js
@@ -38,8 +38,9 @@ const { createPdfEditorAdapterResolver } = require("../ui-editor/pdfAdapterRegis
 
 const { isProviderRequest, createPdfProviderBridge } = require("../print/pdfProviderBridge");
 require("../ui-editor/technicalPdfAdapter.cjs");
+const { createProductivePdfProviderRegistry } = require("../modulePdfProviders");
 let _providerBridge;
-function providerBridge() { return _providerBridge || (_providerBridge = createPdfProviderBridge()); }
+function providerBridge() { return _providerBridge || (_providerBridge = createPdfProviderBridge({ registry: createProductivePdfProviderRegistry() })); }
 
 let _pdfEditorAdapterResolver = null;
 

--- a/src/main/modulePdfProviders.js
+++ b/src/main/modulePdfProviders.js
@@ -1,0 +1,10 @@
+// Productive module composition. Shared registries and the print bridge stay module-neutral.
+const { createModuleServiceProviderRegistry } = require("./moduleServiceProviders");
+
+function createProductivePdfProviderRegistry() {
+  const registry = createModuleServiceProviderRegistry();
+  registry.register(require("./modules/sigeko/technicalPdfProvider").technicalPdfProvider);
+  return registry;
+}
+
+module.exports = { createProductivePdfProviderRegistry };

--- a/src/main/modules/sigeko/technicalPdfProvider.js
+++ b/src/main/modules/sigeko/technicalPdfProvider.js
@@ -1,0 +1,16 @@
+const { PdfDocumentProvider } = require("../../moduleServiceProviders");
+
+// Technischer Anschlussvertrag; keine SiGeKo-Fachfunktion oder Fachfelder.
+const technicalPdfProvider = PdfDocumentProvider({
+  moduleId: "sigeko",
+  type: "technical-neutral",
+  provide({ input }) {
+    if (!input || typeof input.title !== "string" || !input.title.trim() || input.title.length > 80 ||
+        typeof input.body !== "string" || !input.body.trim() || input.body.length > 600 ||
+        /[\r\n]/.test(input.title) || input.body.split(/\r?\n/).length > 10) {
+      throw Object.assign(new Error("Technischer PDF-Inhalt fehlt oder ueberschreitet den Einseitenvertrag."), { code: "PDF_PROVIDER_DATA_INVALID" });
+    }
+    return { title: input.title, body: input.body };
+  },
+});
+module.exports = { technicalPdfProvider };

--- a/src/main/print/pdfProviderBridge.js
+++ b/src/main/print/pdfProviderBridge.js
@@ -15,7 +15,8 @@ function createPdfProviderBridge({ registry, enforce = enforceLicensedFeature, s
     if (payload.mode !== "provider" || !request || typeof request !== "object" || Array.isArray(request)) {
       fail("PDF_PROVIDER_REQUEST_INVALID", "Expliziter PDF-Provider-Request erforderlich.");
     }
-    if (typeof request.moduleId !== "string" || typeof request.providerId !== "string" ||
+    if (typeof request.moduleId !== "string" || !request.moduleId.trim() ||
+        typeof request.providerId !== "string" || !request.providerId.trim() ||
         payload.documentTypeId !== request.providerId || typeof request.projectId !== "string" || !request.projectId.trim() ||
         typeof request.documentId !== "string" || !request.documentId.trim() ||
         (payload.projectId != null && payload.projectId !== request.projectId) ||

--- a/src/main/print/pdfProviderBridge.js
+++ b/src/main/print/pdfProviderBridge.js
@@ -1,0 +1,48 @@
+const { PROVIDER_KINDS } = require("../moduleServiceProviders");
+const { createProductivePdfProviderRegistry } = require("../modulePdfProviders");
+const { getModuleDefinition } = require("../moduleRegistry");
+const { enforceLicensedFeature } = require("../licensing/featureGuard");
+const { createProjectStorageAccess } = require("../ipc/projectStoragePaths");
+
+function fail(code, message) { throw Object.assign(new Error(message), { code }); }
+function isProviderRequest(payload) {
+  return payload?.mode === "provider" || Object.hasOwn(payload || {}, "providerRequest");
+}
+function createPdfProviderBridge({ registry, enforce = enforceLicensedFeature, storage = createProjectStorageAccess() } = {}) {
+  registry ||= createProductivePdfProviderRegistry();
+  function resolve(payload = {}) {
+    const request = payload.providerRequest;
+    if (payload.mode !== "provider" || !request || typeof request !== "object" || Array.isArray(request)) {
+      fail("PDF_PROVIDER_REQUEST_INVALID", "Expliziter PDF-Provider-Request erforderlich.");
+    }
+    if (typeof request.moduleId !== "string" || typeof request.providerId !== "string" ||
+        payload.documentTypeId !== request.providerId || typeof request.projectId !== "string" || !request.projectId.trim() ||
+        typeof request.documentId !== "string" || !request.documentId.trim() ||
+        (payload.projectId != null && payload.projectId !== request.projectId) ||
+        (payload.documentId != null && payload.documentId !== request.documentId)) {
+      fail("PDF_PROVIDER_REQUEST_INVALID", "Dokumenttyp, Provider, Modul und Projekt muessen eindeutig angegeben sein.");
+    }
+    const provider = registry.resolve({ kind: PROVIDER_KINDS.PDF_DOCUMENT, moduleId: request.moduleId, type: request.providerId });
+    if (!provider) fail("PDF_PROVIDER_UNKNOWN", "Unbekannter PDF-Provider.");
+    // PDF ist eine gemeinsame Capability des kanonischen Modulvertrags,
+    // kein Protokoll-Lizenzalias. Die Freigabepruefung selbst bleibt zentral.
+    if (!getModuleDefinition(request.moduleId)?.requiredCapabilities?.includes("pdf")) {
+      fail("PDF_CAPABILITY_MISSING", "Modul deklariert die PDF-Capability nicht.");
+    }
+    enforce(request.moduleId);
+    if (!request.storage || typeof request.storage.target !== "string") fail("PDF_STORAGE_TARGET_REQUIRED", "Explizites Modul-Speicherziel erforderlich.");
+    const paths = storage.resolve({ moduleId: request.moduleId, projectId: request.projectId, baseDir: request.storage.baseDir });
+    if (!Object.hasOwn(paths.targets, request.storage.target)) fail("PDF_STORAGE_TARGET_INVALID", "Unbekanntes Modul-Speicherziel.");
+    return { request: structuredClone(request), provider, directory: paths.targets[request.storage.target] };
+  }
+  return Object.freeze({
+    resolve,
+    async provide(payload) {
+      const { request, provider } = resolve(payload);
+      const document = await provider.provide({ input: structuredClone(request.data) });
+      return { mode: "provider", documentTypeId: request.providerId, projectId: request.projectId, documentId: request.documentId, providerDocument: document, orientation: "portrait", settings: {}, tableLayouts: {} };
+    },
+    outputDirectory(payload) { return resolve(payload).directory; },
+  });
+}
+module.exports = { isProviderRequest, createPdfProviderBridge };

--- a/src/main/print/pdfProviderBridge.js
+++ b/src/main/print/pdfProviderBridge.js
@@ -1,5 +1,4 @@
-const { PROVIDER_KINDS } = require("../moduleServiceProviders");
-const { createProductivePdfProviderRegistry } = require("../modulePdfProviders");
+const { PROVIDER_KINDS, createModuleServiceProviderRegistry } = require("../moduleServiceProviders");
 const { getModuleDefinition } = require("../moduleRegistry");
 const { enforceLicensedFeature } = require("../licensing/featureGuard");
 const { createProjectStorageAccess } = require("../ipc/projectStoragePaths");
@@ -9,7 +8,7 @@ function isProviderRequest(payload) {
   return payload?.mode === "provider" || Object.hasOwn(payload || {}, "providerRequest");
 }
 function createPdfProviderBridge({ registry, enforce = enforceLicensedFeature, storage = createProjectStorageAccess() } = {}) {
-  registry ||= createProductivePdfProviderRegistry();
+  registry ||= createModuleServiceProviderRegistry();
   function resolve(payload = {}) {
     const request = payload.providerRequest;
     if (payload.mode !== "provider" || !request || typeof request !== "object" || Array.isArray(request)) {

--- a/src/main/ui-editor/declarativePdfAdapter.cjs
+++ b/src/main/ui-editor/declarativePdfAdapter.cjs
@@ -138,6 +138,7 @@ function createDeclarativePdfAdapter({ applicationId = "bbm-produktiv", document
       }),
     };
     validateTableColumnGeometry(normalized, "pdf_profile_invalid");
+    validateFontSizes(normalized, "pdf_profile_invalid");
     return normalized;
   }
 
@@ -236,6 +237,21 @@ function createDeclarativePdfAdapter({ applicationId = "bbm-produktiv", document
     }
   }
 
+  function validFontSize(definition, fontSize) {
+    return typeof fontSize === "number" && Number.isFinite(fontSize) && fontSize > 0 &&
+      fontSize >= (definition.layoutBounds?.minFontSize ?? 0) &&
+      fontSize <= (definition.layoutBounds?.maxFontSize ?? Number.POSITIVE_INFINITY);
+  }
+
+  function validateFontSizes(state, errorCode) {
+    for (const entry of state.elements) {
+      const definition = definitions.get(entry.elementId);
+      if (definition?.capabilities?.includes("textResize") && !validFontSize(definition, entry.fontSize)) {
+        throw Object.assign(new Error("PDF-Schriftgroesse liegt ausserhalb der registrierten Grenzen."), { code: errorCode });
+      }
+    }
+  }
+
   function submitPdfChangeRequest(request = {}) {
     const definition = definitions.get(String(request.elementId || ""));
     const previous = working.elements.find((entry) => entry.elementId === definition?.id) || null;
@@ -307,6 +323,14 @@ function createDeclarativePdfAdapter({ applicationId = "bbm-produktiv", document
             ? "PDF-Spaltenbreite wurde unabhaengig angewandt; der Wert liegt ausserhalb der registrierten Empfehlung."
             : "PDF-Spaltenbreite wurde unabhaengig angewandt und zurueckgelesen.",
           previousState: clone(previous), newState: clone(states.get(definition.id)), affectedStates: affected, rollbackSucceeded: true };
+      } else if (request.operation === "textResize") {
+        const fontSize = request.payload?.text?.fontSize;
+        if (!validFontSize(definition, fontSize)) {
+          return failure("pdf_invalid_font_size", "PDF-Schriftgroesse liegt ausserhalb der registrierten Grenzen.");
+        }
+        const next = { ...previous, fontSize };
+        states.set(definition.id, next);
+        affected.push(clone(next));
       } else if (request.operation === "setVisibility") {
         if (typeof request.payload?.visible !== "boolean") return failure("pdf_invalid_payload", "PDF-Sichtbarkeit ist ungueltig.");
         const next = { ...previous, visible: request.payload.visible };
@@ -363,6 +387,7 @@ function createDeclarativePdfAdapter({ applicationId = "bbm-produktiv", document
       if (state?.scopeId !== normalizedRegistry.scopeId || requested.size !== definitions.size) throw Object.assign(new Error("PDF-LayoutState ist ungueltig."), { code: "pdf_layout_incompatible" });
       const next = { scopeId: normalizedRegistry.scopeId, capturedAt: new Date().toISOString(), elements: normalizedRegistry.elements.map((definition) => ({ elementId: definition.id, scopeId: normalizedRegistry.scopeId, ...clone(definition.baseline), ...clone(requested.get(definition.id)) })) };
       validateTableColumnGeometry(next, "pdf_layout_incompatible");
+      validateFontSizes(next, "pdf_layout_incompatible");
       working = next;
       return clone(working);
     },

--- a/src/main/ui-editor/technicalPdfAdapter.cjs
+++ b/src/main/ui-editor/technicalPdfAdapter.cjs
@@ -1,0 +1,36 @@
+const { PDF_TARGET_OPERATIONS, PDF_TARGET_CONTRACT_VERSION, createPdfRegistryFingerprint } = require("ui-editor-kit");
+const { createDeclarativePdfAdapter } = require("./declarativePdfAdapter.cjs");
+const { registerPdfEditorAdapter } = require("./pdfAdapterRegistry.cjs");
+const DOCUMENT_TYPE_ID = "technical-neutral";
+const SCOPE_ID = "pdf.bbm.technical-neutral";
+function element(suffix, parent, kind, selector, order, width, height, fontSize) {
+  const capabilities = fontSize ? ["textResize"] : [];
+  return {
+    id: suffix ? `${SCOPE_ID}.${suffix}` : SCOPE_ID, name: ({ page: "Seite", title: "Titel", body: "Text" })[suffix] || "Technisches Dokument", scopeId: SCOPE_ID,
+    parentId: parent, kind, role: fontSize ? "content" : "layout", pageArea: suffix === "title" ? "header" : fontSize ? "body" : "document",
+    order, visible: true, editable: capabilities.length > 0, capabilities, allowedOps: capabilities,
+    lockedOps: [...PDF_TARGET_OPERATIONS.filter(op => !capabilities.includes(op)), "changeText", "modifyDomainData"],
+    baseline: { x: fontSize ? 12 : 0, y: suffix === "title" ? 18 : suffix === "body" ? 61 : 0, width, height, visible: true, ...(fontSize ? { fontSize } : {}) },
+    layoutBounds: { minX: 0, maxX: 210, minY: 0, maxY: 297, minWidth: 1, maxWidth: 210, minHeight: 1, maxHeight: 297, minFontSize: 8, maxFontSize: 16 },
+    refKey: `technical.${suffix || "document"}`, rendererKey: selector,
+  };
+}
+const base = { applicationId: "bbm-produktiv", documentTypeId: DOCUMENT_TYPE_ID, displayName: "Technisches Dokument", scopeId: SCOPE_ID,
+  unit: "mm", registryVersion: 1, layoutModel: "fixed-layout",
+  pageSettings: { format: "A4", orientation: "portrait", width: 210, height: 297, margins: { top: 10, right: 12, bottom: 10, left: 12 } },
+  elements: [element("", null, "document", ".printRoot", 0, 210, 297),
+    element("page", SCOPE_ID, "page", ".page", 1, 210, 297),
+    element("title", `${SCOPE_ID}.page`, "text", ".providerTitle", 2, 186, 20, 14),
+    element("body", `${SCOPE_ID}.page`, "text", ".providerBody", 3, 186, 150, 11)] };
+const REGISTRY = { ...base, registryFingerprint: createPdfRegistryFingerprint(base) };
+const adapter = createDeclarativePdfAdapter({ applicationId: "bbm-produktiv", documentTypeId: DOCUMENT_TYPE_ID, displayName: "Technisches Dokument", registry: REGISTRY, documentIdentityFields: ["projectId", "documentId"] });
+registerPdfEditorAdapter({ documentTypeId: DOCUMENT_TYPE_ID, moduleId: "sigeko", scopeId: SCOPE_ID, profileStorageKey: "module-sigeko-technical", displayName: "Technisches Dokument",
+  contractVersion: PDF_TARGET_CONTRACT_VERSION, printModes: [], adapter, builtIn: true,
+  buildRegenerationRequest(context) {
+    if (!context.providerRequest || context.providerRequest.projectId !== context.projectId ||
+        context.providerRequest.documentId !== context.documentId ||
+        context.providerRequest.moduleId !== "sigeko" || context.providerRequest.providerId !== DOCUMENT_TYPE_ID) throw new Error("Expliziter Providerkontext fuer Regeneration fehlt.");
+    return { mode: "provider", documentTypeId: DOCUMENT_TYPE_ID, projectId: context.projectId, documentId: context.documentId, providerRequest: structuredClone(context.providerRequest), targetDir: "temp", fileName: "Technisches-Dokument-Editor.pdf" };
+  },
+});
+module.exports = { DOCUMENT_TYPE_ID, SCOPE_ID, REGISTRY };

--- a/src/renderer/print/layout/PrintShell.js
+++ b/src/renderer/print/layout/PrintShell.js
@@ -749,11 +749,15 @@ function _buildSpineNote(data = {}) {
   return wrap;
 }
 
-export function renderPrint({ pages, data } = {}) {
+export function renderPrint({ pages, data, contentSlots = null } = {}) {
   const normalizedMode = normalizePrintMode(data?.mode || "protocol");
   if (!normalizedMode) {
     throw new Error(`Unbekannter Druckmodus: ${String(data?.mode || "").trim() || "-"}`);
   }
+  if (contentSlots && (!contentSlots.fullHeader || !contentSlots.body || !Array.isArray(pages) || pages.length !== 1)) {
+    throw new Error("PDF-Inhaltsslots benötigen genau eine vollständig deklarierte Seite.");
+  }
+  if (normalizedMode === "provider" && !contentSlots) throw new Error("PDF-Provider-Inhaltsslots fehlen.");
   const runtimeData = { ...(data || {}), mode: normalizedMode };
   globalThis.__bbmRestarbeitenLocationLabels = runtimeData?.restarbeitenLocationLabels || null;
   const root = _el("div", "printRoot printV2Root");
@@ -765,7 +769,7 @@ export function renderPrint({ pages, data } = {}) {
     });
   }
   root.dataset.orientation = _normalizeOrientation(runtimeData?.orientation);
-  root.dataset.tableLayout = _getTopLayout(runtimeData).tableKey || "protokoll_tops";
+  if (!contentSlots) root.dataset.tableLayout = _getTopLayout(runtimeData).tableKey || "protokoll_tops";
 
   // Force colors into PDF output (Chromium/Electron)
   root.style.webkitPrintColorAdjust = "exact";
@@ -810,7 +814,9 @@ export function renderPrint({ pages, data } = {}) {
     }
     if (pageNo === 1) {
       pageEl.appendChild(renderV2GlobalHeader({ data: runtimeData }));
-      pageEl.appendChild(normalizedMode === "invoice"
+      pageEl.appendChild(contentSlots
+        ? renderV2FullHeader({ data: runtimeData, pageNo, totalPages, modeLabel, content: contentSlots.fullHeader })
+        : normalizedMode === "invoice"
         ? renderV2FullHeader({
             data: runtimeData,
             pageNo,
@@ -830,6 +836,7 @@ export function renderPrint({ pages, data } = {}) {
       }));
     }
     const pageBody = _el("div", "v2PageBody");
+    if (contentSlots) pageBody.appendChild(contentSlots.body);
     if (normalizedMode === "invoice") {
       markInvoiceEditorElement(pageBody, {
         id: `${INVOICE_SCOPE_ID}.body`,
@@ -842,15 +849,15 @@ export function renderPrint({ pages, data } = {}) {
         if (invoiceIntro) pageBody.appendChild(invoiceIntro);
       }
     }
-    const intro = _buildIntro(page);
+    const intro = contentSlots ? null : _buildIntro(page);
     if (intro) pageBody.appendChild(intro);
-    const preRemarks = _buildPreRemarks(page);
+    const preRemarks = contentSlots ? null : _buildPreRemarks(page);
     if (preRemarks) pageBody.appendChild(preRemarks);
     const isTops = String(page?.table?.type || "") === "tops";
     const isInvoice = String(page?.table?.type || "") === "invoice";
     const hasRows = (page?.table?.rows || []).length > 0;
     // Tops-Tabelle ohne Zeilen nicht rendern (sonst Tabellenkopf allein).
-    const renderTable = !(isTops && !hasRows) && !(isInvoice && page?.suppressTable);
+    const renderTable = !contentSlots && !(isTops && !hasRows) && !(isInvoice && page?.suppressTable);
     if (renderTable) {
       pageBody.appendChild(_buildTable(page, runtimeData));
     }

--- a/src/renderer/print/layout/ProviderDocument.js
+++ b/src/renderer/print/layout/ProviderDocument.js
@@ -1,0 +1,49 @@
+import { headerUtils } from "../v2/header/headerUtils.js";
+
+// The provider supplies content slots; PrintShell owns the page, header and footer.
+export function buildProviderDocumentContent(data) {
+  const content = data?.providerDocument;
+  if (data?.mode !== "provider" || typeof content?.title !== "string" || !content.title.trim() ||
+      typeof content?.body !== "string" || !content.body.trim()) throw new Error("PDF-Providerdaten fehlen.");
+  const title = headerUtils.el("div", "providerTitle", content.title);
+  const body = headerUtils.el("div", "providerBody", content.body);
+  for (const [node, fontSize, height] of [[title, 14, 20], [body, 11, 150]]) {
+    node.style.fontSize = `${fontSize}pt`;
+    node.style.height = `${height}mm`;
+    node.style.lineHeight = "1.35";
+    node.style.whiteSpace = "pre-wrap";
+    node.style.overflowWrap = "anywhere";
+  }
+  return { fullHeader: title, body };
+}
+
+// Measure the final DOM after editor styles and fonts, before print:ready.
+// A bounded single-page document must fail instead of silently clipping text.
+export function validateProviderDocumentLayout(root) {
+  const page = root.querySelector(".page");
+  const title = root.querySelector(".providerTitle");
+  const body = root.querySelector(".providerBody");
+  const footer = root.querySelector(".v2FooterReserveSpacer");
+  if (!page || !title || !body || !footer || root.querySelectorAll(".page").length !== 1) {
+    throw new Error("PDF-Provider-Seitenstruktur ist unvollständig.");
+  }
+  const pageRect = page.getBoundingClientRect();
+  const footerRect = footer.getBoundingClientRect();
+  const pageStyle = getComputedStyle(page);
+  const left = pageRect.left + Number.parseFloat(pageStyle.paddingLeft);
+  const right = pageRect.right - Number.parseFloat(pageStyle.paddingRight);
+  const top = pageRect.top + Number.parseFloat(pageStyle.paddingTop);
+  for (const node of [title, body]) {
+    const rect = node.getBoundingClientRect();
+    if (![left, right, top, footerRect.top, rect.left, rect.right, rect.top, rect.bottom].every(Number.isFinite) ||
+        !(rect.width > 0 && rect.height > 0) || rect.left < left - 1 || rect.right > right + 1 ||
+        rect.top < top - 1 || rect.bottom > footerRect.top + 1 ||
+        node.scrollWidth > node.clientWidth + 1 || node.scrollHeight > node.clientHeight + 1) {
+      throw Object.assign(new Error("PDF-Providerinhalt überschreitet den Einseitenvertrag."), { code: "PDF_PROVIDER_LAYOUT_OVERFLOW" });
+    }
+  }
+  if (title.getBoundingClientRect().bottom > body.getBoundingClientRect().top + 1) {
+    throw Object.assign(new Error("PDF-Providertitel überlagert den Inhalt."), { code: "PDF_PROVIDER_LAYOUT_OVERFLOW" });
+  }
+  return root;
+}

--- a/src/renderer/print/pdfEditorLayout.js
+++ b/src/renderer/print/pdfEditorLayout.js
@@ -199,6 +199,10 @@ export function collectBbmPdfPreviewMetadata(root, data) {
         width: round(rect.width * pageWidthMm / pageRect.width),
         height: round(rect.height * pageHeightMm / pageRect.height),
       };
+      if (entry.capabilities?.includes("textResize")) {
+        const fontSizePx = Number.parseFloat(computed.fontSize);
+        if (Number.isFinite(fontSizePx)) measuredBox.fontSize = round(fontSizePx * 72 / 96);
+      }
       if (part === "track" && canMove) {
         measuredBox.x = round(Number(current.x));
         measuredBox.y = round(Number(current.y));

--- a/src/renderer/print/printApp.js
+++ b/src/renderer/print/printApp.js
@@ -1,3 +1,4 @@
+import { buildProviderDocumentContent, validateProviderDocumentLayout } from "./layout/ProviderDocument.js";
 import {
   appendProtocolTitleMarker,
   buildRestarbeitenColGroup,
@@ -2255,7 +2256,6 @@ async function handleInit(payload) {
 
     const data = res.data || {};
     prepareBbmPdfEditorLayout(data);
-    const topsLayout = _getTopLayout(data);
     // Version/Channel für PDF-Fußnote bereitstellen (falls nicht im Payload enthalten)
     if (!data.appVersion && window.bbmDb?.appGetVersion) {
       try {
@@ -2269,7 +2269,7 @@ async function handleInit(payload) {
         if (chRes?.ok) data.buildChannel = chRes.channel || "";
       } catch (_e) {}
     }
-    if (["protocol", "preview", "vorabzug", "restarbeiten", "invoice"].includes(String(data.mode || "").trim().toLowerCase()) && document.fonts?.load) {
+    if (["protocol", "preview", "vorabzug", "restarbeiten", "invoice", "provider"].includes(String(data.mode || "").trim().toLowerCase()) && document.fonts?.load) {
       try {
         await Promise.all([
           document.fonts.load('400 11pt "Noto Sans"'),
@@ -2295,6 +2295,28 @@ async function handleInit(payload) {
 
     const orientation = _applyPageOrientationStyle(data.orientation);
 
+    if (data.mode === "provider") {
+      const margins = data.pdfEditorRegistry?.pageSettings?.margins;
+      if (!margins) throw new Error("PDF-Provider-Seitenränder fehlen.");
+      data.v2Layout = {
+        ...(data.v2Layout || {}),
+        pagePadTopMm: margins.top,
+        pagePadRightMm: margins.right,
+        pagePadBottomMm: margins.bottom,
+        pagePadLeftMm: margins.left,
+      };
+      const contentSlots = buildProviderDocumentContent(data);
+      const pages = [{ header: { pageNo: 1, totalPages: 1 } }];
+      const root = applyBbmPdfEditorLayout(renderPrint({ pages, data, contentSlots }), data);
+      root._bbmRuntimeData = data;
+      app.innerHTML = "";
+      app.appendChild(root);
+      validateProviderDocumentLayout(root);
+      window.bbmPrint.ready({ jobId: payload?.jobId || null, ok: true, previewMetadata: collectBbmPdfPreviewMetadata(root, data) });
+      return;
+    }
+
+    const topsLayout = _getTopLayout(data);
     if (data.mode === "headerTest") {
       const root = renderHeaderTestPages({ data, debug: !!payload?.debug });
       if (root?.dataset) root.dataset.orientation = orientation;

--- a/src/shared/print/printModes.mjs
+++ b/src/shared/print/printModes.mjs
@@ -1,4 +1,5 @@
 const PRINT_MODE_DEFINITIONS = Object.freeze([
+  Object.freeze({ key: "provider", label: "Technisches Dokument", dialogLabel: "Technisches Dokument", hidden: true }),
   Object.freeze({
     key: "protocol",
     label: "Protokoll",


### PR DESCRIPTION
S1.4a benötigt nach #321 einen expliziten PDF-Provideranschluss, der denselben Druck-, Ablage- und Editorweg verwendet.

Dieses Paket verbindet die Modulzusammensetzung mit einer fachneutralen, injizierbaren Providerbrücke. Ein begrenzter technischer A4-Textbeleg nutzt vorhandene PrintShell-Inhaltsslots, S1.3-Speicherziele und den registrierten fixed-layout-Adapter. Der gemeinsame deklarative Adapter führt freigegebene Schriftgrößenänderungen einschließlich Grenzprüfung und Profilwiederherstellung aus. Der Printweg enthält weiterhin genau einen produktiven printToPDF-Aufruf.

Geprüft:
- Sauberer vollständiger Electron-ABI-Vergleich mit echtem Kit: main 1506 grün / 99 rot → Kandidat 1514 grün / exakt dieselben 99 Fehlernamen; keine fehlenden Bestandstests. Acht neue Vertragstests bestanden.
- [Abnahmelauf 34162498993](https://github.com/SteffenBandholt/BBM-Produktiv/actions/runs/34162498993): Windows und Linux grün. Echte PDF gespeichert, sichtbare interne Vorschau stabil gezeichnet, Datei bytegleich wieder geöffnet, vier gemountete Editor-Refs geprüft, Overflow abgewiesen und wiederhergestellt. Titelgröße im regenerierten PDF tatsächlich 14 → 15 pt bei unverändertem Text.
- Alle 49 vorhandenen PDF-Struktursnapshots und Seitenzahlen im identischen Basis-/Kandidatenlauf exakt gleich.
- Windows-PDF und Vorschauaufnahme visuell geprüft. Der letzte Commit enthält ausschließlich Status und Nachweisdokumentation.

Bekannte Grenzen: Standard-CI bleibt wegen vorhandener Popup-/Lizenzfehler und fehlender Kit-Installation rot; bestehende Fontladewarnungen sind dokumentiert. Keine manuelle WPF-Editorbedienung behauptet. Lokaler GUI-Lauf scheitert am BrowserWindow; reale Nachweise stammen aus GitHub-Runnern.

Rechnung #275 und beide Blankovorlagen bleiben unverändert. S1.5 und A2-Vorlagenüberlagerung sind nicht Bestandteil. Nächster Meilenstein: S1.4.

Details, geänderte Bereiche, Fehlernamen und Hashes: docs/SIGEKO_S1_4A_PDF_PROVIDER.md und docs/SIGEKO_S1_4A_TESTVERGLEICH.json. Bezug #274 / Gesamtplan #277.