### PR TITLE
S1.4: PDF-Ausführung mit SiGeKo allein und sicherem Abbruch

### DIFF
--- a/.github/workflows/sigeko-pdf.yml
+++ b/.github/workflows/sigeko-pdf.yml
@@ -63,7 +63,7 @@ jobs:
           cd BBM-base
           result=0
           for attempt in 1 2 3; do
-            if ! xvfb-run -a node scripts/runSigekoPdfAcceptance.cjs --preview-only; then result=1; fi
+            if ! xvfb-run -a npm run test:sigeko:s1.4a -- --preview-only; then result=1; fi
           done
           exit "$result"
       - name: Real PDF, storage, internal preview and editor regeneration

--- a/.github/workflows/sigeko-pdf.yml
+++ b/.github/workflows/sigeko-pdf.yml
@@ -55,6 +55,16 @@ jobs:
       - name: Real PDF, storage, internal preview and editor regeneration
         working-directory: BBM-Produktiv
         run: xvfb-run -a npm run test:sigeko:s1.4
+      - name: Diagnose unchanged baseline preview with the same acceptance harness
+        if: failure()
+        continue-on-error: true
+        run: |
+          mkdir -p BBM-base/scripts/helpers
+          cp BBM-Produktiv/scripts/runSigekoPdfAcceptance.cjs BBM-base/scripts/
+          cp BBM-Produktiv/scripts/helpers/pdfAcceptanceLicense.cjs BBM-base/scripts/helpers/
+          node -e 'require("fs").appendFileSync("BBM-base/src/main/ipc/printIpc.js", "\nmodule.exports.openInternalPdfPreview = openInternalPdfPreview;\n")'
+          cd BBM-base
+          xvfb-run -a node scripts/runSigekoPdfAcceptance.cjs --preview-only
       - name: Generate 49 baseline PDF snapshots
         if: always()
         working-directory: BBM-base

--- a/.github/workflows/sigeko-pdf.yml
+++ b/.github/workflows/sigeko-pdf.yml
@@ -56,7 +56,7 @@ jobs:
         working-directory: BBM-Produktiv
         run: xvfb-run -a npm run test:sigeko:s1.4
       - name: Diagnose unchanged baseline preview with the same acceptance harness
-        if: failure()
+        if: always()
         continue-on-error: true
         run: |
           mkdir -p BBM-base/scripts/helpers
@@ -64,7 +64,11 @@ jobs:
           cp BBM-Produktiv/scripts/helpers/pdfAcceptanceLicense.cjs BBM-base/scripts/helpers/
           node -e 'require("fs").appendFileSync("BBM-base/src/main/ipc/printIpc.js", "\nmodule.exports.openInternalPdfPreview = openInternalPdfPreview;\n")'
           cd BBM-base
-          xvfb-run -a node scripts/runSigekoPdfAcceptance.cjs --preview-only
+          result=0
+          for attempt in 1 2 3; do
+            if ! xvfb-run -a node scripts/runSigekoPdfAcceptance.cjs --preview-only; then result=1; fi
+          done
+          exit "$result"
       - name: Generate 49 baseline PDF snapshots
         if: always()
         working-directory: BBM-base

--- a/.github/workflows/sigeko-pdf.yml
+++ b/.github/workflows/sigeko-pdf.yml
@@ -52,9 +52,6 @@ jobs:
         run: |
           sudo chown root:root BBM-Produktiv/node_modules/electron/dist/chrome-sandbox BBM-base/node_modules/electron/dist/chrome-sandbox
           sudo chmod 4755 BBM-Produktiv/node_modules/electron/dist/chrome-sandbox BBM-base/node_modules/electron/dist/chrome-sandbox
-      - name: Real PDF, storage, internal preview and editor regeneration
-        working-directory: BBM-Produktiv
-        run: xvfb-run -a npm run test:sigeko:s1.4
       - name: Diagnose unchanged baseline preview with the same acceptance harness
         if: always()
         continue-on-error: true
@@ -69,6 +66,9 @@ jobs:
             if ! xvfb-run -a node scripts/runSigekoPdfAcceptance.cjs --preview-only; then result=1; fi
           done
           exit "$result"
+      - name: Real PDF, storage, internal preview and editor regeneration
+        working-directory: BBM-Produktiv
+        run: xvfb-run -a npm run test:sigeko:s1.4
       - name: Generate 49 baseline PDF snapshots
         if: always()
         working-directory: BBM-base

--- a/.github/workflows/sigeko-pdf.yml
+++ b/.github/workflows/sigeko-pdf.yml
@@ -12,6 +12,9 @@ on:
       - 'src/renderer/print/**'
       - 'src/shared/print/**'
       - 'scripts/runSigekoPdfAcceptance.cjs'
+      - 'scripts/helpers/pdfAcceptanceLicense.cjs'
+      - 'scripts/helpers/pdfExecutionAcceptance.cjs'
+      - 'scripts/tests/printJobLifecycle.test.cjs'
       - '.github/workflows/sigeko-pdf.yml'
 
 permissions:
@@ -51,7 +54,7 @@ jobs:
           sudo chmod 4755 BBM-Produktiv/node_modules/electron/dist/chrome-sandbox BBM-base/node_modules/electron/dist/chrome-sandbox
       - name: Real PDF, storage, internal preview and editor regeneration
         working-directory: BBM-Produktiv
-        run: xvfb-run -a npm run test:sigeko:s1.4a
+        run: xvfb-run -a npm run test:sigeko:s1.4
       - name: Generate 49 baseline PDF snapshots
         if: always()
         working-directory: BBM-base
@@ -114,7 +117,7 @@ jobs:
         env:
           TEMP: ${{ runner.temp }}
           TMP: ${{ runner.temp }}
-        run: npm run test:sigeko:s1.4a
+        run: npm run test:sigeko:s1.4
       - name: Preserve Windows acceptance evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,3 +1,24 @@
+## 2026-09-08 – SiGeKo S1.4: PDF-Ausführung und Abbruchnachweis
+
+S1.4 technisch abgeschlossen auf main-Basis bd5ab3d / S1.4a, Übergabe PR #323.
+Gemeinsamer Druckauftrag gegen Doppelstart, Fenster-/Rendererabbruch und spätes
+Schreiben nach Timeout gesichert. Vor Providerablage erneute zentrale Freigabe.
+Keine Layout-/Tabellen-/Fachänderung und keine zweite PDF-/Editorinfrastruktur.
+
+Volltest in gleicher UTC-Umgebung mit echtem Kit: main 1516/97 -> Kandidat
+1527/97, exakt gleiche 97 Fehlernamen, keine fehlenden Tests, elf neue Tests grün.
+Zwei historische Datumsfehler aus 1514/99 treten bereits auf unverändertem main
+nicht auf; dies wird nicht als Paketverbesserung gezählt. Windows/Linux-Lauf
+34185714616 bestätigt reale PDF, Vorschau, Wiederöffnen, Regeneration, elf
+Fehler-/Abbruchfälle ohne veränderte PDF-Dateien und erfolgreichen Wiederanlauf.
+Alle 49 Bestands-Snapshots und Seitenzahlen identisch. Berechtigungsnachweis mit
+isoliert simuliertem Status nur SiGeKo durch unveränderten zentralen Guard ohne
+DEV-Ausnahmen; keine kryptografische Kundenlizenz- oder native WPF-Abnahme.
+Standard-CI bleibt mit bekannter Kit-/Popup-/Lizenzbaseline rot.
+
+Details: docs/SIGEKO_S1_4_PDF_AUSFUEHRUNG.md und docs/SIGEKO_S1_4_TESTVERGLEICH.json.
+Rechnung #275 und beide Blankovorlagen unverändert. S1.5 nicht begonnen.
+
 ## 2026-09-07 – SiGeKo S1.4a: technische PDF-Providerbrücke
 
 S1.4a technisch abgeschlossen, Übergabe über PR #322 gegen main db0ca2f.

--- a/STATUS.md
+++ b/STATUS.md
@@ -9,12 +9,16 @@ Volltest in gleicher UTC-Umgebung mit echtem Kit: main 1516/97 -> Kandidat
 1527/97, exakt gleiche 97 Fehlernamen, keine fehlenden Tests, elf neue Tests grün.
 Zwei historische Datumsfehler aus 1514/99 treten bereits auf unverändertem main
 nicht auf; dies wird nicht als Paketverbesserung gezählt. Windows/Linux-Lauf
-34185714616 bestätigt reale PDF, Vorschau, Wiederöffnen, Regeneration, elf
+34186341786 bestätigt reale PDF, Vorschau, Wiederöffnen, Regeneration, elf
 Fehler-/Abbruchfälle ohne veränderte PDF-Dateien und erfolgreichen Wiederanlauf.
 Alle 49 Bestands-Snapshots und Seitenzahlen identisch. Berechtigungsnachweis mit
 isoliert simuliertem Status nur SiGeKo durch unveränderten zentralen Guard ohne
 DEV-Ausnahmen; keine kryptografische Kundenlizenz- oder native WPF-Abnahme.
 Standard-CI bleibt mit bekannter Kit-/Popup-/Lizenzbaseline rot.
+Sporadischer dunkler PDF-Viewer auf unverändertem main reproduziert: Lauf
+34186953879, Basis 2/3 bestanden, 1/3 gleicher PDF_PREVIEW_PAINT_TIMEOUT; danach
+vollständiger Kandidat grün. Allgemeiner Vorschaufehler bleibt offen, keine
+behobene Viewer-Langzeitstabilität behauptet.
 
 Details: docs/SIGEKO_S1_4_PDF_AUSFUEHRUNG.md und docs/SIGEKO_S1_4_TESTVERGLEICH.json.
 Rechnung #275 und beide Blankovorlagen unverändert. S1.5 nicht begonnen.

--- a/docs/SIGEKO_S1_4_PDF_AUSFUEHRUNG.md
+++ b/docs/SIGEKO_S1_4_PDF_AUSFUEHRUNG.md
@@ -1,0 +1,97 @@
+# S1.4 – PDF-Provider an die vorhandene Ausführung anschließen
+
+Grundlagen: Gesamtplan #277, SiGeKo #274, main `bd5ab3d` nach S1.4a / PR #322.
+Dieses Paket ergänzt den dort bereits gelieferten erfolgreichen technischen
+PDF-Ablauf um die verbleibenden Freigabe-, Fehler- und Abbruchnachweise.
+Primär Container 6, notwendige kleine Korrektur am gemeinsamen Druckdienst.
+
+## Umfang und Entwurfsentscheidung
+
+Keine neue editorrelevante Ausgabe. Der technische Beleg, seine vier expliziten
+Refs, Parents, Bearbeitungsrechte und Layoutgrenzen aus
+`SIGEKO_S1_4A_PDF_PROVIDER.md` bleiben unverändert. Fachaktionen einschließlich
+Speichern, Anlegen, Löschen, Upload, Import und Datenänderung werden keine
+Editorziele. Bestehende Registry-, DOM- und Regenerationstests bleiben aktiv.
+
+S1.4 verbindet beziehungsweise bestätigt den neutralen Provider im vorhandenen
+Render-, Vorschau- und Speicherweg mit Modulberechtigung ohne Protokollzwang.
+Keine Vorankündigung, kein SiGePlan- oder Berichtsrenderer, keine A2-Überlagerung,
+kein neuer PDF-/Editorweg. Die beiden Blankovorlagen bleiben bytegleich;
+SiGePlan bleibt DIN A2 quer. Rechnung #275 bleibt eingefroren. S1.5 nicht begonnen.
+
+## Korrektur im gemeinsamen Druckauftrag
+
+Der vorhandene `_printToPdf` konnte nach einem Timeout eine inzwischen asynchron
+gelieferte PDF noch schreiben. Mehrfache passende `print:ready`-Meldungen konnten
+mehrere Druckaufrufe starten; Fenster-/Rendererabbrüche warteten bis zum Timeout.
+
+Der Auftrag akzeptiert jetzt genau einen Druckstart und genau einen Abschluss.
+Timeout, geschlossenes Fenster, Renderer-Verlust, Load-, Render-, Druck- oder
+Schreibfehler bleiben Fehler. Nach `printToPDF` wird vor dem Schreiben erneut
+der Abschlusszustand geprüft. Bei Providern wird auch die zentrale Freigabe
+frisch geprüft. Späte Antworten erzeugen nach einem Abbruch keine PDF.
+Load-/Ready-/Abbruchlistener und Timer werden beim Abschluss entfernt.
+
+Die bestehenden Druckoptionen, Dateinamensregeln, Zielauflösung, Layouts und
+Erfolgsmetadaten bleiben erhalten. Es gibt weiterhin genau einen produktiven
+`webContents.printToPDF`-Aufruf. Keine zusätzliche Infrastruktur oder Fachabfrage.
+
+## Nachweis und Grenzen
+
+- `scripts/tests/printJobLifecycle.test.cjs`: elf deterministische Tests am
+  echten exportierten Druckdienst/IPC mit kontrollierten Fenster-/OS-Grenzen.
+  Geprüft sind Fremd-/Doppelmeldungen, tabellarischer Erfolg, Provider-Metadaten,
+  Freigabeentzug während Druck, Timeout mit später PDF-Antwort, Schließen vor/
+  während Druck, Rendererabbruch, Rendererablehnung, Druck-/Schreib-/Loadfehler.
+- `npm run test:sigeko:s1.4` erweitert denselben isolierten Electron-Abnahmelauf
+  aus S1.4a. Der alte Befehlsname bleibt ein Alias. Echte Preload-/IPC-Aufrufe,
+  Chromium-PDFs, Speicherung, interne Vorschau, Wiederöffnen und Editor-
+  Regeneration werden zusätzlich mit negativen Abläufen und Wiederanlauf geprüft.
+- Der Lizenzstatus ist ausdrücklich eine Test-Fixture mit nur `sigeko` oder
+  ohne freigeschaltetes Modul. Der produktive `licenseService` und `featureGuard`
+  laufen unverändert; allein die Statuszufuhr und die App-Fassade des geprüften
+  Guards werden beim synchronen Import isoliert ersetzt. Dadurch gelten keine
+  DEV-Ausnahmen für Protokoll/Restarbeiten. Kein dauerhafter Loader-Hook, keine
+  Produktlizenzänderung, keine Aussage über kryptografische Kundenlizenzprüfung
+  oder eine ausgelieferte Installation. Andere Module werden tatsächlich vom
+  zentralen Guard abgewiesen.
+- Reale Fehlerszenarien: SiGeKo-Entzug an PDF-/Vorschau-Einstiegen, widersprüchlicher
+  Providerkontext ohne Protokoll-Fallback, Protokoll ohne Freigabe, ungültige Daten,
+  fehlendes Projekt, unbrauchbare Ablage, geschlossenes Druckfenster, Timeout und
+  Freigabeentzug vor der Renderer-Datenabfrage. Erwartet werden `ok: false`, kein
+  fertiger Dateipfad, unveränderter PDF-Bestand und aufgeräumte Druckfenster/Listener.
+  Danach muss derselbe Druckweg wieder erfolgreich eine echte PDF erzeugen.
+- Native WPF-Editorbedienung wird durch dieses Paket nicht geprüft. Die frühere
+  Font-/Standard-CI-Baseline wird nicht als bestandene Prüfung ausgegeben.
+
+Volltest in identischer aktueller UTC-/Electron-/Kit-Umgebung: **1516 grün / 97 rot
+auf unverändertem main → 1527 grün / exakt dieselben 97 Fehler**. Kein Bestands-
+prüffall fehlt; elf neue Tests grün. Zwei historische Datumsfehler aus dem früheren
+Stand 1514/99 bestehen bereits im erneuten Basislauf nicht mehr; dies ist keine
+Verbesserung durch S1.4. Exakte Namen, Laufdaten und Loghashes stehen in
+`SIGEKO_S1_4_TESTVERGLEICH.json`.
+
+Reale Windows-/Linux-Abnahme **bestanden** auf Code-/Harness-Stand `895bc4d`:
+[GitHub-Lauf 34185714616](https://github.com/SteffenBandholt/BBM-Produktiv/actions/runs/34185714616).
+Beide Betriebssysteme bestätigen alle elf realen Fehlerfälle ohne neue/veränderte
+PDFs und ohne verbliebene Druckfenster/Ready-Listener; anschließender echter Druck
+funktioniert. Speicherung, sichtbare Vorschau, bytegleiches Wiederöffnen, vier
+explizite DOM-Refs, Overflow-Abweisung und Schriftwechsel 14→15 pt bleiben grün.
+Alle 49 Bestands-Snapshots sind strukturell und in den Seitenzahlen identisch.
+Die Screenshots beider Systeme wurden visuell geprüft; vollständige technische
+Berichte und Artefakt-IDs sind im JSON-Nachweis verzeichnet.
+
+Die Vorläufe `34185354299` und `34185520594` waren teilweise fehlgeschlagen und
+werden nicht als bestanden gewertet. Der Abnahmelauf wartet jetzt auf tatsächlich
+gezeichnete PDFs und asynchron geschlossene Druckfenster. Vor dem Wiederöffnen
+entlädt er die aktive PDF im selben Vorschaufenster; direktes erneutes `loadURL`
+auf die aktive PDF zeigte unter Linux einen dunklen Viewer. Diese Korrekturen
+betreffen ausschließlich den Testablauf, nicht die produktive Vorschau.
+
+Der Standard-`npm test`-Workflow bleibt wegen des dort fehlenden UI-Editor-kit
+und der bekannten acht Popup-/Lizenzfehler rot (Lauf `34185714605`). Er wird
+nicht als grün ausgegeben. Der vollständige Vergleich oben nutzt das echte Kit.
+S1.4 ist technisch abgeschlossen; Übergabe über PR #323.
+
+Kurzfahrplan: S1.4 vollständig nachweisen; Ergebnis in #274/#277 dokumentieren;
+erst danach S1.5 als eigenes Paket beginnen.

--- a/docs/SIGEKO_S1_4_PDF_AUSFUEHRUNG.md
+++ b/docs/SIGEKO_S1_4_PDF_AUSFUEHRUNG.md
@@ -34,7 +34,10 @@ Load-/Ready-/Abbruchlistener und Timer werden beim Abschluss entfernt.
 
 Die bestehenden Druckoptionen, Dateinamensregeln, Zielauflösung, Layouts und
 Erfolgsmetadaten bleiben erhalten. Es gibt weiterhin genau einen produktiven
-`webContents.printToPDF`-Aufruf. Keine zusätzliche Infrastruktur oder Fachabfrage.
+`webContents.printToPDF`-Aufruf. Die vorhandene Funktion `openInternalPdfPreview`
+wird zusätzlich exportiert, damit die Abnahme dieselbe gespeicherte Datei nach
+echtem Fensterschluss durch diesen bestehenden Dienst wieder öffnen kann. Ihr
+Funktionskörper bleibt unverändert. Keine zusätzliche Infrastruktur oder Fachabfrage.
 
 ## Nachweis und Grenzen
 
@@ -71,8 +74,8 @@ Stand 1514/99 bestehen bereits im erneuten Basislauf nicht mehr; dies ist keine
 Verbesserung durch S1.4. Exakte Namen, Laufdaten und Loghashes stehen in
 `SIGEKO_S1_4_TESTVERGLEICH.json`.
 
-Reale Windows-/Linux-Abnahme **bestanden** auf Code-/Harness-Stand `895bc4d`:
-[GitHub-Lauf 34185714616](https://github.com/SteffenBandholt/BBM-Produktiv/actions/runs/34185714616).
+Reale Windows-/Linux-Abnahme **bestanden** auf Code-/Harness-Stand `93321cc`:
+[GitHub-Lauf 34186341786](https://github.com/SteffenBandholt/BBM-Produktiv/actions/runs/34186341786).
 Beide Betriebssysteme bestätigen alle elf realen Fehlerfälle ohne neue/veränderte
 PDFs und ohne verbliebene Druckfenster/Ready-Listener; anschließender echter Druck
 funktioniert. Speicherung, sichtbare Vorschau, bytegleiches Wiederöffnen, vier
@@ -81,12 +84,37 @@ Alle 49 Bestands-Snapshots sind strukturell und in den Seitenzahlen identisch.
 Die Screenshots beider Systeme wurden visuell geprüft; vollständige technische
 Berichte und Artefakt-IDs sind im JSON-Nachweis verzeichnet.
 
-Die Vorläufe `34185354299` und `34185520594` waren teilweise fehlgeschlagen und
-werden nicht als bestanden gewertet. Der Abnahmelauf wartet jetzt auf tatsächlich
-gezeichnete PDFs und asynchron geschlossene Druckfenster. Vor dem Wiederöffnen
-entlädt er die aktive PDF im selben Vorschaufenster; direktes erneutes `loadURL`
-auf die aktive PDF zeigte unter Linux einen dunklen Viewer. Diese Korrekturen
-betreffen ausschließlich den Testablauf, nicht die produktive Vorschau.
+Die Vorläufe `34185354299`, `34185520594`, `34185926740`, `34186095285`,
+`34186462651`, `34186582861` und `34186777729` waren teilweise fehlgeschlagen
+und werden nicht als bestanden gewertet. Der erste Fehler betraf die zu frühe
+Prüfung asynchron geschlossener Druckfenster. Die PDF-Wiederöffnung wurde danach
+vom unzuverlässigen Wiederladen einer aktiven PDF auf echtes Schließen und
+Öffnen durch die vorhandene Vorschaufunktion umgestellt. Auch damit blieb ein
+sporadischer dunkler Viewer bestehen, überwiegend Linux, einmal auch Windows.
+Ein einzelner grüner Zwischenlauf wurde nicht als Behebung gewertet.
+
+**Bestehender Viewerfehler auf main reproduziert:**
+[Vergleichslauf 34186953879](https://github.com/SteffenBandholt/BBM-Produktiv/actions/runs/34186953879)
+verwendet denselben Harness und npm-Start auf Basis `bd5ab3d`. Zur Beobachtbarkeit
+wurde dort ausschließlich der Export der bereits vorhandenen Vorschaufunktion
+ergänzt; Funktionskörper und Druckauftrag blieben unverändert. Von drei isolierten
+Basisläufen bestanden zwei; einer zeigte exakt `PDF_PREVIEW_PAINT_TIMEOUT` mit
+dunkler Seite, sichtbarem/fokussiertem Fenster und nicht reagierender PDF-Extension.
+Der anschließende vollständige Linux-Kandidatenlauf bestand einschließlich aller elf
+Fehlerfälle und Wiederanlauf. Der Linux-Viewerfehler ist somit keine neue
+Testregression von S1.4. Die genaue Chromium-Ursache und eine dauerhafte Behebung
+sind damit ausdrücklich nicht nachgewiesen. Er bleibt ein offener allgemeiner
+PDF-Vorschaupunkt und wird nicht durch neue Infrastruktur umgangen.
+
+Der Windows-Job dieses Vergleichslaufs scheiterte bereits bei `npm ci` an der
+Visual-Studio-Erkennung für `better-sqlite3`; er startete keine PDF-Abnahme.
+Der vollständige Windows-Nachweis auf gleichem Produktcode steht in Lauf
+`34186341786`. Auch der Installationsfehler wird nicht als bestanden gewertet.
+
+Im Workflow bleiben die drei Basisdiagnosen transparent und nicht blockierend;
+ein Kandidatenfehler wird weiterhin rot. `--preview-only` prüft ausschließlich
+Speichern/Anzeigen/Wiederöffnen für diesen Vergleich, niemals die vollständige
+S1.4-Abnahme. Vollständige Berichte, Fehler und Hashes stehen im JSON-Nachweis.
 
 Der Standard-`npm test`-Workflow bleibt wegen des dort fehlenden UI-Editor-kit
 und der bekannten acht Popup-/Lizenzfehler rot (Lauf `34185714605`). Er wird

--- a/docs/SIGEKO_S1_4_TESTVERGLEICH.json
+++ b/docs/SIGEKO_S1_4_TESTVERGLEICH.json
@@ -1,0 +1,1077 @@
+{
+  "package": "S1.4",
+  "date": "2026-09-08",
+  "baseCommit": "bd5ab3dbd2548177ce4433147b0ff0ae6f44b847",
+  "productCodeCommit": "d070ab2898c630541414267659d89dd400c6d206",
+  "kitCommit": "5e0d551d93e97c32d169ea6d5107186a44ecd47f",
+  "runtime": {
+    "electron": "30.5.1",
+    "node": "20.16.0",
+    "abi": 123,
+    "timezone": "UTC"
+  },
+  "baseline": {
+    "log": "bbm-s14-base.log",
+    "sha256": "ec24fc4a2627909d0955f1350017e88e759c568a5d37f501d6196f67bb4de4af",
+    "passed": 1516,
+    "failed": 97
+  },
+  "candidate": {
+    "log": "bbm-s14-full.log",
+    "sha256": "96d548ea780b9ba1046aa3ef1b95bd62896cdf0aac457971bf075fbba8a376cb",
+    "passed": 1527,
+    "failed": 97
+  },
+  "addedFailures": [],
+  "removedFailures": [],
+  "missingTests": [],
+  "addedPassingTests": [
+    "S1.4: shared tabular print ignores foreign and duplicate ready events",
+    "S1.4: provider preview keeps metadata and rechecks permission before saving",
+    "S1.4: permission withdrawn during provider printing prevents output",
+    "S1.4: timeout during printing cannot write a late PDF",
+    "S1.4: closing print window before readiness remains unsuccessful",
+    "S1.4: closing print window during printing remains unsuccessful",
+    "S1.4: renderer process loss rejects immediately and discards late PDF",
+    "S1.4: renderer rejection never starts printing",
+    "S1.4: Chromium print rejection remains a failed IPC result",
+    "S1.4: output write failure remains a failed IPC result",
+    "S1.4: failed print page load removes late initialization listener"
+  ],
+  "unchangedFailureNames": [
+    "meetingTopsRepo: erledigte TOPs werden nur im direkten Folgeprotokoll uebernommen",
+    "ProjectFirmsView: laedt project_firms per IPC und wendet gespeicherte UI-Breiten an",
+    "ProjectFirmsView: fehlender Layout-Payload faellt auf Standardlayout zurueck",
+    "Protokoll Quicklane-Filter sitzt in der screen-eigenen rechten Toolbox",
+    "Protokoll-Projektpfad: Projekt-Einstiege nutzen die Projekt-Protokollauflosung",
+    "Protokoll-Projektpfad: openProjectModule reicht blocked-Payload durch",
+    "Projektverwaltung: Router importiert die Screen-Klassen aus dem Modulpfad",
+    "Projektverwaltung: Legacy-Projekt-Arbeitsbereich bleibt isoliert",
+    "Projektverwaltung: Legacy-Projekt-Arbeitsbereich bleibt isoliert",
+    "Projektverwaltung: sichtbare Firmenbegriffe sind klarer benannt",
+    "Projektverwaltung: Projektklick startet direkt den Protokollpfad",
+    "Projektverwaltung: blockiertes Protokoll wird beim Hauptklick nicht als Erfolg behandelt",
+    "Projektverwaltung: DEV-Version schaltet Modulfreigabe auf alle aktiven Module frei",
+    "Projektverwaltung: Projektkarte rendert rechte Modul-Aktionsleiste und stoppt Bubble",
+    "Projektverwaltung: coreShellHeaderBridge kapselt die Header-/Router-Bridges",
+    "Projektverwaltung: MainHeader source nutzt den textbasierten Kopfbereich",
+    "M86.13: Protokoll und Restarbeiten erhalten den einen zweizeiligen MainHeader",
+    "Projektverwaltung: MainHeader rendert zwei gemeinsame Zeilen mit Plan und DEV-Marker",
+    "Projektverwaltung: Router haelt den Legacy-Projekt-Arbeitsbereich getrennt",
+    "Restarbeiten: generischer UI-Editor-Target-Contract ist erfuellt",
+    "Restarbeiten: Quicklane besitzt echte UI-Editor-Gruppen im DOM",
+    "Restarbeiten: Quicklane-Ampel schaltet auch das Editbox-Ampelsymbol",
+    "Restarbeiten M85.2: Produktvorschau nutzt gefilterte Reihenfolge und internen V2-PDF-Weg",
+    "Restarbeiten: Notiz-Popup bleibt offen und kennzeichnet nicht verfügbaren Druck ehrlich",
+    "Rechnung Step 1.4/2: echter Screen verbindet Belegkopf und Positionsarbeit",
+    "Rechnung Navigation: kanonischer globaler Moduldeskriptor loest den echten Screen auf",
+    "Rechnung Navigation: DRAFT-Eingaben speichern seriell ohne Positionsverlust",
+    "Rechnung Editbox: Inhalt wird nur beim Fokuswechsel vollstaendig markiert",
+    "Rechnung Editbox: Menge bleibt dezimalfaehig, rechtsbuendig und wird durch den 0-bis-4-Stepper begrenzt",
+    "Rechnung Editbox: Gesamtbetrag nutzt die vorhandenen Rechnungssummen dynamisch und formatiert Euro",
+    "Rechnung Preisbedienung: Brutto-Haken rechnet den sichtbaren EP wirtschaftlich gleich um",
+    "Rechnung Briefkopf: Ausstellerdaten bleiben im Kopf schlank, Finanzdaten stehen im Blattfuß",
+    "Rechnung Textlimits: nutzt zentrale Protokoll-Limits, Counter und Settings-Aktualisierung",
+    "Rechnung UI: vertikale Rahmen- und Grenzabstaende sind null",
+    "Rechnung Navigation: normaler Start wartet auf Modulzugriff und nutzt keinen DEV-Pfad",
+    "Rechnung Hierarchie-UI: Anlegekontext, Tiefensperre, Schieben und FROM_ORDER-Sperre folgen dem Protokollprinzip",
+    "Rechnung Navigation: normaler Arbeitsweg rendert das Rechnungsblatt mit Bau-LV und getrennten Anwendungsaktionen",
+    "Rechnungsbuttons: reale Chromium-BoundingBox folgt fuer alle 16 Ziele der angeforderten Breite und Hoehe",
+    "Popup-Standard: aktiviert die freigegebenen Rechnungen- und Produktdialoge",
+    "Popup-Standard: Protokoll-, Firmen- und Teilnehmerdialoge nutzen die zentrale Opt-in-Basis",
+    "Popup-Standard: Import-, Textkorrektur- und Maildialoge nutzen die Opt-in-Basis",
+    "HomeView: zentrales Icon ist sichtbar verkleinert",
+    "HomeView: letzter Projektstart fragt zuerst den Modulstatus ab",
+    "M85 Satzvertrag: alle strukturellen Golden-Snapshots sind reproduzierbar",
+    "M85 Satzvertrag: Tabellenkopf, Reihenfolge, Grenzfall und TOP-Fortsetzung bleiben stabil",
+    "M85 Satzvertrag: Level-1 bleibt mit erstem Inhalt zusammen und Abschluss bleibt als Block zusammen",
+    "M85.2 Restarbeiten: Querformat, 13 Spalten, Filterfolge, Tabellenkopf und Fortsetzungen sind verriegelt",
+    "PDF-V2-INVOICE-002 bis -010: Kopf, Bau-LV, Abschluss und Seitenfooter sind golden verriegelt",
+    "M85 Satzvertrag: Teilnehmerzeilen werden vollständig und mit wiederholtem Tabellenkopf segmentiert",
+    "M85 Satzvertrag: Vorbemerkungen werden wortgenau und sichtbar fortgesetzt",
+    "M85 Satzvertrag: Editor darf Satz- und Fachoperationen nicht freigeben",
+    "M85 Satzvertrag: Editor-Overlay bleibt vor der bestehenden Paginierung",
+    "M85 PDF-Bedienung: Position, Schrift und Seitenwert-Sichtbarkeit wirken im echten Print-DOM",
+    "M85 PDF-Bedienung: innere Spaltengrenze bleibt in Track, Kopf und Daten lueckenlos",
+    "M85 PDF-Readback: Tabellenspalten liefern reale seitenbezogene Track-Geometrie",
+    "M85 PDF-Bedienung: Teilnehmer-Tabelle bleibt bis zur Nutzflaechenkante lueckenlos",
+    "M85 PDF-Meta: Body-Zeilen nutzen die gemeinsame innere Spaltenbreite",
+    "M85 PDF-Bedienung: Tabellenkopf-Text bewegt sich innerhalb der unveraenderten Spalte",
+    "M85 Satzvertrag: Renderer, Paginierung, Profilweg und Altpfade bleiben eindeutig",
+    "Ausgabe: Level-1-Titel reicht vorhandene ToDo- und Beschlusskennzeichnungen in das PDF durch",
+    "Ausgabe: bestehender Outlook-COM-Weg fuegt alle ausgewaehlten Dateien als echte Anhaenge an",
+    "Lizenzmodell: APP/PDF/MAIL/EXPORT bleiben als Alias auf Modul Protokoll erlaubt",
+    "FeatureGuard: Standardfeatures mit gueltiger Lizenz erlaubt",
+    "Development-Lizenz: paketierter Diagnostic-Build erhaelt gueltigen internen Status",
+    "Development-Lizenz: sichtbare Kennzeichnung und zentraler Print-Buildkanal sind verdrahtet",
+    "M52/M80 Startpunkt: Navigation enthaelt die separate UI-Editor-Aktion",
+    "M52/M80 echte Navigationskette: UI-Editor-Aktion startet keinen Screen",
+    "M54 Legacy-Isolation: CoreShell startet den alten RuntimeLauncher nicht automatisch parallel",
+    "M80.1 BBM: führende Registry, vollständige Restarbeiten-Refs und gesperrte Restscopes",
+    "M80.2 Registry: Header, Liste und Editbox sind direkt aktiv; Split ist gesperrt",
+    "M80/M83 Registry: nativer ElectronPipeHostAdapter bildet alle Rechnungstypen oeffentlich ab",
+    "M81 BBM-PDF-Registry ist explizit, vollstaendig und deterministisch",
+    "M81 nutzt echten BBM-printToPDF-Pfad und kein ReferenceOrder-Modell",
+    "M82 BBM: Target-Manifest leitet alle aktiven Scope-Zahlen exakt aus Komponentenvertrag und Registry ab",
+    "M82.1 BBM 01: Registryversion bleibt konsistent",
+    "M82.2 BBM 33: docs/licensing.md bleibt hashgleich",
+    "M82.3 BBM 01: Registryversion bleibt konsistent",
+    "M82.3 BBM 24: kompakter UI-Workspace hat Ein-Zwei-Drei-Modus",
+    "M82.3 BBM 31: docs/licensing.md bleibt hashgleich",
+    "M82.6 BBM 44: Protokoll-Feld erlaubt direkte Breite",
+    "M82.7.1 BBM 34: die allgemeine technische Speichergrenze bleibt erhalten",
+    "M82.7.1 BBM 39: mehrere Schritte lassen sich exakt rueckgaengig machen",
+    "M82.7.2/M83.0 BBM: Inventar umfasst alle 187 textResize-Ziele in sieben produktiven Scopes",
+    "M86.6 BBM 28: generische content-box-Breite verwendet die sichtbare aktuelle Breite ohne Richtungsumkehr",
+    "M82.7.4 BBM 28: licensing-Dokumentation hat weiterhin den Schutz-Hash",
+    "M82.7.5 BBM 01: Registryversion kennzeichnet den erweiterten Vertrag",
+    "M82.7.5 BBM 34: licensing-Dokumentation behaelt den Schutz-Hash",
+    "M83.0 BBM 05: Restarbeiten, Protokoll und Rechnung sind vollstaendig gebuendelt",
+    "M83.0 Rechnung 01: echter Rechnungsscreen mountet alle 131 Einzel-Refs mit vollstaendigem DOM-Vertrag",
+    "M83.0 BBM 16: Schutzdatei licensing bleibt bytegenau unveraendert",
+    "M86.12 03: Chromium berechnet im normalen Profil drei getrennte Header- und Zeilenspalten",
+    "M86.15 Rechnung 07: Rechnungs-Textareas unterschreiten 24 und ueberschreiten 720 ohne Ersatzgrenze",
+    "M86.16: vollständige sichtbare Registry reagiert je Modulzyklus im echten Chromium-Renderer",
+    "M86.21: Restarbeiten bleibt im Hauptviewport ohne horizontale Ueberbreite",
+    "M86.23 04: Restarbeiten und Protokoll behalten bestätigte Layouts nach Close und Neustart",
+    "M86.24: echte Minus-Bounds und sichtbarer Save-and-continue-Pfad bleiben nach Close und Neustart erhalten",
+    "Testharness: alle bisherigen Suite-Einstiege sind genau einmal gruppiert"
+  ],
+  "historicalComparison": {
+    "previous": {
+      "log": "bbm-s14a-final.log",
+      "sha256": "d81d076246a2673be3894add96a02dda140294d20cc2eb72ec93b07eb36632e5",
+      "passed": 1514,
+      "failed": 99
+    },
+    "alreadyPassingOnCurrentUnchangedMain": [
+      "#272 Mail 4b: Protokoll-PDF-Suche behaelt bestehende Dateinamenskandidaten",
+      "Ausgabe: Abschlusslisten werden pro Protokollstand eindeutig benannt und gespeichert"
+    ],
+    "explanation": "Zwei datumsabhaengige Fehler treten in der aktuellen UTC-Umgebung bereits auf unveraendertem main nicht auf; keine Fehlerreduktion durch dieses Paket."
+  },
+  "realAcceptance": {
+    "status": "passed",
+    "failedInitialRun": 34185354299,
+    "initial49GoldenSnapshotsUnchanged": true,
+    "licenseStatusSource": "isolated simulated status through real central licenseService/featureGuard; no development overrides in tested guard",
+    "cryptographicCustomerLicenseVerified": false,
+    "nativeWpfEditorUiVerified": false,
+    "workflowRun": 34185714616,
+    "headCommit": "895bc4df5d24ad87a13ae8e5310a9c37c8b841a0",
+    "workflowUrl": "https://github.com/SteffenBandholt/BBM-Produktiv/actions/runs/34185714616",
+    "failedPreliminaryRuns": [
+      34185354299,
+      34185520594
+    ],
+    "windows": {
+      "artifactId": 10040428623,
+      "reportSha256": "5f4fa0e3bcf30bed03576cf20a37f444fe7aa51d5d889c0724d469b931c611ba",
+      "checks": {
+        "modulePermission": {
+          "source": "simulated-development-license-status",
+          "modules": [
+            "sigeko"
+          ],
+          "cryptographicLicenseVerified": false,
+          "developmentOverridesEnabled": false,
+          "otherModulesDenied": true
+        },
+        "savedPdf": {
+          "filePath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\Ablage\\bbm\\S14A - SiGeKo PDF Technikabnahme\\SiGeKo\\Unterlagen\\Technisches-Dokument.pdf",
+          "bytes": 26931,
+          "sha256": "80361203dbb9706e141539638fe0a0466517d03d4b32d07c30e1c377c7099c62",
+          "pageCount": 1,
+          "pageBox": [
+            0,
+            0,
+            595.91998,
+            842.88
+          ],
+          "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.  © | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV  S1.4a Techniknachweis",
+          "textItems": [
+            {
+              "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.",
+              "fontSizePoints": 10.994999391875005
+            },
+            {
+              "text": "© | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV",
+              "fontSizePoints": 5.99999975
+            },
+            {
+              "text": "S1.4a Techniknachweis",
+              "fontSizePoints": 13.994999416875
+            }
+          ]
+        },
+        "internalPreview": {
+          "filePath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\Ablage\\bbm\\S14A - SiGeKo PDF Technikabnahme\\SiGeKo\\Unterlagen\\Technisches-Dokument (2).pdf",
+          "screenshotPath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\internal-preview.png",
+          "reopenedUnchanged": true,
+          "pageCount": 1,
+          "paint": {
+            "visible": true,
+            "width": 1008,
+            "height": 681,
+            "whiteFraction": 0.633853151397011,
+            "pageLeft": 305,
+            "pageRight": 986,
+            "inkSamples": 407,
+            "stableFrames": 2,
+            "screenshotSha256": "0c4ec14f1e23f305c2e7a181ddb6dcff3ead834df97fe8176b613d7a0d520606"
+          }
+        },
+        "rendererOverflow": {
+          "errorCode": "PDF_PROVIDER_LAYOUT_OVERFLOW",
+          "beforeHeight": 566.921875,
+          "restoredHeight": 566.921875,
+          "mountedRefs": [
+            {
+              "id": "pdf.bbm.technical-neutral",
+              "kind": "document",
+              "label": "Technisches Dokument",
+              "parent": "",
+              "editable": "false",
+              "ops": "",
+              "connected": true,
+              "matches": 1,
+              "parentContains": true
+            },
+            {
+              "id": "pdf.bbm.technical-neutral.page",
+              "kind": "page",
+              "label": "Seite",
+              "parent": "pdf.bbm.technical-neutral",
+              "editable": "false",
+              "ops": "",
+              "connected": true,
+              "matches": 1,
+              "parentContains": true
+            },
+            {
+              "id": "pdf.bbm.technical-neutral.title",
+              "kind": "text",
+              "label": "Titel",
+              "parent": "pdf.bbm.technical-neutral.page",
+              "editable": "true",
+              "ops": "textResize",
+              "connected": true,
+              "matches": 1,
+              "parentContains": true
+            },
+            {
+              "id": "pdf.bbm.technical-neutral.body",
+              "kind": "text",
+              "label": "Text",
+              "parent": "pdf.bbm.technical-neutral.page",
+              "editable": "true",
+              "ops": "textResize",
+              "connected": true,
+              "matches": 1,
+              "parentContains": true
+            }
+          ],
+          "pdfFilesUnchanged": true
+        },
+        "editorRegeneration": {
+          "elementId": "pdf.bbm.technical-neutral.title",
+          "previousFontSize": 14,
+          "fontSize": 15,
+          "metadata": {
+            "state": "current",
+            "stale": false,
+            "generation": 1,
+            "pageCount": 1,
+            "generatedAt": "2026-09-08T04:05:44.622Z",
+            "activeDocumentId": "bbm-produktiv-technical-neutral-3b8991475051b14a24fabdd7",
+            "controlledOutputPath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\temp\\Technisches-Dokument-Editor.pdf",
+            "renderBounds": [
+              {
+                "elementId": "pdf.bbm.technical-neutral",
+                "pageNumber": 1,
+                "box": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 210,
+                  "height": 297
+                }
+              },
+              {
+                "elementId": "pdf.bbm.technical-neutral.page",
+                "pageNumber": 1,
+                "box": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 210,
+                  "height": 297
+                }
+              },
+              {
+                "elementId": "pdf.bbm.technical-neutral.title",
+                "pageNumber": 1,
+                "box": {
+                  "x": 11.997,
+                  "y": 17.996,
+                  "width": 186.005,
+                  "height": 19.997,
+                  "fontSize": 15
+                }
+              },
+              {
+                "elementId": "pdf.bbm.technical-neutral.body",
+                "pageNumber": 1,
+                "box": {
+                  "x": 11.997,
+                  "y": 60.991,
+                  "width": 186.005,
+                  "height": 149.999,
+                  "fontSize": 11
+                }
+              }
+            ]
+          },
+          "pdf": {
+            "filePath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\temp\\Technisches-Dokument-Editor.pdf",
+            "bytes": 26875,
+            "sha256": "90b41a7699b766db75e1c95e9117746d1035933e4bf40f235fb9a24813366da0",
+            "pageCount": 1,
+            "pageBox": [
+              0,
+              0,
+              595.91998,
+              842.88
+            ],
+            "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.  © | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV  S1.4a Techniknachweis",
+            "textItems": [
+              {
+                "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.",
+                "fontSizePoints": 10.994999391875005
+              },
+              {
+                "text": "© | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV",
+                "fontSizePoints": 5.99999975
+              },
+              {
+                "text": "S1.4a Techniknachweis",
+                "fontSizePoints": 14.999999375
+              }
+            ]
+          }
+        },
+        "executionFailures": [
+          {
+            "name": "SiGeKo nicht freigeschaltet: bbmDb.printHtmlToPdf",
+            "ok": false,
+            "error": "Feature nicht freigeschaltet: sigeko",
+            "code": "FEATURE_NOT_ALLOWED",
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "SiGeKo nicht freigeschaltet: bbmPrint.printPdfAndPreviewInternal",
+            "ok": false,
+            "error": "Feature nicht freigeschaltet: sigeko",
+            "code": "FEATURE_NOT_ALLOWED",
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "SiGeKo nicht freigeschaltet: bbmDb.printOpenHtmlPreview",
+            "ok": false,
+            "error": "Feature nicht freigeschaltet: sigeko",
+            "code": "FEATURE_NOT_ALLOWED",
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Kein Protokoll-Fallback bei Providerkontext",
+            "ok": false,
+            "error": "Expliziter PDF-Provider-Request erforderlich.",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Protokoll ohne Freigabe",
+            "ok": false,
+            "error": "Modul Protokoll ist fuer diese Lizenz nicht freigeschaltet.",
+            "code": "FEATURE_NOT_ALLOWED",
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Ungueltiger Providerinhalt",
+            "ok": false,
+            "error": "Technischer PDF-Inhalt fehlt oder ueberschreitet den Einseitenvertrag.",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Projekt fehlt",
+            "ok": false,
+            "error": "Projekt nicht gefunden.",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Ablage kann nicht angelegt werden",
+            "ok": false,
+            "error": "ENOTDIR: not a directory, mkdir 'D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\blocked-storage\\bbm\\S14A - SiGeKo PDF Technikabnahme\\SiGeKo\\Unterlagen'",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Druckfenster geschlossen",
+            "ok": false,
+            "error": "Print-Window geschlossen",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Druckauftrag Timeout",
+            "ok": false,
+            "error": "Print-Window Timeout",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Freigabe waehrend Druck entzogen",
+            "ok": false,
+            "error": "Feature nicht freigeschaltet: sigeko",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          }
+        ],
+        "recoveryAfterFailures": {
+          "ok": true,
+          "pdf": {
+            "filePath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\Ablage\\bbm\\S14A - SiGeKo PDF Technikabnahme\\SiGeKo\\Unterlagen\\Technisches-Dokument (3).pdf",
+            "bytes": 26931,
+            "sha256": "04c1f32114152455dfccc900688190fc26282400500a137a0ae5f8e1a06d3a6a",
+            "pageCount": 1,
+            "pageBox": [
+              0,
+              0,
+              595.91998,
+              842.88
+            ],
+            "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.  © | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV  S1.4a Techniknachweis",
+            "textItems": [
+              {
+                "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.",
+                "fontSizePoints": 10.994999391875005
+              },
+              {
+                "text": "© | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV",
+                "fontSizePoints": 5.99999975
+              },
+              {
+                "text": "S1.4a Techniknachweis",
+                "fontSizePoints": 13.994999416875
+              }
+            ]
+          }
+        }
+      }
+    },
+    "linux": {
+      "artifactId": 10040427655,
+      "reportSha256": "f3ca8c98594ea0552ede20c07da6f61d18309c87b51b1e714698fcbf409718be",
+      "checks": {
+        "modulePermission": {
+          "source": "simulated-development-license-status",
+          "modules": [
+            "sigeko"
+          ],
+          "cryptographicLicenseVerified": false,
+          "developmentOverridesEnabled": false,
+          "otherModulesDenied": true
+        },
+        "savedPdf": {
+          "filePath": "/tmp/bbm-ui-editor-acceptance-7LTpIf/Ablage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument.pdf",
+          "bytes": 12093,
+          "sha256": "ccac3d77191eb88ac081befd682736e4ba5b22d0a41a7f56a5c1de2236fb191c",
+          "pageCount": 1,
+          "pageBox": [
+            0,
+            0,
+            595.91998,
+            842.88
+          ],
+          "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.  © | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV  S1.4a Techniknachweis",
+          "textItems": [
+            {
+              "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.",
+              "fontSizePoints": 10.994999391875005
+            },
+            {
+              "text": "© | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV",
+              "fontSizePoints": 5.99999975
+            },
+            {
+              "text": "S1.4a Techniknachweis",
+              "fontSizePoints": 13.994999416875
+            }
+          ]
+        },
+        "internalPreview": {
+          "filePath": "/tmp/bbm-ui-editor-acceptance-7LTpIf/Ablage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument (2).pdf",
+          "screenshotPath": "/tmp/bbm-ui-editor-acceptance-7LTpIf/internal-preview.png",
+          "reopenedUnchanged": true,
+          "pageCount": 1,
+          "paint": {
+            "visible": true,
+            "width": 1100,
+            "height": 900,
+            "whiteFraction": 0.6666989898989899,
+            "pageLeft": 305,
+            "pageRight": 1080,
+            "inkSamples": 239,
+            "stableFrames": 2,
+            "screenshotSha256": "9e1073fe4b4f42314d629c5adbe7d9c8ad0080781f532428191b06855be97b19"
+          }
+        },
+        "rendererOverflow": {
+          "errorCode": "PDF_PROVIDER_LAYOUT_OVERFLOW",
+          "beforeHeight": 566.921875,
+          "restoredHeight": 566.921875,
+          "mountedRefs": [
+            {
+              "id": "pdf.bbm.technical-neutral",
+              "kind": "document",
+              "label": "Technisches Dokument",
+              "parent": "",
+              "editable": "false",
+              "ops": "",
+              "connected": true,
+              "matches": 1,
+              "parentContains": true
+            },
+            {
+              "id": "pdf.bbm.technical-neutral.page",
+              "kind": "page",
+              "label": "Seite",
+              "parent": "pdf.bbm.technical-neutral",
+              "editable": "false",
+              "ops": "",
+              "connected": true,
+              "matches": 1,
+              "parentContains": true
+            },
+            {
+              "id": "pdf.bbm.technical-neutral.title",
+              "kind": "text",
+              "label": "Titel",
+              "parent": "pdf.bbm.technical-neutral.page",
+              "editable": "true",
+              "ops": "textResize",
+              "connected": true,
+              "matches": 1,
+              "parentContains": true
+            },
+            {
+              "id": "pdf.bbm.technical-neutral.body",
+              "kind": "text",
+              "label": "Text",
+              "parent": "pdf.bbm.technical-neutral.page",
+              "editable": "true",
+              "ops": "textResize",
+              "connected": true,
+              "matches": 1,
+              "parentContains": true
+            }
+          ],
+          "pdfFilesUnchanged": true
+        },
+        "editorRegeneration": {
+          "elementId": "pdf.bbm.technical-neutral.title",
+          "previousFontSize": 14,
+          "fontSize": 15,
+          "metadata": {
+            "state": "current",
+            "stale": false,
+            "generation": 1,
+            "pageCount": 1,
+            "generatedAt": "2026-09-08T04:05:38.064Z",
+            "activeDocumentId": "bbm-produktiv-technical-neutral-123161c3d744f6357961ad9d",
+            "controlledOutputPath": "/tmp/bbm-ui-editor-acceptance-7LTpIf/temp/Technisches-Dokument-Editor.pdf",
+            "renderBounds": [
+              {
+                "elementId": "pdf.bbm.technical-neutral",
+                "pageNumber": 1,
+                "box": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 210,
+                  "height": 297
+                }
+              },
+              {
+                "elementId": "pdf.bbm.technical-neutral.page",
+                "pageNumber": 1,
+                "box": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 210,
+                  "height": 297
+                }
+              },
+              {
+                "elementId": "pdf.bbm.technical-neutral.title",
+                "pageNumber": 1,
+                "box": {
+                  "x": 11.997,
+                  "y": 17.996,
+                  "width": 186.005,
+                  "height": 19.997,
+                  "fontSize": 15
+                }
+              },
+              {
+                "elementId": "pdf.bbm.technical-neutral.body",
+                "pageNumber": 1,
+                "box": {
+                  "x": 11.997,
+                  "y": 60.991,
+                  "width": 186.005,
+                  "height": 149.999,
+                  "fontSize": 11
+                }
+              }
+            ]
+          },
+          "pdf": {
+            "filePath": "/tmp/bbm-ui-editor-acceptance-7LTpIf/temp/Technisches-Dokument-Editor.pdf",
+            "bytes": 12037,
+            "sha256": "50ed818e3157b2f4f4ed0d79fd1f1c3a4b1f47bfe997bd09f2e394c4f6b9f255",
+            "pageCount": 1,
+            "pageBox": [
+              0,
+              0,
+              595.91998,
+              842.88
+            ],
+            "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.  © | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV  S1.4a Techniknachweis",
+            "textItems": [
+              {
+                "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.",
+                "fontSizePoints": 10.994999391875005
+              },
+              {
+                "text": "© | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV",
+                "fontSizePoints": 5.99999975
+              },
+              {
+                "text": "S1.4a Techniknachweis",
+                "fontSizePoints": 14.999999375
+              }
+            ]
+          }
+        },
+        "executionFailures": [
+          {
+            "name": "SiGeKo nicht freigeschaltet: bbmDb.printHtmlToPdf",
+            "ok": false,
+            "error": "Feature nicht freigeschaltet: sigeko",
+            "code": "FEATURE_NOT_ALLOWED",
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "SiGeKo nicht freigeschaltet: bbmPrint.printPdfAndPreviewInternal",
+            "ok": false,
+            "error": "Feature nicht freigeschaltet: sigeko",
+            "code": "FEATURE_NOT_ALLOWED",
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "SiGeKo nicht freigeschaltet: bbmDb.printOpenHtmlPreview",
+            "ok": false,
+            "error": "Feature nicht freigeschaltet: sigeko",
+            "code": "FEATURE_NOT_ALLOWED",
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Kein Protokoll-Fallback bei Providerkontext",
+            "ok": false,
+            "error": "Expliziter PDF-Provider-Request erforderlich.",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Protokoll ohne Freigabe",
+            "ok": false,
+            "error": "Modul Protokoll ist fuer diese Lizenz nicht freigeschaltet.",
+            "code": "FEATURE_NOT_ALLOWED",
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Ungueltiger Providerinhalt",
+            "ok": false,
+            "error": "Technischer PDF-Inhalt fehlt oder ueberschreitet den Einseitenvertrag.",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Projekt fehlt",
+            "ok": false,
+            "error": "Projekt nicht gefunden.",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Ablage kann nicht angelegt werden",
+            "ok": false,
+            "error": "ENOTDIR: not a directory, mkdir '/tmp/bbm-ui-editor-acceptance-7LTpIf/blocked-storage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen'",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Druckfenster geschlossen",
+            "ok": false,
+            "error": "Print-Window geschlossen",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Druckauftrag Timeout",
+            "ok": false,
+            "error": "Print-Window Timeout",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          },
+          {
+            "name": "Freigabe waehrend Druck entzogen",
+            "ok": false,
+            "error": "Feature nicht freigeschaltet: sigeko",
+            "code": null,
+            "expectedFailureVerified": true,
+            "pdfFilesUnchanged": true,
+            "noWindowOrReadyListenerLeak": true
+          }
+        ],
+        "recoveryAfterFailures": {
+          "ok": true,
+          "pdf": {
+            "filePath": "/tmp/bbm-ui-editor-acceptance-7LTpIf/Ablage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument (3).pdf",
+            "bytes": 12093,
+            "sha256": "8964036451b756fd7af48f38f0683f635a21c6efa24c2272f639017b2ef3416b",
+            "pageCount": 1,
+            "pageBox": [
+              0,
+              0,
+              595.91998,
+              842.88
+            ],
+            "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.  © | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV  S1.4a Techniknachweis",
+            "textItems": [
+              {
+                "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.",
+                "fontSizePoints": 10.994999391875005
+              },
+              {
+                "text": "© | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV",
+                "fontSizePoints": 5.99999975
+              },
+              {
+                "text": "S1.4a Techniknachweis",
+                "fontSizePoints": 13.994999416875
+              }
+            ]
+          }
+        }
+      }
+    },
+    "goldenComparison": {
+      "ok": true,
+      "fixtures": [
+        {
+          "id": "i48-invoice-final",
+          "pageCount": 5,
+          "sha256": "e9d35929c43e10546c8adbbd18c13e5b0d4afc5b27250e57662fb87c6f34f535"
+        },
+        {
+          "id": "i49-invoice-preview",
+          "pageCount": 5,
+          "sha256": "5812d9026823559ab421bc3ca7dcda1811db93938d154d6cb4226f343661b286"
+        },
+        {
+          "id": "p01-empty",
+          "pageCount": 1,
+          "sha256": "2b76b1eb245766c2e1efd93a87a0ee9ee22eefa2b4ce8f9bd67d8e28ad4b28de"
+        },
+        {
+          "id": "p02-one-page",
+          "pageCount": 1,
+          "sha256": "39d16d8d640d57652a684436da92fe911b4427e388d9f5aeb6263c81a4840b0a"
+        },
+        {
+          "id": "p03-two-pages",
+          "pageCount": 2,
+          "sha256": "93139f3b7c7c7191b7fd3db142a57cf044a7e52364c443f55385004b30927712"
+        },
+        {
+          "id": "p04-just-fits-first",
+          "pageCount": 1,
+          "sha256": "aaa61de7307c087e91aa1602ed71f6253b70ed13945185be6ff28af88b6887af"
+        },
+        {
+          "id": "p05-just-misses-first",
+          "pageCount": 2,
+          "sha256": "817483619e53cead1eb567bbf241d9c12b61d1c2af94dc2c368f5cfd0b4a323f"
+        },
+        {
+          "id": "p06-level-one-near-end",
+          "pageCount": 1,
+          "sha256": "5275767dde74d32ebe348951b7b23f6085e2e4e989578801a330ec29deafd4c3"
+        },
+        {
+          "id": "p07-short-longtext",
+          "pageCount": 1,
+          "sha256": "40492f6fc237d5c305134b6d1a664d30d899355ab0fdcf29ddd04cd6f603f6c1"
+        },
+        {
+          "id": "p08-very-long-longtext",
+          "pageCount": 2,
+          "sha256": "bb44a995e929525e977974060a3236d5074b62410fe37c58e8b81aca3701d908"
+        },
+        {
+          "id": "p09-continuation",
+          "pageCount": 3,
+          "sha256": "9086347b1a75d34f9c5befeff35b320baac359cb92256c773fbc4e308e0b532a"
+        },
+        {
+          "id": "p10-many-short",
+          "pageCount": 3,
+          "sha256": "83c84f97d82d5ef6f726b8a0eaf0f4e38bd7381cfd0d9fb734ff90ef00e631d4"
+        },
+        {
+          "id": "p11-small-participants",
+          "pageCount": 1,
+          "sha256": "728f06eeee5595a43a98a2cfe61fbc2d914990f9292d22a33d3c6796909a05f7"
+        },
+        {
+          "id": "p12-large-participants",
+          "pageCount": 3,
+          "sha256": "6f62fe6f261069e9cd45c7df47d99c66a368927b18e344ad74c9b2db0de58296"
+        },
+        {
+          "id": "p13-short-preremarks",
+          "pageCount": 1,
+          "sha256": "98f8b3aed763f7573524c05416c6011db8998cd6dd4da30e7b584cedd242ef09"
+        },
+        {
+          "id": "p14-long-preremarks",
+          "pageCount": 4,
+          "sha256": "fd47c42118309424987f9bbbd090da94cbb70e61d2219ace9b6f41e9d2bfb41b"
+        },
+        {
+          "id": "p15-closing-near-end",
+          "pageCount": 2,
+          "sha256": "709dabbaef48f5a88dc81bdef83743fe9a46fb9252ea41efea6b68d1403523d4"
+        },
+        {
+          "id": "p16-changed-columns",
+          "pageCount": 3,
+          "sha256": "2fbde91b6f75294fdb9a925a45acc0f5f1333f190358a278f61a5ff9f141cc07"
+        },
+        {
+          "id": "p17-changed-font",
+          "pageCount": 3,
+          "sha256": "e7b6328f70747ebdacb3ce4705fce4835423bd0ae232236a8f43b1fd59f3de44"
+        },
+        {
+          "id": "p18-changed-line-spacing",
+          "pageCount": 3,
+          "sha256": "871a9d65eb0d70a273dc50eddcf1508b0ebc4713d3dcaf1de2a0dd4883d7d769"
+        },
+        {
+          "id": "p28-participants-exact-boundary",
+          "pageCount": 1,
+          "sha256": "2e076de1401516fb3820a2b452f9110a3c230325b3e54669d7299f69905ed36a"
+        },
+        {
+          "id": "p29-participants-miss-boundary",
+          "pageCount": 2,
+          "sha256": "9f4daee912a4ea33366b71117d04a28c42e82c1b6cac53fe49e874767248841c"
+        },
+        {
+          "id": "p30-participants-three-pages",
+          "pageCount": 3,
+          "sha256": "b6a6c0901f5cff6b130c84cab4352dcd3a7ece97b75f8de59274462847c978ba"
+        },
+        {
+          "id": "p31-single-tall-participant",
+          "pageCount": 2,
+          "sha256": "0ce553b1e91ae837a7d25e671038e44db2b822684cfbc288e6eda64047094626"
+        },
+        {
+          "id": "p32-preremarks-over-boundary",
+          "pageCount": 2,
+          "sha256": "c4be2072e571a396b7cceba92cbb55fd0134c162e8381fe5742e8b1af16ee5de"
+        },
+        {
+          "id": "p33-preremarks-multiple-pages",
+          "pageCount": 4,
+          "sha256": "6b3be1624628843ea4fc7d86aa2cbde7de82e844f4ac3fb0f391feb8835941ce"
+        },
+        {
+          "id": "p34-participants-preremarks-tops",
+          "pageCount": 4,
+          "sha256": "b8e1795377028a198d16cce6266d4f4a1e533368241f6c07b9a79920faf69ce6"
+        },
+        {
+          "id": "r19-empty",
+          "pageCount": 1,
+          "sha256": "cb028d2f8360a4f1d896ef5abbf943cb8e4c19e75a68efc526ad581476719d57"
+        },
+        {
+          "id": "r20-one-page",
+          "pageCount": 1,
+          "sha256": "f2dabc493b438319af5fece45d80e608dc468e4f9721e65f3a951a083e061cf2"
+        },
+        {
+          "id": "r21-multiple-pages",
+          "pageCount": 3,
+          "sha256": "05b31fa82b73beabd2de3262e53a0d3d6cfb6e421182106891ab4b0aee5ad21e"
+        },
+        {
+          "id": "r22-short-record",
+          "pageCount": 1,
+          "sha256": "39c75ad79d060c60804cbde595a657c19f3a81f18bae9b68221fea9ed808422a"
+        },
+        {
+          "id": "r23-very-long-record",
+          "pageCount": 2,
+          "sha256": "5068024494a70d623ea32d9a9b839d10c2489d256d8cad8541cf2fa5e31bbed2"
+        },
+        {
+          "id": "r24-just-before-end",
+          "pageCount": 1,
+          "sha256": "8a52eced97efb6f9ed080e6b022409aa610ae7b8cfb4bba44b1cc0458fbba7f0"
+        },
+        {
+          "id": "r25-just-misses-end",
+          "pageCount": 2,
+          "sha256": "afd36384a9258fdece5b2e16b819092e9b71593e28aefa622467c3abe53d9e86"
+        },
+        {
+          "id": "r26-many-short",
+          "pageCount": 4,
+          "sha256": "0e3757f5452c90f8106c20f165930c0b4e85f81d88fbaa2c0376eacc35f1bb9b"
+        },
+        {
+          "id": "r27-columns-unsupported",
+          "pageCount": 1,
+          "sha256": "631f4975dd6a36ea9f2a81505a495d1b1a8eabba514172d791d315407b7c10dd"
+        },
+        {
+          "id": "r35-very-long-short-text",
+          "pageCount": 2,
+          "sha256": "6ea29eede82404e90410559d354e0a1d02b68199ad7bf710e66389eb38b0168a"
+        },
+        {
+          "id": "r36-very-long-note",
+          "pageCount": 5,
+          "sha256": "082034b4cfa5a7533b86c566c03b67266e584191414ef691e6e10234e5cc7695"
+        },
+        {
+          "id": "r37-two-page-record",
+          "pageCount": 1,
+          "sha256": "745cf09e4618f0b8bff3e43508ef0cfe6cdca012de2901d6980e1327eb3859ce"
+        },
+        {
+          "id": "r38-all-columns-max",
+          "pageCount": 2,
+          "sha256": "ca42122d73bfc216e2f004cf96d089c1a4cd4d1cffd3bfa8afeaa72f1f8ec121"
+        },
+        {
+          "id": "r39-status-ampel",
+          "pageCount": 1,
+          "sha256": "2c7f7e7b4cfa04bd1833b9118088325aa4678d71018ef255bfa6a214e12df108"
+        },
+        {
+          "id": "r40-long-locations",
+          "pageCount": 1,
+          "sha256": "a2e1830431bda4ff4ecef2b1a9416428505ff93cb2f83c64c6e4fa9217f9cde7"
+        },
+        {
+          "id": "r41-filtered-order",
+          "pageCount": 1,
+          "sha256": "dce7edcb2bcab760e15d6f4b15285468b8e7b3f0e01f599e6b4461743857b3d9"
+        },
+        {
+          "id": "r42-deleted-excluded",
+          "pageCount": 1,
+          "sha256": "cbabc9eacfe2b4f262cdaf8faa4b5b22a61f8910772d6ca1782c57ed3abfa41d"
+        },
+        {
+          "id": "r43-no-extra-page",
+          "pageCount": 1,
+          "sha256": "478c23ec2fc695aa83315d839b6da3f883be8a41347681308e6d73149ab0789d"
+        },
+        {
+          "id": "r44-repeated-head",
+          "pageCount": 3,
+          "sha256": "66308c3c02e6cdb66af90bdc4304e3d67e12530a1fb253541df53368d192eec7"
+        },
+        {
+          "id": "r45-footer-boundary",
+          "pageCount": 2,
+          "sha256": "356d9ea16dba40e2cdebaed12050d1c3102b2876a8725937bb3c75a5a5c1235d"
+        },
+        {
+          "id": "r46-landscape-contract",
+          "pageCount": 1,
+          "sha256": "2ca15e36428fc58e773c8a8f8e0426b89c1d22d4dcaaeb0f0429fa9d70856c8c"
+        },
+        {
+          "id": "r47-mixed-long-fields",
+          "pageCount": 1,
+          "sha256": "2d479fae2a59b8200bd90af145655f862d5c8c2ef0f2d1cb033f8050057f7406"
+        }
+      ]
+    },
+    "standardNpmCi": {
+      "status": "known baseline failure",
+      "run": 34185714605,
+      "detail": "Standardworkflow ohne UI-Editor-kit; bekannte acht Popup-/Lizenzfehler. Der vollstaendige lokale Vergleich verwendet echtes Kit und unveraenderte Fehlermengen."
+    }
+  }
+}

--- a/docs/SIGEKO_S1_4_TESTVERGLEICH.json
+++ b/docs/SIGEKO_S1_4_TESTVERGLEICH.json
@@ -2,7 +2,7 @@
   "package": "S1.4",
   "date": "2026-09-08",
   "baseCommit": "bd5ab3dbd2548177ce4433147b0ff0ae6f44b847",
-  "productCodeCommit": "d070ab2898c630541414267659d89dd400c6d206",
+  "productCodeCommit": "e730c9ec9957f5b94159428cbd5aba354228bf6b",
   "kitCommit": "5e0d551d93e97c32d169ea6d5107186a44ecd47f",
   "runtime": {
     "electron": "30.5.1",
@@ -17,8 +17,8 @@
     "failed": 97
   },
   "candidate": {
-    "log": "bbm-s14-full.log",
-    "sha256": "96d548ea780b9ba1046aa3ef1b95bd62896cdf0aac457971bf075fbba8a376cb",
+    "log": "bbm-s14-final-full.log",
+    "sha256": "fd4b7d86c8bae93d2ab7251afb39ff5b34fa675ae2f5fb911b723f2342c4af1d",
     "passed": 1527,
     "failed": 97
   },
@@ -151,22 +151,27 @@
     "explanation": "Zwei datumsabhaengige Fehler treten in der aktuellen UTC-Umgebung bereits auf unveraendertem main nicht auf; keine Fehlerreduktion durch dieses Paket."
   },
   "realAcceptance": {
-    "status": "passed",
+    "status": "passed-with-reproduced-viewer-baseline",
     "failedInitialRun": 34185354299,
     "initial49GoldenSnapshotsUnchanged": true,
     "licenseStatusSource": "isolated simulated status through real central licenseService/featureGuard; no development overrides in tested guard",
     "cryptographicCustomerLicenseVerified": false,
     "nativeWpfEditorUiVerified": false,
-    "workflowRun": 34185714616,
-    "headCommit": "895bc4df5d24ad87a13ae8e5310a9c37c8b841a0",
-    "workflowUrl": "https://github.com/SteffenBandholt/BBM-Produktiv/actions/runs/34185714616",
+    "workflowRun": 34186341786,
+    "headCommit": "93321cccb2aec0b180f0af0c54817bc9162103f9",
+    "workflowUrl": "https://github.com/SteffenBandholt/BBM-Produktiv/actions/runs/34186341786",
     "failedPreliminaryRuns": [
       34185354299,
-      34185520594
+      34185520594,
+      34185926740,
+      34186095285,
+      34186462651,
+      34186582861,
+      34186777729
     ],
     "windows": {
-      "artifactId": 10040428623,
-      "reportSha256": "5f4fa0e3bcf30bed03576cf20a37f444fe7aa51d5d889c0724d469b931c611ba",
+      "artifactId": 10040633030,
+      "reportSha256": "23c64887496401f33ed4ce26c0071134b22f51ef49dafe8458a926f4f55307fc",
       "checks": {
         "modulePermission": {
           "source": "simulated-development-license-status",
@@ -178,9 +183,9 @@
           "otherModulesDenied": true
         },
         "savedPdf": {
-          "filePath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\Ablage\\bbm\\S14A - SiGeKo PDF Technikabnahme\\SiGeKo\\Unterlagen\\Technisches-Dokument.pdf",
+          "filePath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-kltD1C\\Ablage\\bbm\\S14A - SiGeKo PDF Technikabnahme\\SiGeKo\\Unterlagen\\Technisches-Dokument.pdf",
           "bytes": 26931,
-          "sha256": "80361203dbb9706e141539638fe0a0466517d03d4b32d07c30e1c377c7099c62",
+          "sha256": "f65d37eb5419c12f3d42040f00eb595f8dda14c4b0040044be55e77534bc1290",
           "pageCount": 1,
           "pageBox": [
             0,
@@ -205,9 +210,11 @@
           ]
         },
         "internalPreview": {
-          "filePath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\Ablage\\bbm\\S14A - SiGeKo PDF Technikabnahme\\SiGeKo\\Unterlagen\\Technisches-Dokument (2).pdf",
-          "screenshotPath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\internal-preview.png",
+          "filePath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-kltD1C\\Ablage\\bbm\\S14A - SiGeKo PDF Technikabnahme\\SiGeKo\\Unterlagen\\Technisches-Dokument (2).pdf",
+          "screenshotPath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-kltD1C\\internal-preview.png",
           "reopenedUnchanged": true,
+          "reopenedThroughExistingPreviewService": true,
+          "previousWindowClosed": true,
           "pageCount": 1,
           "paint": {
             "visible": true,
@@ -282,9 +289,9 @@
             "stale": false,
             "generation": 1,
             "pageCount": 1,
-            "generatedAt": "2026-09-08T04:05:44.622Z",
-            "activeDocumentId": "bbm-produktiv-technical-neutral-3b8991475051b14a24fabdd7",
-            "controlledOutputPath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\temp\\Technisches-Dokument-Editor.pdf",
+            "generatedAt": "2026-09-08T04:16:17.256Z",
+            "activeDocumentId": "bbm-produktiv-technical-neutral-2e5dfaf3c904cb8262fc9a9a",
+            "controlledOutputPath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-kltD1C\\temp\\Technisches-Dokument-Editor.pdf",
             "renderBounds": [
               {
                 "elementId": "pdf.bbm.technical-neutral",
@@ -331,9 +338,9 @@
             ]
           },
           "pdf": {
-            "filePath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\temp\\Technisches-Dokument-Editor.pdf",
+            "filePath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-kltD1C\\temp\\Technisches-Dokument-Editor.pdf",
             "bytes": 26875,
-            "sha256": "90b41a7699b766db75e1c95e9117746d1035933e4bf40f235fb9a24813366da0",
+            "sha256": "87b605322abd086bd0c75196822bc0c1264861750cf3014485a52c4df2801e35",
             "pageCount": 1,
             "pageBox": [
               0,
@@ -425,7 +432,7 @@
           {
             "name": "Ablage kann nicht angelegt werden",
             "ok": false,
-            "error": "ENOTDIR: not a directory, mkdir 'D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\blocked-storage\\bbm\\S14A - SiGeKo PDF Technikabnahme\\SiGeKo\\Unterlagen'",
+            "error": "ENOTDIR: not a directory, mkdir 'D:\\a\\_temp\\bbm-ui-editor-acceptance-kltD1C\\blocked-storage\\bbm\\S14A - SiGeKo PDF Technikabnahme\\SiGeKo\\Unterlagen'",
             "code": null,
             "expectedFailureVerified": true,
             "pdfFilesUnchanged": true,
@@ -462,9 +469,9 @@
         "recoveryAfterFailures": {
           "ok": true,
           "pdf": {
-            "filePath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-wAi7wm\\Ablage\\bbm\\S14A - SiGeKo PDF Technikabnahme\\SiGeKo\\Unterlagen\\Technisches-Dokument (3).pdf",
+            "filePath": "D:\\a\\_temp\\bbm-ui-editor-acceptance-kltD1C\\Ablage\\bbm\\S14A - SiGeKo PDF Technikabnahme\\SiGeKo\\Unterlagen\\Technisches-Dokument (3).pdf",
             "bytes": 26931,
-            "sha256": "04c1f32114152455dfccc900688190fc26282400500a137a0ae5f8e1a06d3a6a",
+            "sha256": "f85654888dfa2a7223d54277df52e3ae41c53ffa0493551016524f1c5a9efdc3",
             "pageCount": 1,
             "pageBox": [
               0,
@@ -492,8 +499,8 @@
       }
     },
     "linux": {
-      "artifactId": 10040427655,
-      "reportSha256": "f3ca8c98594ea0552ede20c07da6f61d18309c87b51b1e714698fcbf409718be",
+      "artifactId": 10040628021,
+      "reportSha256": "c55b08df958b39146cfb0ceac98cc5367130b08851bba2fdcd1185497e305c9f",
       "checks": {
         "modulePermission": {
           "source": "simulated-development-license-status",
@@ -505,9 +512,9 @@
           "otherModulesDenied": true
         },
         "savedPdf": {
-          "filePath": "/tmp/bbm-ui-editor-acceptance-7LTpIf/Ablage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument.pdf",
+          "filePath": "/tmp/bbm-ui-editor-acceptance-A2g14D/Ablage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument.pdf",
           "bytes": 12093,
-          "sha256": "ccac3d77191eb88ac081befd682736e4ba5b22d0a41a7f56a5c1de2236fb191c",
+          "sha256": "926cb5d06b98ed768a941f3cbca2cb0c94cb3395154743d55d380a66e1e40296",
           "pageCount": 1,
           "pageBox": [
             0,
@@ -532,9 +539,11 @@
           ]
         },
         "internalPreview": {
-          "filePath": "/tmp/bbm-ui-editor-acceptance-7LTpIf/Ablage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument (2).pdf",
-          "screenshotPath": "/tmp/bbm-ui-editor-acceptance-7LTpIf/internal-preview.png",
+          "filePath": "/tmp/bbm-ui-editor-acceptance-A2g14D/Ablage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument (2).pdf",
+          "screenshotPath": "/tmp/bbm-ui-editor-acceptance-A2g14D/internal-preview.png",
           "reopenedUnchanged": true,
+          "reopenedThroughExistingPreviewService": true,
+          "previousWindowClosed": true,
           "pageCount": 1,
           "paint": {
             "visible": true,
@@ -609,9 +618,9 @@
             "stale": false,
             "generation": 1,
             "pageCount": 1,
-            "generatedAt": "2026-09-08T04:05:38.064Z",
-            "activeDocumentId": "bbm-produktiv-technical-neutral-123161c3d744f6357961ad9d",
-            "controlledOutputPath": "/tmp/bbm-ui-editor-acceptance-7LTpIf/temp/Technisches-Dokument-Editor.pdf",
+            "generatedAt": "2026-09-08T04:15:57.211Z",
+            "activeDocumentId": "bbm-produktiv-technical-neutral-29afa40fafd8bc74e1f57037",
+            "controlledOutputPath": "/tmp/bbm-ui-editor-acceptance-A2g14D/temp/Technisches-Dokument-Editor.pdf",
             "renderBounds": [
               {
                 "elementId": "pdf.bbm.technical-neutral",
@@ -658,9 +667,9 @@
             ]
           },
           "pdf": {
-            "filePath": "/tmp/bbm-ui-editor-acceptance-7LTpIf/temp/Technisches-Dokument-Editor.pdf",
+            "filePath": "/tmp/bbm-ui-editor-acceptance-A2g14D/temp/Technisches-Dokument-Editor.pdf",
             "bytes": 12037,
-            "sha256": "50ed818e3157b2f4f4ed0d79fd1f1c3a4b1f47bfe997bd09f2e394c4f6b9f255",
+            "sha256": "fd54a9869a7d162694785391ec6edbbee020625505b2c91e494844b3d1176b01",
             "pageCount": 1,
             "pageBox": [
               0,
@@ -752,7 +761,7 @@
           {
             "name": "Ablage kann nicht angelegt werden",
             "ok": false,
-            "error": "ENOTDIR: not a directory, mkdir '/tmp/bbm-ui-editor-acceptance-7LTpIf/blocked-storage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen'",
+            "error": "ENOTDIR: not a directory, mkdir '/tmp/bbm-ui-editor-acceptance-A2g14D/blocked-storage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen'",
             "code": null,
             "expectedFailureVerified": true,
             "pdfFilesUnchanged": true,
@@ -789,9 +798,9 @@
         "recoveryAfterFailures": {
           "ok": true,
           "pdf": {
-            "filePath": "/tmp/bbm-ui-editor-acceptance-7LTpIf/Ablage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument (3).pdf",
+            "filePath": "/tmp/bbm-ui-editor-acceptance-A2g14D/Ablage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument (3).pdf",
             "bytes": 12093,
-            "sha256": "8964036451b756fd7af48f38f0683f635a21c6efa24c2272f639017b2ef3416b",
+            "sha256": "6679133faed90a74a7bb59d71c9c06d83f93f36cab8a355962e620d0420a0f5d",
             "pageCount": 1,
             "pageBox": [
               0,
@@ -1072,6 +1081,375 @@
       "status": "known baseline failure",
       "run": 34185714605,
       "detail": "Standardworkflow ohne UI-Editor-kit; bekannte acht Popup-/Lizenzfehler. Der vollstaendige lokale Vergleich verwendet echtes Kit und unveraenderte Fehlermengen."
+    },
+    "baselinePreviewComparison": {
+      "workflowRun": 34186953879,
+      "artifactId": 10040849187,
+      "baselineCommit": "bd5ab3dbd2548177ce4433147b0ff0ae6f44b847",
+      "instrumentation": "Identischer aktueller Harness und Lizenz-Fixture auf Basis; nur Export der vorhandenen openInternalPdfPreview ergaenzt, Funktionskoerper und Druckauftrag unveraendert. npm-Starteinstieg wie Kandidat. Drei isolierte Basislaeufe vor Kandidat.",
+      "baselineRuns": [
+        {
+          "ok": false,
+          "reportSha256": "ca13e639f274cac4c476e7894783a48bcb281ca2fc254781dbbad60f9a608e7c",
+          "error": {
+            "message": "Interne PDF-Vorschau zeigt keine stabil gezeichnete Seite mit Text: {\"visible\":false,\"width\":1100,\"height\":900,\"whiteFraction\":0,\"pageLeft\":0,\"pageRight\":0,\"inkSamples\":0}; Diagnose: {\"visible\":true,\"focused\":true,\"url\":\"file:///tmp/bbm-ui-editor-acceptance-CsnX1e/Ablage/bbm/S14A%20-%20SiGeKo%20PDF%20Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument%20(2).pdf\",\"frames\":[{\"url\":\"file:///tmp/bbm-ui-editor-acceptance-CsnX1e/Ablage/bbm/S14A%20-%20SiGeKo%20PDF%20Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument%20(2).pdf\",\"state\":{\"body\":\"<embed name=\\\"E3F5C22CDD854522FB504ED3311B7F5F\\\" style=\\\"position:absolute; left: 0; top: 0;\\\" width=\\\"100%\\\" height=\\\"100%\\\" src=\\\"about:blank\\\" type=\\\"application/pdf\\\" internalid=\\\"E3F5C22CDD854522FB504ED3311B7F5F\\\">\",\"ready\":\"complete\",\"visibility\":\"visible\"}},{\"url\":\"chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html\",\"state\":{\"diagnosticTimeout\":true}}]}",
+            "code": "PDF_PREVIEW_PAINT_TIMEOUT",
+            "validationErrors": [],
+            "stack": "Error: Interne PDF-Vorschau zeigt keine stabil gezeichnete Seite mit Text: {\"visible\":false,\"width\":1100,\"height\":900,\"whiteFraction\":0,\"pageLeft\":0,\"pageRight\":0,\"inkSamples\":0}; Diagnose: {\"visible\":true,\"focused\":true,\"url\":\"file:///tmp/bbm-ui-editor-acceptance-CsnX1e/Ablage/bbm/S14A%20-%20SiGeKo%20PDF%20Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument%20(2).pdf\",\"frames\":[{\"url\":\"file:///tmp/bbm-ui-editor-acceptance-CsnX1e/Ablage/bbm/S14A%20-%20SiGeKo%20PDF%20Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument%20(2).pdf\",\"state\":{\"body\":\"<embed name=\\\"E3F5C22CDD854522FB504ED3311B7F5F\\\" style=\\\"position:absolute; left: 0; top: 0;\\\" width=\\\"100%\\\" height=\\\"100%\\\" src=\\\"about:blank\\\" type=\\\"application/pdf\\\" internalid=\\\"E3F5C22CDD854522FB504ED3311B7F5F\\\">\",\"ready\":\"complete\",\"visibility\":\"visible\"}},{\"url\":\"chrome-extension://mhjfbmdgcfjbbpaeojofohoefgiehjai/index.html\",\"state\":{\"diagnosticTimeout\":true}}]}\n    at capturePaintedPdfPreview (/home/runner/work/BBM-Produktiv/BBM-Produktiv/BBM-base/scripts/runSigekoPdfAcceptance.cjs:105:23)\n    at async runWorker (/home/runner/work/BBM-Produktiv/BBM-Produktiv/BBM-base/scripts/runSigekoPdfAcceptance.cjs:207:19)"
+          },
+          "package": "S1.4"
+        },
+        {
+          "ok": true,
+          "reportSha256": "f10ab7e5945a4001034fe9ed79d889e1d14afd216df7486c4de585b037f13107",
+          "error": null,
+          "package": "S1.4-preview-only"
+        },
+        {
+          "ok": true,
+          "reportSha256": "2609ec7d95d9be310566f1b13875729615f554ffb808c1061801fd474b34b3eb",
+          "error": null,
+          "package": "S1.4-preview-only"
+        }
+      ],
+      "candidate": {
+        "ok": true,
+        "reportSha256": "1e41a224d9027f65b885548a1f503547b670cda82320c3c0ffb60c4372b5c852",
+        "completeChecks": {
+          "modulePermission": {
+            "source": "simulated-development-license-status",
+            "modules": [
+              "sigeko"
+            ],
+            "cryptographicLicenseVerified": false,
+            "developmentOverridesEnabled": false,
+            "otherModulesDenied": true
+          },
+          "savedPdf": {
+            "filePath": "/tmp/bbm-ui-editor-acceptance-i7AMnK/Ablage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument.pdf",
+            "bytes": 12093,
+            "sha256": "acc29aa908b5c42b7be174eb37789db35f94e9830694298249a2c89007373a27",
+            "pageCount": 1,
+            "pageBox": [
+              0,
+              0,
+              595.91998,
+              842.88
+            ],
+            "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.  © | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV  S1.4a Techniknachweis",
+            "textItems": [
+              {
+                "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.",
+                "fontSizePoints": 10.994999391875005
+              },
+              {
+                "text": "© | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV",
+                "fontSizePoints": 5.99999975
+              },
+              {
+                "text": "S1.4a Techniknachweis",
+                "fontSizePoints": 13.994999416875
+              }
+            ]
+          },
+          "internalPreview": {
+            "filePath": "/tmp/bbm-ui-editor-acceptance-i7AMnK/Ablage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument (2).pdf",
+            "screenshotPath": "/tmp/bbm-ui-editor-acceptance-i7AMnK/internal-preview.png",
+            "reopenedUnchanged": true,
+            "reopenedThroughExistingPreviewService": true,
+            "previousWindowClosed": true,
+            "pageCount": 1,
+            "paint": {
+              "visible": true,
+              "width": 1100,
+              "height": 900,
+              "whiteFraction": 0.6666989898989899,
+              "pageLeft": 305,
+              "pageRight": 1080,
+              "inkSamples": 239,
+              "stableFrames": 2,
+              "screenshotSha256": "9e1073fe4b4f42314d629c5adbe7d9c8ad0080781f532428191b06855be97b19"
+            }
+          },
+          "rendererOverflow": {
+            "errorCode": "PDF_PROVIDER_LAYOUT_OVERFLOW",
+            "beforeHeight": 566.921875,
+            "restoredHeight": 566.921875,
+            "mountedRefs": [
+              {
+                "id": "pdf.bbm.technical-neutral",
+                "kind": "document",
+                "label": "Technisches Dokument",
+                "parent": "",
+                "editable": "false",
+                "ops": "",
+                "connected": true,
+                "matches": 1,
+                "parentContains": true
+              },
+              {
+                "id": "pdf.bbm.technical-neutral.page",
+                "kind": "page",
+                "label": "Seite",
+                "parent": "pdf.bbm.technical-neutral",
+                "editable": "false",
+                "ops": "",
+                "connected": true,
+                "matches": 1,
+                "parentContains": true
+              },
+              {
+                "id": "pdf.bbm.technical-neutral.title",
+                "kind": "text",
+                "label": "Titel",
+                "parent": "pdf.bbm.technical-neutral.page",
+                "editable": "true",
+                "ops": "textResize",
+                "connected": true,
+                "matches": 1,
+                "parentContains": true
+              },
+              {
+                "id": "pdf.bbm.technical-neutral.body",
+                "kind": "text",
+                "label": "Text",
+                "parent": "pdf.bbm.technical-neutral.page",
+                "editable": "true",
+                "ops": "textResize",
+                "connected": true,
+                "matches": 1,
+                "parentContains": true
+              }
+            ],
+            "pdfFilesUnchanged": true
+          },
+          "editorRegeneration": {
+            "elementId": "pdf.bbm.technical-neutral.title",
+            "previousFontSize": 14,
+            "fontSize": 15,
+            "metadata": {
+              "state": "current",
+              "stale": false,
+              "generation": 1,
+              "pageCount": 1,
+              "generatedAt": "2026-09-08T04:26:51.483Z",
+              "activeDocumentId": "bbm-produktiv-technical-neutral-99db888a707ad07412913515",
+              "controlledOutputPath": "/tmp/bbm-ui-editor-acceptance-i7AMnK/temp/Technisches-Dokument-Editor.pdf",
+              "renderBounds": [
+                {
+                  "elementId": "pdf.bbm.technical-neutral",
+                  "pageNumber": 1,
+                  "box": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 210,
+                    "height": 297
+                  }
+                },
+                {
+                  "elementId": "pdf.bbm.technical-neutral.page",
+                  "pageNumber": 1,
+                  "box": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 210,
+                    "height": 297
+                  }
+                },
+                {
+                  "elementId": "pdf.bbm.technical-neutral.title",
+                  "pageNumber": 1,
+                  "box": {
+                    "x": 11.997,
+                    "y": 17.996,
+                    "width": 186.005,
+                    "height": 19.997,
+                    "fontSize": 15
+                  }
+                },
+                {
+                  "elementId": "pdf.bbm.technical-neutral.body",
+                  "pageNumber": 1,
+                  "box": {
+                    "x": 11.997,
+                    "y": 60.991,
+                    "width": 186.005,
+                    "height": 149.999,
+                    "fontSize": 11
+                  }
+                }
+              ]
+            },
+            "pdf": {
+              "filePath": "/tmp/bbm-ui-editor-acceptance-i7AMnK/temp/Technisches-Dokument-Editor.pdf",
+              "bytes": 12037,
+              "sha256": "dec490478c6bd5b27b330f441268f032910fa0234c17ccd2cf29dbbbf42fff76",
+              "pageCount": 1,
+              "pageBox": [
+                0,
+                0,
+                595.91998,
+                842.88
+              ],
+              "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.  © | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV  S1.4a Techniknachweis",
+              "textItems": [
+                {
+                  "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.",
+                  "fontSizePoints": 10.994999391875005
+                },
+                {
+                  "text": "© | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV",
+                  "fontSizePoints": 5.99999975
+                },
+                {
+                  "text": "S1.4a Techniknachweis",
+                  "fontSizePoints": 14.999999375
+                }
+              ]
+            }
+          },
+          "executionFailures": [
+            {
+              "name": "SiGeKo nicht freigeschaltet: bbmDb.printHtmlToPdf",
+              "ok": false,
+              "error": "Feature nicht freigeschaltet: sigeko",
+              "code": "FEATURE_NOT_ALLOWED",
+              "expectedFailureVerified": true,
+              "pdfFilesUnchanged": true,
+              "noWindowOrReadyListenerLeak": true
+            },
+            {
+              "name": "SiGeKo nicht freigeschaltet: bbmPrint.printPdfAndPreviewInternal",
+              "ok": false,
+              "error": "Feature nicht freigeschaltet: sigeko",
+              "code": "FEATURE_NOT_ALLOWED",
+              "expectedFailureVerified": true,
+              "pdfFilesUnchanged": true,
+              "noWindowOrReadyListenerLeak": true
+            },
+            {
+              "name": "SiGeKo nicht freigeschaltet: bbmDb.printOpenHtmlPreview",
+              "ok": false,
+              "error": "Feature nicht freigeschaltet: sigeko",
+              "code": "FEATURE_NOT_ALLOWED",
+              "expectedFailureVerified": true,
+              "pdfFilesUnchanged": true,
+              "noWindowOrReadyListenerLeak": true
+            },
+            {
+              "name": "Kein Protokoll-Fallback bei Providerkontext",
+              "ok": false,
+              "error": "Expliziter PDF-Provider-Request erforderlich.",
+              "code": null,
+              "expectedFailureVerified": true,
+              "pdfFilesUnchanged": true,
+              "noWindowOrReadyListenerLeak": true
+            },
+            {
+              "name": "Protokoll ohne Freigabe",
+              "ok": false,
+              "error": "Modul Protokoll ist fuer diese Lizenz nicht freigeschaltet.",
+              "code": "FEATURE_NOT_ALLOWED",
+              "expectedFailureVerified": true,
+              "pdfFilesUnchanged": true,
+              "noWindowOrReadyListenerLeak": true
+            },
+            {
+              "name": "Ungueltiger Providerinhalt",
+              "ok": false,
+              "error": "Technischer PDF-Inhalt fehlt oder ueberschreitet den Einseitenvertrag.",
+              "code": null,
+              "expectedFailureVerified": true,
+              "pdfFilesUnchanged": true,
+              "noWindowOrReadyListenerLeak": true
+            },
+            {
+              "name": "Projekt fehlt",
+              "ok": false,
+              "error": "Projekt nicht gefunden.",
+              "code": null,
+              "expectedFailureVerified": true,
+              "pdfFilesUnchanged": true,
+              "noWindowOrReadyListenerLeak": true
+            },
+            {
+              "name": "Ablage kann nicht angelegt werden",
+              "ok": false,
+              "error": "ENOTDIR: not a directory, mkdir '/tmp/bbm-ui-editor-acceptance-i7AMnK/blocked-storage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen'",
+              "code": null,
+              "expectedFailureVerified": true,
+              "pdfFilesUnchanged": true,
+              "noWindowOrReadyListenerLeak": true
+            },
+            {
+              "name": "Druckfenster geschlossen",
+              "ok": false,
+              "error": "Print-Window geschlossen",
+              "code": null,
+              "expectedFailureVerified": true,
+              "pdfFilesUnchanged": true,
+              "noWindowOrReadyListenerLeak": true
+            },
+            {
+              "name": "Druckauftrag Timeout",
+              "ok": false,
+              "error": "Print-Window Timeout",
+              "code": null,
+              "expectedFailureVerified": true,
+              "pdfFilesUnchanged": true,
+              "noWindowOrReadyListenerLeak": true
+            },
+            {
+              "name": "Freigabe waehrend Druck entzogen",
+              "ok": false,
+              "error": "Feature nicht freigeschaltet: sigeko",
+              "code": null,
+              "expectedFailureVerified": true,
+              "pdfFilesUnchanged": true,
+              "noWindowOrReadyListenerLeak": true
+            }
+          ],
+          "recoveryAfterFailures": {
+            "ok": true,
+            "pdf": {
+              "filePath": "/tmp/bbm-ui-editor-acceptance-i7AMnK/Ablage/bbm/S14A - SiGeKo PDF Technikabnahme/SiGeKo/Unterlagen/Technisches-Dokument (3).pdf",
+              "bytes": 12093,
+              "sha256": "a36571e44c22fc1a77e526751a26f6523113131a4830194ba52390948b2c9778",
+              "pageCount": 1,
+              "pageBox": [
+                0,
+                0,
+                595.91998,
+                842.88
+              ],
+              "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.  © | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV  S1.4a Techniknachweis",
+              "textItems": [
+                {
+                  "text": "Neutraler PDF-Beleg aus dem bestehenden BBM-Druckweg.",
+                  "fontSizePoints": 10.994999391875005
+                },
+                {
+                  "text": "© | v30.5.1 | BBM 2026 | erstellt mit Baubesprechungsmanager | DEV",
+                  "fontSizePoints": 5.99999975
+                },
+                {
+                  "text": "S1.4a Techniknachweis",
+                  "fontSizePoints": 13.994999416875
+                }
+              ]
+            }
+          }
+        }
+      },
+      "baselinePassed": 2,
+      "baselineFailed": 1,
+      "classification": "Sporadischer dunkler PDF-Viewer beim Wiederoeffnen auf funktional unveraendertem main reproduziert. Kein Beleg fuer genaue Chromium-Ursache oder behobene Viewer-Stabilitaet; sichtbar bleiben lassen. Kandidat vollstaendig bestanden.",
+      "windowsInfrastructureFailure": {
+        "jobId": 101937109936,
+        "stage": "npm ci / better-sqlite3 / node-gyp VisualStudio discovery",
+        "acceptanceStarted": false,
+        "classification": "Kein PDF-Lauf; nicht als Abnahme gewertet. Vollstaendiger Windows-Nachweis auf gleichem Produktcode in 34186341786 vorhanden."
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dist": "node scripts/dist.cjs",
     "test": "node scripts/runElectronNodeTest.cjs",
     "test:sigeko:s1.4a": "node scripts/runSigekoPdfAcceptance.cjs",
+    "test:sigeko:s1.4": "node scripts/runSigekoPdfAcceptance.cjs",
     "test:sigeko:s1.3:windows": "node scripts/runSigekoStorageAcceptance.cjs",
     "lint": "eslint \"src/**/*.js\"",
     "lint:fix": "eslint \"src/**/*.js\" --fix",

--- a/scripts/helpers/pdfAcceptanceLicense.cjs
+++ b/scripts/helpers/pdfAcceptanceLicense.cjs
@@ -1,0 +1,84 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const Module = require("node:module");
+const {
+  ACCEPTANCE_SWITCH,
+  readAcceptanceMarker,
+  resolveAcceptanceRoot,
+} = require("../../src/main/startup/uiEditorAcceptanceProfile");
+
+// TEST ONLY: controlled license-status input for the isolated Electron worker.
+// The real licenseService and featureGuard execute unchanged, including fresh
+// reads and error classification. This does NOT verify a customer signature or
+// a packaged installation. Only featureGuard receives a packaged-app facade,
+// so its development overrides cannot silently authorize Protokoll/Restarbeiten.
+// The global loader hook exists solely during the two synchronous imports.
+function createPdfAcceptanceLicense({ electronApp, profile, modules = ["sigeko"] } = {}) {
+  assert.equal(electronApp?.isPackaged, false, "PDF acceptance license fixture requires a source build");
+  assert.equal(profile?.enabled, true, "PDF acceptance license fixture requires an isolated profile");
+  const rootPath = resolveAcceptanceRoot([`${ACCEPTANCE_SWITCH}${profile.rootPath}`]);
+  readAcceptanceMarker(rootPath);
+  for (const name of ["userData", "sessionData"]) {
+    assert.equal(path.resolve(profile[`${name}Path`]), path.join(rootPath, name), `Unexpected ${name} profile path`);
+    assert.equal(path.resolve(electronApp.getPath(name)), path.join(rootPath, name), `Isolated ${name} must be active`);
+  }
+
+  const servicePath = require.resolve("../../src/main/licensing/licenseService");
+  const guardPath = require.resolve("../../src/main/licensing/featureGuard");
+  assert.equal(require.cache[servicePath], undefined, "Install PDF acceptance fixture before licenseService is loaded");
+  assert.equal(require.cache[guardPath], undefined, "Install PDF acceptance fixture before featureGuard is loaded");
+
+  let fixtureStatus;
+  let statusReadCount = 0;
+  function setModules(nextModules) {
+    assert.ok(Array.isArray(nextModules) && (nextModules.length === 0 ||
+      (nextModules.length === 1 && nextModules[0] === "sigeko")), "PDF acceptance fixture supports only SiGeKo or no modules");
+    fixtureStatus = Object.freeze({
+      valid: true,
+      reason: "OK",
+      developmentLicense: true,
+      displayLabel: "Isolierte PDF-Abnahme – simulierter Lizenzstatus",
+      license: Object.freeze({
+        product: "bbm",
+        customerName: "Isolierte PDF-Abnahme",
+        modules: Object.freeze([...nextModules]),
+        features: Object.freeze([]),
+      }),
+    });
+  }
+  setModules(modules);
+
+  const originalLoad = Module._load;
+  let service;
+  let guard;
+  Module._load = function loadAcceptanceDependency(request, parent, isMain) {
+    if (parent?.filename === servicePath && request === "./developmentLicenseLoader") {
+      return { loadDevelopmentLicenseStatus() { statusReadCount += 1; return fixtureStatus; } };
+    }
+    if (parent?.filename === guardPath && request === "electron") {
+      return { app: Object.freeze({ isPackaged: true, getVersion: () => electronApp.getVersion() }) };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  try {
+    service = require(servicePath);
+    guard = require(guardPath);
+  } finally {
+    Module._load = originalLoad;
+  }
+
+  return Object.freeze({
+    source: "simulated-development-license-status",
+    cryptographicLicenseVerified: false,
+    developmentOverridesEnabled: false,
+    setModules,
+    getStatus: service.getStatus,
+    requireFeature: service.requireFeature,
+    enforceLicensedFeature: guard.enforceLicensedFeature,
+    getStatusReadCount: () => statusReadCount,
+  });
+}
+
+module.exports = { createPdfAcceptanceLicense };

--- a/scripts/helpers/pdfExecutionAcceptance.cjs
+++ b/scripts/helpers/pdfExecutionAcceptance.cjs
@@ -7,20 +7,30 @@ const path = require("node:path");
 // Actual preload -> IPC -> print-window path. Faults are confined to this
 // isolated worker; printToPDF, storage and IPC results are never replaced.
 async function verifyPdfExecutionFailures({ app, BrowserWindow, ipcMain, invoke, payload,
-  profile, baseDir, tempPath, licenseFixture, pdfInventory }) {
+  profile, baseDir, tempPath, licenseFixture, pdfInventory, persistentWindowIds }) {
   const results = [];
   const inventory = () => pdfInventory([baseDir, tempPath]);
+  const expectedWindows = [...persistentWindowIds].sort();
+  async function waitForClosedPrintWindows(name) {
+    const deadline = Date.now() + 5000;
+    const current = () => BrowserWindow.getAllWindows().map((window) => window.id).sort();
+    while (JSON.stringify(current()) !== JSON.stringify(expectedWindows) && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.deepEqual(current(), expectedWindows, `${name}: Druckfenster bleibt zurueck`);
+  }
+  // Electron acknowledges close asynchronously, after the print IPC resolves.
+  await waitForClosedPrintWindows("Vor Fehlerabnahme");
   async function rejected(name, request, expected, method = "bbmDb.printHtmlToPdf") {
     const before = inventory();
     const listeners = ipcMain.listenerCount("print:ready");
-    const windows = BrowserWindow.getAllWindows().map((window) => window.id).sort();
     const result = await invoke(method, request);
     assert.equal(result.ok, false, `${name}: ${JSON.stringify(result)}`);
     assert.equal(result.filePath, undefined, `${name}: Fehler darf keinen fertigen Dateipfad melden`);
     assert.match(JSON.stringify(result), expected, name);
     assert.deepEqual(inventory(), before, `${name}: PDF-Bestand veraendert`);
     assert.equal(ipcMain.listenerCount("print:ready"), listeners, `${name}: Ready-Listener bleibt zurueck`);
-    assert.deepEqual(BrowserWindow.getAllWindows().map((window) => window.id).sort(), windows, `${name}: Druckfenster bleibt zurueck`);
+    await waitForClosedPrintWindows(name);
     results.push({ name, ok: false, error: result.error, code: result.code || null, expectedFailureVerified: true,
       pdfFilesUnchanged: true, noWindowOrReadyListenerLeak: true });
   }

--- a/scripts/helpers/pdfExecutionAcceptance.cjs
+++ b/scripts/helpers/pdfExecutionAcceptance.cjs
@@ -1,0 +1,74 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Actual preload -> IPC -> print-window path. Faults are confined to this
+// isolated worker; printToPDF, storage and IPC results are never replaced.
+async function verifyPdfExecutionFailures({ app, BrowserWindow, ipcMain, invoke, payload,
+  profile, baseDir, tempPath, licenseFixture, pdfInventory }) {
+  const results = [];
+  const inventory = () => pdfInventory([baseDir, tempPath]);
+  async function rejected(name, request, expected, method = "bbmDb.printHtmlToPdf") {
+    const before = inventory();
+    const listeners = ipcMain.listenerCount("print:ready");
+    const windows = BrowserWindow.getAllWindows().map((window) => window.id).sort();
+    const result = await invoke(method, request);
+    assert.equal(result.ok, false, `${name}: ${JSON.stringify(result)}`);
+    assert.equal(result.filePath, undefined, `${name}: Fehler darf keinen fertigen Dateipfad melden`);
+    assert.match(JSON.stringify(result), expected, name);
+    assert.deepEqual(inventory(), before, `${name}: PDF-Bestand veraendert`);
+    assert.equal(ipcMain.listenerCount("print:ready"), listeners, `${name}: Ready-Listener bleibt zurueck`);
+    assert.deepEqual(BrowserWindow.getAllWindows().map((window) => window.id).sort(), windows, `${name}: Druckfenster bleibt zurueck`);
+    results.push({ name, ok: false, error: result.error, code: result.code || null, expectedFailureVerified: true,
+      pdfFilesUnchanged: true, noWindowOrReadyListenerLeak: true });
+  }
+
+  licenseFixture.setModules([]);
+  try {
+    for (const method of ["bbmDb.printHtmlToPdf", "bbmPrint.printPdfAndPreviewInternal", "bbmDb.printOpenHtmlPreview"]) {
+      await rejected(`SiGeKo nicht freigeschaltet: ${method}`, payload, /FEATURE_NOT_ALLOWED/, method);
+    }
+  } finally { licenseFixture.setModules(["sigeko"]); }
+  await rejected("Kein Protokoll-Fallback bei Providerkontext", { ...payload, mode: "protocol" }, /Provider|provider/);
+  await rejected("Protokoll ohne Freigabe", { mode: "protocol" }, /FEATURE_NOT_ALLOWED/);
+  const invalidData = structuredClone(payload);
+  invalidData.providerRequest.data.title = "x".repeat(81);
+  await rejected("Ungueltiger Providerinhalt", invalidData, /PDF-Inhalt/);
+  const missingProject = structuredClone(payload);
+  missingProject.projectId = missingProject.providerRequest.projectId = "missing-s14-project";
+  await rejected("Projekt fehlt", missingProject, /Projekt|project/i);
+  const blockedPath = path.join(profile.rootPath, "blocked-storage");
+  fs.writeFileSync(blockedPath, "Datei statt Ablageverzeichnis");
+  const badStorage = structuredClone(payload);
+  badStorage.providerRequest.storage.baseDir = blockedPath;
+  await rejected("Ablage kann nicht angelegt werden", badStorage, /ENOTDIR|EEXIST/);
+
+  // BrowserWindow is real; closing the new print window is the actual abort.
+  let closed = false;
+  const onWindow = (_event, window) => {
+    window.webContents.once("did-finish-load", () => { closed = true; window.close(); });
+  };
+  app.once("browser-window-created", onWindow);
+  try {
+    await rejected("Druckfenster geschlossen", payload, /Print-Window geschlossen/);
+    assert.equal(closed, true, "Abbruchereignis nicht ausgefuehrt");
+  } finally { app.removeListener("browser-window-created", onWindow); }
+
+  await rejected("Druckauftrag Timeout", { ...payload, timeoutMs: 1 }, /Print-Window Timeout/);
+
+  const revokeAtLoad = (_event, window) => {
+    window.webContents.once("did-finish-load", () => licenseFixture.setModules([]));
+  };
+  app.once("browser-window-created", revokeAtLoad);
+  try {
+    await rejected("Freigabe waehrend Druck entzogen", payload, /sigeko|freigeschaltet/i);
+  } finally {
+    app.removeListener("browser-window-created", revokeAtLoad);
+    licenseFixture.setModules(["sigeko"]);
+  }
+  return results;
+}
+
+module.exports = { verifyPdfExecutionFailures };

--- a/scripts/runSigekoPdfAcceptance.cjs
+++ b/scripts/runSigekoPdfAcceptance.cjs
@@ -177,11 +177,14 @@ async function runWorker() {
     assert.ok(previewWindow, "Bestehende interne PDF-Vorschau wurde nicht geoeffnet");
     const previewPdf = await inspectPdf(preview.filePath);
     assert.equal(previewPdf.text, stored.text);
+    const screenshotPath = path.join(profile.rootPath, "internal-preview.png");
+    // PDF viewer initialization outlives loadURL; wait for the initial painted
+    // document before asking that same viewer to reopen its file.
+    await capturePaintedPdfPreview(previewWindow, screenshotPath);
     // Die bestehende Vorschau laedt dieselbe gespeicherte Datei erneut.
     await previewWindow.loadURL(pathToFileURL(preview.filePath).href);
     const reopened = await inspectPdf(preview.filePath);
     assert.equal(reopened.sha256, previewPdf.sha256, "Wiederoeffnen hat gespeicherten PDF-Inhalt veraendert");
-    const screenshotPath = path.join(profile.rootPath, "internal-preview.png");
     const paint = await capturePaintedPdfPreview(previewWindow, screenshotPath);
     report.checks.internalPreview = { filePath: preview.filePath, screenshotPath, reopenedUnchanged: true, pageCount: reopened.pageCount, paint };
 
@@ -267,7 +270,7 @@ async function runWorker() {
     report.checks.editorRegeneration = { elementId: editable.id, previousFontSize: before.fontSize, fontSize, metadata: generated, pdf: regeneratedPdf };
     const { verifyPdfExecutionFailures } = require("./helpers/pdfExecutionAcceptance.cjs");
     report.checks.executionFailures = await verifyPdfExecutionFailures({ app, BrowserWindow, ipcMain, invoke,
-      payload, profile, baseDir, tempPath, licenseFixture, pdfInventory });
+      payload, profile, baseDir, tempPath, licenseFixture, pdfInventory, persistentWindowIds: [caller.id, previewWindow.id] });
     const recovered = await invoke("bbmDb.printHtmlToPdf");
     assert.equal(recovered.ok, true, JSON.stringify(recovered));
     const recoveredPdf = await inspectPdf(recovered.filePath);

--- a/scripts/runSigekoPdfAcceptance.cjs
+++ b/scripts/runSigekoPdfAcceptance.cjs
@@ -11,7 +11,7 @@ const { createAcceptanceProfile, createSanitizedEnvironment } = require("./runIs
 const { ACCEPTANCE_SWITCH, configureUiEditorAcceptanceProfile, isPathInside } = require("../src/main/startup/uiEditorAcceptanceProfile");
 
 const ROOT = path.resolve(__dirname, "..");
-const HELP = `SiGeKo S1.4a: realer bestehender Print-/Preview-/Editor-Regenerationsweg.
+const HELP = `SiGeKo S1.4 / S1.4a: bestehender Print-/Preview-/Editor-Regenerationsweg.
   node scripts/runSigekoPdfAcceptance.cjs
   node scripts/runSigekoPdfAcceptance.cjs --headless
   xvfb-run -a node scripts/runSigekoPdfAcceptance.cjs
@@ -111,7 +111,7 @@ async function runWorker() {
   const { app, BrowserWindow, ipcMain } = require("electron");
   let profile;
   let db;
-  const report = { schemaVersion: 1, package: "S1.4a", ok: false, nativeEditorUiVerified: false, checks: {} };
+  const report = { schemaVersion: 1, package: "S1.4", ok: false, nativeEditorUiVerified: false, checks: {} };
   try {
     app.setAppPath(ROOT);
     // Vor DB-/Lizenz-/Print-Import: vorhandenes validiertes Abnahmeprofil.
@@ -122,13 +122,21 @@ async function runWorker() {
     app.setPath("temp", tempPath);
     app.disableHardwareAcceleration();
     await app.whenReady();
-    console.log("[S1.4a] Electron bereit; isolierte Datenbank und Entwicklungs-Testlizenz");
-    const { getStatus } = require("../src/main/licensing/licenseService");
-    const license = getStatus({ fresh: true });
-    assert.equal(license.valid, true, "Bestehende Entwicklungs-Testlizenz fehlt");
-    assert.ok(license.license.modules.includes("sigeko"));
+    console.log("[S1.4] Electron bereit; isolierte Datenbank und kontrollierter SiGeKo-Lizenzstatus");
+    const { createPdfAcceptanceLicense } = require("./helpers/pdfAcceptanceLicense.cjs");
+    const licenseFixture = createPdfAcceptanceLicense({ electronApp: app, profile });
+    const license = licenseFixture.getStatus({ fresh: true });
+    assert.equal(license.valid, true);
+    assert.deepEqual(license.license.modules, ["sigeko"]);
+    licenseFixture.enforceLicensedFeature("sigeko");
+    for (const moduleId of ["protokoll", "restarbeiten", "rechnung"]) {
+      assert.throws(() => licenseFixture.enforceLicensedFeature(moduleId), new RegExp(`FEATURE_NOT_ALLOWED:${moduleId}`));
+    }
+    report.checks.modulePermission = { source: licenseFixture.source, modules: license.license.modules,
+      cryptographicLicenseVerified: licenseFixture.cryptographicLicenseVerified,
+      developmentOverridesEnabled: licenseFixture.developmentOverridesEnabled, otherModulesDenied: true };
     const { configureDatabaseMigrations, initDatabase } = require("../src/main/db/database");
-    configureDatabaseMigrations({ ...license, license: { ...license.license, modules: ["sigeko"] } }, { allowLegacyImport: false });
+    configureDatabaseMigrations(license, { allowLegacyImport: false });
     db = initDatabase();
     assert.ok(isPathInside(profile.rootPath, db.name), "DB muss im Abnahmeprofil liegen");
     const project = require("../src/main/db/projectsRepo").createProject({ project_number: "S14A", name: "SiGeKo PDF Technikabnahme" });
@@ -153,7 +161,7 @@ async function runWorker() {
     const caller = new BrowserWindow({ show: false, webPreferences: { contextIsolation: true, sandbox: false, nodeIntegration: false, preload: path.join(ROOT, "src/main/preload.js") } });
     console.log("[S1.4a] BrowserWindow erstellt; produktive Preload-/IPC-Bruecke wird geladen");
     await caller.loadURL("data:text/html;charset=utf-8,<title>S1.4a IPC Abnahme</title>");
-    const invoke = (method) => caller.webContents.executeJavaScript(`window.${method}(${JSON.stringify(payload)})`, true);
+    const invoke = (method, request = payload) => caller.webContents.executeJavaScript(`window.${method}(${JSON.stringify(request)})`, true);
     const saved = await invoke("bbmDb.printHtmlToPdf");
     assert.equal(saved.ok, true, JSON.stringify(saved));
     assert.ok(isPathInside(baseDir, saved.filePath), "PDF ausserhalb des festgelegten Test-Ablageziels");
@@ -257,6 +265,14 @@ async function runWorker() {
       }
     }
     report.checks.editorRegeneration = { elementId: editable.id, previousFontSize: before.fontSize, fontSize, metadata: generated, pdf: regeneratedPdf };
+    const { verifyPdfExecutionFailures } = require("./helpers/pdfExecutionAcceptance.cjs");
+    report.checks.executionFailures = await verifyPdfExecutionFailures({ app, BrowserWindow, ipcMain, invoke,
+      payload, profile, baseDir, tempPath, licenseFixture, pdfInventory });
+    const recovered = await invoke("bbmDb.printHtmlToPdf");
+    assert.equal(recovered.ok, true, JSON.stringify(recovered));
+    const recoveredPdf = await inspectPdf(recovered.filePath);
+    assert.equal(recoveredPdf.text, stored.text);
+    report.checks.recoveryAfterFailures = { ok: true, pdf: recoveredPdf };
     report.ok = true;
   } catch (error) {
     report.error = { message: error?.message || String(error), code: error?.code || null, validationErrors: error?.validationErrors || [], stack: error?.stack || "" };
@@ -285,7 +301,7 @@ async function launch() {
   const code = await new Promise((resolve, reject) => { child.once("error", reject); child.once("exit", (exitCode) => resolve(exitCode ?? 1)); }).finally(() => clearTimeout(timeout));
   const reportPath = path.join(profile.rootPath, "acceptance-result.json");
   if (!fs.existsSync(reportPath)) {
-    fs.writeFileSync(reportPath, JSON.stringify({ schemaVersion: 1, package: "S1.4a", ok: false, nativeEditorUiVerified: false, checks: {}, error: { code: "ACCEPTANCE_WORKER_ABORTED", message: `Electron endete ohne Abnahmebericht (Exit ${code}); PDF-/Vorschau-Nachweis nicht erbracht.` } }, null, 2));
+    fs.writeFileSync(reportPath, JSON.stringify({ schemaVersion: 1, package: "S1.4", ok: false, nativeEditorUiVerified: false, checks: {}, error: { code: "ACCEPTANCE_WORKER_ABORTED", message: `Electron endete ohne Abnahmebericht (Exit ${code}); PDF-/Vorschau-Nachweis nicht erbracht.` } }, null, 2));
     console.error(`[S1.4a] FAIL: ${reportPath}`);
   }
   process.exitCode = code || (JSON.parse(fs.readFileSync(reportPath, "utf8")).ok === true ? 0 : 1);

--- a/scripts/runSigekoPdfAcceptance.cjs
+++ b/scripts/runSigekoPdfAcceptance.cjs
@@ -90,7 +90,13 @@ async function capturePaintedPdfPreview(window, screenshotPath) {
     await new Promise((resolve) => setTimeout(resolve, 150));
   }
   if (lastImage) fs.writeFileSync(screenshotPath, lastImage.toPNG());
-  throw Object.assign(new Error(`Interne PDF-Vorschau zeigt keine stabil gezeichnete Seite mit Text: ${JSON.stringify(evidence)}`), { code: "PDF_PREVIEW_PAINT_TIMEOUT" });
+  const diagnostics = { visible: window.isVisible(), focused: window.isFocused(), url: window.webContents.getURL(), frames: [] };
+  for (const frame of window.webContents.mainFrame.framesInSubtree) {
+    try {
+      diagnostics.frames.push({ url: frame.url, state: await frame.executeJavaScript("({ready:document.readyState,visibility:document.visibilityState,body:document.body?.innerHTML.slice(0,1500)})") });
+    } catch (error) { diagnostics.frames.push({ url: frame.url, error: error.message }); }
+  }
+  throw Object.assign(new Error(`Interne PDF-Vorschau zeigt keine stabil gezeichnete Seite mit Text: ${JSON.stringify(evidence)}; Diagnose: ${JSON.stringify(diagnostics)}`), { code: "PDF_PREVIEW_PAINT_TIMEOUT" });
 }
 
 function pdfInventory(directories) {
@@ -195,6 +201,7 @@ async function runWorker() {
     const paint = await capturePaintedPdfPreview(previewWindow, screenshotPath);
     report.checks.internalPreview = { filePath: preview.filePath, screenshotPath, reopenedUnchanged: true,
       reopenedThroughExistingPreviewService: true, previousWindowClosed: true, pageCount: reopened.pageCount, paint };
+    if (process.argv.includes("--preview-only")) { report.package = "S1.4-preview-only"; report.ok = true; return; }
 
     const beforeOverflowPdfs = pdfInventory([baseDir, tempPath]);
     const readyMessages = new Map();
@@ -307,6 +314,7 @@ async function launch() {
   if (process.platform === "linux" && process.getuid?.() === 0) args.push("--no-sandbox");
   if (process.argv.includes("--headless")) args.push("--ozone-platform=headless");
   args.push(__filename, "--worker", `${ACCEPTANCE_SWITCH}${profile.rootPath}`);
+  if (process.argv.includes("--preview-only")) args.push("--preview-only");
   const child = spawn(require("electron"), args, { cwd: ROOT, env: createSanitizedEnvironment(), stdio: "inherit" });
   const timeout = setTimeout(() => { console.error("[S1.4a] FAIL: Abnahme-Timeout"); child.kill("SIGTERM"); }, 180000);
   const code = await new Promise((resolve, reject) => { child.once("error", reject); child.once("exit", (exitCode) => resolve(exitCode ?? 1)); }).finally(() => clearTimeout(timeout));

--- a/scripts/runSigekoPdfAcceptance.cjs
+++ b/scripts/runSigekoPdfAcceptance.cjs
@@ -145,7 +145,7 @@ async function runWorker() {
     const { REGISTRY, DOCUMENT_TYPE_ID } = require("../src/main/ui-editor/technicalPdfAdapter.cjs");
     assert.equal(DOCUMENT_TYPE_ID, "technical-neutral");
     assert.equal(REGISTRY.layoutModel, "fixed-layout");
-    const { registerPrintIpc, generatePdfForUiEditor } = require("../src/main/ipc/printIpc");
+    const { registerPrintIpc, generatePdfForUiEditor, openInternalPdfPreview } = require("../src/main/ipc/printIpc");
     registerPrintIpc();
     const { createPdfEditorAdapterResolver } = require("../src/main/ui-editor/pdfAdapterRegistry.cjs");
     const uiEditorRoot = path.join(profile.userDataPath, "ui-editor");
@@ -173,23 +173,28 @@ async function runWorker() {
     const existingWindows = new Set(BrowserWindow.getAllWindows().map((win) => win.id));
     const preview = await invoke("bbmPrint.printPdfAndPreviewInternal");
     assert.equal(preview.ok, true, JSON.stringify(preview));
-    const previewWindow = BrowserWindow.getAllWindows().find((win) => !existingWindows.has(win.id) && win.webContents.getURL() === pathToFileURL(preview.filePath).href);
+    let previewWindow = BrowserWindow.getAllWindows().find((win) => !existingWindows.has(win.id) && win.webContents.getURL() === pathToFileURL(preview.filePath).href);
     assert.ok(previewWindow, "Bestehende interne PDF-Vorschau wurde nicht geoeffnet");
     const previewPdf = await inspectPdf(preview.filePath);
     assert.equal(previewPdf.text, stored.text);
     const screenshotPath = path.join(profile.rootPath, "internal-preview.png");
-    // PDF viewer initialization outlives loadURL; wait for the initial painted
-    // document before asking that same viewer to reopen its file.
+    // PDF viewer initialization outlives loadURL; verify the first display.
     await capturePaintedPdfPreview(previewWindow, screenshotPath);
-    // Dokument zuerst entladen: ein erneutes loadURL auf dieselbe aktive
-    // PDF-Plugininstanz ist kein verlaesslicher Wiederoeffnungsvorgang.
-    await previewWindow.loadURL("about:blank");
-    // Die bestehende Vorschau oeffnet dieselbe gespeicherte Datei erneut.
-    await previewWindow.loadURL(pathToFileURL(preview.filePath).href);
+    // Real reopen: close the viewer, then use the SAME existing preview service
+    // on the stored file. Reloading an active Chromium PDF plugin is not reopen.
+    const previousWindowId = previewWindow.id;
+    await new Promise((resolve) => { previewWindow.once("closed", resolve); previewWindow.close(); });
+    const beforeReopen = new Set(BrowserWindow.getAllWindows().map((window) => window.id));
+    const reopenResult = await openInternalPdfPreview({ filePath: preview.filePath, title: "PDF Vorschau" });
+    assert.equal(reopenResult.ok, true);
+    previewWindow = BrowserWindow.getAllWindows().find((window) => !beforeReopen.has(window.id) && window.webContents.getURL() === pathToFileURL(preview.filePath).href);
+    assert.ok(previewWindow, "Gespeicherte PDF wurde nicht in der bestehenden Vorschaufunktion geoeffnet");
+    assert.notEqual(previewWindow.id, previousWindowId);
     const reopened = await inspectPdf(preview.filePath);
     assert.equal(reopened.sha256, previewPdf.sha256, "Wiederoeffnen hat gespeicherten PDF-Inhalt veraendert");
     const paint = await capturePaintedPdfPreview(previewWindow, screenshotPath);
-    report.checks.internalPreview = { filePath: preview.filePath, screenshotPath, reopenedUnchanged: true, pageCount: reopened.pageCount, paint };
+    report.checks.internalPreview = { filePath: preview.filePath, screenshotPath, reopenedUnchanged: true,
+      reopenedThroughExistingPreviewService: true, previousWindowClosed: true, pageCount: reopened.pageCount, paint };
 
     const beforeOverflowPdfs = pdfInventory([baseDir, tempPath]);
     const readyMessages = new Map();

--- a/scripts/runSigekoPdfAcceptance.cjs
+++ b/scripts/runSigekoPdfAcceptance.cjs
@@ -181,7 +181,10 @@ async function runWorker() {
     // PDF viewer initialization outlives loadURL; wait for the initial painted
     // document before asking that same viewer to reopen its file.
     await capturePaintedPdfPreview(previewWindow, screenshotPath);
-    // Die bestehende Vorschau laedt dieselbe gespeicherte Datei erneut.
+    // Dokument zuerst entladen: ein erneutes loadURL auf dieselbe aktive
+    // PDF-Plugininstanz ist kein verlaesslicher Wiederoeffnungsvorgang.
+    await previewWindow.loadURL("about:blank");
+    // Die bestehende Vorschau oeffnet dieselbe gespeicherte Datei erneut.
     await previewWindow.loadURL(pathToFileURL(preview.filePath).href);
     const reopened = await inspectPdf(preview.filePath);
     assert.equal(reopened.sha256, previewPdf.sha256, "Wiederoeffnen hat gespeicherten PDF-Inhalt veraendert");

--- a/scripts/runSigekoPdfAcceptance.cjs
+++ b/scripts/runSigekoPdfAcceptance.cjs
@@ -92,9 +92,15 @@ async function capturePaintedPdfPreview(window, screenshotPath) {
   if (lastImage) fs.writeFileSync(screenshotPath, lastImage.toPNG());
   const diagnostics = { visible: window.isVisible(), focused: window.isFocused(), url: window.webContents.getURL(), frames: [] };
   for (const frame of window.webContents.mainFrame.framesInSubtree) {
+    let timeout;
     try {
-      diagnostics.frames.push({ url: frame.url, state: await frame.executeJavaScript("({ready:document.readyState,visibility:document.visibilityState,body:document.body?.innerHTML.slice(0,1500)})") });
+      const state = await Promise.race([
+        frame.executeJavaScript("({ready:document.readyState,visibility:document.visibilityState,body:document.body?.innerHTML.slice(0,1500)})"),
+        new Promise((resolve) => { timeout = setTimeout(() => resolve({ diagnosticTimeout: true }), 1000); }),
+      ]);
+      diagnostics.frames.push({ url: frame.url, state });
     } catch (error) { diagnostics.frames.push({ url: frame.url, error: error.message }); }
+    finally { clearTimeout(timeout); }
   }
   throw Object.assign(new Error(`Interne PDF-Vorschau zeigt keine stabil gezeichnete Seite mit Text: ${JSON.stringify(evidence)}; Diagnose: ${JSON.stringify(diagnostics)}`), { code: "PDF_PREVIEW_PAINT_TIMEOUT" });
 }

--- a/scripts/testGroups.cjs
+++ b/scripts/testGroups.cjs
@@ -148,6 +148,7 @@ const TEST_GROUPS = Object.freeze([
       ["tableLayoutEditorPrototype.test.cjs", "runTableLayoutEditorPrototypeTests"],
       ["printUserDataResolver.test.cjs", "runPrintUserDataResolverTests"],
       ["printOrientation.test.cjs", "runPrintOrientationTests"],
+      ["printJobLifecycle.test.cjs", "runPrintJobLifecycleTests"],
       ["printModes.test.cjs", "runPrintModesTests"],
       ["printTableLayouts.test.cjs", "runPrintTableLayoutsTests"],
       ["m85PdfSatzvertrag.test.cjs", "runM85PdfSatzvertragTests"],

--- a/scripts/tests/printJobLifecycle.test.cjs
+++ b/scripts/tests/printJobLifecycle.test.cjs
@@ -1,0 +1,214 @@
+"use strict";
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Module = require("node:module");
+const { EventEmitter } = require("node:events");
+
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+// Exercise the actual shared print job. Only its OS/window and data boundaries
+// are substituted; no copy of the lifecycle or source-text assertions is used.
+async function withPrintHarness(test) {
+  const modulePath = require.resolve("../../src/main/ipc/printIpc.js");
+  const previousModule = require.cache[modulePath];
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "bbm-print-lifecycle-"));
+  const originalLoad = Module._load;
+  const originalSetTimeout = global.setTimeout;
+  const originalClearTimeout = global.clearTimeout;
+  const created = deferred();
+  const pdf = deferred();
+  const loading = deferred();
+  const timerToken = {};
+  const ipcMain = new EventEmitter();
+  const handlers = new Map();
+  ipcMain.handle = (name, handler) => handlers.set(name, handler);
+  const h = { root, ipcMain, handlers, pdf, loading, created, calls: [], sends: [], writes: 0,
+    providerGuards: 0, allowed: true, dataCalls: 0, providerCalls: 0, timerActive: false };
+  const webContents = new EventEmitter();
+  webContents.send = (...args) => h.sends.push(args);
+  webContents.printToPDF = (options) => { h.calls.push(options); return pdf.promise; };
+  const win = new EventEmitter();
+  win.webContents = webContents;
+  win.close = () => { if (!h.closed) { h.closed = true; win.emit("closed"); } };
+  win.loadURL = () => loading.promise;
+  h.win = win;
+  const bridge = {
+    resolve(payload) {
+      h.providerGuards++;
+      if (!h.allowed) throw new Error("LICENSE_MODULE_DISABLED");
+      return { request: payload.providerRequest };
+    },
+    async provide() { h.providerCalls++; return { providerDocument: { title: "Technical" } }; },
+    outputDirectory: () => root,
+  };
+  const fsBoundary = Object.create(fs);
+  fsBoundary.writeFileSync = (...args) => {
+    h.writes++;
+    if (h.writeError) throw h.writeError;
+    return fs.writeFileSync(...args);
+  };
+  const stubs = {
+    electron: { ipcMain, app: { getPath: () => root }, shell: {}, BrowserWindow: function () {} },
+    fs: fsBoundary,
+    "../print/printWindow": { createPrintWindow: () => { created.resolve(); return win; }, getPrintAppUrl: () => "file:///print-fixture.html" },
+    "../print/printData": { getPrintData: async () => { h.dataCalls++; return {}; } },
+    "../licensing/featureGuard": { enforceLicensedFeature: () => {}, toLicenseErrorPayload: (error) => ({ ok: false, error: error.message }) },
+    "./projectStoragePaths": { sanitizeDirName: (s) => s, resolveProjectFolderName: () => "fixture" },
+    "../buildIdentity": { resolveBuildIdentity: () => ({ channel: "test" }) },
+    "../ui-editor/pdfAdapterRegistry.cjs": {},
+    "../print/pdfProviderBridge": { isProviderRequest: (p) => p.mode === "provider", createPdfProviderBridge: () => bridge },
+    "../modulePdfProviders": { createProductivePdfProviderRegistry: () => ({}) },
+  };
+  for (const name of ["bbmPdfAdapter", "restarbeitenPdfAdapter", "invoicePdfAdapter", "technicalPdfAdapter"]) {
+    stubs[`../ui-editor/${name}.cjs`] = {};
+  }
+  Module._load = function (request, parent, isMain) {
+    if (parent?.filename === modulePath && Object.hasOwn(stubs, request)) return stubs[request];
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  global.setTimeout = (callback, delay, ...args) => {
+    if (delay !== 314159) return originalSetTimeout(callback, delay, ...args);
+    h.timerActive = true;
+    h.expire = () => { assert.equal(h.timerActive, true); h.timerActive = false; callback(...args); };
+    return timerToken;
+  };
+  global.clearTimeout = (token) => {
+    if (token === timerToken) h.timerActive = false;
+    else originalClearTimeout(token);
+  };
+  try {
+    delete require.cache[modulePath];
+    h.service = require(modulePath);
+    // Dependency substitution is restricted to this synchronous module load.
+    Module._load = originalLoad;
+    h.payload = (provider = false) => ({ mode: provider ? "provider" : "protocol", targetDir: "temp", fileName: "result.pdf", timeoutMs: 314159,
+      ...(provider ? { documentTypeId: "technical-neutral", providerRequest: { moduleId: "sigeko", providerId: "technical-neutral", projectId: "p", documentId: "d" } } : {}) });
+    h.start = async ({ provider = false, metadata = false, ipc = false } = {}) => {
+      const payload = h.payload(provider);
+      let result;
+      if (ipc) {
+        h.service.registerPrintIpc();
+        result = handlers.get("print:htmlToPdf")({}, payload);
+      } else result = metadata ? h.service.generatePdfForUiEditor(payload) : h.service.printToPdf(payload);
+      // Attach rejection handling before the test triggers any failure event.
+      h.outcome = result.then((value) => ({ value }), (error) => ({ error }));
+      await created.promise;
+    };
+    h.load = () => { webContents.emit("did-finish-load"); return h.sends.at(-1)?.[1]; };
+    h.ready = (msg = {}, sender = webContents) => ipcMain.emit("print:ready", { sender }, msg);
+    h.assertClean = () => {
+      assert.equal(ipcMain.listenerCount("print:ready"), 0);
+      assert.equal(win.listenerCount("closed"), 0);
+      // The debug pipes retain one informational listener for each event.
+      assert.equal(webContents.listenerCount("render-process-gone"), 1);
+      assert.equal(webContents.listenerCount("did-finish-load"), 1);
+      assert.equal(h.timerActive, false);
+      assert.equal(h.closed, true);
+    };
+    h.assertNoOutput = () => { assert.deepEqual(fs.readdirSync(root), []); };
+    await test(h);
+  } finally {
+    Module._load = originalLoad;
+    global.setTimeout = originalSetTimeout;
+    global.clearTimeout = originalClearTimeout;
+    delete require.cache[modulePath];
+    if (previousModule) require.cache[modulePath] = previousModule;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+async function runPrintJobLifecycleTests(run) {
+  await run("S1.4: shared tabular print ignores foreign and duplicate ready events", () => withPrintHarness(async (h) => {
+    await h.start();
+    const init = h.load();
+    h.ready({ jobId: "foreign-job" });
+    h.ready({ jobId: init.jobId }, new EventEmitter());
+    assert.equal(h.calls.length, 0);
+    h.ready({ jobId: init.jobId }); h.ready({ jobId: init.jobId });
+    assert.equal(h.calls.length, 1);
+    h.pdf.resolve(Buffer.from("PDF fixture"));
+    const { value, error } = await h.outcome;
+    assert.ifError(error);
+    assert.equal(fs.readFileSync(value, "utf8"), "PDF fixture");
+    assert.equal(h.writes, 1); assert.equal(h.dataCalls, 1); assert.equal(h.providerCalls, 0);
+    assert.equal(h.calls[0].pageSize, "A4"); assert.equal(h.calls[0].landscape, false);
+    h.assertClean();
+  }));
+  await run("S1.4: provider preview keeps metadata and rechecks permission before saving", () => withPrintHarness(async (h) => {
+    await h.start({ provider: true, metadata: true });
+    const init = h.load();
+    assert.equal(init.providerRequest.moduleId, "sigeko"); assert.equal(init.pdfEditorPreview, true);
+    const bounds = [{ elementId: "title", xMm: 12 }];
+    h.ready({ jobId: init.jobId, previewMetadata: { pageCount: 1, renderBounds: bounds } });
+    const guardsBeforeCompletion = h.providerGuards;
+    h.pdf.resolve(Buffer.from("provider PDF"));
+    const { value, error } = await h.outcome;
+    assert.ifError(error); assert.equal(value.pageCount, 1); assert.deepEqual(value.renderBounds, bounds);
+    assert.equal(value.filePath, value.controlledOutputPath); assert.ok(Date.parse(value.generatedAt));
+    assert.equal(h.providerGuards, guardsBeforeCompletion + 1);
+    assert.equal(h.dataCalls, 0); assert.equal(h.providerCalls, 1); assert.equal(h.writes, 1);
+    h.assertClean();
+  }));
+  await run("S1.4: permission withdrawn during provider printing prevents output", () => withPrintHarness(async (h) => {
+    await h.start({ provider: true }); h.ready(); h.allowed = false;
+    h.pdf.resolve(Buffer.from("late PDF"));
+    assert.match((await h.outcome).error.message, /LICENSE_MODULE_DISABLED/);
+    assert.equal(h.writes, 0); h.assertNoOutput(); h.assertClean();
+  }));
+  await run("S1.4: timeout during printing cannot write a late PDF", () => withPrintHarness(async (h) => {
+    await h.start(); h.ready(); h.expire();
+    assert.match((await h.outcome).error.message, /Timeout/);
+    h.pdf.resolve(Buffer.from("late PDF")); await Promise.resolve();
+    assert.equal(h.writes, 0); h.assertNoOutput(); h.assertClean();
+  }));
+  for (const duringPrint of [false, true]) {
+    await run(`S1.4: closing print window ${duringPrint ? "during printing" : "before readiness"} remains unsuccessful`, () => withPrintHarness(async (h) => {
+      await h.start({ ipc: true }); if (duringPrint) h.ready(); h.win.close();
+      const { value, error } = await h.outcome;
+      assert.ifError(error); assert.equal(value.ok, false); assert.match(value.error, /Print-Window geschlossen/);
+      h.pdf.resolve(Buffer.from("late PDF")); await Promise.resolve();
+      h.win.webContents.emit("did-finish-load"); h.ready();
+      assert.equal(h.sends.length, 0); assert.equal(h.calls.length, duringPrint ? 1 : 0);
+      assert.equal(h.writes, 0); h.assertNoOutput(); h.assertClean();
+    }));
+  }
+  await run("S1.4: renderer process loss rejects immediately and discards late PDF", () => withPrintHarness(async (h) => {
+    await h.start(); h.ready();
+    h.win.webContents.emit("render-process-gone", {}, { reason: "crashed" });
+    assert.match((await h.outcome).error.message, /Print-Renderer beendet: crashed/);
+    h.pdf.resolve(Buffer.from("late PDF")); await Promise.resolve();
+    assert.equal(h.writes, 0); h.assertNoOutput(); h.assertClean();
+  }));
+  await run("S1.4: renderer rejection never starts printing", () => withPrintHarness(async (h) => {
+    await h.start(); h.ready({ ok: false, error: "layout overflow" });
+    assert.match((await h.outcome).error.message, /layout overflow/);
+    assert.equal(h.calls.length, 0); h.assertNoOutput(); h.assertClean();
+  }));
+  await run("S1.4: Chromium print rejection remains a failed IPC result", () => withPrintHarness(async (h) => {
+    await h.start({ ipc: true }); h.ready(); h.pdf.reject(new Error("Chromium refused PDF"));
+    const { value } = await h.outcome;
+    assert.equal(value.ok, false); assert.match(value.error, /Chromium refused PDF/);
+    assert.equal(h.writes, 0); h.assertNoOutput(); h.assertClean();
+  }));
+  await run("S1.4: output write failure remains a failed IPC result", () => withPrintHarness(async (h) => {
+    await h.start({ ipc: true }); h.writeError = Object.assign(new Error("disk write denied"), { code: "EACCES" });
+    h.ready(); h.pdf.resolve(Buffer.from("PDF"));
+    const { value } = await h.outcome;
+    assert.equal(value.ok, false); assert.match(value.error, /disk write denied/);
+    assert.equal(h.writes, 1); h.assertNoOutput(); h.assertClean();
+  }));
+  await run("S1.4: failed print page load removes late initialization listener", () => withPrintHarness(async (h) => {
+    await h.start(); h.loading.reject(new Error("load failed"));
+    assert.match((await h.outcome).error.message, /load failed/);
+    h.win.webContents.emit("did-finish-load"); h.ready();
+    assert.equal(h.sends.length, 0); assert.equal(h.calls.length, 0); h.assertNoOutput(); h.assertClean();
+  }));
+}
+
+module.exports = { runPrintJobLifecycleTests };

--- a/src/main/ipc/printIpc.js
+++ b/src/main/ipc/printIpc.js
@@ -810,4 +810,4 @@ function registerPrintIpc() {
   );
 }
 
-module.exports = { registerPrintIpc, generatePdfForUiEditor, printToPdf };
+module.exports = { registerPrintIpc, generatePdfForUiEditor, printToPdf, openInternalPdfPreview };

--- a/src/main/ipc/printIpc.js
+++ b/src/main/ipc/printIpc.js
@@ -481,12 +481,16 @@ async function _printToPdf(payload = {}, includeMetadata = false) {
 
   return new Promise((resolve, reject) => {
     let done = false;
+    let printing = false;
     const timeoutMsRaw = Number(payload?.timeoutMs);
     const timeoutMs = Number.isFinite(timeoutMsRaw) && timeoutMsRaw > 0 ? timeoutMsRaw : 120000;
 
     const cleanup = () => {
       try {
         ipcMain.removeListener("print:ready", onReady);
+        win.removeListener("closed", onClosed);
+        win.webContents.removeListener("render-process-gone", onRendererGone);
+        win.webContents.removeListener("did-finish-load", onDidFinishLoad);
       } catch (_e) {}
       try {
         clearTimeout(timeout);
@@ -496,17 +500,25 @@ async function _printToPdf(payload = {}, includeMetadata = false) {
       } catch (_e) {}
     };
 
-    const timeout = setTimeout(() => {
+    const fail = (error) => {
       if (done) return;
       done = true;
-      console.log(`[print:${jobId}] TIMEOUT after ${timeoutMs}ms`);
       cleanup();
-      reject(new Error("Print-Window Timeout"));
+      reject(error);
+    };
+    const onClosed = () => fail(new Error("Print-Window geschlossen"));
+    const onRendererGone = (_event, details) => fail(new Error(`Print-Renderer beendet: ${details?.reason || "unknown"}`));
+
+    const timeout = setTimeout(() => {
+      console.log(`[print:${jobId}] TIMEOUT after ${timeoutMs}ms`);
+      fail(new Error("Print-Window Timeout"));
     }, timeoutMs);
 
     const onReady = async (evt, msg) => {
+      if (done || printing) return;
       if (evt.sender !== win.webContents) return;
       if (msg?.jobId && msg.jobId !== jobId) return;
+      printing = true;
 
       console.log(`[print:${jobId}] print:ready received`);
 
@@ -530,6 +542,9 @@ async function _printToPdf(payload = {}, includeMetadata = false) {
         }
         if (isProviderRequest(payload)) providerBridge().resolve(payload);
         const pdfBuffer = await win.webContents.printToPDF(options);
+        // Ein Timeout oder Fensterabbruch bleibt auch bei spaeter PDF-Antwort erfolglos.
+        if (done) return;
+        if (isProviderRequest(payload)) providerBridge().resolve(payload);
         fs.writeFileSync(outPath, pdfBuffer);
         console.log(`[print:${jobId}] PDF written -> ${outPath}`);
         done = true;
@@ -543,15 +558,16 @@ async function _printToPdf(payload = {}, includeMetadata = false) {
         } : outPath);
       } catch (err) {
         console.log(`[print:${jobId}] printToPDF ERROR: ${err?.message || err}`);
-        done = true;
-        cleanup();
-        reject(err);
+        fail(err);
       }
     };
 
     ipcMain.on("print:ready", onReady);
+    win.once("closed", onClosed);
+    win.webContents.once("render-process-gone", onRendererGone);
 
-    win.webContents.once("did-finish-load", () => {
+    const onDidFinishLoad = () => {
+      if (done) return;
       console.log(`[print:${jobId}] sending print:init (debug=${debug})`);
       win.webContents.send("print:init", {
         jobId,
@@ -571,14 +587,12 @@ async function _printToPdf(payload = {}, includeMetadata = false) {
         layoutCalibrationEnabled: _readLayoutCalibrationEnabled(),
         pdfEditorPreview: payload.pdfEditorPreview === true,
       });
-    });
+    };
+    win.webContents.once("did-finish-load", onDidFinishLoad);
 
     win.loadURL(url).catch((err) => {
-      if (done) return;
-      done = true;
       console.log(`[print:${jobId}] loadURL ERROR: ${err?.message || err}`);
-      cleanup();
-      reject(err);
+      fail(err);
     });
   });
 }


### PR DESCRIPTION
S1.4 vervollständigt den technischen PDF-Anschluss aus S1.4a (#322). Der gemeinsame Druckweg konnte nach einem Timeout noch eine verspätete PDF schreiben und auf doppelte Bereitschaftsmeldungen mehrfach drucken.

Der bestehende Druckauftrag ignoriert jetzt doppelte/späte Meldungen, beendet Fenster- und Rendererabbrüche unmittelbar und prüft den Abschlusszustand vor dem Schreiben. Providerfreigaben werden nach der PDF-Erzeugung erneut geprüft. Die vorhandene Vorschaufunktion ist zusätzlich exportiert, damit dieselbe gespeicherte Datei nach echtem Fensterschluss über denselben Dienst wieder geöffnet werden kann; ihr Funktionskörper bleibt unverändert. Keine neue PDF-/Editorinfrastruktur oder Layoutänderung.

Nachweise:
- Volltest mit echtem Kit, gleiche UTC-Umgebung: main 1516 grün / 97 rot → Kandidat 1527 grün / exakt dieselben 97 Fehler. Kein Bestandstest fehlt; elf neue Ablaufprüfungen grün. Zwei historische Datumsfehler aus 1514/99 treten bereits im erneuten Basislauf nicht auf.
- Vollständige Windows-/Linux-Abnahme bestanden: https://github.com/SteffenBandholt/BBM-Produktiv/actions/runs/34186341786. Reale PDF, Speicherung, sichtbare Vorschau, bytegleiches Wiederöffnen, Editor-Regeneration, elf negative IPC-/Abbruchfälle mit unveränderten Dateien und erfolgreichem Wiederanlauf.
- Alle 49 bestehenden PDF-Struktursnapshots und Seitenzahlen identisch.

Offener allgemeiner Viewerfehler: Mehrere andere Läufe zeigten beim Wiederöffnen sporadisch ein dunkles PDF-Fenster, überwiegend Linux, einmal Windows. Vergleich https://github.com/SteffenBandholt/BBM-Produktiv/actions/runs/34186953879 reproduziert das identische Symptom mit demselben Harness und npm-Start auf der Basis bd5ab3d (nur Export der vorhandenen Vorschaufunktion instrumentiert, keine Verhaltensänderung): zwei Basisläufe bestanden, einer scheiterte mit PDF_PREVIEW_PAINT_TIMEOUT; danach vollständiger Linux-Kandidat grün. Kein neuer Linux-Viewerfehler durch S1.4 nachgewiesen; keine dauerhafte Behebung behauptet. Die Basisdiagnosen bleiben sichtbar, Kandidatenfehler werden weiterhin rot. Der Windows-Job dieses Vergleichslaufs scheiterte vor Teststart bei npm ci/node-gyp; nicht als bestanden gewertet.

Grenzen: Lizenzstatus ist eine isolierte Test-Fixture nur SiGeKo im unveränderten zentralen Lizenzdienst, ohne DEV-Ausnahmen im geprüften Guard. Keine kryptografische Kundenlizenzprüfung oder native WPF-Editorabnahme. Standard-npm-CI bleibt wegen fehlendem Kit und bekannter Popup-/Lizenzbaseline rot.

Exakte Fehlernamen, Vorläufe, Artefakte und Hashes: docs/SIGEKO_S1_4_TESTVERGLEICH.json. Umfang: docs/SIGEKO_S1_4_PDF_AUSFUEHRUNG.md. Bezug #274, #277. Rechnung #275 und Blankovorlagen unverändert; S1.5 nicht begonnen.